### PR TITLE
docs(readme): clarify agent harness is analogous to, not built on, Claude Code/Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 </div>
 
-**SourceLens** is Agentic RAG built on top of an AI coding agent harness (Claude Code, Codex, etc.), running inside a sandboxed environment. Instead of embedding your files into a vector index ahead of time, SourceLens hands them directly to the agent harness, which reads, searches, and reasons over the file system on demand — turning any pile of documents or code into something you can just ask questions of.
+**SourceLens** is Agentic RAG built on an AI coding agent harness — the same kind of harness behind tools like Claude Code or Codex, not those products themselves — running inside a sandboxed environment. Instead of embedding your files into a vector index ahead of time, SourceLens hands them directly to the agent harness, which reads, searches, and reasons over the file system on demand — turning any pile of documents or code into something you can just ask questions of.
 
 ## How It Works
 
@@ -19,7 +19,7 @@
 flowchart TD
     A["User selects documents / code"] --> B[("Local file system storage")]
     B --> C["Pre-retrieval LLM processing<br/>query understanding, context planning"]
-    C --> D["Sandboxed AI agent retrieval<br/>Claude Code / Codex search &amp; analyze"]
+    C --> D["Sandboxed AI agent retrieval<br/>agent harness search &amp; analyze"]
     D --> E["Post-retrieval LLM processing<br/>answer synthesis, citation formatting"]
     E --> F["Structured answer<br/>with source references"]
 ```
@@ -28,7 +28,7 @@ Instead of vector embeddings or keyword indexes, SourceLens uses AI coding agent
 
 ## Why SourceLens
 
-- **Agentic RAG, not embeddings** — the agent harness (Claude Code, Codex) reads and reasons over files directly, no vector DB, no pre-indexing step
+- **Agentic RAG, not embeddings** — an agent harness (the same kind behind Claude Code, Codex, etc.) reads and reasons over files directly, no vector DB, no pre-indexing step
 - **Sandboxed execution** — all agent operations run in isolated environments, safe for arbitrary codebases and documents
 - **Pre/post LLM orchestration** — customizable LLM steps before and after retrieval for query refinement and answer synthesis
 - **Source-traceable** — every answer references exact file paths and code locations

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 </div>
 
-**SourceLens** 是一套基于 Harness 的 Agentic RAG（Agentic Retrieval-Augmented Generation）方案：底层由 AI 编程 agent 所使用的同一套 harness（Claude Code、Codex 等）驱动，在沙箱环境中运行。它不需要提前把文件做 embedding 建成向量索引，而是直接把文档和代码交给 agent harness，由其在文件系统上按需读取、检索、推理——让任意一堆文档或代码都能直接拿来问问题。
+**SourceLens** 是一套基于 Harness 的 Agentic RAG（Agentic Retrieval-Augmented Generation）方案：底层由一套 AI 编程 agent harness 驱动（跟 Claude Code、Codex 背后是同一类 harness，但并非直接集成这些产品本身），在沙箱环境中运行。它不需要提前把文件做 embedding 建成向量索引，而是直接把文档和代码交给 agent harness，由其在文件系统上按需读取、检索、推理——让任意一堆文档或代码都能直接拿来问问题。
 
 ## 工作流程
 
@@ -19,7 +19,7 @@
 flowchart TD
     A["用户选择文档 / 代码"] --> B[("本地文件系统存储")]
     B --> C["检索前 LLM 处理<br/>查询理解、上下文规划"]
-    C --> D["沙箱内 AI agent 检索<br/>Claude Code / Codex 搜索与分析"]
+    C --> D["沙箱内 AI agent 检索<br/>agent harness 搜索与分析"]
     D --> E["检索后 LLM 处理<br/>答案整合、引用格式化"]
     E --> F["带来源引用的<br/>结构化答案"]
 ```
@@ -28,7 +28,7 @@ flowchart TD
 
 ## 为什么选择 SourceLens
 
-- **Agentic RAG，而非 embedding** — agent harness（Claude Code、Codex）直接读取并推理文件，无需向量数据库，无需提前建索引
+- **Agentic RAG，而非 embedding** — agent harness（跟 Claude Code、Codex 背后是同一类 harness）直接读取并推理文件，无需向量数据库，无需提前建索引
 - **沙箱隔离执行** — 所有 agent 操作在隔离环境中运行，安全处理任意代码仓库和文档
 - **LLM 前后置编排** — 检索前后可配置 LLM 步骤，优化查询理解与答案合成
 - **来源可追溯** — 每个答案精确关联到源文件路径和代码位置


### PR DESCRIPTION
### **User description**
## Summary
- The README previously read as if SourceLens directly integrates Claude Code or Codex ("built on top of ... (Claude Code, Codex, etc.)"). It doesn't — SourceLens uses its own agent harness, of the same kind those tools use, not those products themselves.
- Reworded the intro paragraph, the "Why SourceLens" bullet, and the "How It Works" flowchart node in both `README.md` and `README.zh-CN.md` to make that distinction explicit.

## Test plan
- [ ] Re-read both READMEs and confirm no remaining wording implies a direct Claude Code / Codex integration


___

### **PR Type**
Documentation


___

### **Description**
- Clarify agent harness wording in both READMEs

- Avoid implying direct integration with Claude Code/Codex

- Update intro, "Why SourceLens" bullet, and flowchart node


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify agent harness distinction in English README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Reworded intro paragraph to state "the same kind of harness behind <br>tools like Claude Code or Codex, not those products themselves"<br> <li> Updated "Why SourceLens" bullet to use "an agent harness (the same <br>kind behind ...)"<br> <li> Changed flowchart node description from "Claude Code / Codex search <br>&amp; analyze" to "agent harness search &amp; analyze"</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/72/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>Align Chinese README wording with English version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh-CN.md

<ul><li>Reworded Chinese intro to clarify harness is the same type, not direct <br>integration<br> <li> Updated "Why SourceLens" bullet to match English wording<br> <li> Changed flowchart node description accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/72/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

