### PR TITLE
feat(lens): add assistant descriptions to user-facing pages

### DIFF
--- a/backend/lens/migrations/0019_assistant_description.py
+++ b/backend/lens/migrations/0019_assistant_description.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("lens", "0018_runoutputfile"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="assistant",
+            name="description",
+            field=models.TextField(blank=True, default=""),
+        ),
+    ]

--- a/backend/lens/migrations/0020_assistant_description.py
+++ b/backend/lens/migrations/0020_assistant_description.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("lens", "0018_runoutputfile"),
+        ("lens", "0019_lensnode_disconnected_at"),
     ]
 
     operations = [

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -119,6 +119,7 @@ class Assistant(TimestampedUUIDModel):
     objects = AssistantQuerySet.as_manager()
 
     name = models.CharField(max_length=160)
+    description = models.TextField(blank=True, default="")
     slug = models.SlugField(max_length=180, unique=True)
     visibility = models.CharField(
         max_length=16,

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -304,6 +304,7 @@ class AssistantSerializer(serializers.ModelSerializer):
         fields = [
             "uuid",
             "name",
+            "description",
             "slug",
             "lensnode",
             "lensnode_uuid",

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -163,6 +163,7 @@ class LensApiTests(TestCase):
     def test_assistant_create_saves_lensnode_and_bindings(self):
         payload = {
             "name": "API Explorer",
+            "description": "Explore API behavior and implementation.",
             "slug": "api-explorer",
             "lensnode_uuid": str(self.lensnode.uuid),
             "selected_task": "knowledge_qa",
@@ -192,12 +193,35 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 201)
         assistant = Assistant.objects.get(slug="api-explorer")
         self.assertEqual(assistant.lensnode, self.lensnode)
+        self.assertEqual(
+            assistant.description,
+            "Explore API behavior and implementation.",
+        )
+        self.assertEqual(response.data["description"], assistant.description)
         self.assertEqual(assistant.selected_task, "knowledge_qa")
         self.assertEqual(assistant.skill_bindings.count(), 1)
         self.assertEqual(assistant.mcp_bindings.count(), 1)
         self.assertEqual(
             assistant.settings["_model_check"]["agent_model_ref"]["status"],
             "skipped",
+        )
+
+    def test_assistant_update_saves_description(self):
+        response = self.client.patch(
+            f"/api/lens/assistants/{self.assistant.uuid}/",
+            {"description": "Updated assistant description."},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assistant.refresh_from_db()
+        self.assertEqual(
+            self.assistant.description,
+            "Updated assistant description.",
+        )
+        self.assertEqual(
+            response.data["description"],
+            "Updated assistant description.",
         )
 
     def test_assistant_create_saves_workspace_guide_skill(self):
@@ -1541,6 +1565,7 @@ class AssistantAccessTests(TestCase):
         )
         self.assistant = Assistant.objects.create(
             name="Private One",
+            description="Answers private workspace questions.",
             slug="private-one",
             lensnode=self.lensnode,
             selected_task="knowledge_qa",
@@ -1573,6 +1598,7 @@ class AssistantAccessTests(TestCase):
             f"/api/lens/public/assistants/{self.assistant.slug}/"
         )
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["description"], self.assistant.description)
 
     def test_list_hides_private_from_unauthorized_then_group_grant(self):
         client = self._client(self.member)

--- a/backend/lens/views/assistants.py
+++ b/backend/lens/views/assistants.py
@@ -71,6 +71,7 @@ class PublicAssistantView(APIView):
         return Response(
             {
                 "name": assistant.name,
+                "description": assistant.description,
                 "slug": assistant.slug,
                 "status": assistant.status,
             }

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -936,6 +936,7 @@
       "visibility": "Visibility"
     },
     "placeholders": {
+      "assistantDescription": "Describe what this assistant helps users do.",
       "selectLensNode": "Select a LensNode",
       "selectTask": "Select a task",
       "selectDir": "Select a directory",
@@ -1203,6 +1204,7 @@
       "finish": "Done"
     },
     "wizard": {
+      "assistantDescriptionHint": "Use one sentence to explain the assistant's purpose; 80 characters or fewer is recommended.",
       "step1Title": "Basics & Models",
       "step1Desc": "Set name, slug, agent model (required), and optional multimodal model",
       "agentModelHint": "Required — the LensNode uses this model to run deep analysis agents.",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -936,6 +936,7 @@
       "visibility": "可见性"
     },
     "placeholders": {
+      "assistantDescription": "说明该助手可以帮助用户完成什么。",
       "selectLensNode": "请选择节点",
       "selectTask": "请选择任务",
       "selectDir": "请选择目录",
@@ -1203,6 +1204,7 @@
       "finish": "完成"
     },
     "wizard": {
+      "assistantDescriptionHint": "建议用一句话说明助手用途，尽量控制在 80 字以内。",
       "step1Title": "基础与模型",
       "step1Desc": "设置名称、Slug 与 Agent 模型（必填），以及可选的多模态模型",
       "agentModelHint": "必填 — LensNode 使用该模型运行深度分析 Agent。",

--- a/frontend/src/components/lens/AssistantSwitcher.vue
+++ b/frontend/src/components/lens/AssistantSwitcher.vue
@@ -316,8 +316,17 @@
               >
                 {{ assistantInitial(assistant) }}
               </span>
-              <span class="min-w-0 flex-1 truncate font-medium">
-                {{ assistant.name || assistant.slug }}
+              <span class="min-w-0 flex-1">
+                <span class="block truncate font-medium">
+                  {{ assistant.name || assistant.slug }}
+                </span>
+                <span
+                  v-if="assistant.description?.trim()"
+                  class="assistant-switcher-item-description"
+                  :title="assistant.description"
+                >
+                  {{ assistant.description }}
+                </span>
               </span>
               <span
                 v-if="assistant.slug === currentAssistantSlug"
@@ -621,7 +630,7 @@ onUnmounted(() => {
 }
 
 .assistant-switcher-item {
-  @apply flex w-full items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm text-ink-700 transition-colors;
+  @apply flex w-full items-start gap-3 rounded-xl px-2.5 py-2 text-left text-sm text-ink-700 transition-colors;
 }
 
 .assistant-switcher-item:hover {
@@ -633,11 +642,18 @@ onUnmounted(() => {
 }
 
 .assistant-switcher-item-avatar {
-  @apply flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-white;
+  @apply mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-white;
+}
+
+.assistant-switcher-item-description {
+  @apply mt-0.5 overflow-hidden text-xs leading-5 text-ink-500;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .assistant-switcher-pill {
-  @apply shrink-0 rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700;
+  @apply mt-0.5 shrink-0 rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700;
 }
 
 .assistant-switcher-embedded {

--- a/frontend/src/pages/lens/AssistantFormDrawer.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawer.vue
@@ -59,6 +59,16 @@
       <FormRow :label="t('lensAdmin.fields.name')">
         <input v-model="form.name" class="form-input" required />
       </FormRow>
+      <FormRow :label="t('lensAdmin.fields.description')">
+        <textarea
+          v-model="form.description"
+          class="form-input min-h-24"
+          :placeholder="t('lensAdmin.placeholders.assistantDescription')"
+        />
+        <p class="mt-1 text-xs text-ink-500">
+          {{ t('lensAdmin.wizard.assistantDescriptionHint') }}
+        </p>
+      </FormRow>
       <FormRow :label="t('lensAdmin.fields.slug')">
         <input v-model="form.slug" class="form-input" required />
       </FormRow>

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -398,6 +398,7 @@ async function refreshDirs() {
 function defaultForm() {
   return {
     name: '',
+    description: '',
     slug: '',
     lensnode_uuid: '',
     selected_task: '',
@@ -436,6 +437,7 @@ function formFromRow(row) {
   return {
     uuid: row.uuid,
     name: row.name || '',
+    description: row.description || '',
     slug: row.slug || '',
     lensnode_uuid: row.lensnode?.uuid || row.lensnode || '',
     selected_task: row.selected_task || '',
@@ -515,6 +517,7 @@ function buildPayload() {
   const guideContent = (form.value.workspace_guide_overview || '').trim()
   return {
     name: form.value.name,
+    description: form.value.description?.trim() || '',
     slug: form.value.slug,
     lensnode_uuid: form.value.lensnode_uuid,
     selected_task: form.value.selected_task,

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -313,8 +313,18 @@
           <span class="chat-header-title">{{ t('lens.qa.mineTitle') }}</span>
         </template>
         <template v-else>
-          <AssistantSwitcher v-if="switchable" mode="header" />
-          <span v-else class="chat-header-title">{{ assistantName }}</span>
+          <div class="chat-header-assistant">
+            <AssistantSwitcher v-if="switchable" mode="header" />
+            <div v-else class="chat-header-title">{{ assistantName }}</div>
+            <p
+              v-if="assistantDescription"
+              class="chat-header-description"
+              :class="{ 'pl-2': switchable }"
+              :title="assistantDescription"
+            >
+              {{ assistantDescription }}
+            </p>
+          </div>
           <router-link
             v-if="assistantSlug"
             :to="`/lens/assistants/${assistantSlug}/qa`"
@@ -997,6 +1007,13 @@ const emptyVariant = computed(() =>
 
 const assistantName = computed(
   () => selectedAssistant.value?.name || publicAssistant.value?.name || ''
+)
+
+const assistantDescription = computed(
+  () =>
+    selectedAssistant.value?.description?.trim() ||
+    publicAssistant.value?.description?.trim() ||
+    ''
 )
 
 // The top header turns the assistant name into a switcher only when an
@@ -2437,6 +2454,14 @@ onBeforeUnmount(() => {
 
 .chat-header-title {
   @apply min-w-0 truncate text-base font-semibold text-ink-900;
+}
+
+.chat-header-assistant {
+  @apply min-w-0 flex-1;
+}
+
+.chat-header-description {
+  @apply mt-0.5 max-w-2xl truncate text-xs leading-5 text-ink-500;
 }
 
 .chat-header-back {


### PR DESCRIPTION
### **User description**
## Summary

Add optional descriptions to assistants so users can understand what each
assistant is intended for before starting or switching conversations.

- Add an optional `description` field to the `Assistant` model with a schema
  migration and an empty-string default for existing records.
- Expose descriptions through the authenticated assistant serializer and the
  public assistant metadata endpoint.
- Add a description textarea to the assistant create/edit wizard with
  localized guidance for concise user-facing copy.
- Show the current assistant description in the desktop chat header.
- Show descriptions in the assistant switcher with a two-line clamp.
- Omit empty descriptions without leaving blank UI space.

## User experience

The desktop chat header shows a single-line description below the assistant
name. Long descriptions are constrained to a readable maximum width, truncated
with an ellipsis, and exposed in full through the native title tooltip.

The assistant switcher shows up to two lines of description for each assistant,
making it easier to compare assistants without allowing long content to expand
the menu excessively.

The compact mobile header remains name-only to preserve space for navigation
and new-conversation controls.

## Backend

- Add `Assistant.description` as an optional text field.
- Add migration `0019_assistant_description`.
- Include `description` in `AssistantSerializer`.
- Include `description` in public assistant metadata.
- Add API coverage for create, update, and public retrieval behavior.

## Compatibility

- Existing assistants receive an empty description.
- Empty descriptions remain valid and are omitted from the user interface.
- Existing assistant visibility and write-permission rules are unchanged.
- Public descriptions are only returned for active public assistants.
- The migration is additive and does not remove or transform existing data.

## Testing

- [x] Merged the latest `origin/main` before final verification.
- [x] Applied `lens.0019_assistant_description` in the development environment.
- [x] Verified the Assistant ORM can read existing description values.
- [x] Ran the targeted Assistant API tests:

  ```text
  python manage.py test \
    lens.tests.test_api.LensApiTests.test_assistant_create_saves_lensnode_and_bindings \
    lens.tests.test_api.LensApiTests.test_assistant_update_saves_description \
    lens.tests.test_api.AssistantAccessTests.test_public_view_200_when_public
  ```

  All 3 tests passed.

- [x] Ran targeted ESLint validation with zero errors.
- [x] Ran the final frontend production build against the current worktree.
- [x] Verified locale JSON files parse successfully.
- [x] Verified Python syntax for the modified backend files and migration.
- [x] Ran `git diff --check`.
- [x] Manually verified assistant description creation, editing, and persistence.
- [x] Manually verified desktop header alignment, width constraints, and
      single-line truncation.
- [x] Manually verified assistant switcher two-line truncation.
- [x] Manually verified the compact layout at a 390x844 mobile viewport.
- [x] Verified empty descriptions do not render blank UI space.

## Repository note

`makemigrations --check --dry-run` currently detects an unrelated existing
`DatasourceCredential.auth_type` migration drift. This pull request does not
modify that model or include the unrelated migration.

Closes #31


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional description field to Assistant model and migration.

- Expose description in API serializer and public endpoints.

- Add description input to admin assistant form.

- Display description in assistant switcher and chat header.

- Add localized i18n strings for placeholder and hint.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  model["Assistant model: add description field"]
  migration["Migration 0020"]
  serializer["Serializer: expose description"]
  view["Public assistant endpoint: include description"]
  test["Tests: verify create/update and public view"]
  admin_form["Admin form: description textarea"]
  switcher["Assistant Switcher: show description"]
  chat_header["Chat header: show description"]
  i18n_en["English i18n strings"]
  i18n_zh["Chinese i18n strings"]
  model --> migration
  model --> serializer
  serializer --> view
  serializer --> admin_form
  view --> switcher
  view --> chat_header
  admin_form --> i18n_en
  admin_form --> i18n_zh
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0020_assistant_description.py</strong><dd><code>Add migration for assistant description field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-ce6cb3e585b5af972c2786363e08f8e380872ec0366cff112073e6e7adcb71cb">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>models.py</strong><dd><code>Add description field to Assistant model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Expose description in AssistantSerializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistants.py</strong><dd><code>Include description in public assistant endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-92f7afe14b73e094100797819700512a986348eb93b85cdbcad59f0901f7191a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssistantSwitcher.vue</strong><dd><code>Show description in assistant switcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-8ebe891ec13cade36d347b93c2ec34d251724dabf21d3077cc7c0396baefc129">+21/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssistantFormDrawer.vue</strong><dd><code>Add description textarea to admin form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-f64b9b4a617329deaca5b95a3f963e88f74539613fc13c3df98c28d49849d404">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Assistants.vue</strong><dd><code>Include description in form data and payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Show assistant description in chat header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+27/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for assistant description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English i18n strings for description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese i18n strings for description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/50/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

