### PR TITLE
fix(lensnode): attribute all AI gateway usage to run owners (#16)

### DIFF
--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -808,6 +808,30 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 403)
         call_and_track.assert_not_called()
 
+    def test_lensnode_ai_gateway_rejects_malformed_run_uuid(self):
+        token = "dev-lensnode-token"
+        self.lensnode.auth_token_hash = hash_lensnode_token(token)
+        self.lensnode.save(update_fields=["auth_token_hash", "updated_at"])
+        client = APIClient()
+
+        with patch(
+            "agentcore_metering.adapters.django.LLMTracker.call_and_track"
+        ) as call_and_track:
+            response = client.post(
+                "/api/lens/lensnode/ai-gateway/",
+                {
+                    "model_ref": "016d5cf7-2245-4015-b242-d6323e795b58",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "run_uuid": "not-a-uuid",
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "Run not found.")
+        call_and_track.assert_not_called()
+
     def test_lensnode_deliverable_upload_records_output_file(self):
         from django.core.files.uploadedfile import SimpleUploadedFile
         from lens.models import RunOutputFile, Session

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -1,6 +1,7 @@
 import io
 import tempfile
 import zipfile
+from types import SimpleNamespace
 from unittest.mock import ANY, patch
 
 from asgiref.sync import async_to_sync
@@ -11,7 +12,7 @@ from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import AccessToken
 
-from agentcore_metering.adapters.django.models import LLMConfig
+from agentcore_metering.adapters.django.models import LLMConfig, LLMUsage
 from agentcore_task.adapters.django.models import TaskExecution
 
 from lens.lensnode_auth import hash_lensnode_token
@@ -654,11 +655,27 @@ class LensApiTests(TestCase):
         self.assertTrue(call_and_track.call_args.kwargs["return_message"])
 
     def test_lensnode_ai_gateway_forwards_run_correlation(self):
+        from lens.models import Session
+        from lens.services import create_execution_run
+
         token = "dev-lensnode-token"
         self.lensnode.auth_token_hash = hash_lensnode_token(token)
         self.lensnode.save(update_fields=["auth_token_hash", "updated_at"])
         client = APIClient()
-        run_uuid = "3a2b7d54-9c1e-4f7a-8f27-0a4c1d2e3f45"
+        chat_user = User.objects.create_user(
+            username="chat-user",
+            email="chat-user@example.com",
+            password="pass12345",
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=chat_user,
+        )
+        run = create_execution_run(
+            session=session,
+            question="hello",
+            enqueue=False,
+        )
 
         with patch(
             "agentcore_metering.adapters.django.LLMTracker.call_and_track",
@@ -669,7 +686,7 @@ class LensApiTests(TestCase):
                 {
                     "model_ref": "016d5cf7-2245-4015-b242-d6323e795b58",
                     "messages": [{"role": "user", "content": "hello"}],
-                    "run_uuid": run_uuid,
+                    "run_uuid": str(run.uuid),
                     "is_subagent": True,
                 },
                 format="json",
@@ -678,8 +695,118 @@ class LensApiTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         state = call_and_track.call_args.kwargs["state"]
-        self.assertEqual(state["metadata"]["run_uuid"], run_uuid)
+        self.assertEqual(state["user_id"], chat_user.id)
+        self.assertEqual(state["metadata"]["run_uuid"], str(run.uuid))
         self.assertTrue(state["metadata"]["is_subagent"])
+
+    def test_lensnode_ai_gateway_attributes_every_call_to_run_owner(self):
+        from lens.models import Session
+        from lens.services import create_execution_run
+
+        token = "dev-lensnode-token"
+        self.lensnode.auth_token_hash = hash_lensnode_token(token)
+        self.lensnode.save(update_fields=["auth_token_hash", "updated_at"])
+        chat_user = User.objects.create_user(
+            username="usage-chat-user",
+            email="usage-chat-user@example.com",
+            password="pass12345",
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=chat_user,
+        )
+        run = create_execution_run(
+            session=session,
+            question="hello",
+            enqueue=False,
+        )
+        config = LLMConfig.objects.create(
+            scope=LLMConfig.Scope.GLOBAL,
+            model_type=LLMConfig.MODEL_TYPE_LLM,
+            provider="openai",
+            config={"api_key": "test", "model": "gpt-4o-mini"},
+            is_active=True,
+        )
+        completion = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok"),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=2,
+                completion_tokens=1,
+                total_tokens=3,
+                cached_tokens=0,
+                reasoning_tokens=0,
+            ),
+            model="gpt-4o-mini",
+        )
+        client = APIClient()
+        payload = {
+            "model_ref": str(config.uuid),
+            "messages": [{"role": "user", "content": "hello"}],
+            "run_uuid": str(run.uuid),
+        }
+
+        with patch("litellm.completion", return_value=completion):
+            for _ in range(2):
+                response = client.post(
+                    "/api/lens/lensnode/ai-gateway/",
+                    payload,
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                )
+                self.assertEqual(response.status_code, 200)
+
+        usages = list(LLMUsage.objects.order_by("created_at"))
+        self.assertEqual(len(usages), 2)
+        self.assertTrue(all(item.user_id == chat_user.id for item in usages))
+        self.assertTrue(
+            all(
+                item.metadata["run_uuid"] == str(run.uuid)
+                for item in usages
+            )
+        )
+
+    def test_lensnode_ai_gateway_rejects_run_from_another_lensnode(self):
+        from lens.models import Session
+        from lens.services import create_execution_run
+
+        token = "other-lensnode-token"
+        LensNode.objects.create(
+            name="Other LensNode",
+            status=LensNode.Status.ONLINE,
+            enrollment_status=LensNode.EnrollmentStatus.APPROVED,
+            auth_token_hash=hash_lensnode_token(token),
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(
+            session=session,
+            question="hello",
+            enqueue=False,
+        )
+        client = APIClient()
+
+        with patch(
+            "agentcore_metering.adapters.django.LLMTracker.call_and_track"
+        ) as call_and_track:
+            response = client.post(
+                "/api/lens/lensnode/ai-gateway/",
+                {
+                    "model_ref": "016d5cf7-2245-4015-b242-d6323e795b58",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "run_uuid": str(run.uuid),
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 403)
+        call_and_track.assert_not_called()
 
     def test_lensnode_deliverable_upload_records_output_file(self):
         from django.core.files.uploadedfile import SimpleUploadedFile

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -5,6 +5,7 @@ import json
 import os
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.http import FileResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -63,7 +64,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                 run = Run.objects.select_related("session").get(
                     uuid=run_uuid
                 )
-            except Run.DoesNotExist:
+            except (Run.DoesNotExist, ValidationError):
                 return Response(
                     {"detail": "Run not found."},
                     status=status.HTTP_404_NOT_FOUND,

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -57,8 +57,24 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
             "lensnode_uuid": str(lensnode.uuid),
         }
         correlation = {}
-        if request.data.get("run_uuid"):
-            correlation["run_uuid"] = str(request.data["run_uuid"])
+        run_uuid = request.data.get("run_uuid")
+        if run_uuid:
+            try:
+                run = Run.objects.select_related("session").get(
+                    uuid=run_uuid
+                )
+            except Run.DoesNotExist:
+                return Response(
+                    {"detail": "Run not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            if run.lensnode_id != lensnode.id:
+                return Response(
+                    {"detail": "Run does not belong to this LensNode."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            tracker_state["user_id"] = run.session.user_id
+            correlation["run_uuid"] = str(run.uuid)
             correlation["is_subagent"] = bool(
                 request.data.get("is_subagent")
             )

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -160,7 +160,7 @@ class LensSummarizationMiddleware(SummarizationMiddleware):
 
 
 def _build_summarization_middleware(
-    config, model_ref, emit_event, cancel_event=None
+    config, model_ref, emit_event, cancel_event=None, run_uuid=""
 ):
     """Build context-compaction middleware, or None when disabled.
 
@@ -184,6 +184,7 @@ def _build_summarization_middleware(
         token=config.token,
         request_timeout_s=config.request_timeout_s,
         cancel_event=cancel_event,
+        run_uuid=run_uuid,
     )
     middleware = LensSummarizationMiddleware(
         model=summary_model,
@@ -321,6 +322,7 @@ class LensDeepAgentRuntime:
             emit_event=emit_agent_event,
         )
         try:
+            run_uuid = str(command.get("run_uuid") or "")
             model = LensGatewayChatModel(
                 model_ref=str(model_ref),
                 ai_gateway_url=self.config.ai_gateway_url,
@@ -329,7 +331,7 @@ class LensDeepAgentRuntime:
                 emit_output=emit_output,
                 on_activity=on_activity,
                 cancel_event=cancel_event,
-                run_uuid=str(command.get("run_uuid") or ""),
+                run_uuid=run_uuid,
             )
             if _is_general_chat(command):
                 tools = build_general_chat_tools(
@@ -364,7 +366,11 @@ class LensDeepAgentRuntime:
                 kwargs["skills"] = resources.skill_paths
 
             summarizer = _build_summarization_middleware(
-                self.config, model_ref, emit_agent_event, cancel_event
+                self.config,
+                model_ref,
+                emit_agent_event,
+                cancel_event,
+                run_uuid=run_uuid,
             )
             if summarizer is not None:
                 kwargs["middleware"] = [summarizer]

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+from lensnode import agent_runtime
 from lensnode.agent_runtime import (
     _build_initial_messages,
     _run_agent_with_turn_limit,
@@ -47,6 +50,40 @@ def test_build_initial_messages_without_history():
     assert _build_initial_messages(None, "q") == [
         {"role": "user", "content": "q"}
     ]
+
+
+def test_summarization_middleware_forwards_run_uuid(monkeypatch):
+    captured = {}
+
+    class CapturingMiddleware:
+        """Capture the model configured for compaction."""
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "LensSummarizationMiddleware",
+        CapturingMiddleware,
+    )
+    config = SimpleNamespace(
+        ai_gateway_url="http://gateway/ai/",
+        request_timeout_s=120,
+        summary_keep_tokens=8000,
+        summary_trigger_tokens=48000,
+        token="token",
+    )
+    run_uuid = "00000000-0000-0000-0000-000000000009"
+
+    middleware = agent_runtime._build_summarization_middleware(
+        config,
+        "model-ref",
+        lambda *_args, **_kwargs: None,
+        run_uuid=run_uuid,
+    )
+
+    assert isinstance(middleware, CapturingMiddleware)
+    assert captured["model"].run_uuid == run_uuid
 
 
 def test_turn_limit_excludes_historical_assistant_turns():


### PR DESCRIPTION
### **User description**
## Summary

Fix LensNode AI Gateway usage attribution so every metered LLM call
generated during a chat run is assigned to the user who owns the run
session.

This includes both the normal answer model and the separate model used for
context-compaction summaries. The gateway resolves the user server-side from
the trusted `run_uuid` instead of accepting a client-supplied user identifier.

Closes #16.

## Problem

LensNode-backed runs were correctly associated with their session users,
but their corresponding `LLMUsage` records could have `user_id=NULL`.

The normal LensNode answer model already received the current `run_uuid`,
but the separate model created for context compaction did not. When a run
crossed the compaction threshold, the summarization request therefore reached
the AI Gateway without a `run_uuid` and could not be attributed.

The gateway also handled missing runs but did not handle malformed UUID
values. Django raises `ValidationError` before querying the database for
values such as `not-a-uuid`, which could result in an HTTP 500 response.

## Changes

- Resolve the run referenced by `run_uuid` in the LensNode AI Gateway
- Derive usage ownership from `run.session.user_id`
- Validate that the run belongs to the authenticated LensNode
- Pass the same current `run_uuid` to the normal answer model and the
  context-compaction summarization model
- Preserve existing `run_uuid` and `is_subagent` correlation metadata
- Return `404` when the run does not exist or the UUID is malformed
- Return `403` when the run belongs to another LensNode
- Avoid invoking the model for invalid or unauthorized run identifiers
- Keep gateway calls without `run_uuid` backward compatible

## Security

The gateway does not trust a user identifier supplied by LensNode. User
attribution is derived from the server-side `Run -> Session -> User`
relationship. Before invoking the model, the gateway also verifies that the
referenced Run belongs to the authenticated LensNode.

Malformed run identifiers are handled as stable client errors instead of
propagating internal validation exceptions.

## Tests

Added regression coverage that verifies:

- a non-admin chat user ID is passed to the metering tracker
- multiple LLM calls for one Run create `LLMUsage` records assigned to the
  Run owner
- the compaction summarization model receives the current Run UUID
- run correlation metadata remains present
- a LensNode cannot use a Run owned by another LensNode
- malformed `run_uuid` values return `404` without invoking the model
- existing bearer-token and tool-calling behavior remains compatible

Validation completed:

- backend AI Gateway tests: 6 passed
- LensNode compaction and gateway tests: 7 passed
- Python compilation check passed
- staged and unstaged `git diff --check` passed
- manual verification confirmed that all five usage records generated for
  one new Run were attributed to the Run owner

## Review Feedback Addressed

The latest review identified two blocking findings:

1. Context-compaction usage was not attributed because the summarization
   model did not receive the current `run_uuid`.
2. Malformed non-empty `run_uuid` values could raise Django
   `ValidationError` and return HTTP 500.

Both findings are addressed with implementation changes and dedicated
regression coverage.

## Compatibility

- No database migration is required.
- Gateway calls without `run_uuid` remain supported.
- Existing historical records with `user_id=NULL` are not backfilled.
- Only usage generated after this fix receives corrected attribution.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Attribute LensNode AI gateway usage to originating session user

- Validate run ownership and reject unauthorized or malformed run_uuid

- Pass run_uuid to context-compaction summarization model

- Add regression tests for user attribution and security checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
    LN["LensNode"] --> GW["AI Gateway"]
    GW -- "run_uuid" --> R["Run lookup"]
    R -- "session.user_id" --> Attr["user_id in tracker_state"]
    Attr --> Meter["LLMUsage.user_id set"]
    R -- "ownership check" --> Auth["403 if wrong lensnode"]
    R -- "malformed UUID" --> Err["404 response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway.py</strong><dd><code>Resolve run owner and validate ownership in gateway</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/views/gateway.py

<ul><li>Resolve Run from run_uuid and set tracker_state user_id from session<br> <li> Return 404 for missing or malformed run_uuid (catches ValidationError)<br> <li> Return 403 if run does not belong to the authenticated LensNode</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/66/files#diff-7a38a41d1d2cc8239be8f186a349fee86254f97ad1ad16b566c0bacdc0d4fb4d">+19/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_runtime.py</strong><dd><code>Forward run_uuid to summarization model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime.py

<ul><li>Pass run_uuid to context-compaction summarization middleware<br> <li> Extract run_uuid variable once for reuse in both model and summarizer</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/66/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add regression tests for run owner attribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_api.py

<ul><li>Verify LLMUsage.user_id is set for LensNode gateway calls<br> <li> Verify 403 when run_uuid belongs to another LensNode<br> <li> Verify 404 for malformed run_uuid<br> <li> Update existing correlation test to check user_id in state</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/66/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+155/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Test run_uuid forwarding to summarization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_history.py

- Add test that summarization middleware receives correct run_uuid


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/66/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

