### PR TITLE
fix(nginx): stream SSE live through the outer proxy (fix stuck QUEUED)

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -31,6 +31,11 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # Re-emit so the outer proxy (NPM/openresty) also disables buffering for
+    # SSE streams. nginx consumes the upstream X-Accel-Buffering header and does
+    # not forward it, so without this the outer proxy buffers the event stream
+    # and the chat UI stays stuck on "Queued" until the run finishes.
+    add_header X-Accel-Buffering "no" always;
 
     # Backend API proxy
     location /api/ {
@@ -163,6 +168,11 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # Re-emit so the outer proxy (NPM/openresty) also disables buffering for
+    # SSE streams. nginx consumes the upstream X-Accel-Buffering header and does
+    # not forward it, so without this the outer proxy buffers the event stream
+    # and the chat UI stays stuck on "Queued" until the run finishes.
+    add_header X-Accel-Buffering "no" always;
 
     # Backend API proxy
     location /api/ {


### PR DESCRIPTION
## Problem
In production the chat UI stays on **QUEUED** for the whole run, then the full answer appears at once. Locally it works instantly.

## Root cause
Diagnosed on prod: runs actually dispatch in ~1s (DB shows QUEUED→streaming immediately), but the **SSE event stream is buffered by the outer proxy** (Nginx Proxy Manager / openresty, `proxy_buffering on` by default). The backend sets `X-Accel-Buffering: no`, but the **inner nginx consumes that header and does not forward it**, so the outer proxy never sees it and buffers all events until the run completes. Locally there is no outer proxy, hence no buffering. (This is also why raising lensnode concurrency in v0.2.2 did not help — it was never a concurrency problem.)

## Fix
Re-emit `add_header X-Accel-Buffering "no" always;` from the inner nginx (both server blocks) so the outer proxy also disables buffering for the stream.

## Verification (on prod, hot-applied + reloaded)
Before: all events arrived in a single 10ms burst at run completion (run spanned 8s).
After: events arrive incrementally as the run progresses (e.g. +0s, +8s, +15s, +19s) — live streaming restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)