### PR TITLE
fix(docker): clean python base image + restore runtime diagnostics (for #56)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Backend builder image
 # -----------------------------------------------------------------------------
 
-FROM m.daocloud.io/docker.io/library/python:3.12-slim-bookworm AS backend-builder
+FROM python:3.12-slim-bookworm AS backend-builder
 
 SHELL ["/bin/bash", "-c"]
 
@@ -105,7 +105,7 @@ RUN DJANGO_DEBUG=true python manage.py compilemessages -l zh_Hans -l en \
 # Backend runtime image
 # -----------------------------------------------------------------------------
 
-FROM m.daocloud.io/docker.io/library/python:3.12-slim-bookworm AS backend
+FROM python:3.12-slim-bookworm AS backend
 
 SHELL ["/bin/bash", "-c"]
 
@@ -135,9 +135,14 @@ RUN set -eux; \
         bash \
         ca-certificates \
         curl \
+        dnsutils \
         git \
+        htop \
+        iputils-ping \
         libmagic1 \
-        postgresql-client; \
+        net-tools \
+        postgresql-client \
+        procps; \
     rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
 
 ARG DEV_MODE=0


### PR DESCRIPTION
### **User description**
A small fix on top of #56, for @fengren to review before #56 merges. Targets the #56 branch so it lands as part of that PR.

## Why

The backend `Dockerfile` builder/runtime stages hardcode `FROM m.daocloud.io/docker.io/library/python:3.12-slim-bookworm`. Two problems:

1. **It bypasses the project's base-image convention.** `main`'s `ubuntu:24.04` and this PR's own **lensnode** Dockerfile use a *clean* image reference and let the Docker daemon's `registry-mirrors` handle China access. Hardcoding one mirror in `FROM` diverges from that (and from your own lensnode stage).
2. **It currently fails to build.** That endpoint returns `401 Unauthorized`, so `docker build` can't even resolve the base from a clean context — which breaks #55's own acceptance criterion ("builds successfully from clean Docker contexts").

## What this changes

- Both backend stages → clean `python:3.12-slim-bookworm` (daemon mirror resolves it in China; CI/overseas pulls straight from Docker Hub). APT/pip mirror args are untouched — that switching already worked.
- Restore the runtime diagnostic tools the multi-stage refactor dropped (`procps`, `net-tools`, `iputils-ping`, `dnsutils`, `htop`) for parity with the pre-refactor image. **Your call:** if the slimmer attack surface from #55 is preferred, drop these again.

## Verified

- Builds clean (base pulled via the daemon mirror), Django system checks pass.
- Backend image **583MB vs the current 1.14GB (~49% smaller)** — the multi-stage win holds with the fix.

## Not touched (but worth your confirmation)

- litellm cap `<=1.91.3` in the pinned `agentcore-metering` correctly obsoletes the `fastapi` workaround — sound, but it does change the deployed litellm; a Q&A smoke test after deploy is advisable.
- LensNode MarkItDown narrowed to `docx,pdf,pptx,xlsx` — please confirm no other formats are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use clean Python base image (remove hardcoded mirror) to fix build failure

- Restore runtime diagnostic tools (procps, net-tools, iputils-ping, dnsutils, htop)


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Fix base image and restore runtime tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Changed FROM from hardcoded mirror to clean python:3.12-slim-bookworm <br>for both builder and runtime stages<br> <li> Restored runtime diagnostic packages: dnsutils, htop, iputils-ping, <br>net-tools, procps</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/58/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

