### PR TITLE
fix(lens): keep pasted image upload spinner centered

### DIFF
--- a/frontend/e2e/chat-image-upload-layout.spec.js
+++ b/frontend/e2e/chat-image-upload-layout.spec.js
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test'
+
+const viewports = [
+  { name: 'desktop', width: 1280, height: 800 },
+  { name: 'mobile', width: 390, height: 844 }
+]
+
+async function mockChat(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const path = new URL(request.url()).pathname
+    if (!path.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+
+    if (
+      path === '/api/lens/sessions/session-1/attachments/' &&
+      request.method() === 'POST'
+    ) {
+      return
+    }
+
+    const payloads = {
+      '/api/v1/auth/user': {
+        username: 'tester',
+        features: ['workspace'],
+        permissions: []
+      },
+      '/api/lens/assistants/': [
+        {
+          uuid: 'assistant-1',
+          slug: 'image-layout-test',
+          name: 'Image Layout Test',
+          status: 'active',
+          multimodal_model_ref: 'model-1'
+        }
+      ],
+      '/api/lens/shares/': [],
+      '/api/lens/sessions/': [
+        {
+          uuid: 'session-1',
+          title: 'Image layout test',
+          assistant: 'assistant-1'
+        }
+      ],
+      '/api/lens/sessions/session-1/messages/': []
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payloads[path] ?? [] })
+    })
+  })
+}
+
+async function pasteImage(page) {
+  await page.locator('.composer-input').evaluate((element) => {
+    const data = new Uint8Array([137, 80, 78, 71])
+    const transfer = new DataTransfer()
+    transfer.items.add(new File([data], 'pasted.png', { type: 'image/png' }))
+    element.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer
+      })
+    )
+  })
+}
+
+for (const viewport of viewports) {
+  test(`pasted image upload spinner is centered on ${viewport.name}`, async ({
+    page
+  }) => {
+    await page.setViewportSize(viewport)
+    await mockChat(page)
+    await page.goto('/lens/assistants/image-layout-test/chat')
+
+    await expect(page.locator('.composer-input')).toBeVisible()
+    await pasteImage(page)
+
+    const thumb = page.locator('.composer-thumb.is-uploading')
+    const spinner = thumb.locator('.composer-thumb-spinner')
+    await expect(spinner).toBeVisible()
+    await page.addStyleTag({
+      content: `
+        .composer-thumb-spinner {
+          animation-delay: -0.35s !important;
+          animation-play-state: paused !important;
+        }
+      `
+    })
+
+    const centers = await thumb.evaluate((element) => {
+      const thumbBox = element.getBoundingClientRect()
+      const spinnerBox = element
+        .querySelector('.composer-thumb-spinner')
+        .getBoundingClientRect()
+      return {
+        thumbX: thumbBox.left + thumbBox.width / 2,
+        thumbY: thumbBox.top + thumbBox.height / 2,
+        spinnerX: spinnerBox.left + spinnerBox.width / 2,
+        spinnerY: spinnerBox.top + spinnerBox.height / 2
+      }
+    })
+
+    expect(Math.abs(centers.spinnerX - centers.thumbX)).toBeLessThanOrEqual(1)
+    expect(Math.abs(centers.spinnerY - centers.thumbY)).toBeLessThanOrEqual(1)
+  })
+}

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2961,8 +2961,8 @@ onBeforeUnmount(() => {
 }
 
 .composer-thumb-spinner {
-  @apply absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2
-    rounded-full border-2 border-gray-300 border-t-primary-500;
+  @apply absolute inset-0 m-auto h-5 w-5 rounded-full border-2
+    border-gray-300 border-t-primary-500;
   animation: spin 0.7s linear infinite;
 }
 


### PR DESCRIPTION
### **User description**
## Summary

- Center the pasted-image upload spinner without relying on a translate transform.
- Prevent the rotation animation from overriding the spinner positioning.
- Add Playwright regression coverage for desktop and mobile viewports.

## Root cause

The spinner used a translation transform for centering while its rotation animation also modified the transform property. During the animation, rotation replaced translation and shifted the spinner away from the thumbnail center.

The spinner now uses absolute inset positioning with automatic margins, leaving transform exclusively available to the rotation animation.

## Testing

- Playwright pasted-image spinner regression: 2 passed.
- Desktop viewport: 1280 x 800.
- Mobile viewport: 390 x 844.
- ESLint passed.
- Git diff check passed.
- Manual browser verification passed.

Closes #53


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Center pasted image upload spinner without transform conflict

- Replace translate centering with inset auto margins

- Add Playwright regression tests for desktop and mobile viewports


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Fix spinner centering CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Changed spinner centering from translate-based to inset-0 with auto <br>margins<br> <li> Prevents rotation animation from overriding centering transform</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/64/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-image-upload-layout.spec.js</strong><dd><code>Add spinner centering e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-image-upload-layout.spec.js

<ul><li>Added Playwright tests for pasted image upload spinner centering<br> <li> Covers desktop and mobile viewport sizes<br> <li> Mocks API responses to isolate UI behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/64/files#diff-8f20d8d9ef25cc4b3b5046c255c2f7b5c7b82438ebf2615c59ab611ef4c78db8">+115/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

