### PR TITLE
feat(lensnode): graceful drain of in-flight runs on shutdown/upgrade (#47)

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -73,6 +73,8 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             await self._handle_hello(content)
         elif frame_type == "heartbeat":
             await self._handle_heartbeat(content)
+        elif frame_type == "node_draining":
+            await self._handle_node_draining(content)
         elif frame_type == "run_event":
             await self._handle_run_event(content)
         elif frame_type == "run_output":
@@ -208,6 +210,29 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
                 "type": "heartbeat_ack",
                 "ts": timezone.now().isoformat(),
             }
+        )
+
+    async def _handle_node_draining(self, content):
+        """Flip the node to DRAINING so no new runs are dispatched to it.
+
+        Sent by a node shutting down/upgrading. The node stops heartbeating
+        once draining, so this DRAINING status is not overwritten back to
+        ONLINE until the node reconnects with a fresh hello.
+        """
+
+        del content
+        await self._mark_draining(self.lensnode.uuid, self.channel_name)
+
+    @database_sync_to_async
+    def _mark_draining(self, lensnode_uuid, connection_id):
+        """Mark a LensNode DRAINING if this connection still owns it."""
+
+        LensNode.objects.filter(
+            uuid=lensnode_uuid,
+            connection_id=connection_id,
+        ).update(
+            status=LensNode.Status.DRAINING,
+            updated_at=timezone.now(),
         )
 
     @database_sync_to_async

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -425,6 +425,8 @@ def validate_run_dispatch(run):
     lensnode = run.lensnode
     if lensnode is None:
         raise LensNodeDispatchError("LENSNODE_REQUIRED")
+    if lensnode.status == LensNode.Status.DRAINING:
+        raise LensNodeDispatchError("LENSNODE_DRAINING")
     if lensnode.status != LensNode.Status.ONLINE:
         raise LensNodeDispatchError("LENSNODE_OFFLINE")
     if lensnode.enrollment_status != LensNode.EnrollmentStatus.APPROVED:

--- a/backend/lens/tests/test_draining.py
+++ b/backend/lens/tests/test_draining.py
@@ -1,0 +1,95 @@
+from asgiref.sync import async_to_sync
+from django.contrib.auth import get_user_model
+from django.test import TransactionTestCase
+
+from core.asgi import application
+from lens.lensnode_auth import issue_lensnode_token
+from lens.models import (
+    Assistant,
+    LensNode,
+    Run,
+    Session,
+)
+from lens.services import (
+    LensNodeDispatchError,
+    create_execution_run,
+    validate_run_dispatch,
+)
+
+User = get_user_model()
+
+
+class LensNodeDrainingTests(TransactionTestCase):
+    """A draining LensNode is excluded from new-run dispatch.
+
+    Complements the disconnect grace-period: this is the node's own
+    shutdown/upgrade path, where it announces draining so no new run is routed
+    to it while it finishes in-flight work.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="drain-user",
+            email="drain-user@example.com",
+            password="pass12345",
+        )
+        self.lensnode = LensNode.objects.create(
+            name="Drain LensNode",
+            status=LensNode.Status.ONLINE,
+            enrollment_status=LensNode.EnrollmentStatus.APPROVED,
+            workspace_path="/workspace",
+            available_dirs=[{"path": "/workspace/repo"}],
+            tasks=[{"name": "knowledge_qa"}],
+        )
+        self.assistant = Assistant.objects.create(
+            name="Advisor",
+            slug="advisor",
+            lensnode=self.lensnode,
+            selected_task="knowledge_qa",
+            selected_dirs=[{"path": "/workspace/repo"}],
+        )
+        self.session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title="",
+        )
+
+    def test_dispatch_rejects_draining_node(self):
+        run = create_execution_run(
+            session=self.session, question="q", enqueue=False
+        )
+        run.lensnode = self.lensnode
+        run.save(update_fields=["lensnode"])
+        self.lensnode.status = LensNode.Status.DRAINING
+        self.lensnode.save(update_fields=["status"])
+
+        with self.assertRaises(LensNodeDispatchError) as ctx:
+            validate_run_dispatch(run)
+        self.assertEqual(str(ctx.exception), "LENSNODE_DRAINING")
+
+    def test_node_draining_frame_sets_status_draining(self):
+        token = issue_lensnode_token(self.lensnode)
+        # Read the status while still connected — a later disconnect flips it
+        # to OFFLINE, so the DRAINING state must be observed before that.
+        status = async_to_sync(self._connect_send_draining)(token)
+        self.assertEqual(status, LensNode.Status.DRAINING)
+
+    async def _connect_send_draining(self, token):
+        from channels.db import database_sync_to_async
+        from channels.testing import WebsocketCommunicator
+
+        communicator = WebsocketCommunicator(
+            application,
+            f"/ws/lens/lensnodes/?token={token}",
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        await communicator.receive_json_from()
+        await communicator.send_json_to({"type": "node_draining"})
+        # No reply is expected; the wait lets the consumer process the frame.
+        await communicator.receive_nothing(timeout=1)
+        status = await database_sync_to_async(
+            lambda: LensNode.objects.get(uuid=self.lensnode.uuid).status
+        )()
+        await communicator.disconnect()
+        return status

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -139,6 +139,10 @@ services:
     image: oneprocloud/sourcelens-lensnode:${APP_VERSION:-latest}
     container_name: sourcelens-lensnode
     restart: unless-stopped
+    # On stop/upgrade the node drains in-flight runs (up to
+    # LENSNODE_DRAIN_TIMEOUT_S) before exiting; give docker enough grace to let
+    # that finish before SIGKILL. Must stay larger than LENSNODE_DRAIN_TIMEOUT_S.
+    stop_grace_period: 270s
     env_file:
       - ./.env
     environment:
@@ -154,6 +158,8 @@ services:
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}
       LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
+      # Graceful-drain budget on shutdown/upgrade. Keep below stop_grace_period.
+      LENSNODE_DRAIN_TIMEOUT_S: ${LENSNODE_DRAIN_TIMEOUT_S:-240}
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
     volumes:
       - ./data/workspace:/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,11 @@ services:
     image: oneprocloud/sourcelens-lensnode:${APP_VERSION:-latest}
     container_name: sourcelens-lensnode
     restart: unless-stopped
+    # On stop/upgrade the node drains in-flight runs (up to
+    # LENSNODE_DRAIN_TIMEOUT_S) before exiting; give docker enough grace to let
+    # that finish before SIGKILL, otherwise a long run is cut short. Must stay
+    # larger than LENSNODE_DRAIN_TIMEOUT_S.
+    stop_grace_period: 270s
     env_file:
       - ./.env
     environment:
@@ -187,6 +192,8 @@ services:
       LENSNODE_HEARTBEAT_INTERVAL_S: 15
       LENSNODE_REQUEST_TIMEOUT_S: ${LENSNODE_REQUEST_TIMEOUT_S:-240}
       LENSNODE_RUN_IDLE_TIMEOUT_S: ${LENSNODE_RUN_IDLE_TIMEOUT_S:-180}
+      # Graceful-drain budget on shutdown/upgrade. Keep below stop_grace_period.
+      LENSNODE_DRAIN_TIMEOUT_S: ${LENSNODE_DRAIN_TIMEOUT_S:-240}
       # Max concurrent runs per node. Each run holds a slot for the full answer
       # duration; without this it falls back to 1 and questions queue.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}

--- a/env.sample
+++ b/env.sample
@@ -91,6 +91,11 @@ LENSNODE_REQUEST_TIMEOUT_S=240
 # progress) arrives for this long. The gateway heartbeats every ~10s, so
 # this only trips on a dead pipe, never on a quiet-but-alive model call.
 LENSNODE_RUN_IDLE_TIMEOUT_S=180
+# Graceful-drain budget on shutdown/upgrade: a node receiving SIGTERM stops
+# taking new runs and lets in-flight runs finish for up to this long before
+# exiting (only runs still active past it are cancelled). The compose
+# lensnode service's stop_grace_period must stay larger than this.
+LENSNODE_DRAIN_TIMEOUT_S=240
 # Max concurrent runs a single lensnode executes. Each run holds a slot for
 # the full answer duration; raise for more parallelism (avoids long Queued).
 LENSNODE_MAX_CONCURRENT_RUNS=8

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -18,6 +18,7 @@ class LensNodeConfig:
     heartbeat_interval_s: int
     request_timeout_s: int
     run_idle_timeout_s: int
+    drain_timeout_s: int
     max_concurrent_runs: int
     summary_trigger_tokens: int
     summary_keep_tokens: int
@@ -66,6 +67,9 @@ def load_config():
         request_timeout_s=int(os.getenv("LENSNODE_REQUEST_TIMEOUT_S", "240")),
         run_idle_timeout_s=int(
             os.getenv("LENSNODE_RUN_IDLE_TIMEOUT_S", "180")
+        ),
+        drain_timeout_s=int(
+            os.getenv("LENSNODE_DRAIN_TIMEOUT_S", "240")
         ),
         max_concurrent_runs=int(os.getenv("LENSNODE_MAX_CONCURRENT_RUNS", "1")),
         summary_trigger_tokens=int(

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -32,6 +32,10 @@ class LensNodeClient:
         self.config = config
         self.executor = LensNodeExecutor(config)
         self.stopping = asyncio.Event()
+        # Set while draining on shutdown/upgrade: stop accepting new runs and
+        # stop heartbeating (a heartbeat would flip the node back to ONLINE
+        # server-side and undo the DRAINING state). See stop().
+        self.draining = asyncio.Event()
         self.websocket = None
         self.connected_at = None
         self.connect_started_at = None
@@ -132,13 +136,43 @@ class LensNodeClient:
             backoff_s = min(backoff_s * 2, 30)
 
     async def stop(self):
-        """Stop the client and close its WebSocket."""
+        """Gracefully drain in-flight runs, then stop the client.
 
-        if self.stopping.is_set():
+        Triggered by SIGTERM/SIGINT on shutdown/upgrade (see _run_client).
+        This is the single, reusable drain entry point: a future control-plane
+        drain/upgrade command (issue #27) can call this same method. It stops
+        accepting new runs, announces draining so the control plane routes new
+        runs elsewhere, lets in-flight runs finish within the drain timeout,
+        then closes the socket and cancels only what is still running past the
+        deadline. An idle node (no in-flight runs) drains and exits at once.
+        """
+
+        if self.stopping.is_set() or self.draining.is_set():
             return
+        self.draining.set()
         LOGGER.info(
-            task_log(f"Stopping service LensNode {self.config.name}.")
+            task_log(
+                f"Draining LensNode {self.config.name} before shutdown.",
+                details=[
+                    f"InFlightRuns: {len(self.running_tasks)}",
+                    "DrainTimeout: "
+                    f"{format_duration(self.config.drain_timeout_s)}",
+                ],
+            )
         )
+        # Announce draining so the control plane flips this node out of
+        # dispatch. Enqueued (not sent directly) so it stays ordered behind
+        # buffered frames and never races the send loop on the socket; the
+        # heartbeat loop has already stopped (it gates on draining), so this is
+        # the node's last state frame and the DRAINING status sticks.
+        self._enqueue(
+            {
+                "type": "node_draining",
+                "lensnode_name": self.config.name,
+            }
+        )
+        await self._drain_running_tasks()
+        await self._flush_outbox()
         self.stopping.set()
         if self.websocket is not None:
             await self.websocket.close()
@@ -149,6 +183,38 @@ class LensNodeClient:
                 *self.running_tasks.values(),
                 return_exceptions=True,
             )
+
+    async def _drain_running_tasks(self):
+        """Wait for in-flight runs to finish, bounded by the drain timeout."""
+
+        tasks = list(self.running_tasks.values())
+        if not tasks:
+            return
+        done, pending = await asyncio.wait(
+            tasks, timeout=self.config.drain_timeout_s
+        )
+        if pending:
+            LOGGER.warning(
+                task_log(
+                    (
+                        f"Drain deadline reached for LensNode "
+                        f"{self.config.name}; cancelling runs still active."
+                    ),
+                    details=[f"StillActive: {len(pending)}"],
+                )
+            )
+
+    async def _flush_outbox(self, attempts=50):
+        """Let the send loop flush buffered frames before the socket closes.
+
+        The send loop runs until stopping is set (not draining), so it is still
+        active here — this just yields long enough for node_draining and any
+        final run_done frames to reach the server before we close.
+        """
+
+        while self._outbox and attempts > 0:
+            await asyncio.sleep(0.1)
+            attempts -= 1
 
     def _ws_url(self):
         """Return the token-authenticated WebSocket URL."""
@@ -317,6 +383,9 @@ class LensNodeClient:
 
         run_uuid = str(message.get("run_uuid") or "")
         if not run_uuid:
+            return
+        if self.draining.is_set():
+            await self._send_busy(run_uuid, "LENSNODE_DRAINING")
             return
         if run_uuid in self.running_tasks:
             await self._send_busy(run_uuid, "LENSNODE_RUN_ACTIVE")
@@ -598,9 +667,14 @@ class LensNodeClient:
         )
 
     async def _heartbeat_loop(self):
-        """Periodically report workspace state while connected."""
+        """Periodically report workspace state while connected.
 
-        while not self.stopping.is_set():
+        Stops once draining: a heartbeat sets the node ONLINE server-side,
+        which would undo the DRAINING state and let new runs be dispatched
+        here mid-shutdown.
+        """
+
+        while not self.stopping.is_set() and not self.draining.is_set():
             await asyncio.sleep(self.config.heartbeat_interval_s)
             dirs = available_dirs(self.config.workspace_path)
             signature = (

--- a/lensnode/tests/test_drain.py
+++ b/lensnode/tests/test_drain.py
@@ -1,0 +1,120 @@
+import asyncio
+import json
+
+from lensnode.main import LensNodeClient
+
+
+def _make_client(drain_timeout_s=5):
+    """Build a client with a throwaway config (executor is unused here)."""
+
+    config = type(
+        "Config",
+        (),
+        {
+            "name": "test-node",
+            "request_timeout_s": 240,
+            "drain_timeout_s": drain_timeout_s,
+            "max_concurrent_runs": 1,
+        },
+    )()
+    return LensNodeClient(config)
+
+
+class FakeWebSocket:
+    """Records sent frames and supports close()."""
+
+    def __init__(self):
+        self.sent = []
+        self.closed = False
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        self.closed = True
+
+
+def _sent_types(ws):
+    return [json.loads(item).get("type") for item in ws.sent]
+
+
+def test_drain_lets_in_flight_run_finish_then_stops():
+    """A run finishing within the drain window completes, is not cancelled."""
+
+    async def exercise():
+        client = _make_client(drain_timeout_s=5)
+        ws = FakeWebSocket()
+        client.websocket = ws
+        send_task = asyncio.create_task(client._send_loop(ws))
+
+        finished = asyncio.Event()
+
+        async def fake_run():
+            await asyncio.sleep(0.1)
+            finished.set()
+
+        run = asyncio.create_task(fake_run())
+        client.running_tasks["run-1"] = run
+        run.add_done_callback(
+            lambda item: client.running_tasks.pop("run-1", None)
+        )
+
+        await client.stop()
+
+        assert finished.is_set()
+        assert not run.cancelled()
+        assert client.draining.is_set()
+        assert client.stopping.is_set()
+        assert ws.closed
+        # Draining was announced so the control plane stops routing here.
+        assert "node_draining" in _sent_types(ws)
+
+        send_task.cancel()
+
+    asyncio.run(exercise())
+
+
+def test_drain_rejects_new_runs():
+    """While draining, a new run_start is rejected with LENSNODE_DRAINING."""
+
+    async def exercise():
+        client = _make_client()
+        client.draining.set()
+
+        await client._start_command(
+            {"run_uuid": "new-run", "task": "knowledge_qa"}
+        )
+
+        # No task was started; the node replied busy/draining instead.
+        assert "new-run" not in client.running_tasks
+        frames = [dict(item) for item in client._outbox]
+        errors = [f.get("error") for f in frames]
+        assert "LENSNODE_DRAINING" in errors
+        assert any(f.get("type") == "run_done" for f in frames)
+
+    asyncio.run(exercise())
+
+
+def test_drain_cancels_runs_past_deadline():
+    """A run still active past the drain deadline is cancelled."""
+
+    async def exercise():
+        client = _make_client(drain_timeout_s=0)
+        ws = FakeWebSocket()
+        client.websocket = ws
+        send_task = asyncio.create_task(client._send_loop(ws))
+
+        async def long_run():
+            await asyncio.sleep(30)
+
+        run = asyncio.create_task(long_run())
+        client.running_tasks["run-1"] = run
+
+        await client.stop()
+
+        assert run.cancelled()
+        assert client.stopping.is_set()
+
+        send_task.cancel()
+
+    asyncio.run(exercise())


### PR DESCRIPTION
### **User description**
Part of #47. Gives a LensNode a **graceful drain** on shutdown/upgrade so a node restart (the common case: a co-located node's image is bumped on nearly every release) no longer hard-cancels its in-flight runs.

Complements #43 (which keeps runs alive when the **API** is recycled but the node stays up); this is the node's-**own**-restart survival.

## Behaviour

On `SIGTERM`/`SIGINT`, `stop()` is now a drain-then-stop sequence:
1. mark draining — new `run_start` frames are rejected with `LENSNODE_DRAINING` (the control plane re-queues elsewhere);
2. announce a `node_draining` frame so the server flips the node to `DRAINING` and dispatch stops routing to it;
3. wait for in-flight runs to finish, bounded by `LENSNODE_DRAIN_TIMEOUT_S` (default 240s, aligned with the request timeout);
4. flush the outbox, close the socket, and cancel **only** runs still active past the deadline.

An idle node (no in-flight runs) drains and exits immediately, so ordinary deploys are unaffected.

## Changes

- **Agent** (`lensnode/lensnode/main.py`): reusable drain in `stop()`; `_start_command` rejects while draining; the heartbeat loop stops when draining (a heartbeat would flip the node back to `ONLINE` server-side and undo `DRAINING`).
- **Config** (`config.py`, `env.sample`): `LENSNODE_DRAIN_TIMEOUT_S`.
- **Server** (`backend/lens/consumers.py`): handle the `node_draining` frame → `LensNode.Status.DRAINING`, respecting connection ownership. (`backend/lens/services.py`): `validate_run_dispatch` raises a distinct `LENSNODE_DRAINING` reason (a draining node was already excluded via `!= ONLINE`).
- **Compose** (`docker-compose.yml`, `docker-compose.standalone.yml`): `lensnode` gains `stop_grace_period: 270s` (> the drain timeout) so docker does not `SIGKILL` mid-drain.

## Tests

- Agent `tests/test_drain.py`: a run finishing within the window completes and is **not** cancelled + `node_draining` is announced; a new run while draining is rejected with `LENSNODE_DRAINING`; a run still active past the deadline is cancelled.
- Backend `lens/tests/test_draining.py`: a `node_draining` frame sets `DRAINING`; `validate_run_dispatch` raises `LENSNODE_DRAINING`.

Verified: agent 3/3, backend 2/2, and the full `lens` suite shows **zero new failures** — the 3 failures + 1 error reproduce identically on `main` (pre-existing datasource/smoke/public-qa). Added code matches the surrounding style (repo is not `black`/`isort`-clean on `main`).

## Scope / composition

- Composes with #43: a fully drained node's disconnect finds no `RUNNING` runs, so the disconnect grace-check no-ops.
- Scope is the **co-located / `SIGTERM`** trigger — exercised directly by the blue/green lensnode roll. The **distributed control-plane drain/upgrade command** trigger is deferred to #27, which reuses the same `stop()` drain sequence (one-line wire-up). #47 stays open until then; every acceptance criterion except the #27-gated one is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Graceful drain on LensNode shutdown/upgrade

- Server marks DRAINING, dispatch rejects draining nodes

- New tests for drain behavior and dispatch rejection

- Docker compose adds stop_grace_period for drain completion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  N["LensNode"] -- "SIGTERM" --> Draining["Start drain"]
  Draining -- "node_draining" --> S["Backend"]
  S -- "status = DRAINING" --> D["Dispatch stops routing"]
  Draining -- "drain_timeout" --> Finish["In-flight runs finish"]
  Draining -- "deadline" --> Cancel["Cancel stragglers"]
  Finish --> Exit["Exit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>consumers.py</strong><dd><code>Handle node_draining frame, mark node DRAINING</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add LENSNODE_DRAINING dispatch rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.py</strong><dd><code>Add drain_timeout_s configuration field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Implement graceful drain sequence on shutdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+79/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_draining.py</strong><dd><code>Tests for draining node dispatch rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-6bda58acfa63b1fb3b1702b3113a37446bbf27536e4ce317c9ea653e4a6d1350">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_drain.py</strong><dd><code>Tests for drain behavior and straggler cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-7a8e3a7bc0056f4c38c6864bfb2918f40a1fd9f2f2b24467cf560ba1d845434c">+120/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>docker-compose.standalone.yml</strong><dd><code>Add stop_grace_period and drain timeout env var</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-9ce448f74e566e43c1699bd469713bd9cd36e5f11ffccd6b824cd840f3077228">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Add stop_grace_period and drain timeout env var</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.sample</strong><dd><code>Add LENSNODE_DRAIN_TIMEOUT_S sample config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/54/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

