### PR TITLE
feat(deploy): single-node blue/green zero-downtime deploy infrastructure (#6, PR1/2)

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -125,6 +125,12 @@ jobs:
     needs:
       - prepare-version
       - build-images
+    # Gate: auto-deploy runs only when the repo/environment variable
+    # SOURCELENS_AUTO_DEPLOY is "true". It is intentionally left unset for the
+    # first blue/green cutover, which is done manually and supervised on the
+    # host; a tag push then only builds+pushes images. Set the variable to
+    # "true" after the first cutover succeeds to make releases hands-off.
+    if: ${{ vars.SOURCELENS_AUTO_DEPLOY == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -45,7 +45,13 @@ jobs:
             VERSION="${{ inputs.version }}"
             REF="v${{ inputs.version }}"
           else
-            VERSION="${GITHUB_SHA::7}"
+            # No tag, no manual version: build/deploy the pushed commit. Use the
+            # FULL SHA for both — install.sh derives the image tag from the ref
+            # it fetches (${ref#v}), so a 7-char VERSION with a 40-char REF would
+            # tag images :<short> but make install.sh pull :<full> (a nonexistent
+            # tag). raw.githubusercontent.com resolves a full SHA but not a short
+            # one, so the full SHA is the value that works for both.
+            VERSION="${GITHUB_SHA}"
             REF="${GITHUB_SHA}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -27,19 +27,29 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      ref: ${{ steps.version.outputs.ref }}
     steps:
       - name: Resolve version
         id: version
         shell: bash
         run: |
+          # version = the image tag (v-stripped); ref = the git ref
+          # scripts/install.sh fetches deploy assets from and derives the same
+          # image tag out of (${ref#v}). For a tag push they line up exactly.
+          # A manual dispatch is assumed to redeploy an existing release, so its
+          # ref is the corresponding v<version> tag.
           if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ -n "${GITHUB_REF_NAME}" ]; then
             VERSION="${GITHUB_REF_NAME#v}"
+            REF="${GITHUB_REF_NAME}"
           elif [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
+            REF="v${{ inputs.version }}"
           else
             VERSION="${GITHUB_SHA::7}"
+            REF="${GITHUB_SHA}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
   build-images:
     runs-on: ubuntu-latest
@@ -94,6 +104,7 @@ jobs:
           # and lensnode builds ignore them (harmless unused-arg warnings).
           build-args: |
             USE_MIRROR=false
+            APP_VERSION=${{ needs.prepare-version.outputs.version }}
             VITE_API_BASE_URL=${{ vars.VITE_API_BASE_URL }}
             VITE_TURNSTILE_SITE_KEY=${{ vars.VITE_TURNSTILE_SITE_KEY }}
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
@@ -119,8 +130,12 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           if_key_exists: fail
 
-      # Only the compose files are shipped to the server; application source
-      # stays out of the deploy host (images carry the code).
+      # No source or compose files are shipped from CI anymore: scripts/install.sh
+      # self-fetches the small set of declarative deploy assets (compose file,
+      # nginx/postgres config, the scripts themselves) straight from the public
+      # repo at the release ref, then runs the health-gated blue/green switch. It
+      # owns its own single-flight lock, so the ad-hoc lock the old inline script
+      # kept is gone too.
       - name: Ensure deploy directory exists
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -130,17 +145,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: mkdir -p ${{ env.DEPLOY_PATH }}
 
-      - name: Copy compose files to server
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ env.SSH_HOST }}
-          username: ${{ env.SSH_USER }}
-          port: ${{ env.SSH_PORT }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "docker-compose.yml,docker"
-          target: ${{ env.DEPLOY_PATH }}
-
-      - name: Deploy to Server
+      - name: Deploy to Server (blue/green install.sh)
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ env.SSH_HOST }}
@@ -148,51 +153,26 @@ jobs:
           port: ${{ env.SSH_PORT }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           command_timeout: 3600s
-          # Stop and fail the job on the first failing command so a broken
-          # deploy (e.g. `up -d` aborting) surfaces as red instead of a
-          # false "success".
+          # Fail the job on the first failing command so a broken deploy (health
+          # gate timing out, migration failing) surfaces as red, not a false
+          # "success".
           script_stop: true
-          # Use Docker Compose v2 (`docker compose`). Unlike legacy
-          # docker-compose v1, v2 does not require a service's build context to
-          # exist on the host when an image is present — it pulls the tagged
-          # image and only builds on `--build`, so `build:` can stay in the
-          # compose file while prod deploys purely from pushed images.
           script: |
+            set -euo pipefail
             cd ${{ env.DEPLOY_PATH }}
-            APP_VERSION="${{ needs.prepare-version.outputs.version }}"
-            LOCK_FILE="/tmp/sourcelens-deploy.lock"
-            MAX_WAIT=300
-            WAIT_INTERVAL=5
-            ELAPSED=0
+            DEPLOY_REF="${{ needs.prepare-version.outputs.ref }}"
+            echo "Bootstrapping scripts/install.sh at ${DEPLOY_REF}..."
+            # Public repo: raw fetch needs no auth. Atomic write so a running
+            # install.sh reading itself isn't truncated mid-run.
+            mkdir -p scripts
+            curl -fsSL \
+              "https://raw.githubusercontent.com/HyperBDR/sourcelens/${DEPLOY_REF}/scripts/install.sh" \
+              -o scripts/install.sh.tmp
+            mv scripts/install.sh.tmp scripts/install.sh
+            chmod +x scripts/install.sh
+            # install.sh fetches the remaining assets, runs migrations against
+            # the idle color, health-gates it, flips nginx (no dropped requests),
+            # observes, retires the old color, then rolls the workers/lensnode.
+            DEPLOY_PATH="${{ env.DEPLOY_PATH }}" ./scripts/install.sh "${DEPLOY_REF}"
 
-            # Wait for any existing deployment to complete
-            while [ -f "$LOCK_FILE" ] && [ $ELAPSED -lt $MAX_WAIT ]; do
-              echo "Deployment in progress, waiting... (${ELAPSED}s/${MAX_WAIT}s)"
-              sleep $WAIT_INTERVAL
-              ELAPSED=$((ELAPSED + WAIT_INTERVAL))
-            done
-
-            if [ -f "$LOCK_FILE" ]; then
-              echo "Timeout waiting for deployment lock. Proceeding anyway..."
-            fi
-
-            # Create lock file
-            echo "$$ $(date)" > "$LOCK_FILE"
-            trap "rm -f $LOCK_FILE" EXIT
-
-            echo "Starting sourcelens deployment for version ${APP_VERSION}..."
-            # Pull the specified image tag
-            APP_VERSION="${APP_VERSION}" docker compose -f docker-compose.yml pull
-            # Recreate only the containers whose image/config changed (the
-            # new app images). Avoid --force-recreate: it rebuilds every
-            # service (incl. db/nginx) and can abort the deploy mid-way.
-            APP_VERSION="${APP_VERSION}" docker compose -f docker-compose.yml up -d
-            # Reload nginx config in place; fall back to a restart if reload
-            # fails. (The old nginx-reload issue that motivated force-recreate
-            # is fixed, so a full recreate is no longer needed.)
-            APP_VERSION="${APP_VERSION}" docker compose -f docker-compose.yml exec -T nginx nginx -s reload 2>/dev/null || APP_VERSION="${APP_VERSION}" docker compose -f docker-compose.yml restart nginx
-            docker system prune -f
-
-            echo "sourcelens deployment completed for version ${APP_VERSION}"
-            echo "Note: Celery workers are gracefully shutting down old tasks in the background (up to 30 minutes)"
-            rm -f "$LOCK_FILE"
+            echo "sourcelens blue/green deploy completed for ${DEPLOY_REF}"

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ celerybeat.pid
 
 # Blue/green deploy runtime state (bootstrapped by scripts/install.sh, never committed)
 /.active_color
+/.rollback_version
 /docker/nginx/conf.d/upstream.conf
 
 # Environments

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ downloads/
 eggs/
 .eggs/
 lib/
+# But keep the blue/green deploy helpers (scripts/lib/ is source, not a build dir)
+!scripts/lib/
+!scripts/lib/**
 lib64/
 parts/
 sdist/
@@ -118,6 +121,10 @@ celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
+
+# Blue/green deploy runtime state (bootstrapped by scripts/install.sh, never committed)
+/.active_color
+/docker/nginx/conf.d/upstream.conf
 
 # Environments
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,14 +230,20 @@ agentcore 是独立维护的包，通过 git submodule 引入。子模块被当�
 
 ## 部署编排选择（三选一）
 
-三份 compose 各司其职，**同一主机/目录只跑其中一个**（它们共享默认 project 名与
-`postgresql`/`redis` 服务名，同目录并起会互相顶掉容器）：
+三份 compose 各司其职：
 
-| 文件 | 场景 | 起停方式 | 镜像 | 零停机 |
-|---|---|---|---|---|
-| `docker-compose.dev.yml` | 开发 | 裸 `docker compose -f … up -d` | 源码构建 + 热挂载 | 否 |
-| `docker-compose.standalone.yml` | 生产 · 简单单实例 | 裸 `docker compose -f … up -d` | 拉发布镜像（无源码挂载） | 否 |
-| `docker-compose.yml` | 生产 · 零停机 | `scripts/install.sh`（蓝绿） | 拉发布镜像 | 是 |
+| 文件 | 场景 | project 名 | 起停方式 | 镜像 | 零停机 |
+|---|---|---|---|---|---|
+| `docker-compose.dev.yml` | 开发 | `sourcelens-dev` | 裸 `docker compose -f … up -d` | 源码构建 + 热挂载 | 否 |
+| `docker-compose.standalone.yml` | 生产 · 简单单实例 | `sourcelens` | 裸 `docker compose -f … up -d` | 拉发布镜像（无源码挂载） | 否 |
+| `docker-compose.yml` | 生产 · 零停机 | `sourcelens` | `scripts/install.sh`（蓝绿） | 拉发布镜像 | 是 |
+
+> **铁律：dev 与 prod 必须用不同的 compose project 名。** 每个 compose 文件都
+> **显式**设顶层 `name:`（dev 为 `sourcelens-dev`，生产为 `sourcelens`），绝不
+> 依赖"目录名"默认值——否则三者共享同一 project 命名空间 + 同名 `postgresql`/
+> `redis` 服务键，在本目录起生产栈会**把 dev 容器顶掉重建**（反之亦然）。生产两
+> 份共享 `sourcelens`（同一单例库数据），**只跑其一**。要隔离测试某个生产栈用
+> `COMPOSE_PROJECT_NAME=sourcelens-verify`（覆盖文件里的 `name:`），不扰动其它。
 
 - **只想 `docker compose up` 一把起、不要零停机** → `docker-compose.standalone.yml`
   （单 `backend-api` + 单文件 `docker/nginx/default.standalone.conf` 直连，无

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,25 @@ agentcore 是独立维护的包，通过 git submodule 引入。子模块被当�
 - **Django/DRF**：优先使用 CBV（复杂逻辑）和 DRF 内置功能，不手写原始 SQL
 - **调试用 print**：避免使用，用 logging 代替
 
+## 部署编排选择（三选一）
+
+三份 compose 各司其职，**同一主机/目录只跑其中一个**（它们共享默认 project 名与
+`postgresql`/`redis` 服务名，同目录并起会互相顶掉容器）：
+
+| 文件 | 场景 | 起停方式 | 镜像 | 零停机 |
+|---|---|---|---|---|
+| `docker-compose.dev.yml` | 开发 | 裸 `docker compose -f … up -d` | 源码构建 + 热挂载 | 否 |
+| `docker-compose.standalone.yml` | 生产 · 简单单实例 | 裸 `docker compose -f … up -d` | 拉发布镜像（无源码挂载） | 否 |
+| `docker-compose.yml` | 生产 · 零停机 | `scripts/install.sh`（蓝绿） | 拉发布镜像 | 是 |
+
+- **只想 `docker compose up` 一把起、不要零停机** → `docker-compose.standalone.yml`
+  （单 `backend-api` + 单文件 `docker/nginx/default.standalone.conf` 直连，无
+  profiles、无 upstream 运行时状态）。部署就是 `pull` + `up -d`，会短暂重建
+  backend-api（在途请求会断）。
+- **要零停机** → 走下方蓝绿方案。注意 `docker-compose.yml` **不能**用裸
+  `docker compose up -d` 起（API/UI 是 profiled 服务，且 nginx 依赖运行时
+  `upstream.conf`），必须用 `install.sh`。
+
 ## 零停机部署 (Blue/Green)
 
 单生产主机、无 k8s/Swarm。API/UI 各有 blue、green 两份，同一时刻只有一个颜色在

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,10 @@ agentcore 是独立维护的包，通过 git submodule 引入。子模块被当�
 nginx 流量路径上。升级时先起空闲色、健康门控、原子切换 nginx（`nginx -s reload`，
 不断连），观察一段时间后再退役旧色；回滚就是切回另一色。
 
+> 完整的**可复用规范**（架构、逐项适配清单、正确性必须项清单、验证协议，供其他
+> 项目移植）见 [`docs/blue-green-deployment.md`](docs/blue-green-deployment.md)。
+> 本节是 sourcelens 的速查；改动部署脚本/nginx 前先过一遍那份的「正确性清单」。
+
 ### 命令
 
 - **安装 / 升级**：`scripts/install.sh <tag>`（或 `--local [tag]` 用本地工作树

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,16 @@ docker restart sourcelens-scheduler-dev
 > 速记：**改普通代码** → api 自动生效、worker 手动重启；
 > **加 migration** → 额外重启 api。
 
-### Docker 生产构建
+### Docker 生产构建（蓝绿零停机）
+
+生产使用 `scripts/install.sh` 做蓝绿部署，**不要**直接 `docker compose up -d`
+（API/UI 是 blue/green profiled 服务，裸 `up` 不会启动任何一个颜色）。详见下方
+「零停机部署 (Blue/Green)」章节。
+
 ```bash
-cp env.sample .env
-docker-compose up -d
+# 首次安装 / 每次升级，同一条命令幂等：
+curl -fsSL https://raw.githubusercontent.com/HyperBDR/sourcelens/<tag>/scripts/install.sh \
+    -o install.sh && chmod +x install.sh && ./install.sh <tag>
 # 默认端口: HTTP 10080, HTTPS 10443
 ```
 
@@ -221,6 +227,43 @@ agentcore 是独立维护的包，通过 git submodule 引入。子模块被当�
 - **业务逻辑位置**：放在 models、serializers、services 中，views 只处理请求
 - **Django/DRF**：优先使用 CBV（复杂逻辑）和 DRF 内置功能，不手写原始 SQL
 - **调试用 print**：避免使用，用 logging 代替
+
+## 零停机部署 (Blue/Green)
+
+单生产主机、无 k8s/Swarm。API/UI 各有 blue、green 两份，同一时刻只有一个颜色在
+nginx 流量路径上。升级时先起空闲色、健康门控、原子切换 nginx（`nginx -s reload`，
+不断连），观察一段时间后再退役旧色；回滚就是切回另一色。
+
+### 命令
+
+- **安装 / 升级**：`scripts/install.sh <tag>`（或 `--local [tag]` 用本地工作树
+  构建、跳过远程拉取，便于对未提交改动做整链路测试）。一条命令幂等，首装与每次
+  升级同路径。CI（`.github/workflows/build_and_deploy.yml`）在服务器上引导并运行
+  它。
+- **日常运维**：`scripts/sourcelensctl.sh {status|restart-workers|rollback}`。与
+  install.sh 共享单飞锁与 `deploy-common.sh` 助手，但独立入口——"装新版本"和"操作
+  已在跑的东西"风险面不同。`rollback` 不做 pull/build/migrate，只在目标色镜像仍在
+  本地时可用。
+
+### 关键约束
+
+- **nginx 按整目录挂载**：`docker/nginx/conf.d/` 整个目录 bind-mount，**不是**单
+  文件。切流用 `sed -i`/rename 原子改写 `upstream.conf`（换 inode）；单文件挂载会
+  钉死在旧 inode，导致持续 502、旧色退役后变成 `host not found in upstream`。
+- **运行时状态不提交**：`.active_color` 与 `docker/nginx/conf.d/upstream.conf` 由
+  install.sh 首次从 `upstream.conf.default` 引导后即为运行时状态，`.gitignore` 已
+  忽略，切勿提交或被 install 覆盖。
+- **install.sh 是唯一支持的起停入口**：blue/green 服务之间不写 `depends_on`（
+  profiled 服务被非 profiled 服务引用会破坏所有不带 `--profile` 的 compose 命令
+  校验），起停顺序由脚本命令式掌控。裸 `docker compose up -d` 不受支持。
+- **lensnode 经 nginx 寻址**：`LENSNODE_SERVER_URL=http://nginx:80`，始终打到
+  active 色，切换时靠重连过渡（PR2 增加断连宽限期后，在途 run 不会被误判失败）。
+
+### 迁移必须 expand/contract 安全
+
+观察窗内，**旧色仍在对切换后的库表结构提供服务**。因此**同一发布**里既删/改列或
+收紧约束、又上线不再使用它的代码，会在窗口内打挂旧色。此类变更必须拆成两个发布：
+先加、双写/兼容，下个版本再删。
 
 ## 安全与配置
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,11 @@ nginx 流量路径上。升级时先起空闲色、健康门控、原子切换 n
 - **nginx 按整目录挂载**：`docker/nginx/conf.d/` 整个目录 bind-mount，**不是**单
   文件。切流用 `sed -i`/rename 原子改写 `upstream.conf`（换 inode）；单文件挂载会
   钉死在旧 inode，导致持续 502、旧色退役后变成 `host not found in upstream`。
-- **运行时状态不提交**：`.active_color` 与 `docker/nginx/conf.d/upstream.conf` 由
-  install.sh 首次从 `upstream.conf.default` 引导后即为运行时状态，`.gitignore` 已
-  忽略，切勿提交或被 install 覆盖。
+- **运行时状态不提交**：`.active_color`、`.rollback_version` 与
+  `docker/nginx/conf.d/upstream.conf` 由 install.sh 首次从 `upstream.conf.default`
+  引导/切换时写入，均为运行时状态，`.gitignore` 已忽略，切勿提交或被 install 覆盖。
+  （`.rollback_version` 记录被退役旧色的镜像版本，供 `sourcelensctl.sh rollback`
+  用正确的旧镜像重建，而非 `:latest`。）
 - **install.sh 是唯一支持的起停入口**：blue/green 服务之间不写 `depends_on`（
   profiled 服务被非 profiled 服务引用会破坏所有不带 `--profile` 的 compose 命令
   校验），起停顺序由脚本命令式掌控。裸 `docker compose up -d` 不受支持。

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@ ARG APT_MIRROR_URL=http://archive.ubuntu.com/ubuntu
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_TRUSTED_HOST=pypi.org
 
-# Stamp the release version onto the image so scripts/install.sh can read it
-# (docker inspect Config.Labels) to skip redeploying a color that already runs
-# this version. Absent/default => 0.0.0, which install.sh treats as "never skip".
-ARG APP_VERSION=0.0.0
-LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
-
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -125,6 +119,14 @@ RUN mkdir -p /var/log/gunicorn /var/log/celery /var/cache/sourcelens
 # Copy entrypoint script
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Stamp the release version onto the image so scripts/install.sh can read it
+# (docker inspect Config.Labels) to skip redeploying a color that already runs
+# this version. Absent/default => 0.0.0, which install.sh treats as "never skip".
+# Kept as the last layer so a version bump never invalidates the expensive
+# apt/pip build layers above it.
+ARG APP_VERSION=0.0.0
+LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
 
 # Set default command
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ ARG APT_MIRROR_URL=http://archive.ubuntu.com/ubuntu
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_TRUSTED_HOST=pypi.org
 
+# Stamp the release version onto the image so scripts/install.sh can read it
+# (docker inspect Config.Labels) to skip redeploying a color that already runs
+# this version. Absent/default => 0.0.0, which install.sh treats as "never skip".
+ARG APP_VERSION=0.0.0
+LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
+
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,11 @@
+# Distinct compose project name so the dev stack is fully isolated from the
+# production stacks (docker-compose.yml / docker-compose.standalone.yml, which
+# use project "sourcelens"). Without this all three would default to the
+# directory name and share a project namespace + the postgresql/redis service
+# keys, so bringing up a production stack in this directory would recreate the
+# dev containers (and vice versa).
+name: sourcelens-dev
+
 services:
   backend-api:
     image: sourcelens-api:latest

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -12,10 +12,13 @@
 # unlike the dev stack. For zero-downtime instead, use docker-compose.yml with
 # scripts/install.sh.
 #
-# Pick ONE stack per host/directory: this file, docker-compose.yml, and
-# docker-compose.dev.yml share the default compose project name and overlapping
-# service names (postgresql/redis), so running two of them in the same directory
-# will fight over the shared containers.
+# Pick ONE production stack per host: this file and docker-compose.yml (blue/
+# green) are the two production shapes and share project name "sourcelens" (and
+# the postgresql/redis singletons), so run only one of them. The dev stack
+# (docker-compose.dev.yml) is isolated under project "sourcelens-dev" and does
+# not collide with either.
+name: sourcelens
+
 services:
   backend-api:
     image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,240 @@
+# Standalone single-instance production deployment.
+#
+# This is the simple path: one backend-api, one frontend, no blue/green, no
+# scripts/install.sh — a plain `docker compose -f docker-compose.standalone.yml
+# up -d` brings the whole stack up. Use it when zero-downtime deploys are not
+# required and the operational simplicity of bare compose is preferred; a deploy
+# is a normal `pull` + `up -d` that briefly recreates backend-api (in-flight
+# requests drop, unlike the blue/green stack).
+#
+# It pulls released images by default (no source bind-mounts, no DEV_MODE hot
+# reload — that is docker-compose.dev.yml's job), so it is production-shaped
+# unlike the dev stack. For zero-downtime instead, use docker-compose.yml with
+# scripts/install.sh.
+#
+# Pick ONE stack per host/directory: this file, docker-compose.yml, and
+# docker-compose.dev.yml share the default compose project name and overlapping
+# service names (postgresql/redis), so running two of them in the same directory
+# will fight over the shared containers.
+services:
+  backend-api:
+    image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
+    container_name: sourcelens-api
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend
+      args:
+        APP_VERSION: ${APP_VERSION:-0.0.0}
+        APT_MIRROR_URL: ${APT_MIRROR_URL:-https://mirrors.tuna.tsinghua.edu.cn/ubuntu}
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
+        PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn}
+    env_file:
+      - ./.env
+    environment:
+      LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
+      LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
+      LENSNODE_WORKSPACE_PATH: /workspace
+    volumes:
+      - ./data/django/staticfiles:/opt/backend/core/staticfiles
+      - ./data/logs/api:/var/log/gunicorn
+      - ./data/storage:/opt/storage
+      - ./data/deliverables:/opt/deliverables
+      - ./docker/nginx/certs:/opt/certs
+    networks:
+      - backend_network
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: gunicorn
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+  frontend:
+    image: oneprocloud/sourcelens-frontend:${APP_VERSION:-latest}
+    container_name: sourcelens-ui
+    restart: unless-stopped
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        APP_VERSION: ${APP_VERSION:-0.0.0}
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+        VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:-}
+        VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+        VITE_SENTRY_ENVIRONMENT: ${VITE_SENTRY_ENVIRONMENT:-}
+        VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-}
+        VITE_SENTRY_SEND_DEFAULT_PII: ${VITE_SENTRY_SEND_DEFAULT_PII:-}
+        VITE_GA_ID: ${VITE_GA_ID:-}
+    expose:
+      - "80"
+    networks:
+      - backend_network
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -Y off --quiet --tries=1 --spider http://127.0.0.1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  backend-worker:
+    image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
+    container_name: sourcelens-worker
+    restart: unless-stopped
+    stop_grace_period: 120s
+    env_file:
+      - ./.env
+    volumes:
+      - ./data/logs/worker:/var/log/celery
+      - ./data/storage:/opt/storage
+      - ./data/deliverables:/opt/deliverables
+    networks:
+      - backend_network
+    depends_on:
+      backend-api:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: celery
+
+  backend-scheduler:
+    image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
+    container_name: sourcelens-scheduler
+    restart: unless-stopped
+    stop_grace_period: 30s
+    env_file:
+      - ./.env
+    volumes:
+      - ./data/logs/scheduler:/var/log/celery
+    networks:
+      - backend_network
+    depends_on:
+      backend-api:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: celery-beat
+
+  lensnode:
+    build:
+      context: ./lensnode
+      dockerfile: Dockerfile
+      args:
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
+        PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn}
+    image: oneprocloud/sourcelens-lensnode:${APP_VERSION:-latest}
+    container_name: sourcelens-lensnode
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    environment:
+      LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
+      LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
+      # Single fixed backend-api here (no blue/green), so talk to it directly
+      # rather than through nginx. These override the nginx-based defaults the
+      # blue/green stack puts in env.sample.
+      LENSNODE_SERVER_URL: http://backend-api:8000
+      LENSNODE_CONTROL_WS_URL: ws://backend-api:8000/ws/lens/lensnodes/
+      LENSNODE_AI_GATEWAY_URL: http://backend-api:8000/api/lens/lensnode/ai-gateway/
+      LENSNODE_WORKSPACE_PATH: /workspace
+      LENSNODE_HEARTBEAT_INTERVAL_S: 15
+      LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}
+      LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
+      LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
+    volumes:
+      - ./data/workspace:/workspace
+    networks:
+      - backend_network
+    depends_on:
+      backend-api:
+        condition: service_healthy
+
+  nginx:
+    image: nginx:latest
+    container_name: sourcelens-nginx
+    restart: unless-stopped
+    volumes:
+      - ./docker/nginx/default.standalone.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/nginx/certs:/etc/nginx/certs:ro
+      - ./data/django/staticfiles:/staticfiles:ro
+      - ./data/storage:/opt/storage:ro
+      - ./data/logs/nginx:/var/log/nginx
+    ports:
+      - "${NGINX_HTTP_PORT:-10080}:80"
+      - "${NGINX_HTTPS_PORT:-10443}:443"
+    networks:
+      - backend_network
+    depends_on:
+      backend-api:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  postgresql:
+    image: postgres:17
+    container_name: sourcelens-postgres
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-backend}
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: md5
+    volumes:
+      - ./docker/postgresql/initdb.d:/docker-entrypoint-initdb.d:ro
+      - ./docker/postgresql/etc/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+      - ./data/postgresql/data:/var/lib/postgresql/data
+      - ./data/logs/postgresql:/var/log/postgresql
+    entrypoint: ["bash", "-c", "mkdir -p /var/log/postgresql && chown -R postgres:postgres /var/log/postgresql && chmod -R 755 /var/log/postgresql && exec docker-entrypoint.sh \"$$@\""]
+    command:
+      - "postgres"
+      - "-c"
+      - "config_file=/etc/postgresql/postgresql.conf"
+    networks:
+      - backend_network
+    healthcheck:
+      test: ["CMD-SHELL", "PGPASSWORD=\"$$POSTGRES_PASSWORD\" psql -h 127.0.0.1 -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\" -c 'SELECT 1' >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: redis:alpine
+    container_name: sourcelens-redis
+    restart: unless-stopped
+    command: redis-server
+    volumes:
+      - ./data/redis:/data
+      - ./data/logs/redis:/var/log/redis
+    networks:
+      - backend_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+networks:
+  backend_network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,110 @@
+# Blue/green API + UI: only one color is ever in nginx's traffic path at a time
+# (see docker/nginx/conf.d/upstream.conf, written by scripts/install.sh — not
+# committed, it's runtime state). `profiles` keeps `docker compose up` from
+# starting both colors by default; scripts/install.sh passes `--profile <color>`
+# explicitly when bringing a color up or down.
+#
+# nginx mounts the whole docker/nginx/conf.d/ DIRECTORY, not the individual
+# files inside it, on purpose: `sed -i`/rename-based atomic file replacement
+# (used by switch_traffic() and install.sh's asset fetcher) works by writing a
+# new inode and renaming it over the old path. A single-file bind mount is
+# pinned to the original inode and never sees that replacement — it produces
+# sustained 502s and eventually "host not found in upstream" once the old color
+# is gone. Mounting the directory instead means file replacement is a
+# directory-entry change, which the bind mount does see.
+#
+# scripts/install.sh is the ONLY supported way to bring this stack up/down: the
+# blue/green services carry no `depends_on` on each other (a profiled service
+# referenced by an unprofiled one breaks `docker compose` validation for every
+# command that doesn't pass `--profile <color>`), so ordering — migrate, health-
+# gate the deploy color, switch nginx, roll workers — is owned imperatively by
+# the script, not declaratively here.
+x-sourcelens-api-common: &sourcelens-api-common
+  image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
+  restart: unless-stopped
+  build:
+    context: .
+    dockerfile: Dockerfile
+    target: backend
+    args:
+      DEV_MODE: "1"
+      APP_VERSION: ${APP_VERSION:-0.0.0}
+      APT_MIRROR_URL: ${APT_MIRROR_URL:-https://mirrors.tuna.tsinghua.edu.cn/ubuntu}
+      PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
+      PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn}
+  env_file:
+    - ./.env
+  environment:
+    LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
+    LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
+    LENSNODE_WORKSPACE_PATH: /workspace
+  volumes:
+    - ./data/django/staticfiles:/opt/backend/core/staticfiles
+    - ./data/logs/api:/var/log/gunicorn
+    - ./data/storage:/opt/storage
+    - ./data/deliverables:/opt/deliverables
+    - ./docker/nginx/certs:/opt/certs
+  networks:
+    - backend_network
+  depends_on:
+    postgresql:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  command: gunicorn
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 120s
+
+x-sourcelens-ui-common: &sourcelens-ui-common
+  image: oneprocloud/sourcelens-frontend:${APP_VERSION:-latest}
+  restart: unless-stopped
+  build:
+    context: ./frontend
+    dockerfile: Dockerfile
+    args:
+      APP_VERSION: ${APP_VERSION:-0.0.0}
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+      VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      VITE_SENTRY_ENVIRONMENT: ${VITE_SENTRY_ENVIRONMENT:-}
+      VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-}
+      VITE_SENTRY_SEND_DEFAULT_PII: ${VITE_SENTRY_SEND_DEFAULT_PII:-}
+      VITE_GA_ID: ${VITE_GA_ID:-}
+  expose:
+    - "80"
+  networks:
+    - backend_network
+  healthcheck:
+    test: ["CMD", "sh", "-c", "wget -Y off --quiet --tries=1 --spider http://127.0.0.1 || exit 1"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 60s
+
 services:
-  backend-api:
-    image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
-    container_name: sourcelens-api
-    restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: backend
-      args:
-        DEV_MODE: "1"
-        APT_MIRROR_URL: ${APT_MIRROR_URL:-https://mirrors.tuna.tsinghua.edu.cn/ubuntu}
-        PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
-        PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn}
-    env_file:
-      - ./.env
-    environment:
-      LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
-      LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
-      LENSNODE_WORKSPACE_PATH: /workspace
-    volumes:
-      - ./data/django/staticfiles:/opt/backend/core/staticfiles
-      - ./data/logs/api:/var/log/gunicorn
-      - ./data/storage:/opt/storage
-      - ./data/deliverables:/opt/deliverables
-      - ./docker/nginx/certs:/opt/certs
-    networks:
-      - backend_network
-    depends_on:
-      postgresql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    command: gunicorn
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
+  sourcelens-api-blue:
+    <<: *sourcelens-api-common
+    container_name: sourcelens-api-blue
+    profiles: ["blue"]
+
+  sourcelens-api-green:
+    <<: *sourcelens-api-common
+    container_name: sourcelens-api-green
+    profiles: ["green"]
+
+  sourcelens-ui-blue:
+    <<: *sourcelens-ui-common
+    container_name: sourcelens-ui-blue
+    profiles: ["blue"]
+
+  sourcelens-ui-green:
+    <<: *sourcelens-ui-common
+    container_name: sourcelens-ui-green
+    profiles: ["green"]
 
   backend-worker:
     image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
@@ -52,9 +119,12 @@ services:
       - ./data/deliverables:/opt/deliverables
     networks:
       - backend_network
+    # No dependency on any sourcelens-api-* color here: there's no longer a
+    # single "backend-api" service to depend on post-blue/green, and depending
+    # on one specific color would break `docker compose` validation for every
+    # command that doesn't pass --profile <that color>. scripts/install.sh
+    # migrates before starting anything else, then rolls this service.
     depends_on:
-      backend-api:
-        condition: service_healthy
       postgresql:
         condition: service_healthy
       redis:
@@ -73,39 +143,11 @@ services:
     networks:
       - backend_network
     depends_on:
-      backend-api:
-        condition: service_healthy
       postgresql:
         condition: service_healthy
       redis:
         condition: service_healthy
     command: celery-beat
-
-  frontend:
-    container_name: sourcelens-ui
-    restart: unless-stopped
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-      args:
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
-        VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:-}
-        VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
-        VITE_SENTRY_ENVIRONMENT: ${VITE_SENTRY_ENVIRONMENT:-}
-        VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-}
-        VITE_SENTRY_SEND_DEFAULT_PII: ${VITE_SENTRY_SEND_DEFAULT_PII:-}
-        VITE_GA_ID: ${VITE_GA_ID:-}
-    image: oneprocloud/sourcelens-frontend:${APP_VERSION:-latest}
-    expose:
-      - "80"
-    networks:
-      - backend_network
-    healthcheck:
-      test: ["CMD", "sh", "-c", "wget -Y off --quiet --tries=1 --spider http://127.0.0.1 || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
 
   lensnode:
     build:
@@ -122,22 +164,22 @@ services:
     environment:
       LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
       LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
-      LENSNODE_CONTROL_WS_URL: ws://backend-api:8000/ws/lens/lensnodes/
-      LENSNODE_AI_GATEWAY_URL: http://backend-api:8000/api/lens/lensnode/ai-gateway/
+      # Reach the API through nginx, not a color-specific container: nginx
+      # always proxies to the active color, so lensnode rides a blue/green
+      # switch by simply reconnecting (control WS, AI gateway and deliverable
+      # upload URLs are all derived from LENSNODE_SERVER_URL in config.py).
+      LENSNODE_SERVER_URL: http://nginx:80
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}
       LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
-      # Max concurrent runs per node. Each run holds a slot for the full
-      # answer duration; without this it falls back to 1 and questions queue.
+      # Max concurrent runs per node. Each run holds a slot for the full answer
+      # duration; without this it falls back to 1 and questions queue.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
     volumes:
       - ./data/workspace:/workspace
     networks:
       - backend_network
-    depends_on:
-      backend-api:
-        condition: service_healthy
 
   # Recommend to use nginx proxy manager to manage the outside access
   nginx:
@@ -145,7 +187,7 @@ services:
     container_name: sourcelens-nginx
     restart: unless-stopped
     volumes:
-      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/nginx/conf.d:/etc/nginx/conf.d
       - ./docker/nginx/certs:/etc/nginx/certs:ro
       - ./data/django/staticfiles:/staticfiles:ro
       - ./data/storage:/opt/storage:ro
@@ -155,11 +197,11 @@ services:
       - "${NGINX_HTTPS_PORT:-10443}:443"
     networks:
       - backend_network
-    depends_on:
-      backend-api:
-        condition: service_healthy
-      frontend:
-        condition: service_started
+    # No depends_on here on purpose: nginx would need to depend on "whichever
+    # color is active", which compose can't express, and depending on one
+    # specific color breaks validation of every compose command that doesn't
+    # pass --profile <that color>. scripts/install.sh owns ordering: it brings
+    # up postgresql/redis, then the deploy color, health-gates it, then nginx.
     healthcheck:
       test: ["CMD", "nginx", "-t"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,9 +166,16 @@ services:
       LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
       # Reach the API through nginx, not a color-specific container: nginx
       # always proxies to the active color, so lensnode rides a blue/green
-      # switch by simply reconnecting (control WS, AI gateway and deliverable
-      # upload URLs are all derived from LENSNODE_SERVER_URL in config.py).
+      # switch by simply reconnecting. These are set explicitly here (not just
+      # via env.sample) so they override any stale ws://backend-api:8000 values
+      # left in an existing .env from before the blue/green upgrade — config.py
+      # prefers an explicit LENSNODE_CONTROL_WS_URL/LENSNODE_AI_GATEWAY_URL over
+      # deriving from LENSNODE_SERVER_URL, and compose `environment:` wins over
+      # `env_file:`. LENSNODE_SERVER_URL still drives the derived deliverable
+      # upload URL.
       LENSNODE_SERVER_URL: http://nginx:80
+      LENSNODE_CONTROL_WS_URL: ws://nginx:80/ws/lens/lensnodes/
+      LENSNODE_AI_GATEWAY_URL: http://nginx:80/api/lens/lensnode/ai-gateway/
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,13 @@
 # command that doesn't pass `--profile <color>`), so ordering — migrate, health-
 # gate the deploy color, switch nginx, roll workers — is owned imperatively by
 # the script, not declaratively here.
+
+# Explicit production project name — keeps this stack isolated from the dev
+# stack (docker-compose.dev.yml, project "sourcelens-dev"); scripts/install.sh's
+# bare `docker compose` commands still resolve to this. (COMPOSE_PROJECT_NAME /
+# -p still override it, e.g. for an isolated local switch test.)
+name: sourcelens
+
 x-sourcelens-api-common: &sourcelens-api-common
   image: oneprocloud/sourcelens-backend:${APP_VERSION:-latest}
   restart: unless-stopped

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,12 +1,19 @@
-# sourcelens_api_active / sourcelens_ui_active are defined in upstream.conf, a
-# sibling file in this same conf.d directory (picked up automatically by the
-# base image's `include conf.d/*.conf` inside its http {} block). upstream.conf
-# is runtime state, not committed — see docker/nginx/upstream.conf.default and
-# scripts/install.sh for how it's bootstrapped and switched between blue/green
-# on each deploy. The whole conf.d/ directory is bind-mounted as a unit (see
-# docker-compose.yml's nginx volumes comment) specifically so upstream.conf can
-# be rewritten in place via sed/rename without the container being stuck looking
-# at a stale inode.
+# $sourcelens_api_active / $sourcelens_ui_active are `map` variables defined in
+# upstream.conf, a sibling file in this same conf.d directory (picked up
+# automatically by the base image's `include conf.d/*.conf` inside its http {}
+# block). upstream.conf is runtime state, not committed — see
+# docker/nginx/upstream.conf.default and scripts/install.sh for how it's
+# bootstrapped and switched between blue/green on each deploy. The whole conf.d/
+# directory is bind-mounted as a unit (see docker-compose.yml's nginx volumes
+# comment) specifically so upstream.conf can be rewritten in place via
+# sed/rename without the container being stuck looking at a stale inode.
+#
+# proxy_pass targets a variable (not a static upstream), so with the resolver
+# below nginx re-resolves the color hostname per request via Docker's embedded
+# DNS: nginx starts even when the active color isn't up yet (no reboot-time
+# "host not found" crash-loop), and a color container recreated with a new IP is
+# picked up within `valid=10s` instead of a stale IP being cached forever.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # HTTPS server configuration
 server {
@@ -44,7 +51,7 @@ server {
     location /api/ {
         proxy_buffering off;
         proxy_cache off;
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -58,7 +65,7 @@ server {
 
     # LensNode WebSocket endpoint
     location /ws/ {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -74,7 +81,7 @@ server {
 
     # Backend authentication endpoints (OAuth, etc.)
     location ~ ^/(accounts|_allauth)/ {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -88,7 +95,7 @@ server {
 
     # Django Admin
     location ~ ^/admin {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -119,7 +126,7 @@ server {
 
     # Health check endpoint
     location /health {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -128,7 +135,7 @@ server {
 
     # Swagger and API documentation
     location ~ ^/(swagger|redoc|api/schema) {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -138,7 +145,7 @@ server {
 
     # Frontend proxy to frontend container
     location / {
-        proxy_pass http://sourcelens_ui_active;
+        proxy_pass http://$sourcelens_ui_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -179,7 +186,7 @@ server {
     location /api/ {
         proxy_buffering off;
         proxy_cache off;
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -193,7 +200,7 @@ server {
 
     # LensNode WebSocket endpoint
     location /ws/ {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -209,7 +216,7 @@ server {
 
     # Backend authentication endpoints (OAuth, etc.)
     location ~ ^/(accounts|_allauth)/ {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -223,7 +230,7 @@ server {
 
     # Django Admin
     location ~ ^/admin {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -254,7 +261,7 @@ server {
 
     # Health check endpoint
     location /health {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -263,7 +270,7 @@ server {
 
     # Swagger and API documentation
     location ~ ^/(swagger|redoc|api/schema) {
-        proxy_pass http://sourcelens_api_active;
+        proxy_pass http://$sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -273,7 +280,7 @@ server {
 
     # Frontend proxy to frontend container
     location / {
-        proxy_pass http://sourcelens_ui_active;
+        proxy_pass http://$sourcelens_ui_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,7 +1,12 @@
-# Use Docker's internal DNS so upstream hostnames are re-resolved on each
-# request instead of being cached at startup. Without this, nginx can keep a
-# stale backend IP after containers are recreated.
-resolver 127.0.0.11 valid=10s ipv6=off;
+# sourcelens_api_active / sourcelens_ui_active are defined in upstream.conf, a
+# sibling file in this same conf.d directory (picked up automatically by the
+# base image's `include conf.d/*.conf` inside its http {} block). upstream.conf
+# is runtime state, not committed — see docker/nginx/upstream.conf.default and
+# scripts/install.sh for how it's bootstrapped and switched between blue/green
+# on each deploy. The whole conf.d/ directory is bind-mounted as a unit (see
+# docker-compose.yml's nginx volumes comment) specifically so upstream.conf can
+# be rewritten in place via sed/rename without the container being stuck looking
+# at a stale inode.
 
 # HTTPS server configuration
 server {
@@ -18,8 +23,6 @@ server {
     ssl_prefer_server_ciphers on;
 
     client_max_body_size 100M;
-    set $api_upstream http://backend-api:8000;
-    set $ui_upstream http://frontend:80;
 
     # Enable gzip compression
     gzip on;
@@ -41,7 +44,7 @@ server {
     location /api/ {
         proxy_buffering off;
         proxy_cache off;
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -55,7 +58,7 @@ server {
 
     # LensNode WebSocket endpoint
     location /ws/ {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -71,7 +74,7 @@ server {
 
     # Backend authentication endpoints (OAuth, etc.)
     location ~ ^/(accounts|_allauth)/ {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -85,7 +88,7 @@ server {
 
     # Django Admin
     location ~ ^/admin {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -116,7 +119,7 @@ server {
 
     # Health check endpoint
     location /health {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -125,7 +128,7 @@ server {
 
     # Swagger and API documentation
     location ~ ^/(swagger|redoc|api/schema) {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -135,7 +138,7 @@ server {
 
     # Frontend proxy to frontend container
     location / {
-        proxy_pass $ui_upstream;
+        proxy_pass http://sourcelens_ui_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -155,8 +158,6 @@ server {
     server_name localhost;
 
     client_max_body_size 100M;
-    set $api_upstream http://backend-api:8000;
-    set $ui_upstream http://frontend:80;
 
     # Enable gzip compression
     gzip on;
@@ -178,7 +179,7 @@ server {
     location /api/ {
         proxy_buffering off;
         proxy_cache off;
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -190,9 +191,25 @@ server {
         proxy_read_timeout 600s;
     }
 
+    # LensNode WebSocket endpoint
+    location /ws/ {
+        proxy_pass http://sourcelens_api_active;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
     # Backend authentication endpoints (OAuth, etc.)
     location ~ ^/(accounts|_allauth)/ {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -206,7 +223,7 @@ server {
 
     # Django Admin
     location ~ ^/admin {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -237,7 +254,7 @@ server {
 
     # Health check endpoint
     location /health {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -246,7 +263,7 @@ server {
 
     # Swagger and API documentation
     location ~ ^/(swagger|redoc|api/schema) {
-        proxy_pass $api_upstream;
+        proxy_pass http://sourcelens_api_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -256,7 +273,7 @@ server {
 
     # Frontend proxy to frontend container
     location / {
-        proxy_pass $ui_upstream;
+        proxy_pass http://sourcelens_ui_active;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/default.standalone.conf
+++ b/docker/nginx/default.standalone.conf
@@ -1,0 +1,257 @@
+# Single-file nginx config for docker-compose.standalone.yml (single-instance,
+# non-blue/green production). Unlike the blue/green prod stack — which mounts
+# the whole conf.d/ directory and swaps a runtime upstream.conf between colors —
+# this proxies straight to the fixed backend-api / frontend service names.
+#
+# The upstreams are resolved via Docker's embedded DNS on each request (set +
+# resolver, not a static upstream block) so a plain `docker compose up -d`
+# recreating backend-api in place is picked up without an nginx reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
+
+# HTTPS server configuration
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate /etc/nginx/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/nginx-selfsigned.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    client_max_body_size 100M;
+    set $api_upstream http://backend-api:8000;
+    set $ui_upstream http://frontend:80;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Accel-Buffering "no" always;
+
+    location /api/ {
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /ws/ {
+        proxy_pass $api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/(accounts|_allauth)/ {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/admin {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /static/ {
+        alias /staticfiles/;
+        autoindex off;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /media/storage/ {
+        alias /opt/storage/;
+        autoindex off;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        add_header X-Content-Type-Options "nosniff";
+    }
+
+    location /health {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location ~ ^/(swagger|redoc|api/schema) {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    location / {
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+}
+
+# HTTP server configuration
+server {
+    listen 80;
+    server_name localhost;
+
+    client_max_body_size 100M;
+    set $api_upstream http://backend-api:8000;
+    set $ui_upstream http://frontend:80;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Accel-Buffering "no" always;
+
+    location /api/ {
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /ws/ {
+        proxy_pass $api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/(accounts|_allauth)/ {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/admin {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /static/ {
+        alias /staticfiles/;
+        autoindex off;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /media/storage/ {
+        alias /opt/storage/;
+        autoindex off;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        add_header X-Content-Type-Options "nosniff";
+    }
+
+    location /health {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/(swagger|redoc|api/schema) {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    location / {
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+}

--- a/docker/nginx/upstream.conf.default
+++ b/docker/nginx/upstream.conf.default
@@ -6,10 +6,19 @@
 # It lives inside conf.d/ specifically so nginx's directory bind mount (not a
 # single-file mount) sees in-place rewrites — see docker-compose.yml's nginx
 # volumes comment for why that distinction matters here.
-upstream sourcelens_api_active {
-    server sourcelens-api-blue:8000;
+#
+# These are `map`s (not `upstream` blocks) on purpose: default.conf proxies to
+# them via a variable + `resolver` (per-request DNS re-resolution), so nginx
+# does NOT resolve the color hostname at config-parse/start time. That means
+# nginx starts (and `nginx -t` passes) even when the active color's container
+# isn't up yet — no "host not found in upstream" crash-loop on a host reboot —
+# and a color container recreated with a new IP is picked up within the
+# resolver's `valid` window instead of being cached forever. switch_traffic
+# flips the default value here from one color to the other.
+map $host $sourcelens_api_active {
+    default sourcelens-api-blue:8000;
 }
 
-upstream sourcelens_ui_active {
-    server sourcelens-ui-blue:80;
+map $host $sourcelens_ui_active {
+    default sourcelens-ui-blue:80;
 }

--- a/docker/nginx/upstream.conf.default
+++ b/docker/nginx/upstream.conf.default
@@ -1,0 +1,15 @@
+# Bootstrap template for docker/nginx/conf.d/upstream.conf — copied into place
+# by scripts/install.sh on first run only, if upstream.conf doesn't already
+# exist. From then on this file is runtime state (which color is live) and is
+# rewritten in place by install.sh's blue/green switch (switch_traffic); it is
+# never synced from the repo again and must never be committed (see .gitignore).
+# It lives inside conf.d/ specifically so nginx's directory bind mount (not a
+# single-file mount) sees in-place rewrites — see docker-compose.yml's nginx
+# volumes comment for why that distinction matters here.
+upstream sourcelens_api_active {
+    server sourcelens-api-blue:8000;
+}
+
+upstream sourcelens_ui_active {
+    server sourcelens-ui-blue:80;
+}

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -173,6 +173,18 @@ was caught only in review. Treat them as acceptance criteria.
       `install.sh` derives the image tag from the ref it fetches (`${ref#v}`),
       then a build tagged with a *short* SHA but fetched from the *full* SHA pulls
       a nonexistent tag. Use one consistent value.
+- [ ] **First cutover cleans up the old single-container stack.** Migrating a
+      host from a pre-blue/green single-container deploy: the old single `api`/`ui`
+      containers are NOT part of the blue/green compose, so `up` leaves them
+      running as orphans (holding DB connections / memory) — `--remove-orphans`
+      won't catch them across different compose files either. Add a one-time
+      `docker rm -f <app>-api <app>-ui || true` after the first install. The
+      first cutover's only downtime is the nginx **container recreate** (single-
+      file → directory mount), which is sub-second when the new color is
+      health-gated up *before* nginx is recreated; steady-state deploys are a
+      reload (zero-downtime).
+      *(sourcelens `install.sh` does NOT do this cleanup yet — copy it from the
+      devify implementation, which does `docker rm -f devify-api devify-ui`.)*
 
 ### 5.2 nginx
 

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -24,6 +24,28 @@ Do **not** reach for it when you have k8s/Swarm (use their rolling updates), or
 when a brief blip on deploy is acceptable — then the simpler *standalone* topology
 below is enough.
 
+### Scope: single host only — NOT multi-node
+
+This pattern is **single-node by construction** and does **not** extend to a
+multi-host fleet. Everything that makes the switch work is local to one machine:
+
+- `.active_color` / `.rollback_version` / `upstream.conf` are **local files** on
+  one host — there is no shared or coordinated "current color" across machines.
+- `install.sh` runs on **one** host and drives that host's `docker compose`.
+- nginx runs on the **same** host and proxies to colors by container name over
+  the **local** Docker network; the switch is `docker exec <that-nginx> nginx -s
+  reload`. There is no cross-host load balancer.
+
+Multi-node zero-downtime is a **different architecture**, not an extension of
+this one: it needs a fronting cross-host load balancer (or DNS/anycast), the
+active color promoted to **shared/coordinated cluster state**, and something to
+**orchestrate the switch across the whole fleet** (including that hosts briefly
+serve mixed colors/versions during the roll — the same expand/contract
+constraint, now fleet-wide). At that point you are rebuilding a slice of an
+orchestrator — use k8s/Swarm/a service mesh instead. Running this playbook
+independently per host behind an external LB is possible but is *N independent
+single-node deploys*, not a coordinated fleet switch; don't mistake it for one.
+
 ---
 
 ## 2. Topology model — three compose files, pick one per host

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -1,0 +1,239 @@
+# Single-node Blue/Green Deployment — Reusable Playbook
+
+A portable specification for zero-downtime deployment on a **single host with no
+orchestrator** (no k8s / Swarm). It captures the architecture, the per-project
+adaptation points, and — most importantly — a **correctness checklist** distilled
+from bugs found in real ports of this pattern, so a new project can adopt it
+without re-discovering them.
+
+sourcelens is the reference implementation. Paths below in `code font` point at
+sourcelens files; the `<app>` / `<service>` placeholders are what you rename per
+project (see [Adaptation](#per-project-adaptation)).
+
+---
+
+## 1. When to use this
+
+Use it when **all** of these hold:
+
+- One production host, no orchestrator (a plain Docker + Docker Compose box).
+- You need zero dropped requests during an upgrade, plus a fast rollback.
+- Your user-facing services are stateless (state lives in Postgres/Redis/volumes).
+
+Do **not** reach for it when you have k8s/Swarm (use their rolling updates), or
+when a brief blip on deploy is acceptable — then the simpler *standalone* topology
+below is enough.
+
+---
+
+## 2. Topology model — three compose files, pick one per host
+
+Keeping these separate is the whole mental model. **Only one runs per
+host/directory** (they share the default compose project name and the
+`postgresql`/`redis` service names, so two in the same dir fight over shared
+containers).
+
+| File | Role | Brought up by | Images | Zero-downtime |
+|---|---|---|---|---|
+| `docker-compose.dev.yml` | development | `docker compose -f … up -d` | built from source, hot-reload mounts | no |
+| `docker-compose.standalone.yml` | simple prod, single instance | `docker compose -f … up -d` | pulled release images, no source mounts | no |
+| `docker-compose.yml` | zero-downtime prod | **`scripts/install.sh`** (blue/green) | pulled release images | **yes** |
+
+The blue/green file **cannot** be brought up with a bare `docker compose up -d`
+(API/UI are `profiles`-gated, and nginx needs bootstrapped runtime state) — that
+is by design; `install.sh` is its only entrypoint.
+
+---
+
+## 3. Architecture (blue/green file)
+
+- **Two colors per stateless service.** `<app>-api-blue` / `<app>-api-green`,
+  `<app>-ui-blue` / `<app>-ui-green`, defined once via a YAML anchor and split by
+  compose `profiles: ["blue"|"green"]`. Only one color is ever in nginx's traffic
+  path. (`docker-compose.yml`)
+- **Stateful services stay singleton** — `postgresql`, `redis`, and any volume-
+  backed service. Never blue/green'd.
+- **Background workers roll normally.** Celery workers / schedulers / WS workers
+  are recreated with a plain `up -d` on deploy (rely on graceful shutdown —
+  `stop_grace_period`, late ack, `prefetch=1`), not blue/green'd.
+- **nginx routing state** lives in a bind-mounted **directory**
+  (`docker/nginx/conf.d/`), not a single file. `default.conf` proxies to a
+  variable whose value is a `map` in `upstream.conf`; the deploy flips that map.
+  (See [Correctness §5.2](#52-nginx).)
+- **Runtime state files** (gitignored, bootstrapped once, never committed):
+  `.active_color`, `.rollback_version`, `docker/nginx/conf.d/upstream.conf`, and
+  the self-signed TLS cert.
+- **Two scripts, shared lib.**
+  - `scripts/install.sh` — install **and** upgrade (idempotent, one command).
+  - `scripts/<app>ctl.sh` — day-2 ops: `status` / `restart-workers` / `rollback`.
+  - `scripts/lib/deploy-common.sh` — `current_color` / `other_color` /
+    `wait_for_healthy` / `switch_traffic` shared by both.
+
+### The deploy sequence (`install.sh`)
+
+1. Fetch the small set of declarative assets from the target git ref (compose,
+   nginx/postgres config, the scripts themselves — self-updating). `--local`
+   skips this and builds from the working tree.
+2. Bootstrap runtime state **only if missing** (never clobber).
+3. Determine current color from `.active_color`; if its API container isn't
+   running, this is a first install → deploy to that color directly (nothing to
+   switch/retire). Otherwise deploy to the **other** color.
+4. Pull/build images for the deploy color; migrate (or let the color's own
+   startup migrate) — no traffic yet.
+5. Bring up the deploy color, **health-gate** it (poll `/health`, bounded
+   retries). Abort cleanly if it never turns healthy — current color stays live.
+6. **Switch** nginx to the new color (`nginx -t` then `nginx -s reload`, no
+   dropped connections). Write `.active_color` + `.rollback_version`
+   **immediately**. Observe a fixed window, then retire the old color.
+7. Roll workers (`up -d`). Prune old image tags. Single-flight lock throughout.
+
+---
+
+## 4. Per-project adaptation
+
+Rename these; everything else is mechanical:
+
+| Thing | sourcelens value | Where |
+|---|---|---|
+| Service/container names | `sourcelens-api-{blue,green}`, `sourcelens-ui-…`, `sourcelens-{worker,scheduler,nginx,postgres,redis}` | compose, scripts, nginx |
+| Image repos | `oneprocloud/sourcelens-backend`, `…-frontend` | compose, `install.sh` |
+| Git repo (asset fetch) | `HyperBDR/sourcelens` | `install.sh` `REPO=` |
+| Health endpoint | `GET /health` on `:8000` | `deploy-common.sh` `wait_for_healthy`, compose healthcheck |
+| Version LABEL | `com.oneprocloud.sourcelens.version` | Dockerfiles + `deploy-common.sh` |
+| nginx upstream var names | `$sourcelens_api_active` / `$sourcelens_ui_active` | `default.conf` + `upstream.conf` |
+| WS worker (if any) | `lensnode` (reaches API via nginx) | compose env, backend grace-period |
+
+---
+
+## 5. Correctness checklist (MUST)
+
+These are not style preferences — each is a bug that shipped in a real port and
+was caught only in review. Treat them as acceptance criteria.
+
+### 5.1 Deploy scripts
+
+- [ ] **Atomic single-flight lock.** Acquire with `set -o noclobber`
+      (`while ! (set -o noclobber; echo $$ > "$LOCK"); do …`), never a
+      `[ -f "$LOCK" ] && echo > "$LOCK"` check-then-write — that is a TOCTOU race
+      two deploys can both pass. Keep a stale-lock takeover after a max wait.
+- [ ] **Rollback pins the old image version.** After a switch, the retired
+      color's container is removed, so `docker compose up -d <color>` recreates it
+      from `image: …:${VERSION:-latest}` = **latest** = the *current* (bad)
+      release. Record the outgoing color's version to `.rollback_version` right
+      before retiring it, and have `rollback` export `APP_VERSION` from that file.
+      Without this, "rollback" silently redeploys the broken version.
+- [ ] **Write `.active_color` immediately after the switch**, before the
+      observe/retire window — not at the end. An interrupt mid-window otherwise
+      leaves nginx on the new color while `.active_color` names the old one,
+      desyncing the next rollback.
+- [ ] **Version-skip is `>=`, not `>`.** `sort -V | tail -1 != TARGET` never
+      no-ops an *equal* re-deploy (max equals target). Add an explicit equality
+      clause if you want an idempotent re-run to skip.
+- [ ] **Guard `set -euo pipefail` pipelines that may legitimately not match.**
+      e.g. the tag-prune `docker images … | grep -vE '^latest$' | …` aborts the
+      whole script when a repo has only `latest` (grep exits 1). Append `|| true`.
+- [ ] **CI: the image tag and the asset-fetch ref must not diverge.** If
+      `install.sh` derives the image tag from the ref it fetches (`${ref#v}`),
+      then a build tagged with a *short* SHA but fetched from the *full* SHA pulls
+      a nonexistent tag. Use one consistent value.
+
+### 5.2 nginx
+
+- [ ] **Variable `proxy_pass` + `resolver`, not a static `upstream` block.**
+      A static `upstream { server <app>-api-blue:8000; }` is resolved once and
+      cached forever: nginx **crash-loops on a host reboot** if the active color
+      isn't up yet (`host not found in upstream`), and serves **stale-IP 502s**
+      after a container is recreated without a reload. Instead put a `map` in
+      `upstream.conf` and `proxy_pass http://$<app>_api_active;` with
+      `resolver 127.0.0.11 valid=10s;` in `default.conf`. nginx then starts even
+      when the color is down and self-heals within `valid` after a recreate.
+      *(This is the one place sourcelens improves on the pattern it ported.)*
+- [ ] **Mount `conf.d/` as a whole directory**, never the single `upstream.conf`
+      file. The switch does a `sed -i` (rename → new inode); a single-file bind
+      mount pins the original inode and nginx keeps serving the pre-switch color.
+
+### 5.3 Migrations (expand/contract)
+
+- [ ] During the observe window the **outgoing** color still serves traffic
+      against the **post-migration** schema. A migration that drops/renames a
+      column or tightens a constraint in the same release as the code that stops
+      using it breaks the outgoing color mid-window. **Split such changes across
+      two releases** (expand, then contract).
+
+### 5.4 WebSocket worker survival (if you have one)
+
+A worker connected over WebSocket drops its socket when the API color is
+recycled. That is **not** proof its in-flight work failed.
+
+- [ ] **Server: grace period before failing runs.** On disconnect, don't fail the
+      node's runs immediately — stamp `disconnected_at` and schedule a **Celery
+      countdown** task (not an in-process timer: the API process is what gets
+      recycled). Fail the runs only if the node is still gone after the window.
+- [ ] **Episode-pin the grace check with a tolerance, not exact timestamp
+      strings.** Comparing `disconnected_at.isoformat()` to the scheduled string
+      breaks on any DB that truncates sub-second precision (the check then always
+      no-ops). Compare parsed datetimes within ~1s.
+- [ ] **Handle the disconnect CAS miss.** If a health sweep already marked the
+      node offline and cleared its `connection_id`, the disconnect's
+      `connection_id`-scoped update matches 0 rows — still schedule the check (on
+      the ownerless row) so a genuinely-dead node's runs are failed, not left
+      hanging until the idle reaper.
+- [ ] **Wrap the scheduling `apply_async` in try/except.** It's a broker call in
+      the disconnect path; a broker hiccup must not raise out of `disconnect()`.
+      The periodic idle reaper is the backstop.
+- [ ] **Client: durable, bounded outbound buffer.** Frames a run emits *while
+      disconnected* must survive to the next connection (buffer across reconnects,
+      don't drop). But the buffer **must be bounded** — a prolonged outage with a
+      producing run OOM-kills the worker otherwise; drop oldest past a cap with a
+      warning.
+- [ ] **Client: send `hello` directly on the socket, not through the durable
+      buffer.** A buffered hello gets replayed on the next connection carrying a
+      stale `active_runs` snapshot, triggering a spurious server-side reconcile.
+      Send it from the connect path before the send loop starts.
+- [ ] **Client: pop-before-send, re-queue-at-front on failure.** Pop a frame out
+      of the buffer before awaiting the send (so a concurrent drop-oldest can't
+      race the in-flight frame) and re-queue it at the front on a mid-send error.
+      Accept that this is **at-least-once** (a frame whose bytes reached the
+      server before the error is re-sent) — make it harmless by having the run's
+      terminal/`final_content` frame reconcile the accumulated output.
+
+---
+
+## 6. Verification protocol
+
+Prove it, don't assume it. On an isolated compose project
+(`COMPOSE_PROJECT_NAME=<app>-verify`, so you never disturb a dev stack in the
+same dir):
+
+1. **First install:** `./scripts/install.sh --local` → blue built, health-gated,
+   nginx serving it; `curl` `/health` = 200.
+2. **Zero-downtime switch:** run a tight `/health` load loop, then
+   `./scripts/install.sh --local` again (blue→green). **Expect zero non-200s**
+   across the whole run (build, health-gate, `nginx -s reload`, observe, retire).
+   sourcelens measured 2115/2115 = 200 end-to-end via `install.sh`, and 800/800
+   across a bare `switch_traffic` reload.
+3. **Resolver self-heal:** recreate the active color's container with no nginx
+   reload → `/health` recovers within `valid=10s`.
+4. **Day-2:** `<app>ctl.sh status` shows the active color healthy; `rollback`
+   flips to the other color **without a rebuild** and lands on the *old* version;
+   `restart-workers` restarts workers gracefully.
+5. **WS worker (if any):** start a long run, switch mid-run → the run stays
+   RUNNING, the worker reconnects, buffered frames flush, the run completes; keep
+   the worker down past the grace window → the run correctly fails.
+
+---
+
+## 7. Adopting it in a new project
+
+1. Copy `docker-compose.yml` (blue/green), `docker-compose.standalone.yml`,
+   `docker/nginx/conf.d/default.conf`, `docker/nginx/upstream.conf.default`,
+   `docker/nginx/default.standalone.conf`, and `scripts/{install,<app>ctl}.sh` +
+   `scripts/lib/deploy-common.sh`.
+2. Apply the [Adaptation](#per-project-adaptation) renames.
+3. Add the version `LABEL` (fed by an `APP_VERSION` build arg) as the **last**
+   Dockerfile layer, so a version bump doesn't bust the apt/pip/npm cache.
+4. Gitignore the runtime-state files; commit `upstream.conf.default` only.
+5. Walk the [Correctness checklist](#5-correctness-checklist-must) line by line.
+6. Run the [Verification protocol](#6-verification-protocol) before trusting it.
+7. If you have a WebSocket worker, implement §5.4 — it's the one genuinely new
+   piece, not a copy.

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -48,18 +48,29 @@ single-node deploys*, not a coordinated fleet switch; don't mistake it for one.
 
 ---
 
-## 2. Topology model — three compose files, pick one per host
+## 2. Topology model — three compose files
 
-Keeping these separate is the whole mental model. **Only one runs per
-host/directory** (they share the default compose project name and the
-`postgresql`/`redis` service names, so two in the same dir fight over shared
-containers).
+| File | Role | Project name | Brought up by | Images | Zero-downtime |
+|---|---|---|---|---|---|
+| `docker-compose.dev.yml` | development | `<app>-dev` | `docker compose -f … up -d` | built from source, hot-reload mounts | no |
+| `docker-compose.standalone.yml` | simple prod, single instance | `<app>` | `docker compose -f … up -d` | pulled release images, no source mounts | no |
+| `docker-compose.yml` | zero-downtime prod | `<app>` | **`scripts/install.sh`** (blue/green) | pulled release images | **yes** |
 
-| File | Role | Brought up by | Images | Zero-downtime |
-|---|---|---|---|---|
-| `docker-compose.dev.yml` | development | `docker compose -f … up -d` | built from source, hot-reload mounts | no |
-| `docker-compose.standalone.yml` | simple prod, single instance | `docker compose -f … up -d` | pulled release images, no source mounts | no |
-| `docker-compose.yml` | zero-downtime prod | **`scripts/install.sh`** (blue/green) | pulled release images | **yes** |
+> ### IRON RULE — dev and prod must use distinct compose project names
+>
+> **Every compose file MUST set an explicit top-level `name:`.** Dev gets its own
+> project (`<app>-dev`); the production shapes share `<app>`. Without an explicit
+> `name:` every file defaults to the **directory name** and they share one
+> project namespace — and because they also share service keys (`postgresql`,
+> `redis`, …), bringing up a production stack in that directory **recreates the
+> dev containers** (and vice versa), silently taking down the other environment.
+> This is not hypothetical: it happened during this project's own testing.
+>
+> Dev must be isolated from prod. Of the two **production** shapes, run only one
+> per host — they intentionally share `<app>` (and the singleton
+> postgres/redis data). `COMPOSE_PROJECT_NAME` / `-p` still override the file's
+> `name:`, which is how you run an isolated *test* copy of a prod stack
+> (`COMPOSE_PROJECT_NAME=<app>-verify`) without disturbing anything.
 
 The blue/green file **cannot** be brought up with a bare `docker compose up -d`
 (API/UI are `profiles`-gated, and nginx needs bootstrapped runtime state) — that
@@ -134,6 +145,10 @@ was caught only in review. Treat them as acceptance criteria.
 
 ### 5.1 Deploy scripts
 
+- [ ] **Every compose file sets an explicit distinct `name:`** (IRON RULE, §2):
+      dev under `<app>-dev`, prod under `<app>`. Never rely on the directory-name
+      default — a prod `up` in the repo dir otherwise recreates the dev
+      containers (shared project namespace + `postgresql`/`redis` service keys).
 - [ ] **Atomic single-flight lock.** Acquire with `set -o noclobber`
       (`while ! (set -o noclobber; echo $$ > "$LOCK"); do …`), never a
       `[ -f "$LOCK" ] && echo > "$LOCK"` check-then-write — that is a TOCTOU race

--- a/env.sample
+++ b/env.sample
@@ -76,8 +76,13 @@ CHANNEL_LAYER_REDIS_URL=redis://redis:6379/2
 LENSNODE_NAME=local-dev-lensnode
 LENSNODE_TOKEN=change-me-lensnode-token
 LENSNODE_WORKSPACE_PATH=/workspace
-LENSNODE_CONTROL_WS_URL=ws://backend-api:8000/ws/lens/lensnodes/
-LENSNODE_AI_GATEWAY_URL=http://backend-api:8000/api/lens/lensnode/ai-gateway/
+# Reach the API through nginx, not a color-specific container: under blue/green
+# there is no single "backend-api" host, and nginx always proxies to the active
+# color, so lensnode rides a deploy switch by simply reconnecting. (The compose
+# file also sets LENSNODE_SERVER_URL=http://nginx:80, which derives the
+# deliverable-upload URL the same way.)
+LENSNODE_CONTROL_WS_URL=ws://nginx:80/ws/lens/lensnodes/
+LENSNODE_AI_GATEWAY_URL=http://nginx:80/api/lens/lensnode/ai-gateway/
 LENSNODE_HEARTBEAT_INTERVAL_S=15
 # Must be greater than the LiteLLM/provider request timeout so the control
 # plane reports provider failures before LensNode gives up.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,6 +37,12 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
+# Stamp the release version onto the runtime image so scripts/install.sh can
+# read it (docker inspect Config.Labels) for its version-skip check. Absent =>
+# 0.0.0, which install.sh treats as "never skip".
+ARG APP_VERSION=0.0.0
+LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
+
 # Copy built files from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,17 +37,18 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
-# Stamp the release version onto the runtime image so scripts/install.sh can
-# read it (docker inspect Config.Labels) for its version-skip check. Absent =>
-# 0.0.0, which install.sh treats as "never skip".
-ARG APP_VERSION=0.0.0
-LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
-
 # Copy built files from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy custom nginx configuration for SPA routing
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Stamp the release version onto the runtime image so scripts/install.sh can
+# read it (docker inspect Config.Labels) for its version-skip check. Absent =>
+# 0.0.0, which install.sh treats as "never skip". Kept last so a version bump
+# doesn't invalidate the COPY layers above it.
+ARG APP_VERSION=0.0.0
+LABEL com.oneprocloud.sourcelens.version=$APP_VERSION
 
 # Expose port
 EXPOSE 80

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# SourceLens install / upgrade script — one command, no git required on the
+# host. curl this file to bootstrap a brand-new host; the exact same command
+# upgrades an existing one.
+#
+#   curl -fsSL https://raw.githubusercontent.com/HyperBDR/sourcelens/<tag>/scripts/install.sh \
+#       -o install.sh && chmod +x install.sh && ./install.sh <tag>
+#
+# What it does, every single run (there is no separate "first run" mode):
+#   1. Fetch the small set of declarative deploy files (docker-compose.yml,
+#      nginx/postgres config, this script itself) straight from
+#      raw.githubusercontent.com at the given tag — not the whole repo.
+#   2. Bootstrap runtime-state files if missing (nginx upstream.conf,
+#      .active_color, self-signed TLS cert) — never touched again after that.
+#   3. Blue/green switch: bring up the idle color, health-check it, flip nginx's
+#      upstream to it via `nginx -s reload` (no dropped requests), then retire
+#      the previously-active color. On a genuinely first-ever install (nothing
+#      running yet) there's no old color to switch from or retire, so this step
+#      degrades to a plain health-gated bring-up.
+#
+# Migrations: the API image runs `sourcelens_init` (migrate + register periodic
+# tasks + collectstatic) on startup, so bringing the deploy color up migrates it
+# against the DB before it reports healthy — the health gate below covers a
+# failed migration (the color never turns healthy, the deploy aborts, the
+# current color stays live). See CLAUDE.md's "零停机部署" section for the
+# expand/contract migration discipline this requires.
+#
+# --local mode — for testing this script itself, or debugging the blue/green
+# flow directly on a host without touching GitHub:
+#
+#   ./scripts/install.sh --local [tag]
+#
+# Skips step 1 entirely (uses whatever's already on disk — e.g. your working
+# tree when run from a repo checkout) and builds images from local source
+# (`docker compose build`) instead of pulling from the registry, so the whole
+# flow runs against your uncommitted changes with no network access to GitHub or
+# the registry required. [tag] defaults to "local" and, unlike remote mode, is
+# never used to skip an already-current deploy — local mode always runs the full
+# switch, since re-testing the same tag is the point.
+#
+# Day-2 ops (status / restart-workers / rollback) are NOT here — this script is
+# only for installing or upgrading. See scripts/sourcelensctl.sh, which this
+# script installs/refreshes alongside itself (see ASSETS below) so it's always
+# available once install.sh has run at least once.
+set -euo pipefail
+
+REPO="HyperBDR/sourcelens"
+# Must match docker-compose.yml's `image:` lines — used only to prune old
+# version tags after a remote deploy (see prune_old_image_tags below).
+API_IMAGE_REPO="oneprocloud/sourcelens-backend"
+UI_IMAGE_REPO="oneprocloud/sourcelens-frontend"
+# Image LABEL used for the "already on this version, skip" check (see below).
+VERSION_LABEL="com.oneprocloud.sourcelens.version"
+
+LOCAL_MODE=false
+if [ "${1:-}" = "--local" ]; then
+    LOCAL_MODE=true
+    shift
+fi
+
+if [ "$LOCAL_MODE" = "true" ]; then
+    GIT_REF="${1:-local}"
+else
+    GIT_REF="${1:?Usage: install.sh <git-tag-or-ref>, e.g. install.sh v1.2.3 (or: install.sh --local [tag] to test against local files)}"
+fi
+IMAGE_TAG="${GIT_REF#v}"  # docker/metadata-action strips the leading 'v'
+DEPLOY_PATH="${DEPLOY_PATH:-$(pwd)}"
+POST_SWITCH_OBSERVE_SECONDS="${POST_SWITCH_OBSERVE_SECONDS:-30}"
+# GRACE_HEALTH_RETRIES/GRACE_HEALTH_INTERVAL are declared in
+# scripts/lib/deploy-common.sh, sourced below once bootstrap_runtime_state
+# guarantees it's present.
+
+log() { echo -e "\033[1;36m[install]\033[0m $*"; }
+die() { echo -e "\033[1;31m[install] ERROR:\033[0m $*" >&2; exit 1; }
+
+cd "$DEPLOY_PATH"
+
+# --- Single-flight lock: refuses to run two deploys at once on one host ---
+LOCK_FILE="/tmp/sourcelens-install.lock"
+MAX_WAIT=300; WAITED=0
+while [ -f "$LOCK_FILE" ] && [ "$WAITED" -lt "$MAX_WAIT" ]; do
+    log "Another install is running (lock: $LOCK_FILE), waiting... (${WAITED}s)"
+    sleep 5; WAITED=$((WAITED + 5))
+done
+echo "$$ $(date)" > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+# --- Load host secrets if present (never fetched, never committed) ---
+if [ -f "$DEPLOY_PATH/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$DEPLOY_PATH/.env"
+    set +a
+fi
+
+AUTH_HEADER=()
+if [ -n "${DEPLOY_GITHUB_TOKEN:-}" ]; then
+    AUTH_HEADER=(-H "Authorization: token ${DEPLOY_GITHUB_TOKEN}")
+fi
+
+# --- Step 1: fetch declarative assets fresh from the target ref ---------
+# Directory listing isn't a thing on raw.githubusercontent.com, so
+# docker/postgresql/initdb.d/*'s file names are spelled out explicitly. Adding a
+# new initdb script means adding a line here too.
+ASSETS=(
+    docker-compose.yml
+    docker/nginx/conf.d/default.conf
+    docker/nginx/upstream.conf.default
+    docker/nginx/certs/README.md
+    docker/postgresql/etc/postgresql.conf
+    docker/postgresql/initdb.d/000-create-databases.sql
+    docker/postgresql/initdb.d/001-grant-schema-privileges.sh
+    docker/postgresql/initdb.d/002-setup-log-permissions.sh
+    env.sample
+    scripts/install.sh
+    scripts/sourcelensctl.sh
+    scripts/lib/deploy-common.sh
+)
+
+fetch_asset() {
+    local path="$1"
+    local dest="$DEPLOY_PATH/$path"
+    mkdir -p "$(dirname "$dest")"
+    # Atomic replace: curl writes to a temp file, then `mv` (rename) swaps it in.
+    # This file may be scripts/install.sh itself — the currently-running process
+    # keeps reading its already-open fd's old content until it exits, so this is
+    # safe even for self-update. (A plain `curl -o "$dest"` truncates in place
+    # instead and would risk corrupting a script reading itself mid-run.)
+    curl -fsSL "${AUTH_HEADER[@]}" \
+        "https://raw.githubusercontent.com/${REPO}/${GIT_REF}/${path}" \
+        -o "${dest}.tmp"
+    mv "${dest}.tmp" "$dest"
+    # curl's temp file gets default (non-executable) permissions, and `mv`
+    # preserves whatever it was — so every fetch would silently strip +x off
+    # these scripts. The documented upgrade path is `./scripts/install.sh <tag>`
+    # (no outer re-curl), so whatever this run leaves on disk is exactly what the
+    # next invocation depends on — re-chmod the scripts here.
+    case "$path" in
+        scripts/install.sh|scripts/sourcelensctl.sh|scripts/lib/deploy-common.sh)
+            chmod +x "$dest"
+            ;;
+    esac
+}
+
+if [ "$LOCAL_MODE" = "true" ]; then
+    log "Local mode: using files already in $DEPLOY_PATH, skipping remote fetch"
+else
+    log "Fetching deploy assets at ${GIT_REF}..."
+    for path in "${ASSETS[@]}"; do
+        fetch_asset "$path"
+    done
+    log "Fetched ${#ASSETS[@]} file(s) into $DEPLOY_PATH"
+fi
+
+# --- First-run stop: need real secrets before starting anything ---------
+if [ ! -f "$DEPLOY_PATH/.env" ]; then
+    if [ -f "$DEPLOY_PATH/env.sample" ]; then
+        cp "$DEPLOY_PATH/env.sample" "$DEPLOY_PATH/.env"
+        chmod 600 "$DEPLOY_PATH/.env"
+        log "No .env found — seeded one from env.sample at $DEPLOY_PATH/.env"
+    fi
+    die "Edit $DEPLOY_PATH/.env with real secrets (DB password, SECRET_KEY, ...), then re-run this command."
+fi
+
+# --- Step 2: bootstrap runtime state (only if missing, never overwritten) -
+bootstrap_runtime_state() {
+    # Lives at docker/nginx/conf.d/upstream.conf — inside the directory nginx
+    # bind-mounts as a whole (see docker-compose.yml's nginx volumes comment for
+    # why it can't be its own single-file mount).
+    mkdir -p "$DEPLOY_PATH/docker/nginx/conf.d"
+    if [ ! -f "$DEPLOY_PATH/docker/nginx/conf.d/upstream.conf" ]; then
+        log "No upstream.conf yet — initializing from template (color: blue)"
+        cp "$DEPLOY_PATH/docker/nginx/upstream.conf.default" \
+            "$DEPLOY_PATH/docker/nginx/conf.d/upstream.conf"
+    fi
+
+    if [ ! -f "$DEPLOY_PATH/.active_color" ]; then
+        log "No .active_color yet — defaulting to blue"
+        echo "blue" > "$DEPLOY_PATH/.active_color"
+    fi
+
+    local cert_dir="$DEPLOY_PATH/docker/nginx/certs"
+    if [ ! -f "$cert_dir/nginx-selfsigned.crt" ] || [ ! -f "$cert_dir/nginx-selfsigned.key" ]; then
+        log "No TLS certificate found — generating a self-signed one"
+        log "(harmless no-op if you terminate TLS externally, e.g. Nginx Proxy Manager)"
+        mkdir -p "$cert_dir"
+        docker run --rm -v "$cert_dir:/certs" alpine/openssl req -x509 \
+            -newkey rsa:2048 -nodes -days 3650 \
+            -keyout /certs/nginx-selfsigned.key \
+            -out /certs/nginx-selfsigned.crt \
+            -subj "/CN=${DOMAIN:-localhost}" \
+            -addext "subjectAltName=DNS:${DOMAIN:-localhost},DNS:*.localhost,IP:127.0.0.1"
+    fi
+}
+bootstrap_runtime_state
+
+# Sourced only now — guaranteed present by this point, either just fetched above
+# (remote mode) or already on disk (--local). Provides
+# current_color/other_color/wait_for_healthy/switch_traffic, shared with
+# scripts/sourcelensctl.sh (day-2 ops: status/restart-workers/rollback —
+# deliberately a separate script, not more subcommands bolted onto this one; see
+# CLAUDE.md's "零停机部署" section for why).
+# shellcheck source=./lib/deploy-common.sh
+source "$DEPLOY_PATH/scripts/lib/deploy-common.sh"
+
+log "Ensuring postgresql/redis are up..."
+docker compose up -d postgresql redis
+
+CURRENT_COLOR="$(current_color)"
+NEXT_COLOR="$(other_color "$CURRENT_COLOR")"
+
+# First install ever (nothing running yet) is a genuinely different case from a
+# normal upgrade, not just "the idle color happens to be empty": there's no old
+# color serving traffic to health-gate against or retire, so DEPLOY_COLOR is
+# CURRENT_COLOR itself (always "blue", from bootstrap_runtime_state's default)
+# rather than NEXT_COLOR.
+FIRST_INSTALL=false
+if [ "$(docker inspect -f '{{.State.Running}}' "sourcelens-api-${CURRENT_COLOR}" 2>/dev/null)" != "true" ]; then
+    FIRST_INSTALL=true
+    DEPLOY_COLOR="$CURRENT_COLOR"
+    log "sourcelens-api-${CURRENT_COLOR} isn't running — first install, deploying directly to ${DEPLOY_COLOR} (nothing to switch from or retire)"
+else
+    DEPLOY_COLOR="$NEXT_COLOR"
+    log "Current color: $CURRENT_COLOR, deploying to: $DEPLOY_COLOR"
+fi
+
+# --- Skip if the currently-active color is already this version ---------
+# Only meaningful for a normal upgrade: not in local mode (re-running against the
+# same "local" tag to pick up uncommitted changes is the point) and not on first
+# install (nothing to compare against yet). Best-effort: if the image carries no
+# version LABEL the reading falls back to 0.0.0 and never skips.
+if [ "$LOCAL_MODE" != "true" ] && [ "$FIRST_INSTALL" != "true" ]; then
+    CURRENT_VERSION=$(docker inspect \
+        --format="{{index .Config.Labels \"${VERSION_LABEL}\"}}" \
+        "sourcelens-api-${CURRENT_COLOR}" 2>/dev/null || echo "0.0.0")
+    [ -z "$CURRENT_VERSION" ] && CURRENT_VERSION="0.0.0"
+    if [ "$(printf '%s\n%s\n' "$CURRENT_VERSION" "$IMAGE_TAG" | sort -V | tail -1)" != "$IMAGE_TAG" ]; then
+        log "SKIP: sourcelens-api-${CURRENT_COLOR} already running $CURRENT_VERSION >= target $IMAGE_TAG"
+        exit 0
+    fi
+fi
+
+export APP_VERSION="$IMAGE_TAG"
+
+# In local mode, build from the working tree instead of pulling a registry
+# image — that's the only way local, uncommitted changes end up in the
+# container. `docker compose build` is cheap to re-run (layer cache), so this
+# stays fast on repeat local iterations too.
+sync_images() {
+    if [ "$LOCAL_MODE" = "true" ]; then
+        log "Building locally: $*"
+        docker compose build "$@"
+    else
+        log "Pulling: $*"
+        docker compose pull "$@"
+    fi
+}
+
+# --- Sync images for the deploy color -----------------------------------
+sync_images "sourcelens-api-${DEPLOY_COLOR}" "sourcelens-ui-${DEPLOY_COLOR}"
+
+# --- Bring up the deploy color (its startup runs migrate/collectstatic) --
+if [ "$FIRST_INSTALL" != "true" ]; then
+    log "Reminder: migrations in this release must be expand/contract-safe —"
+    log "the outgoing color keeps serving traffic against the post-migration schema"
+    log "for a short window until it's retired below."
+fi
+log "Starting sourcelens-api-${DEPLOY_COLOR} / sourcelens-ui-${DEPLOY_COLOR}..."
+docker compose --profile "$DEPLOY_COLOR" up -d \
+    "sourcelens-api-${DEPLOY_COLOR}" "sourcelens-ui-${DEPLOY_COLOR}"
+
+# --- Health-gate before touching any traffic ---------------------------
+log "Waiting for sourcelens-api-${DEPLOY_COLOR} to report healthy..."
+if ! wait_for_healthy "sourcelens-api-${DEPLOY_COLOR}"; then
+    log "Health check timed out"
+    docker compose --profile "$DEPLOY_COLOR" stop \
+        "sourcelens-api-${DEPLOY_COLOR}" "sourcelens-ui-${DEPLOY_COLOR}"
+    if [ "$FIRST_INSTALL" = "true" ]; then
+        die "sourcelens-api-${DEPLOY_COLOR} never became healthy; first install aborted"
+    fi
+    die "sourcelens-api-${DEPLOY_COLOR} never became healthy; deploy aborted, nothing switched, $CURRENT_COLOR stays live"
+fi
+log "sourcelens-api-${DEPLOY_COLOR} is healthy"
+
+# Always ensure nginx is actually running before doing anything that touches it.
+# `switch_traffic` does `docker exec sourcelens-nginx ...`, which fails outright
+# if nginx isn't running (crashed, manually stopped, or left half-started from a
+# previous failed deploy); on a normal host nginx has been running continuously
+# since the last deploy, so this is a no-op `up -d` in the common case.
+docker compose up -d nginx
+
+if [ "$FIRST_INSTALL" = "true" ]; then
+    # upstream.conf's bootstrap template already points at blue (== DEPLOY_COLOR
+    # here), so nginx starts straight into serving it — no switch, nothing to
+    # retire.
+    log "First install: nginx started serving sourcelens-api-${DEPLOY_COLOR} directly"
+else
+    # --- Switch traffic: rewrite upstream.conf, validate, reload ---------
+    switch_traffic "$CURRENT_COLOR" "$DEPLOY_COLOR"
+
+    log "Observing for ${POST_SWITCH_OBSERVE_SECONDS}s before retiring ${CURRENT_COLOR}..."
+    sleep "$POST_SWITCH_OBSERVE_SECONDS"
+
+    # --- Retire the previously-active color -------------------------------
+    log "Stopping sourcelens-api-${CURRENT_COLOR} / sourcelens-ui-${CURRENT_COLOR}"
+    docker compose --profile "$CURRENT_COLOR" stop \
+        "sourcelens-api-${CURRENT_COLOR}" "sourcelens-ui-${CURRENT_COLOR}"
+    docker compose --profile "$CURRENT_COLOR" rm -f \
+        "sourcelens-api-${CURRENT_COLOR}" "sourcelens-ui-${CURRENT_COLOR}"
+fi
+
+echo "$DEPLOY_COLOR" > "$DEPLOY_PATH/.active_color"
+
+# --- Worker/scheduler/lensnode: no blue/green, just a rolling restart ----
+# CELERY_TASK_ACKS_LATE + prefetch + stop_grace_period already make `up -d` here
+# a graceful drain-and-replace, not a hard kill. lensnode reconnects to the new
+# active color through nginx on its own.
+log "Rolling backend-worker / backend-scheduler / lensnode to ${IMAGE_TAG}..."
+sync_images backend-worker backend-scheduler lensnode
+docker compose up -d backend-worker backend-scheduler lensnode
+
+# --- Prune old version tags (remote mode only — --local only ever has a
+# single "local"-ish tag, nothing to prune) ------------------------------
+# Every deploy pulls a new version tag and never removes the old one, so without
+# this, disk fills with retired versions until `docker compose pull`/`build`
+# starts failing with "no space left on device". Keeps the 2 most recent version
+# tags (current + one rollback target) plus `latest`, removes everything else.
+prune_old_image_tags() {
+    local repo="$1"
+    docker images "$repo" --format "{{.Tag}}" \
+        | grep -vE '^latest$' | sort -rV | tail -n +3 \
+        | while read -r tag; do
+            docker rmi "${repo}:${tag}" >/dev/null 2>&1 \
+                && log "Pruned old image: ${repo}:${tag}"
+        done
+}
+if [ "$LOCAL_MODE" != "true" ]; then
+    prune_old_image_tags "$API_IMAGE_REPO"
+    prune_old_image_tags "$UI_IMAGE_REPO"
+    docker image prune -f >/dev/null
+fi
+
+log "Deploy complete: ${GIT_REF} (active color: ${DEPLOY_COLOR})"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,8 +49,8 @@ REPO="HyperBDR/sourcelens"
 # version tags after a remote deploy (see prune_old_image_tags below).
 API_IMAGE_REPO="oneprocloud/sourcelens-backend"
 UI_IMAGE_REPO="oneprocloud/sourcelens-frontend"
-# Image LABEL used for the "already on this version, skip" check (see below).
-VERSION_LABEL="com.oneprocloud.sourcelens.version"
+# VERSION_LABEL / color_image_version() come from scripts/lib/deploy-common.sh
+# (sourced below, before either is used).
 
 LOCAL_MODE=false
 if [ "${1:-}" = "--local" ]; then
@@ -76,13 +76,23 @@ die() { echo -e "\033[1;31m[install] ERROR:\033[0m $*" >&2; exit 1; }
 cd "$DEPLOY_PATH"
 
 # --- Single-flight lock: refuses to run two deploys at once on one host ---
+# Acquire atomically with `set -o noclobber` (the redirect fails instead of
+# truncating when the file already exists), so two installs starting at the same
+# instant can't both pass a `[ -f ]` check and proceed — a real TOCTOU race
+# given the CI concurrency group isn't the only caller (manual runs, ops
+# commands). After MAX_WAIT we take the lock over anyway (a crashed run may have
+# left a stale file).
 LOCK_FILE="/tmp/sourcelens-install.lock"
 MAX_WAIT=300; WAITED=0
-while [ -f "$LOCK_FILE" ] && [ "$WAITED" -lt "$MAX_WAIT" ]; do
+while ! (set -o noclobber; echo "$$ $(date)" > "$LOCK_FILE") 2>/dev/null; do
+    if [ "$WAITED" -ge "$MAX_WAIT" ]; then
+        log "Lock $LOCK_FILE still held after ${MAX_WAIT}s — taking it over"
+        echo "$$ $(date)" > "$LOCK_FILE"
+        break
+    fi
     log "Another install is running (lock: $LOCK_FILE), waiting... (${WAITED}s)"
     sleep 5; WAITED=$((WAITED + 5))
 done
-echo "$$ $(date)" > "$LOCK_FILE"
 trap 'rm -f "$LOCK_FILE"' EXIT
 
 # --- Load host secrets if present (never fetched, never committed) ---
@@ -230,11 +240,15 @@ fi
 # install (nothing to compare against yet). Best-effort: if the image carries no
 # version LABEL the reading falls back to 0.0.0 and never skips.
 if [ "$LOCAL_MODE" != "true" ] && [ "$FIRST_INSTALL" != "true" ]; then
-    CURRENT_VERSION=$(docker inspect \
-        --format="{{index .Config.Labels \"${VERSION_LABEL}\"}}" \
-        "sourcelens-api-${CURRENT_COLOR}" 2>/dev/null || echo "0.0.0")
+    CURRENT_VERSION=$(color_image_version "$CURRENT_COLOR")
     [ -z "$CURRENT_VERSION" ] && CURRENT_VERSION="0.0.0"
-    if [ "$(printf '%s\n%s\n' "$CURRENT_VERSION" "$IMAGE_TAG" | sort -V | tail -1)" != "$IMAGE_TAG" ]; then
+    # Skip when the live version is already >= target: equal (idempotent
+    # re-deploy of the same tag) OR strictly newer (current is the max and
+    # differs from target). The equal case needs the explicit first clause —
+    # `sort -V | tail -1` returns target when they're equal, so the `!=` guard
+    # alone would never no-op an equal re-deploy despite the ">=" wording.
+    if [ "$CURRENT_VERSION" = "$IMAGE_TAG" ] || \
+        [ "$(printf '%s\n%s\n' "$CURRENT_VERSION" "$IMAGE_TAG" | sort -V | tail -1)" != "$IMAGE_TAG" ]; then
         log "SKIP: sourcelens-api-${CURRENT_COLOR} already running $CURRENT_VERSION >= target $IMAGE_TAG"
         exit 0
     fi
@@ -294,9 +308,24 @@ if [ "$FIRST_INSTALL" = "true" ]; then
     # here), so nginx starts straight into serving it — no switch, nothing to
     # retire.
     log "First install: nginx started serving sourcelens-api-${DEPLOY_COLOR} directly"
+    echo "$DEPLOY_COLOR" > "$DEPLOY_PATH/.active_color"
 else
     # --- Switch traffic: rewrite upstream.conf, validate, reload ---------
     switch_traffic "$CURRENT_COLOR" "$DEPLOY_COLOR"
+
+    # Record the now-live color immediately — BEFORE the observe/retire window.
+    # If the run is interrupted after the switch but before this write,
+    # .active_color must already match what nginx serves, or a later
+    # sourcelensctl.sh rollback would compute the wrong target.
+    echo "$DEPLOY_COLOR" > "$DEPLOY_PATH/.active_color"
+
+    # Record the outgoing color's version so rollback can recreate it from the
+    # RIGHT image (its container is about to be removed; the version-tagged
+    # image is still in the local cache). Read while it's still running.
+    OUTGOING_VERSION="$(color_image_version "$CURRENT_COLOR")"
+    if [ -n "$OUTGOING_VERSION" ]; then
+        echo "$OUTGOING_VERSION" > "$DEPLOY_PATH/.rollback_version"
+    fi
 
     log "Observing for ${POST_SWITCH_OBSERVE_SECONDS}s before retiring ${CURRENT_COLOR}..."
     sleep "$POST_SWITCH_OBSERVE_SECONDS"
@@ -308,8 +337,6 @@ else
     docker compose --profile "$CURRENT_COLOR" rm -f \
         "sourcelens-api-${CURRENT_COLOR}" "sourcelens-ui-${CURRENT_COLOR}"
 fi
-
-echo "$DEPLOY_COLOR" > "$DEPLOY_PATH/.active_color"
 
 # --- Worker/scheduler/lensnode: no blue/green, just a rolling restart ----
 # CELERY_TASK_ACKS_LATE + prefetch + stop_grace_period already make `up -d` here
@@ -327,12 +354,15 @@ docker compose up -d backend-worker backend-scheduler lensnode
 # tags (current + one rollback target) plus `latest`, removes everything else.
 prune_old_image_tags() {
     local repo="$1"
+    # `|| true`: when a repo has no non-`latest` tag, `grep` exits 1 and (under
+    # `set -o pipefail`) fails the whole pipeline, which with `set -e` would
+    # abort the script right after an otherwise-successful deploy.
     docker images "$repo" --format "{{.Tag}}" \
         | grep -vE '^latest$' | sort -rV | tail -n +3 \
         | while read -r tag; do
             docker rmi "${repo}:${tag}" >/dev/null 2>&1 \
                 && log "Pruned old image: ${repo}:${tag}"
-        done
+        done || true
 }
 if [ "$LOCAL_MODE" != "true" ]; then
     prune_old_image_tags "$API_IMAGE_REPO"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -338,6 +338,14 @@ else
         "sourcelens-api-${CURRENT_COLOR}" "sourcelens-ui-${CURRENT_COLOR}"
 fi
 
+# One-time cleanup of the legacy pre-blue/green single containers, if present.
+# Migrating a host from the old single-container deploy (service backend-api /
+# frontend, containers sourcelens-api / sourcelens-ui) to blue/green leaves those
+# old containers running as orphans — they are not part of this compose's
+# services, so `up` never touches them and they keep holding a DB connection and
+# memory. Retire them here. No-op once the host is already on blue/green.
+docker rm -f sourcelens-api sourcelens-ui >/dev/null 2>&1 || true
+
 # --- Worker/scheduler/lensnode: no blue/green, just a rolling restart ----
 # CELERY_TASK_ACKS_LATE + prefetch + stop_grace_period already make `up -d` here
 # a graceful drain-and-replace, not a hard kill. lensnode reconnects to the new

--- a/scripts/lib/deploy-common.sh
+++ b/scripts/lib/deploy-common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Shared blue/green helpers for scripts/install.sh and
+# scripts/sourcelensctl.sh. Not meant to be run directly — source it after the
+# caller has already set DEPLOY_PATH, cd'd into it, and defined log()/die()
+# (this file intentionally doesn't define its own, or a lock helper — those are
+# needed before this file is guaranteed to exist on a brand-new host, see
+# install.sh's own bootstrap-ordering comment, so they stay duplicated inline in
+# both scripts instead of being shared here).
+#
+# Installed/refreshed by install.sh like every other deploy asset (it's in
+# install.sh's ASSETS list) — always present once install.sh has run at least
+# once, which sourcelensctl.sh assumes.
+
+GRACE_HEALTH_RETRIES="${GRACE_HEALTH_RETRIES:-40}"
+GRACE_HEALTH_INTERVAL="${GRACE_HEALTH_INTERVAL:-3}"
+
+current_color() {
+    cat "$DEPLOY_PATH/.active_color" 2>/dev/null || echo "blue"
+}
+
+other_color() {
+    [ "$1" = "green" ] && echo "blue" || echo "green"
+}
+
+# Polls a container's /health endpoint. Returns 0 once healthy, 1 on timeout —
+# never raises, callers decide what to do on failure.
+wait_for_healthy() {
+    local container="$1"
+    local i
+    for i in $(seq 1 "$GRACE_HEALTH_RETRIES"); do
+        if docker exec "$container" \
+            curl -fs http://127.0.0.1:8000/health >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep "$GRACE_HEALTH_INTERVAL"
+    done
+    return 1
+}
+
+# Flips nginx's upstream from color $1 to color $2, validates, reloads. Does not
+# touch .active_color or start/stop any container — callers own that
+# (install.sh's full deploy and sourcelensctl.sh's rollback both call this the
+# same way, only what happens before/after it differs).
+switch_traffic() {
+    local from="$1" to="$2"
+    log "Switching nginx upstream: ${from} -> ${to}"
+    sed -i \
+        -e "s/sourcelens-api-${from}/sourcelens-api-${to}/" \
+        -e "s/sourcelens-ui-${from}/sourcelens-ui-${to}/" \
+        "$DEPLOY_PATH/docker/nginx/conf.d/upstream.conf"
+    docker exec sourcelens-nginx nginx -t
+    docker exec sourcelens-nginx nginx -s reload
+    log "Traffic switched to ${to}"
+}

--- a/scripts/lib/deploy-common.sh
+++ b/scripts/lib/deploy-common.sh
@@ -14,6 +14,19 @@
 GRACE_HEALTH_RETRIES="${GRACE_HEALTH_RETRIES:-40}"
 GRACE_HEALTH_INTERVAL="${GRACE_HEALTH_INTERVAL:-3}"
 
+# Image LABEL (stamped by the Dockerfiles from the APP_VERSION build arg) used
+# by install.sh's version-skip check and by sourcelensctl.sh's rollback to
+# recreate a color from the right image version.
+VERSION_LABEL="com.oneprocloud.sourcelens.version"
+
+# Read the release version stamped on a color's running API container, or empty
+# if the container/label is absent.
+color_image_version() {
+    docker inspect \
+        --format="{{index .Config.Labels \"${VERSION_LABEL}\"}}" \
+        "sourcelens-api-$1" 2>/dev/null || echo ""
+}
+
 current_color() {
     cat "$DEPLOY_PATH/.active_color" 2>/dev/null || echo "blue"
 }

--- a/scripts/sourcelensctl.sh
+++ b/scripts/sourcelensctl.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Day-2 operations for an already-installed sourcelens — status, restarting
+# services, rolling back a blue/green switch. NOT for installing or upgrading to
+# a new version — that's scripts/install.sh. Deliberately a separate script
+# rather than more subcommands on install.sh: "install a new version" and
+# "operate on what's already running" have different risk profiles and don't
+# belong behind the same entrypoint.
+#
+# Installed/refreshed automatically every time install.sh runs (it's in
+# install.sh's ASSETS list) — no separate curl needed once install.sh has run at
+# least once on this host.
+#
+#   ./scripts/sourcelensctl.sh status            # active color + health + which containers are up
+#   ./scripts/sourcelensctl.sh restart-workers   # graceful restart, no image pull, no color switch
+#   ./scripts/sourcelensctl.sh rollback          # flip traffic back to the other color, no pull/build/migrate
+set -euo pipefail
+
+DEPLOY_PATH="${DEPLOY_PATH:-$(pwd)}"
+cd "$DEPLOY_PATH"
+
+log() { echo -e "\033[1;36m[sourcelensctl]\033[0m $*"; }
+die() { echo -e "\033[1;31m[sourcelensctl] ERROR:\033[0m $*" >&2; exit 1; }
+
+# --- Single-flight lock: shared with install.sh's lock file, so an ops command
+# can't race a deploy (or another ops command) in flight.
+acquire_deploy_lock() {
+    local lock_file="/tmp/sourcelens-install.lock"
+    local max_wait=300 waited=0
+    while [ -f "$lock_file" ] && [ "$waited" -lt "$max_wait" ]; do
+        log "install.sh (or another ops command) is running, waiting... (${waited}s)"
+        sleep 5; waited=$((waited + 5))
+    done
+    echo "$$ $(date)" > "$lock_file"
+    trap 'rm -f "'"$lock_file"'"' EXIT
+}
+
+[ -f "$DEPLOY_PATH/scripts/lib/deploy-common.sh" ] || die "scripts/lib/deploy-common.sh not found — run scripts/install.sh at least once first"
+# shellcheck source=./lib/deploy-common.sh
+source "$DEPLOY_PATH/scripts/lib/deploy-common.sh"
+
+if [ -f "$DEPLOY_PATH/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$DEPLOY_PATH/.env"
+    set +a
+fi
+
+cmd_status() {
+    local color; color="$(current_color)"
+    log "Active color: $color"
+    echo
+    docker compose ps \
+        "sourcelens-api-${color}" "sourcelens-ui-${color}" \
+        backend-worker backend-scheduler lensnode nginx \
+        2>/dev/null || true
+    echo
+    if docker exec "sourcelens-api-${color}" \
+        curl -fs http://127.0.0.1:8000/health >/dev/null 2>&1; then
+        log "sourcelens-api-${color} (active): healthy"
+    else
+        log "sourcelens-api-${color} (active): NOT healthy"
+    fi
+}
+
+cmd_restart_workers() {
+    acquire_deploy_lock
+    log "Restarting backend-worker / backend-scheduler / lensnode"
+    log "(graceful: CELERY_TASK_ACKS_LATE + stop_grace_period mean in-flight"
+    log "tasks finish before the old process exits, not a hard kill)"
+    docker compose restart backend-worker backend-scheduler lensnode
+    log "Done"
+}
+
+cmd_rollback() {
+    acquire_deploy_lock
+    local active target
+    active="$(current_color)"
+    target="$(other_color "$active")"
+    log "Active color is ${active}; rolling back to ${target}"
+    log "(no pull, no build, no migration — this only works if"
+    log "sourcelens-api-${target}'s image is still present locally)"
+
+    if ! docker compose --profile "$target" up -d \
+        "sourcelens-api-${target}" "sourcelens-ui-${target}"; then
+        die "Could not start sourcelens-api-${target}/sourcelens-ui-${target}. If that color's image was pruned, rollback isn't possible this way — redeploy the target version instead: ./scripts/install.sh <tag>"
+    fi
+
+    log "Waiting for sourcelens-api-${target} to report healthy..."
+    if ! wait_for_healthy "sourcelens-api-${target}"; then
+        docker compose --profile "$target" stop \
+            "sourcelens-api-${target}" "sourcelens-ui-${target}"
+        die "sourcelens-api-${target} never became healthy; rollback aborted, ${active} stays live"
+    fi
+
+    switch_traffic "$active" "$target"
+    echo "$target" > "$DEPLOY_PATH/.active_color"
+
+    log "Rolled back: active color is now ${target}."
+    log "${active} was left running (not stopped) so you can inspect its logs."
+    log "Once you've confirmed ${target} is good, retire it yourself:"
+    log "  docker compose --profile ${active} stop sourcelens-api-${active} sourcelens-ui-${active}"
+    log "  docker compose --profile ${active} rm -f sourcelens-api-${active} sourcelens-ui-${active}"
+}
+
+case "${1:-}" in
+    status) cmd_status ;;
+    restart-workers) cmd_restart_workers ;;
+    rollback) cmd_rollback ;;
+    *) die "Usage: $0 {status|restart-workers|rollback}" ;;
+esac

--- a/scripts/sourcelensctl.sh
+++ b/scripts/sourcelensctl.sh
@@ -26,11 +26,17 @@ die() { echo -e "\033[1;31m[sourcelensctl] ERROR:\033[0m $*" >&2; exit 1; }
 acquire_deploy_lock() {
     local lock_file="/tmp/sourcelens-install.lock"
     local max_wait=300 waited=0
-    while [ -f "$lock_file" ] && [ "$waited" -lt "$max_wait" ]; do
+    # Atomic acquire via noclobber (see install.sh for why a `[ -f ]` check is a
+    # TOCTOU race); take over a stale lock after max_wait.
+    while ! (set -o noclobber; echo "$$ $(date)" > "$lock_file") 2>/dev/null; do
+        if [ "$waited" -ge "$max_wait" ]; then
+            log "Lock $lock_file still held after ${max_wait}s — taking it over"
+            echo "$$ $(date)" > "$lock_file"
+            break
+        fi
         log "install.sh (or another ops command) is running, waiting... (${waited}s)"
         sleep 5; waited=$((waited + 5))
     done
-    echo "$$ $(date)" > "$lock_file"
     trap 'rm -f "'"$lock_file"'"' EXIT
 }
 
@@ -73,16 +79,36 @@ cmd_restart_workers() {
 
 cmd_rollback() {
     acquire_deploy_lock
-    local active target
+    local active target rollback_version from_version
     active="$(current_color)"
     target="$(other_color "$active")"
-    log "Active color is ${active}; rolling back to ${target}"
+
+    # The target color's container was removed when it was retired, so `up -d`
+    # recreates it from the compose image ref `...:${APP_VERSION:-latest}`. Left
+    # unset, that resolves to `latest` = the CURRENT (being-rolled-back-from)
+    # release, so rollback would silently redeploy the bad version on the other
+    # color. Pin APP_VERSION to the version install.sh recorded when it retired
+    # that color.
+    rollback_version=""
+    if [ -f "$DEPLOY_PATH/.rollback_version" ]; then
+        rollback_version="$(cat "$DEPLOY_PATH/.rollback_version")"
+    fi
+    if [ -z "$rollback_version" ]; then
+        die "No .rollback_version recorded (need at least one prior upgrade on this host) — can't tell which image to roll back to. Redeploy the target version explicitly: ./scripts/install.sh <tag>"
+    fi
+    export APP_VERSION="$rollback_version"
+
+    # Remember the version we're rolling back FROM so a subsequent rollback can
+    # return to it (read now, while the active color is still up).
+    from_version="$(color_image_version "$active")"
+
+    log "Active color is ${active}; rolling back to ${target} (version ${rollback_version})"
     log "(no pull, no build, no migration — this only works if"
-    log "sourcelens-api-${target}'s image is still present locally)"
+    log "sourcelens-api-${target}'s image ${rollback_version} is still present locally)"
 
     if ! docker compose --profile "$target" up -d \
         "sourcelens-api-${target}" "sourcelens-ui-${target}"; then
-        die "Could not start sourcelens-api-${target}/sourcelens-ui-${target}. If that color's image was pruned, rollback isn't possible this way — redeploy the target version instead: ./scripts/install.sh <tag>"
+        die "Could not start sourcelens-api-${target}/sourcelens-ui-${target}. If that color's image ${rollback_version} was pruned, rollback isn't possible this way — redeploy the target version instead: ./scripts/install.sh <tag>"
     fi
 
     log "Waiting for sourcelens-api-${target} to report healthy..."
@@ -94,8 +120,11 @@ cmd_rollback() {
 
     switch_traffic "$active" "$target"
     echo "$target" > "$DEPLOY_PATH/.active_color"
+    if [ -n "$from_version" ]; then
+        echo "$from_version" > "$DEPLOY_PATH/.rollback_version"
+    fi
 
-    log "Rolled back: active color is now ${target}."
+    log "Rolled back: active color is now ${target} (version ${rollback_version})."
     log "${active} was left running (not stopped) so you can inspect its logs."
     log "Once you've confirmed ${target} is good, retire it yourself:"
     log "  docker compose --profile ${active} stop sourcelens-api-${active} sourcelens-ui-${active}"


### PR DESCRIPTION
### **User description**
Part 1 of 2 for #6 — **deploy infrastructure**. Ports newshub's single-node blue/green zero-downtime deployment model to sourcelens. PR2 will add the lensnode WebSocket disconnect grace-period (backend) and client outbound-buffer persistence so in-flight lensnode runs survive a switch.

## What this does

No k8s/Swarm. Two API/UI copies ("blue"/"green") run behind nginx, only one ever in the traffic path. An upgrade brings up the idle color, health-gates it, atomically flips nginx (`nginx -s reload`, no dropped requests), observes for a window, then retires the old color. Rollback is just flipping back.

## Changes

- **`docker-compose.yml`** — blue/green profiled `sourcelens-api/ui-{blue,green}` via YAML anchors; worker/scheduler/lensnode/nginx/postgresql/redis stay singleton. Removed every `depends_on: backend-api` (a profiled service referenced by an unprofiled one breaks `docker compose` validation) — `install.sh` owns ordering. nginx bind-mounts the whole `conf.d/` **directory** so a `sed`/rename on `upstream.conf` swaps the inode the container sees (a single-file mount pins a stale inode → 502s).
- **nginx** — moved `default.conf` into `conf.d/`, proxying to named `upstream` blocks (`sourcelens_api_active` / `sourcelens_ui_active`) instead of the old `set $api_upstream` variable + resolver. Added committed `upstream.conf.default` template; runtime `upstream.conf` + `.active_color` are gitignored.
- **`scripts/`** — `install.sh` (one idempotent command: fetch assets from the ref, bootstrap runtime state, health-gated switch, observation window, safe first-install path, `--local` test mode, best-effort version-skip via image LABEL, single-flight lock, image pruning), `sourcelensctl.sh` (`status` / `restart-workers` / `rollback` — rollback needs no rebuild), and shared `lib/deploy-common.sh` helpers.
- **lensnode → nginx** — `LENSNODE_SERVER_URL=http://nginx:80` plus nginx-based control-WS / AI-gateway URLs in `env.sample`, so lensnode always reaches the active color and rides a switch by reconnecting.
- **Dockerfile / frontend/Dockerfile** — stamp `com.oneprocloud.sourcelens.version` LABEL from an `APP_VERSION` build arg for the version-skip check.
- **CI** — the deploy job bootstraps and runs `install.sh` on the host instead of SCP + `compose pull/up`.
- **AGENTS.md** — documents the blue/green model, the nginx directory-mount gotcha, and the **expand/contract migration discipline** required (the outgoing color serves traffic against the post-migration schema during the observe window).

## Verification

Ran end-to-end on an isolated compose project (`COMPOSE_PROJECT_NAME=sourcelens-bg`, prebuilt `:latest` images), fully isolated from the running dev stack:

- First-install bring-up: bootstraps `upstream.conf`/`.active_color`/cert, blue healthy, nginx serves it (`/health`, UI both 200).
- **Zero-downtime switch**: hammered `/health` through nginx while `switch_traffic` flipped blue↔green — **600/600 requests stayed 200 across the `nginx -s reload`**.
- `sourcelensctl.sh status` shows the active color healthy; `rollback` flips traffic to the other color with no rebuild; `.active_color` + `upstream.conf` update correctly.
- `docker compose config` parses for both profiles; nginx config passes `nginx -t`; deploy scripts pass `bash -n`.

## Notes

- After this PR, HTTP/UI switches are zero-downtime, but an API switch still fails in-flight lensnode runs on disconnect — **the same failure mode as today's single-container deploy, no regression**. PR2 fixes that.
- No behavioral change is needed in `install.sh`'s use of the default compose project name: a production host only runs this stack. The isolated `COMPOSE_PROJECT_NAME` above was only to test alongside a dev stack sharing the repo directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e8SmX7GC91wx8SpSRDuUQ


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Blue/green zero-downtime deploy infrastructure

- One-command install script with health-gated switch

- nginx upstream map switching via directory mount

- Day-2 ops: status, restart-workers, rollback


___

### Diagram Walkthrough


```mermaid
flowchart LR
    install["install.sh"] --> fetch["Fetch deploy assets"]
    fetch --> bootstrap["Bootstrap runtime state"]
    bootstrap --> switch["Blue/green switch"]
    switch --> health["Health gate"]
    health --> nginx["nginx -s reload"]
    nginx --> observe["Observe window"]
    observe --> retire["Retire old color"]
    retire --> workers["Roll workers/lensnode"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>install.sh</strong><dd><code>one-command install/upgrade script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc">+381/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sourcelensctl.sh</strong><dd><code>day-2 ops: status, restart-workers, rollback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-99b884bd33f41d997a4674e4e3104d0b498fdcb7e6d07135d40f17fbe28fb30a">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>deploy-common.sh</strong><dd><code>shared blue/green helpers (color, health, traffic switch)</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-f84d8a3ec3661adf22c938f2c71bb9d70c325ed20bb2aace869e6e125ae6b630">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build_and_deploy.yml</strong><dd><code>adopt install.sh for blue/green deploy in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-8812abff9ed11e2e98d5066031a3181c6d44b28aea00f0d369532d5cb254650f">+51/-59</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>default.conf</strong><dd><code>proxy to upstream map variables for color switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-f583d11fcce9311b02b20054d21bc42d9c3ce8337322f0f4c66a16f36825f766">+44/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>add version label for install.sh skip check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>add version label for install.sh skip check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>blue-green-deployment.md</strong><dd><code>reusable blue/green deployment playbook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-b04584ccf2811fab42fe33a3c5f7d3e46e40863c597d1f30afd5d1a276e258fe">+288/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong><dd><code>document expand/contract migration discipline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+77/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>docker-compose.yml</strong><dd><code>blue/green profiles for API and UI via YAML anchors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+138/-82</a></td>

</tr>

<tr>
  <td><strong>docker-compose.standalone.yml</strong><dd><code>single-instance production stack without blue/green</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-9ce448f74e566e43c1699bd469713bd9cd36e5f11ffccd6b824cd840f3077228">+243/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>default.standalone.conf</strong><dd><code>nginx config for single-instance standalone deployment</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-e70d78e193559e2316b65e3c1c8dc3eb7f1c1cee3dd060b7019cb63cfa7c42d7">+257/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>upstream.conf.default</strong><dd><code>bootstrap template for runtime upstream.conf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-342c7f713876fe7c922fffd1ee04b98ac49892adcf3cd24d80d4133c52ac96fa">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.sample</strong><dd><code>point lensnode to nginx instead of backend-api</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.dev.yml</strong><dd><code>add explicit project name for dev isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/41/files#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

