### PR TITLE
fix(lens): stop false MODEL_TIMEOUT on long runs (activity watchdog / heartbeat / cancellation) + fastapi dep

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -196,12 +196,14 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         if run_uuid is None:
             await self._send_bad_frame("run_uuid is invalid")
             return
-        await database_sync_to_async(record_lensnode_run_event)(
+        step = await database_sync_to_async(record_lensnode_run_event)(
             run_uuid,
             content.get("step_type") or "retrieval",
             content.get("status") or "running",
             content.get("detail") or {},
         )
+        if step is None:
+            return
         LOGGER.info(
             "Recorded LensNode run event run_uuid=%s step_type=%s status=%s",
             run_uuid,

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -629,9 +629,23 @@ def append_lensnode_output(
 
 
 def record_lensnode_run_event(run_uuid, step_type, status, detail):
-    """Persist a structured LensNode event into a RunStep row."""
+    """Persist a structured LensNode event into a RunStep row.
+
+    Events for a run that already reached a terminal state are dropped:
+    a cancelled agent thread can keep emitting for a while, and those
+    late events must not rewrite the trace of a settled run. The warning
+    makes orphan-thread activity observable.
+    """
 
     run = Run.objects.get(uuid=run_uuid)
+    if run.status in TERMINAL_RUN_STATUSES:
+        logger.warning(
+            "run %s: dropping late %s event (run already %s)",
+            run_uuid,
+            step_type,
+            run.status,
+        )
+        return None
     sequence = _step_sequence(step_type)
     step, _ = RunStep.objects.get_or_create(
         run=run,

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -629,6 +629,34 @@ class LensApiTests(TestCase):
         )
         self.assertTrue(call_and_track.call_args.kwargs["return_message"])
 
+    def test_lensnode_ai_gateway_forwards_run_correlation(self):
+        token = "dev-lensnode-token"
+        self.lensnode.auth_token_hash = hash_lensnode_token(token)
+        self.lensnode.save(update_fields=["auth_token_hash", "updated_at"])
+        client = APIClient()
+        run_uuid = "3a2b7d54-9c1e-4f7a-8f27-0a4c1d2e3f45"
+
+        with patch(
+            "agentcore_metering.adapters.django.LLMTracker.call_and_track",
+            return_value=("ok", {"total_tokens": 1}),
+        ) as call_and_track:
+            response = client.post(
+                "/api/lens/lensnode/ai-gateway/",
+                {
+                    "model_ref": "016d5cf7-2245-4015-b242-d6323e795b58",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "run_uuid": run_uuid,
+                    "is_subagent": True,
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        state = call_and_track.call_args.kwargs["state"]
+        self.assertEqual(state["metadata"]["run_uuid"], run_uuid)
+        self.assertTrue(state["metadata"]["is_subagent"])
+
     def test_session_run_flow_returns_completed_run_with_execution(self):
         session_response = self.client.post(
             "/api/lens/sessions/",

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -9,6 +9,7 @@ from lens.models import Assistant, LensNode, Run, Session
 from lens.services import (
     create_execution_run,
     reconcile_lensnode_active_runs,
+    record_lensnode_run_event,
     touch_run_activity,
 )
 from lens.tasks import lensnode_cleanup_task
@@ -75,6 +76,34 @@ class RunLifecycleTests(TestCase):
         self.assertLess(
             (timezone.now() - run.last_activity_at).total_seconds(), 5
         )
+
+    def test_record_run_event_drops_late_event_for_terminal_run(self):
+        run = self._run(
+            Run.Status.FAILED,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        step = record_lensnode_run_event(
+            run.uuid, "retrieval", "running", {"message": "late"}
+        )
+
+        self.assertIsNone(step)
+        self.assertEqual(run.steps.count(), 0)
+
+    def test_record_run_event_persists_for_active_run(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+
+        step = record_lensnode_run_event(
+            run.uuid, "retrieval", "running", {"message": "progress"}
+        )
+
+        self.assertIsNotNone(step)
+        self.assertEqual(run.steps.count(), 1)
 
     def test_idle_reaper_fails_silent_run(self):
         run = self._run(

--- a/backend/lens/views.py
+++ b/backend/lens/views.py
@@ -1649,6 +1649,13 @@ class GlobalSettingViewSet(BaseAdminViewSet):
         )
 
 
+# While a provider call is thinking (reasoning, composing a tool call)
+# the SSE stream can carry no tokens for minutes. Periodic heartbeats
+# prove transport liveness to the LensNode watchdog so it only aborts
+# on a genuinely dead pipe, never on a quiet-but-alive model call.
+GATEWAY_STREAM_HEARTBEAT_S = 10
+
+
 class LensNodeAIGatewayView(APIView):
     """AI gateway endpoint authenticated by the LensNode token."""
 
@@ -1680,6 +1687,14 @@ class LensNodeAIGatewayView(APIView):
             "source_type": "lensnode_gateway",
             "lensnode_uuid": str(lensnode.uuid),
         }
+        correlation = {}
+        if request.data.get("run_uuid"):
+            correlation["run_uuid"] = str(request.data["run_uuid"])
+            correlation["is_subagent"] = bool(
+                request.data.get("is_subagent")
+            )
+        if correlation:
+            tracker_state["metadata"] = correlation
         if request.data.get("stream"):
             return self._stream_response(
                 lensnode,
@@ -1823,7 +1838,13 @@ class LensNodeAIGatewayView(APIView):
             future = loop.run_in_executor(None, run_in_thread)
             try:
                 while True:
-                    item = await queue.get()
+                    try:
+                        item = await asyncio.wait_for(
+                            queue.get(), timeout=GATEWAY_STREAM_HEARTBEAT_S
+                        )
+                    except asyncio.TimeoutError:
+                        yield self._sse({"type": "heartbeat"})
+                        continue
                     if item[0] == "event":
                         yield self._sse(item[1])
                         if item[1].get("type") == "error":

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -171,6 +171,7 @@ services:
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-600}
+      LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
       # Max concurrent runs per node. Increase in production based on node resources.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
       PYTHONPATH: /opt/lensnode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}
+      LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
       # Max concurrent runs per node. Each run holds a slot for the full
       # answer duration; without this it falls back to 1 and questions queue.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}

--- a/env.sample
+++ b/env.sample
@@ -82,6 +82,10 @@ LENSNODE_HEARTBEAT_INTERVAL_S=15
 # Must be greater than the LiteLLM/provider request timeout so the control
 # plane reports provider failures before LensNode gives up.
 LENSNODE_REQUEST_TIMEOUT_S=240
+# Run watchdog: abort when NO gateway activity (heartbeats, tokens,
+# progress) arrives for this long. The gateway heartbeats every ~10s, so
+# this only trips on a dead pipe, never on a quiet-but-alive model call.
+LENSNODE_RUN_IDLE_TIMEOUT_S=180
 # Max concurrent runs a single lensnode executes. Each run holds a slot for
 # the full answer duration; raise for more parallelism (avoids long Queued).
 LENSNODE_MAX_CONCURRENT_RUNS=8

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -12,7 +12,7 @@ from .agent_tools import (
     build_agent_tools,
     build_general_chat_tools,
 )
-from .gateway_model import LensGatewayChatModel
+from .gateway_model import LensGatewayChatModel, RunCancelledError
 from .logging_utils import elapsed_since, task_log, utc_now
 from .runtime_resources import cleanup_runtime_resources
 from .runtime_resources import prepare_runtime_resources
@@ -126,7 +126,9 @@ class LensSummarizationMiddleware(SummarizationMiddleware):
         return result
 
 
-def _build_summarization_middleware(config, model_ref, emit_event):
+def _build_summarization_middleware(
+    config, model_ref, emit_event, cancel_event=None
+):
     """Build context-compaction middleware, or None when disabled.
 
     The summary is produced by a non-streaming gateway model so its tokens
@@ -148,6 +150,7 @@ def _build_summarization_middleware(config, model_ref, emit_event):
         ai_gateway_url=config.ai_gateway_url,
         token=config.token,
         request_timeout_s=config.request_timeout_s,
+        cancel_event=cancel_event,
     )
     middleware = LensSummarizationMiddleware(
         model=summary_model,
@@ -166,7 +169,14 @@ class LensDeepAgentRuntime:
     def __init__(self, config):
         self.config = config
 
-    async def answer(self, command, emit_progress=None, emit_output=None):
+    async def answer(
+        self,
+        command,
+        emit_progress=None,
+        emit_output=None,
+        on_activity=None,
+        cancel_event=None,
+    ):
         """Execute a run_start command with create_deep_agent."""
 
         return await asyncio.to_thread(
@@ -174,9 +184,18 @@ class LensDeepAgentRuntime:
             command,
             emit_progress,
             emit_output,
+            on_activity,
+            cancel_event,
         )
 
-    def _answer_sync(self, command, emit_progress=None, emit_output=None):
+    def _answer_sync(
+        self,
+        command,
+        emit_progress=None,
+        emit_output=None,
+        on_activity=None,
+        cancel_event=None,
+    ):
         """Synchronous Deep Agents invocation run in a worker thread."""
 
         started_at = utc_now()
@@ -220,6 +239,9 @@ class LensDeepAgentRuntime:
                 token=self.config.token,
                 request_timeout_s=self.config.request_timeout_s,
                 emit_output=emit_output,
+                on_activity=on_activity,
+                cancel_event=cancel_event,
+                run_uuid=str(command.get("run_uuid") or ""),
             )
             if _is_general_chat(command):
                 tools = build_general_chat_tools(
@@ -248,7 +270,7 @@ class LensDeepAgentRuntime:
                 kwargs["skills"] = resources.skill_paths
 
             summarizer = _build_summarization_middleware(
-                self.config, model_ref, emit_agent_event
+                self.config, model_ref, emit_agent_event, cancel_event
             )
             if summarizer is not None:
                 kwargs["middleware"] = [summarizer]
@@ -283,6 +305,7 @@ class LensDeepAgentRuntime:
                 max_turns,
                 emit_event=emit_agent_event,
                 answer_language=_detect_answer_language(question),
+                cancel_event=cancel_event,
             )
             if not (answer or "").strip():
                 # the model finished a turn without emitting answer text (e.g.
@@ -638,7 +661,12 @@ def _build_initial_messages(history, question):
 
 
 def _run_agent_with_turn_limit(
-    agent, messages, max_turns, emit_event=None, answer_language="English"
+    agent,
+    messages,
+    max_turns,
+    emit_event=None,
+    answer_language="English",
+    cancel_event=None,
 ):
     """Stream agent events and stop after max_turns NEW AI turns.
 
@@ -662,6 +690,10 @@ def _run_agent_with_turn_limit(
         stream_mode="values",
         config={"recursion_limit": 500},
     ):
+        if cancel_event is not None and cancel_event.is_set():
+            raise RunCancelledError(
+                "Run was cancelled; stopping the agent loop."
+            )
         last_state = state
         current = state.get("messages", [])
         if not seeded_baseline:

--- a/lensnode/lensnode/executor.py
+++ b/lensnode/lensnode/executor.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 
 from .agent_runtime import LensDeepAgentRuntime
 from .logging_utils import elapsed_since, format_duration, task_log, utc_now
@@ -8,6 +9,18 @@ LOGGER = logging.getLogger("lensnode")
 
 # How often the inactivity watchdog checks for stalled output.
 WATCHDOG_INTERVAL_S = 5
+
+
+class RunStalledError(TimeoutError):
+    """No transport activity at all for the whole idle window.
+
+    The gateway heartbeats every few seconds while a model call is in
+    flight, so tripping this means the pipe to the gateway is dead or
+    the agent is wedged between calls — distinct from MODEL_TIMEOUT,
+    which the gateway reports when the provider itself times out.
+    """
+
+    code = "NO_ACTIVITY_TIMEOUT"
 
 
 def _failure_error_code(exc):
@@ -128,13 +141,17 @@ class LensNodeExecutor:
         step_type = _execution_step_type(command)
         target_dirs = command.get("target_dirs") or []
         timeout_s = getattr(self.agent.config, "request_timeout_s", 120)
+        idle_timeout_s = getattr(
+            self.agent.config, "run_idle_timeout_s", 180
+        )
         target_dir_names = ", ".join(
             item.get("path", "") for item in target_dirs
         ) or "none"
         start_message = task_log(
             (
                 f"Starting to run command: {task}({run_uuid}). "
-                f"The timeout is set to {format_duration(timeout_s)}."
+                f"Request timeout {format_duration(timeout_s)}, "
+                f"idle timeout {format_duration(idle_timeout_s)}."
             ),
             started_at,
             [
@@ -180,14 +197,17 @@ class LensNodeExecutor:
                 }
             )
 
-            idle_timeout_s = getattr(
-                self.agent.config, "run_idle_timeout_s", 180
-            )
             loop = asyncio.get_running_loop()
             activity = {"at": loop.time()}
+            cancel_event = threading.Event()
+
+            def touch_activity():
+                activity["at"] = loop.time()
 
             def emit_progress(message, extra_detail=None):
-                activity["at"] = loop.time()
+                if cancel_event.is_set():
+                    return
+                touch_activity()
                 detail = {
                     "message": message,
                 }
@@ -204,7 +224,9 @@ class LensNodeExecutor:
                 )
 
             def emit_output(content, reset=False):
-                activity["at"] = loop.time()
+                if cancel_event.is_set():
+                    return
+                touch_activity()
                 emit(
                     {
                         "type": "run_output",
@@ -214,34 +236,50 @@ class LensNodeExecutor:
                     }
                 )
 
-            # Inactivity watchdog: abort if the agent produces no output or
-            # progress for idle_timeout_s. A live answer streams tokens
-            # continuously so it never trips, however long it runs; a hung
-            # upstream call (which the streaming gateway can mask) does.
+            # Inactivity watchdog on TRANSPORT activity, not user-visible
+            # output: any gateway SSE event (heartbeats, reasoning and
+            # tool-call tokens) refreshes the clock via on_activity, so a
+            # silent long model call never trips it. Provider stalls are
+            # the gateway's call to make (litellm read timeout -> error
+            # event); this watchdog only fires when the pipe itself dies.
+            # Cancelling the asyncio task cannot stop the agent worker
+            # thread, so cancel_event tells the thread to unwind at its
+            # next chunk or model-call boundary and mutes its late emits.
             answer_task = asyncio.create_task(
                 self.agent.answer(
                     command,
                     emit_progress=emit_progress,
                     emit_output=emit_output,
+                    on_activity=touch_activity,
+                    cancel_event=cancel_event,
                 )
             )
-            while True:
-                done, _ = await asyncio.wait(
-                    {answer_task}, timeout=WATCHDOG_INTERVAL_S
-                )
-                if answer_task in done:
-                    result = answer_task.result()
-                    break
-                if loop.time() - activity["at"] > idle_timeout_s:
-                    answer_task.cancel()
-                    try:
-                        await answer_task
-                    except (asyncio.CancelledError, Exception):
-                        pass
-                    raise TimeoutError(
-                        "Run produced no output for "
-                        f"{format_duration(idle_timeout_s)}; aborting."
+            try:
+                while True:
+                    done, _ = await asyncio.wait(
+                        {answer_task}, timeout=WATCHDOG_INTERVAL_S
                     )
+                    if answer_task in done:
+                        result = answer_task.result()
+                        break
+                    if loop.time() - activity["at"] > idle_timeout_s:
+                        cancel_event.set()
+                        answer_task.cancel()
+                        try:
+                            await answer_task
+                        except (asyncio.CancelledError, Exception):
+                            pass
+                        raise RunStalledError(
+                            "Run saw no gateway activity for "
+                            f"{format_duration(idle_timeout_s)}; aborting."
+                        )
+            except asyncio.CancelledError:
+                # run_cancel cancels this coroutine, which does not cancel
+                # answer_task or its worker thread on its own. Signal both
+                # so the agent stops issuing model calls for a dead run.
+                cancel_event.set()
+                answer_task.cancel()
+                raise
             samples = result.get("samples") or []
             sample_paths = [item["path"] for item in samples]
             retrieval_done_message = task_log(

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -22,6 +22,18 @@ class GatewayStreamError(RuntimeError):
         super().__init__(message or self.code)
 
 
+class RunCancelledError(RuntimeError):
+    """Raised inside a worker thread once its run has been cancelled.
+
+    Cancelling the asyncio task cannot interrupt the synchronous agent
+    thread, so the thread checks a shared cancel event at every stream
+    chunk and before every model call, and unwinds itself with this
+    error instead of issuing further model calls for a dead run.
+    """
+
+    code = "RUN_CANCELLED"
+
+
 def _in_subagent_context():
     """Return True if the current LLM call originates from a subagent.
 
@@ -48,6 +60,12 @@ class LensGatewayChatModel(BaseChatModel):
     token: str
     request_timeout_s: int = 120
     emit_output: Optional[Any] = None
+    # Called on EVERY gateway SSE event (reasoning/tool-call tokens,
+    # heartbeats, done) to prove transport liveness to the run watchdog.
+    # emit_output stays content-only for the user-facing stream.
+    on_activity: Optional[Any] = None
+    cancel_event: Optional[Any] = None
+    run_uuid: str = ""
 
     @property
     def _llm_type(self):
@@ -80,6 +98,14 @@ class LensGatewayChatModel(BaseChatModel):
             **kwargs,
         )
 
+    def _check_cancelled(self):
+        """Abort the current call when the run has been cancelled."""
+
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            raise RunCancelledError(
+                "Run was cancelled; aborting in-flight model call."
+            )
+
     def _generate(
         self,
         messages: list[BaseMessage],
@@ -90,10 +116,14 @@ class LensGatewayChatModel(BaseChatModel):
         """Generate a response through the LensNode AI gateway."""
 
         del stop, run_manager
+        self._check_cancelled()
         payload = {
             "model_ref": self.model_ref,
             "messages": [_message_to_gateway(message) for message in messages],
         }
+        if self.run_uuid:
+            payload["run_uuid"] = self.run_uuid
+            payload["is_subagent"] = _in_subagent_context()
         if kwargs.get("tools") is not None:
             payload["tools"] = kwargs["tools"]
         if kwargs.get("tool_choice") is not None:
@@ -152,6 +182,7 @@ class LensGatewayChatModel(BaseChatModel):
                 response.raise_for_status()
                 buffer = ""
                 for chunk in response.iter_text():
+                    self._check_cancelled()
                     buffer += chunk
                     while "\n\n" in buffer:
                         event_str, buffer = buffer.split("\n\n", 1)
@@ -162,6 +193,12 @@ class LensGatewayChatModel(BaseChatModel):
                                 data = json.loads(line[6:])
                             except ValueError:
                                 continue
+                            # Any decoded event — heartbeat, reasoning or
+                            # tool-call token, done — proves the gateway
+                            # stream is alive, even when nothing is
+                            # user-visible.
+                            if self.on_activity is not None:
+                                self.on_activity()
                             if data.get("type") == "token":
                                 kind = data.get("kind") or "content"
                                 text = data.get("content") or ""

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -18,8 +18,15 @@ class FakeAgent:
 
     config = Config()
 
-    async def answer(self, command, emit_progress=None, emit_output=None):
-        del command, emit_progress
+    async def answer(
+        self,
+        command,
+        emit_progress=None,
+        emit_output=None,
+        on_activity=None,
+        cancel_event=None,
+    ):
+        del command, emit_progress, on_activity, cancel_event
         emit_output("streamed")
         return {
             "answer": "streamed final",
@@ -53,6 +60,114 @@ def test_executor_emits_streamed_output_delta():
         "run_uuid": "00000000-0000-0000-0000-000000000001",
         "final_content": "streamed final",
     } in events
+
+
+class StallingAgent:
+    """Fake agent that never produces output until cancelled."""
+
+    class Config:
+        request_timeout_s = 240
+        run_idle_timeout_s = 0.1
+
+    config = Config()
+
+    def __init__(self):
+        self.cancel_event = None
+
+    async def answer(
+        self,
+        command,
+        emit_progress=None,
+        emit_output=None,
+        on_activity=None,
+        cancel_event=None,
+    ):
+        del command, emit_progress, on_activity
+        self.cancel_event = cancel_event
+        try:
+            await asyncio.sleep(3600)
+        finally:
+            # A cancelled worker thread may still try to emit; the
+            # executor must mute it so a settled run stays untouched.
+            emit_output("late output")
+
+
+def test_executor_watchdog_fails_stalled_run_and_mutes_late_emits(
+    monkeypatch,
+):
+    monkeypatch.setattr("lensnode.executor.WATCHDOG_INTERVAL_S", 0.02)
+    executor = LensNodeExecutor.__new__(LensNodeExecutor)
+    agent = StallingAgent()
+    executor.agent = agent
+    events = []
+
+    asyncio.run(
+        executor.execute(
+            {
+                "run_uuid": "00000000-0000-0000-0000-000000000004",
+                "task": "knowledge_qa",
+                "target_dirs": [],
+            },
+            events.append,
+        )
+    )
+
+    done = [event for event in events if event["type"] == "run_done"]
+    assert done[-1]["status"] == "failed"
+    assert done[-1]["error"] == "NO_ACTIVITY_TIMEOUT"
+    assert agent.cancel_event is not None
+    assert agent.cancel_event.is_set()
+    assert not any(
+        event.get("content_delta") == "late output" for event in events
+    )
+
+
+class HeartbeatOnlyAgent:
+    """Fake agent alive through on_activity only, with no output."""
+
+    class Config:
+        request_timeout_s = 240
+        run_idle_timeout_s = 0.15
+
+    config = Config()
+
+    async def answer(
+        self,
+        command,
+        emit_progress=None,
+        emit_output=None,
+        on_activity=None,
+        cancel_event=None,
+    ):
+        del command, emit_progress, emit_output, cancel_event
+        for _ in range(10):
+            await asyncio.sleep(0.05)
+            on_activity()
+        return {
+            "answer": "quiet but alive",
+            "samples": [],
+        }
+
+
+def test_executor_watchdog_survives_on_transport_activity(monkeypatch):
+    monkeypatch.setattr("lensnode.executor.WATCHDOG_INTERVAL_S", 0.02)
+    executor = LensNodeExecutor.__new__(LensNodeExecutor)
+    executor.agent = HeartbeatOnlyAgent()
+    events = []
+
+    asyncio.run(
+        executor.execute(
+            {
+                "run_uuid": "00000000-0000-0000-0000-000000000005",
+                "task": "knowledge_qa",
+                "target_dirs": [],
+            },
+            events.append,
+        )
+    )
+
+    done = [event for event in events if event["type"] == "run_done"]
+    assert done[-1]["status"] == "done"
 
 
 def test_runtime_resources_collect_context_skill_content(tmp_path):

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -1,0 +1,86 @@
+import threading
+
+import httpx
+import pytest
+from langchain_core.messages import HumanMessage
+
+from lensnode.gateway_model import LensGatewayChatModel, RunCancelledError
+
+
+SSE_BODY = (
+    'data: {"type": "heartbeat"}\n\n'
+    'data: {"type": "token", "kind": "reasoning", "content": "thinking"}\n\n'
+    'data: {"type": "token", "kind": "content", "content": "Hello"}\n\n'
+    'data: {"type": "done", "usage": {"total_tokens": 5}, '
+    '"tool_calls": []}\n\n'
+)
+
+
+def _install_transport(monkeypatch, handler):
+    """Route the module's httpx.Client through a mock transport."""
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def fake_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "lensnode.gateway_model.httpx.Client", fake_client
+    )
+
+
+def test_streaming_touches_activity_on_every_event(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["payload"] = request.read()
+        return httpx.Response(200, content=SSE_BODY.encode("utf-8"))
+
+    _install_transport(monkeypatch, handler)
+    outputs = []
+    activity = {"count": 0}
+
+    def on_activity():
+        activity["count"] += 1
+
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        emit_output=outputs.append,
+        on_activity=on_activity,
+        run_uuid="00000000-0000-0000-0000-000000000009",
+    )
+
+    result = model._generate([HumanMessage(content="hi")])
+
+    message = result.generations[0].message
+    assert message.content == "Hello"
+    # heartbeat + reasoning + content + done all count as activity,
+    # while only the content token reaches the user-facing stream.
+    assert activity["count"] == 4
+    assert outputs == ["Hello"]
+    assert b'"run_uuid"' in captured["payload"]
+    assert b'"is_subagent"' in captured["payload"]
+
+
+def test_cancelled_run_aborts_before_model_call(monkeypatch):
+    def handler(request):
+        raise AssertionError("cancelled run must not call the gateway")
+
+    _install_transport(monkeypatch, handler)
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        emit_output=lambda *_args, **_kwargs: None,
+        cancel_event=cancel_event,
+    )
+
+    with pytest.raises(RunCancelledError):
+        model._generate([HumanMessage(content="hi")])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "uvicorn[standard]==0.30.6",
     "langchain-core==1.4.0",
     "langgraph==1.2.1",
+    # litellm >=1.92 imports its proxy/MCP handler during completion(),
+    # which pulls in fastapi even for plain streaming calls. Declare it so
+    # the LensNode AI gateway does not fail with ModuleNotFoundError.
+    "fastapi",
     # Agentcore submodules. Docker local builds rewrite these to local
     # file paths from backend/agentcore to avoid GitHub during image builds.
     "agentcore-metering @ git+https://github.com/cloud2ai/agentcore-metering.git",


### PR DESCRIPTION
## Background

Long-running queries in production kept reporting `MODEL_TIMEOUT` falsely. The timeout architecture collapsed three distinct situations into one error: the LensNode watchdog only watched **user-visible output** (`emit_output` content), so the model was killed during quiet-but-alive phases (reasoning, tool-call argument generation, subagent calls). The real provider read timeout only surfaced ~90s later, by which point the error could no longer be attributed correctly.

## Changes

**LensNode**
- `gateway_model`: new `on_activity` callback fires on **every** decoded gateway SSE event (heartbeat, reasoning/tool tokens, done) to refresh transport activity; `emit_output` stays content-only. The watchdog now watches **transport activity** instead of visible output, so a long quiet model call is no longer killed.
- Watchdog aborts get a dedicated `NO_ACTIVITY_TIMEOUT` code instead of collapsing into `MODEL_TIMEOUT`.
- Cooperative cancellation: a `threading.Event` checked per stream chunk, before each model call, and per agent superstep; both watchdog aborts and user cancellation stop the worker thread and mute its late emits.
- Fix the misleading startup timeout log (print both request and idle timeouts).

**Gateway (backend)**
- Emit `{"type":"heartbeat"}` SSE every 10s while the provider is quiet, proving transport liveness during reasoning / tool-call generation when no tokens hit the wire.
- Forward `run_uuid` / `is_subagent` into `LLMUsage.metadata` for per-call correlation.
- `record_lensnode_run_event` refuses to write events for a run that already reached a terminal state.

**Dependency**
- Declare `fastapi`: litellm >= 1.92 imports its proxy/MCP handler during `completion()`, which needs fastapi; without it the gateway fails with `ModuleNotFoundError` surfaced as `MODEL_STREAM_ERROR`. The dependency was unpinned (`litellm>=1.0.0`), so the 1.91 -> 1.92 drift introduced it.
- Surface `LENSNODE_RUN_IDLE_TIMEOUT_S` in env.sample and both compose files.

## Testing

- New unit tests: gateway_model (activity callback / cancellation), executor (watchdog stays alive on activity / fails on silence and mutes late emits), run_lifecycle (terminal-state guard).
- End-to-end in dev: baseline query (done), **a 234s long run (done, no false timeout)**, mid-run cancellation (clean cooperative stop, no late-event pollution).

## Known limitation (phase 2)

Cooperative cancellation is prompt for streaming calls but cannot interrupt an in-flight blocking httpx request; the full fix is subprocess isolation / LangGraph checkpoint-resumable cancellation. Having the gateway close the provider stream on client disconnect is also still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e8SmX7GC91wx8SpSRDuUQ