### PR TITLE
fix(lens): clear composer draft when starting a new session

### DIFF
--- a/frontend/e2e/chat-new-session.spec.js
+++ b/frontend/e2e/chat-new-session.spec.js
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test'
+
+async function mockChat(page, createStatus = 200) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const path = new URL(request.url()).pathname
+    if (!path.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+
+    if (path === '/api/lens/sessions/' && request.method() === 'POST') {
+      await route.fulfill({
+        status: createStatus,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data:
+            createStatus === 200
+              ? { uuid: 'session-2', title: '' }
+              : { detail: 'Create failed' }
+        })
+      })
+      return
+    }
+
+    const payloads = {
+      '/api/v1/auth/user': {
+        username: 'tester',
+        features: ['workspace'],
+        permissions: []
+      },
+      '/api/lens/assistants/': [
+        {
+          uuid: 'assistant-1',
+          slug: 'draft-test',
+          name: 'Draft Test',
+          status: 'active'
+        }
+      ],
+      '/api/lens/shares/': [],
+      '/api/lens/sessions/': [{ uuid: 'session-1', title: 'Existing' }],
+      '/api/lens/sessions/session-1/messages/': []
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payloads[path] ?? [] })
+    })
+  })
+}
+
+test('starting a new session clears the composer draft', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await mockChat(page)
+  await page.goto('/lens/assistants/draft-test/chat')
+
+  const composer = page.locator('.composer-input')
+  await expect(composer).toBeVisible()
+  const initialHeight = await composer.evaluate(
+    (element) => element.getBoundingClientRect().height
+  )
+  const draft = 'Unsent draft\nwith several\nlines\nfrom the old session'
+  await composer.fill(draft)
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => element.getBoundingClientRect().height)
+    )
+    .toBeGreaterThan(initialHeight)
+
+  await page.locator('.new-chat-btn').click()
+
+  await expect(page).toHaveURL(/session=session-2/)
+  await expect(composer).toHaveValue('')
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => element.getBoundingClientRect().height)
+    )
+    .toBe(initialHeight)
+})
+
+test('a failed session creation preserves the composer draft', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await mockChat(page, 500)
+  await page.goto('/lens/assistants/draft-test/chat')
+
+  const composer = page.locator('.composer-input')
+  await expect(composer).toBeVisible()
+  await composer.fill('Keep this draft if creation fails')
+
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/lens/sessions/' &&
+      response.request().method() === 'POST'
+  )
+  await page.locator('.new-chat-btn').click()
+  await responsePromise
+
+  await expect(page).toHaveURL(/session=session-1/)
+  await expect(composer).toHaveValue('Keep this draft if creation fails')
+})

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -195,6 +195,7 @@
       "sessionAccessDenied": "You don't have access to this session, or it no longer exists. Select one of your recent sessions or start a new one.",
       "sessionTitle": "{name} query",
       "sessionCreated": "Session created.",
+      "sessionCreateFailed": "Failed to create session, please try again.",
       "messageCopied": "Message copied.",
       "copyFailed": "Copy failed.",
       "downloadFailed": "Download failed, please try again.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -195,6 +195,7 @@
       "sessionAccessDenied": "你无权访问该会话，或该会话已不存在。请从自己的最近会话中选择，或新建会话。",
       "sessionTitle": "{name} 查询",
       "sessionCreated": "已创建会话。",
+      "sessionCreateFailed": "创建会话失败，请重试。",
       "messageCopied": "已复制消息。",
       "copyFailed": "复制失败。",
       "downloadFailed": "下载失败，请稍后重试。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1542,15 +1542,25 @@ async function createNewSession(notify = true) {
   }
   mySharesOpen.value = false
 
-  const session = await createSession({
-    assistant_uuid: selectedAssistant.value.uuid,
-    title: ''
-  })
+  let session
+  try {
+    session = await createSession({
+      assistant_uuid: selectedAssistant.value.uuid,
+      title: ''
+    })
+  } catch {
+    showError(t('lens.chat.sessionCreateFailed'))
+    return null
+  }
 
   sessions.value = [session, ...sessions.value]
   selectedSessionUuid.value = session.uuid
+  question.value = ''
+  if (composerRef.value) composerRef.value.style.height = 'auto'
+  clearAttachments()
   messages.value = []
   currentRun.value = null
+  resetStreamState()
   router.replace({
     path: route.path,
     query: { session: session.uuid }


### PR DESCRIPTION
### **User description**
## Summary

- clear the unsent composer draft, uploaded attachments, and stream state after a new session is created
- reset the composer height when switching to the newly created session
- preserve the existing draft when session creation fails and show a localized error message
- add Playwright coverage for successful and failed session creation

## Testing

- `npx eslint src/pages/lens/Chat.vue e2e/chat-new-session.spec.js --ext .vue,.js --no-fix`
- `npm run build`
- `BASE_URL=http://127.0.0.1:8000 npx playwright test e2e/chat-new-session.spec.js`

All checks passed. The Playwright suite completed with 2 passing tests.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Handle session creation failures gracefully.

- Clear composer draft, attachments, and stream state on success.

- Add localized error message for failed creation.

- Add Playwright coverage for both success and failure paths.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks New Chat"] --> B["Call createSession API"]
  B -- "Success" --> C["Clear draft, attachments, stream state"]
  C --> D["Reset composer height"]
  D --> E["Navigate to new session"]
  B -- "Failure" --> F["Preserve draft, show error toast"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Clear composer state on new session creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Wrap session creation in try/catch, return null on failure.<br> <li> On success: reset <code>question.value</code>, clear attachments, reset stream <br>state, and reset composer height.<br> <li> Show localized error message when creation fails.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/48/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-new-session.spec.js</strong><dd><code>Add Playwright tests for session creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-new-session.spec.js

<ul><li>Add Playwright test for successful session creation clearing draft.<br> <li> Add Playwright test for failed session creation preserving draft.<br> <li> Mock API endpoints with configurable response status.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/48/files#diff-d9b7357884ac6c28f3bee28a7a398a2c4edde16e6005bb93418b9a581acfb188">+106/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/en.json

- Add English string "sessionCreateFailed".


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/48/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/zh-CN.json

- Add Chinese string "sessionCreateFailed".


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/48/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

