### PR TITLE
fix(lens): improve user message layout

### DIFF
--- a/frontend/e2e/chat-message-layout.spec.js
+++ b/frontend/e2e/chat-message-layout.spec.js
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test'
+
+const viewports = [
+  { name: 'desktop', width: 1280, height: 800 },
+  { name: 'mobile', width: 390, height: 844 }
+]
+
+const messages = [
+  {
+    uuid: 'short-message',
+    role: 'user',
+    content: 'Short question',
+    created_at: '2026-07-16T09:00:00Z'
+  },
+  {
+    uuid: 'long-message',
+    role: 'user',
+    content:
+      'First paragraph with a long unbroken value: ' +
+      'x'.repeat(120) +
+      '\n\nSecond paragraph remains inside the same message card.',
+    created_at: '2026-07-16T09:01:00Z'
+  }
+]
+
+async function mockChat(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+    const payloads = {
+      '/api/v1/auth/user': {
+        username: 'tester',
+        features: ['workspace'],
+        permissions: []
+      },
+      '/api/lens/assistants/': [
+        {
+          uuid: 'assistant-1',
+          slug: 'layout-test',
+          name: 'Layout Test',
+          status: 'active'
+        }
+      ],
+      '/api/lens/shares/': [],
+      '/api/lens/sessions/': [
+        {
+          uuid: 'session-1',
+          title: 'Layout test'
+        }
+      ],
+      '/api/lens/sessions/session-1/messages/': messages
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payloads[path] ?? [] })
+    })
+  })
+}
+
+for (const viewport of viewports) {
+  test(`user messages use a contained, left-aligned layout on ${viewport.name}`, async ({
+    page
+  }) => {
+    await page.setViewportSize(viewport)
+    await mockChat(page)
+    await page.goto('/lens/assistants/layout-test/chat')
+
+    const cards = page.locator('.message-card.user')
+    await expect(cards).toHaveCount(2)
+
+    const shortCard = cards.nth(0)
+    const longCard = cards.nth(1)
+    const shortStyles = await shortCard.evaluate((element) => {
+      const styles = getComputedStyle(element)
+      return {
+        backgroundColor: styles.backgroundColor,
+        padding: styles.padding,
+        textAlign: styles.textAlign
+      }
+    })
+    const longStyles = await longCard.evaluate((element) => {
+      const styles = getComputedStyle(element)
+      return {
+        backgroundColor: styles.backgroundColor,
+        padding: styles.padding,
+        textAlign: styles.textAlign,
+        whiteSpace: getComputedStyle(element.querySelector('.message-text'))
+          .whiteSpace
+      }
+    })
+
+    expect(shortStyles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)')
+    expect(shortStyles.padding).not.toBe('0px')
+    expect(shortStyles.textAlign).toBe('left')
+    expect(longStyles).toMatchObject(shortStyles)
+    expect(longStyles.whiteSpace).toBe('pre-wrap')
+
+    const fitsContainer = await longCard.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth
+    )
+    expect(fitsContainer).toBe(true)
+
+    const box = await longCard.boundingBox()
+    expect(box.x).toBeGreaterThanOrEqual(0)
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width)
+  })
+}

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2519,11 +2519,18 @@ onBeforeUnmount(() => {
 }
 
 .message-row-user .message-body {
-  @apply w-fit max-w-[640px] flex-none text-right;
+  @apply w-fit flex-none text-right;
+  max-width: min(640px, calc(100% - 46px));
 }
 
 .message-card {
   @apply min-w-0;
+}
+
+.message-card.user {
+  @apply rounded-2xl px-4 py-3 text-left;
+  background: #f3f4f6;
+  overflow-wrap: anywhere;
 }
 
 .message-time {


### PR DESCRIPTION
### **User description**
## Summary

User messages in the assistant chat lacked a clear visual boundary, especially for long multi-paragraph content. The message body also inherited right-aligned text from its row-level layout, and its fixed maximum width did not account for the available mobile row width.

- Add a distinct background, rounded corners, and consistent padding to user message cards.
- Keep user message text left-aligned while preserving the existing right-aligned conversation layout.
- Constrain message width to the available row space so long content wraps without horizontal overflow on mobile.
- Add Playwright regression coverage for short and long user messages at desktop and mobile viewport widths.

## Impact

User messages now remain visually contained and readable across short, long, and multi-paragraph inputs on desktop and mobile layouts.

## Testing

- `npx playwright test e2e/chat-message-layout.spec.js --repeat-each=2 --reporter=list`
- `npx eslint src/pages/lens/Chat.vue e2e/chat-message-layout.spec.js`
- `npm run build`
- Visually verified at 1280×800 and 390×844 viewport sizes.

Closes #40


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add background card for user messages

- Left-align text and apply consistent padding

- Constrain width for mobile overflow

- Add Playwright regression test for layout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CSS["CSS changes in Chat.vue"] --> Card["User message card styling"]
  Card --> Background["Background: #f3f4f6, rounded-2xl"]
  Card --> Alignment["Text left-aligned, padding: px-4 py-3"]
  CSS --> MaxWidth["max-width: min(640px, calc(100% - 46px))"]
  Test["New Playwright test file"] --> Verification["Verifies background, padding, alignment, no overflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Style user message card with background and padding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added <code>.message-card.user</code> class with rounded corners, background, <br>padding, and left alignment<br> <li> Changed max-width from fixed 640px to responsive <code>min(640px, calc(100% </code><br><code>- 46px))</code><br> <li> Added <code>overflow-wrap: anywhere</code> for long content</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/46/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-message-layout.spec.js</strong><dd><code>Add regression test for user message layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-message-layout.spec.js

<ul><li>Added Playwright test covering desktop and mobile viewports<br> <li> Mocks chat API with short and long user messages<br> <li> Verifies background, padding, text alignment, and no horizontal <br>overflow</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/46/files#diff-6c3bf0a714759e01c56c0755b20d3e401484ca65a30a8da582c8d20400d8c432">+115/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

