### PR TITLE
fix(lensnode): default max_concurrent_runs to 8 (avoid prolonged QUEUED)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -172,7 +172,7 @@ services:
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: 600
       # Max concurrent runs per node. Increase in production based on node resources.
-      LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-5}
+      LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
       PYTHONPATH: /opt/lensnode
     volumes:
       - ./data.dev/workspace:/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,9 @@ services:
       LENSNODE_AI_GATEWAY_URL: http://backend-api:8000/api/lens/lensnode/ai-gateway/
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
+      # Max concurrent runs per node. Each run holds a slot for the full
+      # answer duration; without this it falls back to 1 and questions queue.
+      LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
     volumes:
       - ./data/workspace:/workspace
     networks:

--- a/env.sample
+++ b/env.sample
@@ -79,6 +79,9 @@ LENSNODE_WORKSPACE_PATH=/workspace
 LENSNODE_CONTROL_WS_URL=ws://backend-api:8000/ws/lens/lensnodes/
 LENSNODE_AI_GATEWAY_URL=http://backend-api:8000/api/lens/lensnode/ai-gateway/
 LENSNODE_HEARTBEAT_INTERVAL_S=15
+# Max concurrent runs a single lensnode executes. Each run holds a slot for
+# the full answer duration; raise for more parallelism (avoids long Queued).
+LENSNODE_MAX_CONCURRENT_RUNS=8
 
 # -----------------------------------------------------------------------------
 # Admin bootstrap


### PR DESCRIPTION
## Problem
In production, runs frequently sit in **QUEUED** for a long time before responding; locally they start immediately.

## Root cause
The production `docker-compose.yml` never set `LENSNODE_MAX_CONCURRENT_RUNS`, so the lensnode fell back to the **code default of 1** (`lensnode/config.py`). A slot is held for the entire answer duration, so any concurrent/follow-up question is rejected `LENSNODE_BUSY` → bounced back to QUEUED and retried every 5s. Local dev set it to 5 and never hit this. (A past manual bump to 8 on the box was wiped by a redeploy because it wasn't persisted.)

## Fix
- `docker-compose.yml` (prod): add `LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}`
- `docker-compose.dev.yml`: default 5 → 8 (consistency)
- `env.sample`: document `LENSNODE_MAX_CONCURRENT_RUNS=8`

Verified locally: the dev lensnode now reads `8`. The deploy scp's `docker-compose.yml` to the host, so this reaches prod on the next tagged deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)