### PR TITLE
fix(lens): repair post-merge health-check drift (#77)

### DIFF
--- a/backend/lens/management/commands/lens_smoke_test.py
+++ b/backend/lens/management/commands/lens_smoke_test.py
@@ -19,6 +19,7 @@ EXPECTED_MODELS = {
     "LensNode",
     "Run",
     "RunExecution",
+    "RunOutputFile",
     "RunStep",
     "ScheduledTask",
     "Session",

--- a/backend/lens/migrations/0021_alter_datasourcecredential_auth_type.py
+++ b/backend/lens/migrations/0021_alter_datasourcecredential_auth_type.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0020_assistant_description"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="datasourcecredential",
+            name="auth_type",
+            field=models.CharField(
+                choices=[
+                    ("none", "Public Access"),
+                    ("https_token", "HTTPS Token"),
+                    ("feishu_app", "Feishu App"),
+                ],
+                default="https_token",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -1192,12 +1192,15 @@ def _validate_unique_datasource_target_path(target_path, lensnode, instance):
     for datasource in query.only("target_path"):
         if not datasource.target_path:
             continue
-        existing = PurePosixPath(
-            normalize_workspace_target_path(
-                datasource.target_path,
-                lensnode.workspace_path,
+        try:
+            existing = PurePosixPath(
+                normalize_workspace_target_path(
+                    datasource.target_path,
+                    lensnode.workspace_path,
+                )
             )
-        )
+        except DataSourcePathError:
+            continue
         if existing == target:
             raise serializers.ValidationError(
                 {

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -538,6 +538,9 @@ class LensServiceTests(TransactionTestCase):
                 "documents": 0,
                 "by_extension": {},
                 "by_type": {},
+                "repository_summaries": [],
+                "failed_repositories": [],
+                "partial_success": False,
                 "target_path": self.datasource.target_path,
             },
         )


### PR DESCRIPTION
## Summary

Repair the Lens test and migration drift reported in #77:

- include `RunOutputFile` in the Lens smoke-test model set
- prevent stale datasource paths from an old LensNode workspace from blocking
  new datasource creation
- align the datasource-sync metrics test with the current result contract
- record the `Public Access` credential label in a migration

## Root Cause

The failures originated from several earlier feature changes whose surrounding
health checks were not fully reconciled:

- `328aad8` introduced `RunOutputFile` without adding it to the exact model set
  checked by `lens_smoke_test`.
- `b4d6098` added datasource target-path uniqueness validation, but attempted
  to normalize every existing datasource against the LensNode's current
  workspace. A datasource retained from an older workspace could therefore
  block creation of an unrelated datasource.
- `51152f7` added `repository_summaries`, `failed_repositories`, and
  `partial_success` to datasource-sync metrics without updating the existing
  regression test.
- `7ebc8bb` changed the unauthenticated credential label from
  `No Authentication` to `Public Access` without recording the model-state
  change in a migration.

## Changes

### Lens smoke check

Add `RunOutputFile` to `EXPECTED_MODELS` so the smoke command matches the
current concrete Lens model set.

### Datasource path validation

Ignore existing datasource paths that cannot be normalized under the
LensNode's current workspace.

These stale paths cannot conflict with a valid target in the current
workspace. Exact duplicates within the current workspace continue to be
rejected.

### Datasource-sync metrics test

Update the expected `last_metrics` value with the repository aggregation
defaults returned by `complete_datasource_sync_task`:

- `repository_summaries`
- `failed_repositories`
- `partial_success`

### Migration state

Add `0021_alter_datasourcecredential_auth_type` to record the `Public Access`
choice label.

This is a model-state-only migration. It does not modify stored credential
values.

## Verification

Executed against a clean source snapshot in the Docker development
environment:

- targeted Issue #77 regression tests: 3 passed
- complete Lens test suite: 150 passed
- `python manage.py makemigrations --check --dry-run`: no changes detected
- `python manage.py check`: no issues
- `git diff --check`: passed
- migration chain successfully applied through
  `0021_alter_datasourcecredential_auth_type`
- latest `origin/main` merged with no conflicts

Fixes #77
