### PR TITLE
feat(lensnode): add configurable TLS verification (#17)

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -83,6 +83,10 @@ LENSNODE_WORKSPACE_PATH=/workspace
 # deliverable-upload URL the same way.)
 LENSNODE_CONTROL_WS_URL=ws://nginx:80/ws/lens/lensnodes/
 LENSNODE_AI_GATEWAY_URL=http://nginx:80/api/lens/lensnode/ai-gateway/
+# Keep certificate and hostname verification enabled by default. For a private
+# CA, mount its certificate into LensNode and set the container path below.
+LENSNODE_TLS_SKIP_VERIFY=false
+# LENSNODE_TLS_CA_FILE=/etc/sourcelens/ca.crt
 LENSNODE_HEARTBEAT_INTERVAL_S=15
 # Must be greater than the LiteLLM/provider request timeout so the control
 # plane reports provider failures before LensNode gives up.

--- a/lensnode/README.md
+++ b/lensnode/README.md
@@ -13,3 +13,33 @@ docker compose up --build
 The standalone compose file only starts the LensNode service. Point
 `LENSNODE_CONTROL_WS_URL` and `LENSNODE_AI_GATEWAY_URL` at an existing
 SourceLens backend.
+
+## TLS verification
+
+LensNode verifies SourceLens HTTPS and WSS certificates with the system trust
+store by default. This applies to the control channel, AI Gateway requests,
+Skill package downloads, and deliverable uploads.
+
+For a SourceLens deployment that uses a private CA, mount the CA certificate
+into the LensNode container and configure its container path:
+
+```yaml
+services:
+  lensnode:
+    environment:
+      LENSNODE_TLS_CA_FILE: /etc/sourcelens/ca.crt
+    volumes:
+      - ./ca.crt:/etc/sourcelens/ca.crt:ro
+```
+
+For local development with a self-signed certificate, verification can be
+disabled explicitly:
+
+```env
+LENSNODE_TLS_SKIP_VERIFY=true
+```
+
+This disables both certificate and hostname verification and must not be used
+in production. `LENSNODE_TLS_SKIP_VERIFY` defaults to `false`. When it is
+`true`, it takes precedence over `LENSNODE_TLS_CA_FILE` and LensNode logs a
+warning at startup.

--- a/lensnode/docker-compose.yml
+++ b/lensnode/docker-compose.yml
@@ -15,10 +15,14 @@ services:
       LENSNODE_TOKEN: ${LENSNODE_TOKEN:-dev-lensnode-token}
       LENSNODE_CONTROL_WS_URL: ${LENSNODE_CONTROL_WS_URL:-ws://host.docker.internal:8000/ws/lens/lensnodes/}
       LENSNODE_AI_GATEWAY_URL: ${LENSNODE_AI_GATEWAY_URL:-http://host.docker.internal:8000/api/lens/lensnode/ai-gateway/}
+      LENSNODE_TLS_SKIP_VERIFY: ${LENSNODE_TLS_SKIP_VERIFY:-false}
+      LENSNODE_TLS_CA_FILE: ${LENSNODE_TLS_CA_FILE:-}
       LENSNODE_WORKSPACE_PATH: /workspace
       LENSNODE_HEARTBEAT_INTERVAL_S: ${LENSNODE_HEARTBEAT_INTERVAL_S:-15}
       PYTHONPATH: /opt/lensnode
     volumes:
       - ./workspace:/workspace
+      # Mount a private CA when LENSNODE_TLS_CA_FILE points to this path.
+      # - ./ca.crt:/etc/sourcelens/ca.crt:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -183,6 +183,8 @@ def _build_summarization_middleware(
         ai_gateway_url=config.ai_gateway_url,
         token=config.token,
         request_timeout_s=config.request_timeout_s,
+        tls_skip_verify=getattr(config, "tls_skip_verify", False),
+        tls_ca_file=getattr(config, "tls_ca_file", None),
         cancel_event=cancel_event,
         run_uuid=run_uuid,
     )
@@ -328,6 +330,10 @@ class LensDeepAgentRuntime:
                 ai_gateway_url=self.config.ai_gateway_url,
                 token=self.config.token,
                 request_timeout_s=self.config.request_timeout_s,
+                tls_skip_verify=getattr(
+                    self.config, "tls_skip_verify", False
+                ),
+                tls_ca_file=getattr(self.config, "tls_ca_file", None),
                 emit_output=emit_output,
                 on_activity=on_activity,
                 cancel_event=cancel_event,

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -11,6 +11,7 @@ import httpx
 from langchain_core.tools import tool
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+from .tls import create_config_ssl_context
 from .workspace import (
     DEFAULT_EXCLUDED_DIRS,
     DEFAULT_EXCLUDED_EXTENSIONS,
@@ -525,7 +526,10 @@ def _build_save_deliverable_tool(command, resources, config, emit_event):
             mimetypes.guess_type(filename)[0] or "application/octet-stream"
         )
         try:
-            with httpx.Client(timeout=config.request_timeout_s) as client:
+            with httpx.Client(
+                timeout=config.request_timeout_s,
+                verify=create_config_ssl_context(config),
+            ) as client:
                 response = client.post(
                     config.deliverable_upload_url,
                     headers={"Authorization": f"Bearer {config.token}"},

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -11,6 +11,8 @@ class LensNodeConfig:
     control_ws_url: str
     ai_gateway_url: str
     deliverable_upload_url: str
+    tls_skip_verify: bool
+    tls_ca_file: str | None
     deliverable_max_bytes: int
     workspace_path: str
     protocol_version: str
@@ -30,6 +32,15 @@ def _optional_int(value):
     """Return int(value), or None when the env var is unset or empty."""
 
     return int(value) if value not in (None, "") else None
+
+
+def _env_bool(name, default=False):
+    """Return a case-insensitive boolean environment setting."""
+
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _derive_ws_url(server_url):
@@ -63,6 +74,8 @@ def load_config():
         or f"{server_url}/api/lens/lensnode/ai-gateway/",
         deliverable_upload_url=os.getenv("LENSNODE_DELIVERABLE_UPLOAD_URL")
         or f"{server_url}/api/lens/lensnode/deliverables/",
+        tls_skip_verify=_env_bool("LENSNODE_TLS_SKIP_VERIFY"),
+        tls_ca_file=os.getenv("LENSNODE_TLS_CA_FILE") or None,
         deliverable_max_bytes=int(
             os.getenv("LENSNODE_DELIVERABLE_MAX_BYTES", str(50 * 1024 * 1024))
         ),

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -245,6 +245,8 @@ def _sync_context(command, target):
         ),
         "ai_gateway_url": command.get("ai_gateway_url") or "",
         "lensnode_token": command.get("lensnode_token") or "",
+        "tls_skip_verify": bool(command.get("tls_skip_verify", False)),
+        "tls_ca_file": command.get("tls_ca_file") or None,
         "vision_model_ref": conversion.get("vision_model_ref") or "",
     }
 

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -1706,6 +1706,8 @@ def describe_image_bytes(image_bytes, mime_type, context):
         model_ref=model_ref,
         ai_gateway_url=gateway_url,
         token=token,
+        tls_skip_verify=context.get("tls_skip_verify", False),
+        tls_ca_file=context.get("tls_ca_file"),
     )
     return result.get("content") or "", result.get("usage") or {}
 

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -11,6 +11,8 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
 
+from .tls import create_ssl_context
+
 LOGGER = logging.getLogger("lensnode")
 
 
@@ -59,6 +61,8 @@ class LensGatewayChatModel(BaseChatModel):
     ai_gateway_url: str
     token: str
     request_timeout_s: int = 120
+    tls_skip_verify: bool = False
+    tls_ca_file: str | None = None
     emit_output: Optional[Any] = None
     # Called on EVERY gateway SSE event (reasoning/tool-call tokens,
     # heartbeats, done) to prove transport liveness to the run watchdog.
@@ -138,7 +142,13 @@ class LensGatewayChatModel(BaseChatModel):
 
         payload["return_message"] = True
         start = time.monotonic()
-        with httpx.Client(timeout=self.request_timeout_s) as client:
+        with httpx.Client(
+            timeout=self.request_timeout_s,
+            verify=create_ssl_context(
+                self.tls_skip_verify,
+                self.tls_ca_file,
+            ),
+        ) as client:
             response = client.post(
                 self.ai_gateway_url,
                 headers={"Authorization": f"Bearer {self.token}"},
@@ -172,7 +182,13 @@ class LensGatewayChatModel(BaseChatModel):
 
         start = time.monotonic()
         done_received = False
-        with httpx.Client(timeout=self.request_timeout_s) as client:
+        with httpx.Client(
+            timeout=self.request_timeout_s,
+            verify=create_ssl_context(
+                self.tls_skip_verify,
+                self.tls_ca_file,
+            ),
+        ) as client:
             with client.stream(
                 "POST",
                 self.ai_gateway_url,
@@ -352,6 +368,8 @@ def describe_image(
     model_ref,
     ai_gateway_url,
     token,
+    tls_skip_verify=False,
+    tls_ca_file=None,
 ):
     """Describe one image through the AI gateway."""
 
@@ -362,6 +380,8 @@ def describe_image(
         model_ref=model_ref,
         ai_gateway_url=ai_gateway_url,
         token=token,
+        tls_skip_verify=tls_skip_verify,
+        tls_ca_file=tls_ca_file,
     )
     return result.get("content") or ""
 
@@ -374,6 +394,8 @@ def describe_image_result(
     model_ref,
     ai_gateway_url,
     token,
+    tls_skip_verify=False,
+    tls_ca_file=None,
 ):
     """Describe one image and return content plus usage."""
 
@@ -396,7 +418,10 @@ def describe_image_result(
             }
         ],
     }
-    with httpx.Client(timeout=120) as client:
+    with httpx.Client(
+        timeout=120,
+        verify=create_ssl_context(tls_skip_verify, tls_ca_file),
+    ) as client:
         response = client.post(
             ai_gateway_url,
             headers={"Authorization": f"Bearer {token}"},

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -20,6 +20,8 @@ from .logging_utils import (
     task_log,
     utc_now,
 )
+from .tls import create_config_ssl_context
+from .tls import warn_if_verification_disabled
 from .workspace import available_dirs
 
 LOGGER = logging.getLogger("lensnode")
@@ -30,6 +32,7 @@ class LensNodeClient:
 
     def __init__(self, config):
         self.config = config
+        self.ssl_context = create_config_ssl_context(config)
         self.executor = LensNodeExecutor(config)
         self.stopping = asyncio.Event()
         # Set while draining on shutdown/upgrade: stop accepting new runs and
@@ -229,10 +232,15 @@ class LensNodeClient:
         """Run one WebSocket connection until it closes."""
 
         connected = False
+        connection_options = {
+            "open_timeout": 10,
+            "ping_interval": None,
+        }
+        if url.lower().startswith("wss://"):
+            connection_options["ssl"] = self.ssl_context
         async with connect(
             url,
-            open_timeout=10,
-            ping_interval=None,
+            **connection_options,
         ) as websocket:
             self.websocket = websocket
             try:
@@ -525,6 +533,10 @@ class LensNodeClient:
                 **message,
                 "ai_gateway_url": self.config.ai_gateway_url,
                 "lensnode_token": self.config.token,
+                "tls_skip_verify": getattr(
+                    self.config, "tls_skip_verify", False
+                ),
+                "tls_ca_file": getattr(self.config, "tls_ca_file", None),
             }
             result = await asyncio.to_thread(
                 sync_datasource,
@@ -779,7 +791,9 @@ class LensNodeClient:
 async def _run_client():
     """Run LensNode and bind process signals to graceful shutdown."""
 
-    client = LensNodeClient(load_config())
+    config = load_config()
+    warn_if_verification_disabled(config, LOGGER)
+    client = LensNodeClient(config)
     loop = asyncio.get_running_loop()
     for signum in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -10,6 +10,8 @@ from pathlib import Path, PurePosixPath
 
 import httpx
 
+from .tls import create_config_ssl_context
+
 MAX_SKILL_PACKAGE_BYTES = 25 * 1024 * 1024
 
 
@@ -149,7 +151,10 @@ def _download_skill_package(config, skill):
     if not skill_uuid:
         raise ValueError("skill_uuid is required to download a Skill package")
     url = _skill_package_url(config.ai_gateway_url, skill_uuid)
-    with httpx.Client(timeout=config.request_timeout_s) as client:
+    with httpx.Client(
+        timeout=config.request_timeout_s,
+        verify=create_config_ssl_context(config),
+    ) as client:
         response = client.get(
             url,
             headers={"Authorization": f"Bearer {config.token}"},

--- a/lensnode/lensnode/tls.py
+++ b/lensnode/lensnode/tls.py
@@ -1,0 +1,37 @@
+import logging
+import ssl
+
+
+def create_ssl_context(skip_verify=False, ca_file=None):
+    """Create the TLS context used for SourceLens connections."""
+
+    if skip_verify:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        return context
+    return ssl.create_default_context(cafile=ca_file or None)
+
+
+def create_config_ssl_context(config):
+    """Create a SourceLens TLS context from LensNode configuration."""
+
+    return create_ssl_context(
+        skip_verify=getattr(config, "tls_skip_verify", False),
+        ca_file=getattr(config, "tls_ca_file", None),
+    )
+
+
+def warn_if_verification_disabled(config, logger=None):
+    """Warn once at startup when SourceLens TLS verification is disabled."""
+
+    if not getattr(config, "tls_skip_verify", False):
+        return
+    target_logger = logger or logging.getLogger("lensnode")
+    message = (
+        "LensNode TLS certificate and hostname verification is disabled. "
+        "LENSNODE_TLS_SKIP_VERIFY is intended for development only."
+    )
+    if getattr(config, "tls_ca_file", None):
+        message += " LENSNODE_TLS_CA_FILE is ignored."
+    target_logger.warning(message)

--- a/lensnode/tests/test_config.py
+++ b/lensnode/tests/test_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from lensnode.config import load_config
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("0", False),
+        ("invalid", False),
+    ],
+)
+def test_load_config_parses_tls_skip_verify(monkeypatch, value, expected):
+    monkeypatch.setenv("LENSNODE_TLS_SKIP_VERIFY", value)
+
+    config = load_config()
+
+    assert config.tls_skip_verify is expected
+
+
+def test_load_config_uses_secure_tls_defaults(monkeypatch):
+    monkeypatch.delenv("LENSNODE_TLS_SKIP_VERIFY", raising=False)
+    monkeypatch.delenv("LENSNODE_TLS_CA_FILE", raising=False)
+
+    config = load_config()
+
+    assert config.tls_skip_verify is False
+    assert config.tls_ca_file is None
+
+
+def test_load_config_reads_tls_ca_file(monkeypatch):
+    monkeypatch.setenv("LENSNODE_TLS_CA_FILE", "/etc/sourcelens/ca.crt")
+
+    config = load_config()
+
+    assert config.tls_ca_file == "/etc/sourcelens/ca.crt"

--- a/lensnode/tests/test_deliverable.py
+++ b/lensnode/tests/test_deliverable.py
@@ -1,4 +1,5 @@
 import json
+import ssl
 from pathlib import Path
 
 import httpx
@@ -17,6 +18,8 @@ def _config():
         control_ws_url="ws://backend/ws/",
         ai_gateway_url="http://b/api/lens/lensnode/ai-gateway/",
         deliverable_upload_url="http://b/api/lens/lensnode/deliverables/",
+        tls_skip_verify=True,
+        tls_ca_file=None,
         deliverable_max_bytes=50 * 1024 * 1024,
         workspace_path="/workspace",
         protocol_version="v1",
@@ -24,9 +27,12 @@ def _config():
         heartbeat_interval_s=15,
         request_timeout_s=30,
         run_idle_timeout_s=180,
+        drain_timeout_s=240,
         max_concurrent_runs=1,
         summary_trigger_tokens=48000,
         summary_keep_tokens=16000,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
     )
 
 
@@ -41,13 +47,15 @@ def _resources(root):
     )
 
 
-def _install_transport(monkeypatch, handler):
+def _install_transport(monkeypatch, handler, client_options=None):
     """Route agent_tools' httpx.Client through a mock transport."""
 
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
     def fake_client(*args, **kwargs):
+        if client_options is not None:
+            client_options.update(kwargs)
         kwargs["transport"] = transport
         return real_client(*args, **kwargs)
 
@@ -57,6 +65,7 @@ def _install_transport(monkeypatch, handler):
 def test_save_deliverable_uploads_file(monkeypatch, tmp_path):
     (tmp_path / "report.html").write_text("<h1>ok</h1>", encoding="utf-8")
     captured = {}
+    client_options = {}
 
     def handler(request):
         captured["url"] = str(request.url)
@@ -64,7 +73,7 @@ def test_save_deliverable_uploads_file(monkeypatch, tmp_path):
         captured["body"] = request.read()
         return httpx.Response(201, json={"ok": True})
 
-    _install_transport(monkeypatch, handler)
+    _install_transport(monkeypatch, handler, client_options)
     events = []
     tool = _build_save_deliverable_tool(
         {"run_uuid": "run-123"},
@@ -79,6 +88,7 @@ def test_save_deliverable_uploads_file(monkeypatch, tmp_path):
     assert payload["filename"] == "report.html"
     assert captured["url"].endswith("/api/lens/lensnode/deliverables/")
     assert captured["auth"] == "Bearer test-token"
+    assert client_options["verify"].verify_mode == ssl.CERT_NONE
     assert b"run-123" in captured["body"]
     assert b"<h1>ok</h1>" in captured["body"]
     assert ("tool.save_deliverable.done", None) not in events

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -1,10 +1,17 @@
+import ssl
 import threading
+from types import SimpleNamespace
 
 import httpx
 import pytest
 from langchain_core.messages import HumanMessage
 
-from lensnode.gateway_model import LensGatewayChatModel, RunCancelledError
+from lensnode.agent_runtime import _build_summarization_middleware
+from lensnode.gateway_model import (
+    LensGatewayChatModel,
+    RunCancelledError,
+    describe_image_result,
+)
 
 
 SSE_BODY = (
@@ -16,13 +23,15 @@ SSE_BODY = (
 )
 
 
-def _install_transport(monkeypatch, handler):
+def _install_transport(monkeypatch, handler, client_options=None):
     """Route the module's httpx.Client through a mock transport."""
 
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
     def fake_client(*args, **kwargs):
+        if client_options is not None:
+            client_options.update(kwargs)
         kwargs["transport"] = transport
         return real_client(*args, **kwargs)
 
@@ -33,12 +42,13 @@ def _install_transport(monkeypatch, handler):
 
 def test_streaming_touches_activity_on_every_event(monkeypatch):
     captured = {}
+    client_options = {}
 
     def handler(request):
         captured["payload"] = request.read()
         return httpx.Response(200, content=SSE_BODY.encode("utf-8"))
 
-    _install_transport(monkeypatch, handler)
+    _install_transport(monkeypatch, handler, client_options)
     outputs = []
     activity = {"count": 0}
 
@@ -64,6 +74,7 @@ def test_streaming_touches_activity_on_every_event(monkeypatch):
     assert outputs == ["Hello"]
     assert b'"run_uuid"' in captured["payload"]
     assert b'"is_subagent"' in captured["payload"]
+    assert client_options["verify"].verify_mode == ssl.CERT_REQUIRED
 
 
 def test_cancelled_run_aborts_before_model_call(monkeypatch):
@@ -84,3 +95,74 @@ def test_cancelled_run_aborts_before_model_call(monkeypatch):
 
     with pytest.raises(RunCancelledError):
         model._generate([HumanMessage(content="hi")])
+
+
+def test_https_gateway_request_uses_configured_tls_context(monkeypatch):
+    client_options = {}
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"message": {"role": "assistant", "content": "ok"}},
+        )
+
+    _install_transport(monkeypatch, handler, client_options)
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="https://gateway.example/ai/",
+        token="token",
+        tls_skip_verify=True,
+    )
+
+    result = model._generate([HumanMessage(content="hi")])
+
+    assert result.generations[0].message.content == "ok"
+    context = client_options["verify"]
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False
+
+
+def test_image_gateway_request_uses_configured_tls_context(monkeypatch):
+    client_options = {}
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"message": {"content": "described"}},
+        )
+
+    _install_transport(monkeypatch, handler, client_options)
+
+    result = describe_image_result(
+        b"image",
+        "Describe this image.",
+        "image/png",
+        model_ref="vision-model",
+        ai_gateway_url="https://gateway.example/ai/",
+        token="token",
+        tls_skip_verify=True,
+    )
+
+    assert result["content"] == "described"
+    assert client_options["verify"].verify_mode == ssl.CERT_NONE
+
+
+def test_summarization_model_receives_tls_configuration():
+    config = SimpleNamespace(
+        summary_trigger_tokens=1000,
+        summary_keep_tokens=500,
+        ai_gateway_url="https://gateway.example/ai/",
+        token="token",
+        request_timeout_s=30,
+        tls_skip_verify=True,
+        tls_ca_file="/ignored/ca.crt",
+    )
+
+    middleware = _build_summarization_middleware(
+        config,
+        "summary-model",
+        lambda *args: None,
+    )
+
+    assert middleware.model.tls_skip_verify is True
+    assert middleware.model.tls_ca_file == "/ignored/ca.crt"

--- a/lensnode/tests/test_main_tls.py
+++ b/lensnode/tests/test_main_tls.py
@@ -1,0 +1,75 @@
+import asyncio
+import ssl
+
+import pytest
+
+from lensnode.main import LensNodeClient
+
+
+class FakeWebSocketContext:
+    """Minimal asynchronous WebSocket connection context."""
+
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+def _make_client():
+    """Build a LensNode client for transport option tests."""
+
+    config = type(
+        "Config",
+        (),
+        {
+            "name": "test-node",
+            "request_timeout_s": 30,
+            "max_concurrent_runs": 1,
+            "tls_skip_verify": True,
+            "tls_ca_file": None,
+        },
+    )()
+    return LensNodeClient(config)
+
+
+@pytest.mark.parametrize(
+    "url,uses_tls",
+    [
+        ("wss://server.example/ws/lens/lensnodes/", True),
+        ("ws://server.example/ws/lens/lensnodes/", False),
+    ],
+)
+def test_websocket_connection_uses_tls_context_only_for_wss(
+    monkeypatch,
+    url,
+    uses_tls,
+):
+    captured = {}
+
+    def fake_connect(target, **options):
+        captured["target"] = target
+        captured["options"] = options
+        return FakeWebSocketContext()
+
+    async def connected():
+        return None
+
+    async def loop(*args):
+        return None
+
+    client = _make_client()
+    monkeypatch.setattr("lensnode.main.connect", fake_connect)
+    monkeypatch.setattr(client, "_on_connected", connected)
+    monkeypatch.setattr(client, "_send_loop", loop)
+    monkeypatch.setattr(client, "_heartbeat_loop", loop)
+    monkeypatch.setattr(client, "_receive_loop", loop)
+
+    assert asyncio.run(client._run_connection(url)) is True
+    assert captured["target"] == url
+    if uses_tls:
+        context = captured["options"]["ssl"]
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+    else:
+        assert "ssl" not in captured["options"]

--- a/lensnode/tests/test_runtime_resources_tls.py
+++ b/lensnode/tests/test_runtime_resources_tls.py
@@ -1,0 +1,42 @@
+import ssl
+from types import SimpleNamespace
+
+import httpx
+
+from lensnode.runtime_resources import _download_skill_package
+
+
+def test_skill_package_download_uses_configured_tls_context(monkeypatch):
+    captured = {}
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, content=b"package")
+    )
+    real_client = httpx.Client
+
+    def fake_client(*args, **kwargs):
+        captured.update(kwargs)
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "lensnode.runtime_resources.httpx.Client",
+        fake_client,
+    )
+    config = SimpleNamespace(
+        ai_gateway_url="https://server.example/api/lens/lensnode/ai-gateway/",
+        token="token",
+        request_timeout_s=30,
+        tls_skip_verify=True,
+        tls_ca_file=None,
+    )
+
+    package = _download_skill_package(
+        config,
+        {
+            "skill_uuid": "11111111-1111-1111-1111-111111111111",
+            "package_hash": "sha256:abc",
+        },
+    )
+
+    assert package == b"package"
+    assert captured["verify"].verify_mode == ssl.CERT_NONE

--- a/lensnode/tests/test_tls.py
+++ b/lensnode/tests/test_tls.py
@@ -1,0 +1,69 @@
+import logging
+import ssl
+from types import SimpleNamespace
+
+from lensnode.tls import create_ssl_context
+from lensnode.tls import warn_if_verification_disabled
+
+
+def test_default_context_verifies_certificate_and_hostname():
+    context = create_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+
+def test_custom_ca_is_loaded_with_verification_enabled(monkeypatch):
+    expected = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    calls = []
+
+    def fake_create_default_context(*, cafile=None):
+        calls.append(cafile)
+        return expected
+
+    monkeypatch.setattr(
+        ssl,
+        "create_default_context",
+        fake_create_default_context,
+    )
+
+    context = create_ssl_context(ca_file="/etc/sourcelens/ca.crt")
+
+    assert context is expected
+    assert calls == ["/etc/sourcelens/ca.crt"]
+
+
+def test_skip_verify_disables_certificate_and_hostname_checks():
+    context = create_ssl_context(
+        skip_verify=True,
+        ca_file="/ignored/ca.crt",
+    )
+
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False
+
+
+def test_skip_verify_logs_one_startup_warning(caplog):
+    config = SimpleNamespace(
+        tls_skip_verify=True,
+        tls_ca_file="/ignored/ca.crt",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="lensnode"):
+        warn_if_verification_disabled(config)
+
+    assert len(caplog.records) == 1
+    assert "development only" in caplog.text
+    assert "LENSNODE_TLS_CA_FILE is ignored" in caplog.text
+
+
+def test_secure_tls_configuration_does_not_warn(caplog):
+    config = SimpleNamespace(
+        tls_skip_verify=False,
+        tls_ca_file="/etc/sourcelens/ca.crt",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="lensnode"):
+        warn_if_verification_disabled(config)
+
+    assert caplog.records == []


### PR DESCRIPTION
### **User description**
Closes #17.

## Problem

LensNode derives HTTPS and WSS endpoints when SourceLens is configured with an
HTTPS server URL, but its Python clients previously had no way to trust a
private CA or explicitly allow a self-signed development certificate.

Operators therefore had to choose between certificate verification failures and
falling back to plaintext HTTP/WS, which is not appropriate when LensNode
traffic crosses hosts or networks.

## Configuration and behavior

This PR adds two LensNode environment variables:

| Configuration | Behavior |
| --- | --- |
| Neither variable configured | Verify with the system trust store |
| `LENSNODE_TLS_CA_FILE` configured | Verify the certificate and hostname with the specified CA file |
| `LENSNODE_TLS_SKIP_VERIFY=true` | Disable certificate and hostname verification |
| Both configured | Skip verification takes precedence and logs one startup warning |

`LENSNODE_TLS_SKIP_VERIFY` defaults to `false`. Disabling verification is
documented as development-only.

## Changes

- Add a shared LensNode TLS helper that creates the `ssl.SSLContext` used by
  SourceLens WebSocket and HTTP clients.
- Parse `LENSNODE_TLS_SKIP_VERIFY` and `LENSNODE_TLS_CA_FILE` in the LensNode
  runtime configuration.
- Pass the configured SSL context to the WSS control channel while leaving
  plain WS connections unchanged.
- Apply the same TLS policy to every LensNode HTTPX request targeting
  SourceLens:
  - normal and streaming AI Gateway calls;
  - image model calls;
  - summarization model calls;
  - Skill package downloads;
  - deliverable uploads.
- Propagate TLS configuration through datasource document conversion so image
  Gateway requests use the same policy.
- Log one clear startup warning when certificate verification is disabled,
  including when a configured CA file is ignored because skip verification
  takes precedence.
- Document secure defaults, private-CA mounting, and the development-only skip
  mode in `env.sample`, the LensNode README, and the standalone LensNode Compose
  example.

## Scope and safety

- TLS verification remains enabled by default.
- A missing or invalid custom CA fails explicitly instead of silently disabling
  verification.
- The setting is passed only to LensNode clients that communicate with the
  SourceLens control plane.
- It does not modify the global Python SSL context or affect unrelated external
  datasources, MCP endpoints, provider endpoints, or Skill scripts.
- Existing HTTP and WS deployments continue to work without additional
  configuration.
- No backend migration or frontend change is required.

## Tests

- TLS-focused tests: **26 passed**.
- Full LensNode suite introduces no new failures compared with `origin/main`.
- The remaining failures reproduce on `origin/main` and are unrelated to this
  TLS change.
- Python compilation check passes.
- `git diff --check` passes.
- `docker compose -f lensnode/docker-compose.yml config` passes.

## Manual verification

A live certificate matrix has not yet been run. Before merge, the recommended
manual verification is:

- a system-trusted HTTPS/WSS deployment connects successfully;
- a private-CA deployment connects with `LENSNODE_TLS_CA_FILE`;
- a self-signed deployment fails with verification enabled and no CA;
- the same self-signed development deployment connects with
  `LENSNODE_TLS_SKIP_VERIFY=true`;
- normal and streaming model calls, image processing, summarization, Skill
  downloads, and deliverable uploads succeed in the applicable successful
  scenarios.

## Backward compatibility

The change is backward compatible. TLS certificate and hostname verification
remain enabled unless an operator explicitly opts into the development-only
skip mode. Existing HTTP and WS deployments require no new configuration.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add configurable TLS verification for LensNode connections

- Parse LENSNODE_TLS_SKIP_VERIFY and LENSNODE_TLS_CA_FILE

- Create shared TLS helper for SSL contexts

- Propagate settings to WebSocket, Gateway, downloads, and tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  env["LENSNODE_TLS_SKIP_VERIFY<br>LENSNODE_TLS_CA_FILE"]
  config["LensNodeConfig<br>tls_skip_verify, tls_ca_file"]
  helper["tls.create_ssl_context()"]
  ws["WebSocket<br>connection"]
  gw["AI Gateway<br>HTTP requests"]
  tools["Deliverable upload<br>Skill download"]
  ds["Datasource sync<br>Image description"]
  env --> config
  config --> helper
  helper --> ws
  helper --> gw
  helper --> tools
  helper --> ds
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Propagate TLS config to summarization and runtime models</code>&nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_tools.py</strong><dd><code>Apply TLS context to deliverable upload client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.py</strong><dd><code>Parse TLS environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Pass TLS settings to sync context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document_convert.py</strong><dd><code>Forward TLS config to image description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway_model.py</strong><dd><code>Use TLS context in Gateway HTTP clients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+28/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Integrate TLS context into WebSocket client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Apply TLS context to skill package download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls.py</strong><dd><code>New shared TLS helper module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-134957d69d69103a001275f5fc38afad05347b3e409dfdfddeb5dd9b81b8590d">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_config.py</strong><dd><code>Test TLS environment parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-fe4181ec6e0283de70ef882d03ccbe78488c22434fb88d7f599b174dd0a0b1a8">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_deliverable.py</strong><dd><code>Verify TLS context in deliverable upload test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-149616217e0907a6f71a64a22ddf4e15001c9c97f2d3b575e44304d4ae92c1e2">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gateway_model.py</strong><dd><code>Add TLS context tests for Gateway and summarization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+85/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_main_tls.py</strong><dd><code>Test TLS context only for WSS connections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-bc99d96e237833f5aeb490bb1f7fa15fd7719bb19a09c919215612bbc0676cd3">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_runtime_resources_tls.py</strong><dd><code>Test TLS context in skill package download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-33f723fdcea852ee1706523445f8d6fcd4655e7be216708f2a7806322cd04295">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tls.py</strong><dd><code>Unit tests for TLS helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-16432acb6727ac0c1d9ea239eccb2045ebb1c1e89a1ff3405b6a429b1c42f90d">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>env.sample</strong><dd><code>Document TLS environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add TLS verification section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-e05e28c347a9f65fac63628bd4059e505e4e75e5850b02c719ac3d189321ca31">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Add TLS environment variables to compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/65/files#diff-3ef09104a5bd79ec8fe2f3f772bad1587e3754903e61d785e5956ea99f9885c9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

