### PR TITLE
fix(lens): label assistant task column as type and localize values

### DIFF
--- a/frontend/e2e/assistant-types.spec.js
+++ b/frontend/e2e/assistant-types.spec.js
@@ -1,0 +1,162 @@
+import { expect, test } from '@playwright/test'
+
+const assistants = [
+  {
+    uuid: 'knowledge-assistant',
+    name: 'Knowledge Assistant',
+    slug: 'knowledge-assistant',
+    selected_task: 'knowledge_qa'
+  },
+  {
+    uuid: 'legacy-assistant',
+    name: 'Legacy Assistant',
+    slug: 'legacy-assistant',
+    selected_task: 'qa'
+  },
+  {
+    uuid: 'code-assistant',
+    name: 'Code Assistant',
+    slug: 'code-assistant',
+    selected_task: 'code_analysis'
+  },
+  {
+    uuid: 'chat-assistant',
+    name: 'Chat Assistant',
+    slug: 'chat-assistant',
+    selected_task: 'general_chat'
+  },
+  {
+    uuid: 'future-assistant',
+    name: 'Future Assistant',
+    slug: 'future-assistant',
+    selected_task: 'future_assistant'
+  },
+  {
+    uuid: 'empty-assistant',
+    name: 'Empty Assistant',
+    slug: 'empty-assistant',
+    selected_task: ''
+  }
+].map((assistant) => ({
+  ...assistant,
+  status: 'inactive',
+  visibility: 'public'
+}))
+
+const lensnodes = [
+  {
+    uuid: 'test-lensnode',
+    name: 'Test LensNode',
+    tasks: [
+      { name: 'knowledge_qa', title: 'Knowledge Q&A' },
+      { name: 'code_analysis', title: 'Code Analysis' },
+      { name: 'general_chat', title: 'General Chat' }
+    ]
+  }
+]
+
+async function mockAssistantsPage(page) {
+  await page.setExtraHTTPHeaders({ 'Cache-Control': 'no-cache' })
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+    localStorage.setItem('userLanguage', 'en')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+
+    const payloads = {
+      '/api/v1/auth/user': { username: 'admin', is_staff: true },
+      '/api/lens/assistants/': assistants,
+      '/api/lens/admin/lensnodes/': lensnodes,
+      '/api/v1/admin/llm-config/all/': [
+        {
+          uuid: 'test-model',
+          provider: 'test',
+          config: { model: 'test-model' }
+        }
+      ]
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payloads[path] ?? [] })
+    })
+  })
+}
+
+function assistantTypeCell(page, assistantName) {
+  return page
+    .getByRole('row')
+    .filter({ hasText: assistantName })
+    .getByRole('cell')
+    .nth(2)
+}
+
+test('localizes assistant types with readable fallback values', async ({
+  page
+}) => {
+  await mockAssistantsPage(page)
+  await page.goto('/management/lens/assistants')
+
+  await expect(page.getByRole('columnheader', { name: 'Type' })).toBeVisible()
+  await expect(assistantTypeCell(page, 'Knowledge Assistant')).toHaveText(
+    'Knowledge Q&A'
+  )
+  await expect(assistantTypeCell(page, 'Legacy Assistant')).toHaveText(
+    'Knowledge Q&A'
+  )
+  await expect(assistantTypeCell(page, 'Code Assistant')).toHaveText(
+    'Code Analysis'
+  )
+  await expect(assistantTypeCell(page, 'Chat Assistant')).toHaveText(
+    'General Chat'
+  )
+  await expect(assistantTypeCell(page, 'Future Assistant')).toHaveText(
+    'future assistant'
+  )
+  await expect(assistantTypeCell(page, 'Empty Assistant')).toHaveText('—')
+
+  await page.locator('button[title="Language"]').click()
+  await page.getByRole('button', { name: /简体中文/ }).click()
+
+  await expect(page.getByRole('columnheader', { name: '类型' })).toBeVisible()
+  await expect(assistantTypeCell(page, 'Knowledge Assistant')).toHaveText(
+    '知识问答'
+  )
+  await expect(assistantTypeCell(page, 'Knowledge Assistant')).toHaveCSS(
+    'white-space',
+    'nowrap'
+  )
+  await expect(assistantTypeCell(page, 'Legacy Assistant')).toHaveText(
+    '知识问答'
+  )
+  await expect(assistantTypeCell(page, 'Code Assistant')).toHaveText('代码分析')
+  await expect(assistantTypeCell(page, 'Chat Assistant')).toHaveText('通用对话')
+  await expect(assistantTypeCell(page, 'Future Assistant')).toHaveText(
+    'future assistant'
+  )
+  await expect(assistantTypeCell(page, 'Empty Assistant')).toHaveText('—')
+
+  await page.getByRole('button', { name: '新建 Assistant' }).click()
+  const drawer = page.locator('.fixed.inset-0.z-50')
+  const textInputs = drawer.locator('input.form-input:not([type="number"])')
+  await textInputs.nth(0).fill('Localized Assistant')
+  await textInputs.nth(1).fill('localized-assistant')
+  await drawer.locator('select.form-input').nth(0).selectOption('test-model')
+  await drawer.getByRole('button', { name: '下一步' }).click()
+
+  const executionSelects = drawer.locator('select.form-input')
+  await executionSelects.nth(0).selectOption('test-lensnode')
+  await expect(drawer.getByText('类型', { exact: true })).toBeVisible()
+  await expect(executionSelects.nth(1).locator('option')).toHaveText([
+    '请选择类型',
+    '知识问答',
+    '代码分析',
+    '通用对话'
+  ])
+})

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -716,6 +716,11 @@
     "skillDetail": {
       "title": "Skill Detail"
     },
+    "assistantTypes": {
+      "knowledgeQa": "Knowledge Q&A",
+      "codeAnalysis": "Code Analysis",
+      "generalChat": "General Chat"
+    },
     "columns": {
       "assistant": "Assistant",
       "lensnode": "Node",
@@ -944,6 +949,7 @@
       "assistantDescription": "Describe what this assistant helps users do.",
       "selectLensNode": "Select a LensNode",
       "selectTask": "Select a task",
+      "selectType": "Select a type",
       "selectDir": "Select a directory",
       "selectModel": "Select a model",
       "noModel": "Default",
@@ -1216,7 +1222,7 @@
       "multimodalModelHint": "Optional — for vision or image-aware tasks.",
       "maxConcurrencyHint": "Maximum simultaneous runs for this assistant. Extra requests queue automatically.",
       "step2Title": "Execution",
-      "step2Desc": "Select node, task, directories, and retrieval policy",
+      "step2Desc": "Select node, type, directories, and retrieval policy",
       "generalChatExecutionHint": "General Chat uses bound Skills and bundled scripts. Workspace directory retrieval is disabled for this assistant.",
       "step3Title": "Skills & Workspace",
       "step3Desc": "Bind Skills and MCP, and add workspace context — all optional",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -716,6 +716,11 @@
     "skillDetail": {
       "title": "Skill 详情"
     },
+    "assistantTypes": {
+      "knowledgeQa": "知识问答",
+      "codeAnalysis": "代码分析",
+      "generalChat": "通用对话"
+    },
     "columns": {
       "assistant": "Assistant",
       "lensnode": "节点",
@@ -944,6 +949,7 @@
       "assistantDescription": "说明该助手可以帮助用户完成什么。",
       "selectLensNode": "请选择节点",
       "selectTask": "请选择任务",
+      "selectType": "请选择类型",
       "selectDir": "请选择目录",
       "selectModel": "请选择模型",
       "noModel": "默认",
@@ -1216,7 +1222,7 @@
       "multimodalModelHint": "可选 — 用于视觉或图像相关任务。",
       "maxConcurrencyHint": "该 Assistant 同时运行的最大任务数，超出后自动排队。",
       "step2Title": "执行配置",
-      "step2Desc": "选择执行节点、任务、目录与检索策略",
+      "step2Desc": "选择执行节点、类型、目录与检索策略",
       "generalChatExecutionHint": "通用对话使用绑定的 Skill 和内置脚本运行，不启用工作区目录检索。",
       "step3Title": "技能与工作区",
       "step3Desc": "绑定 Skills 与 MCP，并补充工作区背景，均为可选",

--- a/frontend/src/pages/lens/AssistantFormDrawer.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawer.vue
@@ -147,10 +147,10 @@
             </option>
           </select>
         </FormRow>
-        <FormRow :label="t('lensAdmin.fields.task')">
+        <FormRow :label="t('lensAdmin.fields.type')">
           <select v-model="form.selected_task" class="form-input" required>
             <option value="">
-              {{ t('lensAdmin.placeholders.selectTask') }}
+              {{ t('lensAdmin.placeholders.selectType') }}
             </option>
             <option
               v-for="task in selectedLensNodeTasks"
@@ -158,7 +158,9 @@
               :value="task.name"
               :title="task.description"
             >
-              {{ task.title || task.name }}
+              {{
+                formatAssistantType(task.name, t, task.title || task.name)
+              }}
             </option>
           </select>
         </FormRow>
@@ -609,7 +611,11 @@ import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseDrawer from '@/components/ui/BaseDrawer.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
 
-import { EMPTY_VALUE, formatLLMConfigLabel } from './adminHelpers'
+import {
+  EMPTY_VALUE,
+  formatAssistantType,
+  formatLLMConfigLabel
+} from './adminHelpers'
 
 const props = defineProps({
   show: Boolean,

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -74,9 +74,10 @@
               <thead class="bg-surface-sunken">
                 <tr>
                   <th
-                    v-for="column in activeColumns"
+                    v-for="(column, index) in activeColumns"
                     :key="column"
                     class="table-head"
+                    :class="{ 'assistant-type-column': index === 2 }"
                   >
                     {{ column }}
                   </th>
@@ -99,8 +100,8 @@
                   <td class="table-cell text-ink-600">
                     {{ lensNodeName(row.lensnode) }}
                   </td>
-                  <td class="table-cell text-ink-600">
-                    {{ row.selected_task || emptyValue }}
+                  <td class="assistant-type-column table-cell text-ink-600">
+                    {{ assistantTypeLabel(row.selected_task) }}
                   </td>
                   <td class="table-cell font-mono text-xs text-ink-500">
                     {{ row.selected_dirs?.[0]?.path || emptyValue }}
@@ -238,6 +239,7 @@ import AssistantFormDrawer from './AssistantFormDrawer.vue'
 import RowActions from './components/RowActions.vue'
 import {
   EMPTY_VALUE as emptyValue,
+  formatAssistantType,
   listToText,
   normalizeList,
   selectedDirsFromValue,
@@ -270,7 +272,7 @@ const activeColumns = computed(() =>
   [
     'assistant',
     'lensnode',
-    'task',
+    'type',
     'dirs',
     'tools',
     'visibility',
@@ -306,6 +308,10 @@ function lensNodeName(value) {
   const uuid = typeof value === 'object' ? value?.uuid : value
   const found = lensnodes.value.find((lensnode) => lensnode.uuid === uuid)
   return found?.name || uuid || emptyValue
+}
+
+function assistantTypeLabel(value) {
+  return formatAssistantType(value, t)
 }
 
 function shareUrl(row) {
@@ -621,5 +627,10 @@ onMounted(load)
 
 .table-cell {
   @apply px-4 py-4 text-sm text-ink-700;
+}
+
+.assistant-type-column {
+  white-space: nowrap;
+  word-break: keep-all;
 }
 </style>

--- a/frontend/src/pages/lens/adminHelpers.js
+++ b/frontend/src/pages/lens/adminHelpers.js
@@ -8,6 +8,27 @@
 
 export const EMPTY_VALUE = '—'
 
+const ASSISTANT_TYPE_TRANSLATION_KEYS = {
+  code_analysis: 'codeAnalysis',
+  general_chat: 'generalChat',
+  knowledge_qa: 'knowledgeQa',
+  qa: 'knowledgeQa'
+}
+
+export function formatAssistantType(value, t, fallback = '') {
+  const normalizedValue = String(value || '').trim()
+  if (!normalizedValue) {
+    return EMPTY_VALUE
+  }
+
+  const translationKey = ASSISTANT_TYPE_TRANSLATION_KEYS[normalizedValue]
+  if (translationKey) {
+    return t(`lensAdmin.assistantTypes.${translationKey}`)
+  }
+
+  return fallback || normalizedValue.replace(/[_-]+/g, ' ')
+}
+
 export function compactUuid(value) {
   if (!value) {
     return EMPTY_VALUE


### PR DESCRIPTION
### **User description**
## Summary

- Rename the Lens Assistants table column from Task to Type.
- Localize known assistant type labels in English and Chinese.
- Reuse the localized labels in the assistant create and edit drawer.
- Keep legacy, unknown, and empty assistant type values readable.
- Prevent Chinese assistant type labels from wrapping vertically.
- Add Playwright regression coverage for the list and form flows.

## Root cause

The assistants table rendered `selected_task` directly and labeled the field as
Task, even though it represents the assistant type in this UI. This exposed
internal identifiers such as `knowledge_qa` and `general_chat`, while the form
used English-only titles reported by LensNode.

Chinese labels could also wrap one character per line when the table compressed
the type column.

## Changes

- Use the existing localized Type column heading.
- Add localized labels for `knowledge_qa`, legacy `qa`, `code_analysis`, and
  `general_chat`.
- Map `qa` to the same label as `knowledge_qa`.
- Humanize unknown identifiers instead of rendering missing translation keys.
- Preserve the existing em dash placeholder for empty values.
- Share assistant type formatting between the table and form drawer.
- Rename the form label and placeholder from task to type.
- Keep type headers and values on one line.
- Preserve the original `selected_task` API values and execution behavior.

## Testing

- Frontend production build passed in the shared development container.
- Playwright assistant type regression passed: 1 test.
- Verified English and Chinese language switching.
- Verified known, legacy, unknown, and empty values.
- Verified localized assistant type options in the create drawer.
- Verified Chinese type values use `white-space: nowrap`.
- ESLint passed.
- Locale JSON parsing passed.
- `git diff --check` passed.

Closes #68


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Renamed "Task" column header to "Type" in Lens Assistants table

- Localized known assistant type labels (knowledge_qa, general_chat, etc.)

- Added formatAssistantType helper for legacy and unknown values

- Updated form drawer labels, placeholders, and step descriptions

- Added Playwright regression test for type display in both languages


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AssistantFormDrawer.vue</strong><dd><code>Localize type field in assistant create drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/AssistantFormDrawer.vue

<ul><li>Changed <code>FormRow</code> label key from <code>lensAdmin.fields.task</code> to <br><code>lensAdmin.fields.type</code><br> <li> Updated placeholder key from <code>lensAdmin.placeholders.selectTask</code> to <br><code>lensAdmin.placeholders.selectType</code><br> <li> Localized option labels using <code>formatAssistantType</code> instead of raw <br><code>task.title || task.name</code><br> <li> Imported <code>formatAssistantType</code> from adminHelpers</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-f64b9b4a617329deaca5b95a3f963e88f74539613fc13c3df98c28d49849d404">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Assistants.vue</strong><dd><code>Rename column and localize type display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Assistants.vue

<ul><li>Renamed column header key from <code>'task'</code> to <code>'type'</code><br> <li> Applied CSS class <code>assistant-type-column</code> (white-space: nowrap) to third <br>column header and cells<br> <li> Replaced raw <code>row.selected_task</code> display with <code>assistantTypeLabel()</code> <br>computed using <code>formatAssistantType</code><br> <li> Added <code>assistantTypeLabel</code> function and imported <code>formatAssistantType</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>adminHelpers.js</strong><dd><code>Add formatAssistantType helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/adminHelpers.js

<ul><li>Added <code>ASSISTANT_TYPE_TRANSLATION_KEYS</code> mapping for four known types <br>(including legacy <code>qa</code> mapped to <code>knowledgeQa</code>)<br> <li> Implemented <code>formatAssistantType(value, t, fallback)</code> function<br> <li> Returns <code>EMPTY_VALUE</code> for empty values, localized label for known keys, <br>fallback or humanized identifier otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-c2d556977bbb8b63082de1988f277adcad52620a22107685cd242c22969a93a5">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assistant-types.spec.js</strong><dd><code>Add Playwright test for type localization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/assistant-types.spec.js

<ul><li>Added comprehensive Playwright test for assistant type localization<br> <li> Mocks six assistants with known, legacy, unknown, and empty <br><code>selected_task</code> values<br> <li> Verifies English and Chinese column headers and cell values<br> <li> Checks CSS <code>white-space: nowrap</code> on Chinese type cell<br> <li> Tests form drawer localization (header, placeholder, options)</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-72b6bef7af901df8b2fc58e70aaf99f5644dda20953143cfe77ba4f7b5cea6aa">+162/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add localization keys for type labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/en.json

<ul><li>Added <code>lensAdmin.assistantTypes</code> with three localized type labels<br> <li> Added placeholder key <code>selectType</code> in both languages<br> <li> Updated wizard step2 description to refer to "type" instead of "task"</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese localization for type labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/zh-CN.json

<ul><li>Added Chinese translations for assistant types (知识问答, 代码分析, 通用对话)<br> <li> Added placeholder <code>selectType</code> as 请选择类型<br> <li> Updated step2 description to use "类型" instead of "任务"</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/70/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

