### PR TITLE
chore(compose): stop mounting the workspace volume into backend services

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,6 @@ services:
       - ./backend:/opt/backend
       - ./docker/nginx/certs:/opt/certs
       - ./data.dev/storage:/opt/storage
-      - ./data.dev/workspace:/workspace
     networks:
       - backend_network
     depends_on:
@@ -51,7 +50,6 @@ services:
     volumes:
       - ./data.dev/logs/worker:/var/log/celery
       - ./data.dev/storage:/opt/storage
-      - ./data.dev/workspace:/workspace
       - ./backend:/opt/backend
       - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - ./data/django/staticfiles:/opt/backend/core/staticfiles
       - ./data/logs/api:/var/log/gunicorn
       - ./data/storage:/opt/storage
-      - ./data/workspace:/workspace
       - ./docker/nginx/certs:/opt/certs
     networks:
       - backend_network
@@ -49,7 +48,6 @@ services:
     volumes:
       - ./data/logs/worker:/var/log/celery
       - ./data/storage:/opt/storage
-      - ./data/workspace:/workspace
     networks:
       - backend_network
     depends_on:


### PR DESCRIPTION
## What

Remove the `/workspace` volume mount from **backend-api** and **backend-worker** in both `docker-compose.yml` and `docker-compose.dev.yml`. The mount stays only on **lensnode**.

## Why it is safe

The backend never touches the workspace filesystem:
- Datasource sync is **dispatched to the LensNode** over the control channel — the node clones into its own workspace and reports `datasource_sync_event` / `datasource_sync_done` back. The backend Celery task returns right after dispatching.
- Every backend reference to `/workspace` / `WORKSPACE_ROOT` is **path-string computation** used to build the commands sent to the node, not a filesystem read/write. A repo-wide search for real file ops (`open`/`Path`/`shutil`/`os.walk`/`glob`) landing on the workspace returns nothing.
- The only module with real git operations, `source_sync.py`, is **uncalled dead code** (no import, no caller).

## Why do it

Makes the workspace volume **private to the LensNode** — the control plane can no longer see it — matching the intended isolation model (a remote LensNode must not share storage with the backend). It is also the prerequisite for delivering LensNode-generated files to users **on demand over the control channel** instead of via a shared volume.

The lensnode mount and its host source path are unchanged, so **no synced data is lost**.

## Verification

In dev, with the mount removed from backend-api/worker: a code-analysis query completes normally (`done`, correct answer) — the LensNode reads its own workspace and answers, confirming the backend does not need the mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e8SmX7GC91wx8SpSRDuUQ