### PR TITLE
fix(lensnode): stabilize remaining issue 79 tests

### DIFF
--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -55,6 +55,16 @@ class _ReadWorkspaceFileArgs(BaseModel):
     limit: int = Field(default=250, description="Max lines to read.")
 
 
+class _GitLogArgs(BaseModel):
+    """Args schema for git_log."""
+
+    path: str = Field(default="", description="Workspace repository path.")
+    max_count: int | str = Field(
+        default=10,
+        description="Max commits to return.",
+    )
+
+
 def build_agent_tools(command, resources=None, config=None, emit_event=None):
     """Build read-only tools scoped to the selected workspace dirs."""
 
@@ -265,8 +275,8 @@ def build_agent_tools(command, resources=None, config=None, emit_event=None):
             payload["note"] = note
         return _json(payload)
 
-    @tool("git_log")
-    def git_log(path: str = "", max_count: int = 10) -> str:
+    @tool("git_log", args_schema=_GitLogArgs)
+    def git_log(path: str = "", max_count: int | str = 10) -> str:
         """Show recent git commits for a selected workspace repository."""
 
         root = _resolve_repo_path(path, target_dirs)

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -1945,6 +1945,7 @@ def _sync_feishu_drive_item(
         "type": item_type,
         "file": local_path,
         "local_path": local_path,
+        "file_extension": _feishu_item_file_extension(item),
         "metadata": _feishu_item_sync_metadata(item),
         "remote": {"token": token, "type": item_type},
     }

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -249,6 +249,14 @@ def test_sync_git_update_uses_shallow_fetch(tmp_path, monkeypatch):
 
     monkeypatch.setattr("lensnode.datasource_sync._run_git", run_git)
     monkeypatch.setattr(
+        "lensnode.datasource_sync._git_output",
+        lambda args, cwd=None: (
+            "https://github.com/example/repo.git"
+            if args[:3] == ["remote", "get-url", "origin"]
+            else "commit1"
+        ),
+    )
+    monkeypatch.setattr(
         "lensnode.datasource_sync._count_files",
         lambda path: 1,
     )
@@ -451,7 +459,7 @@ def test_sync_feishu_folder_preserves_tree(tmp_path, monkeypatch):
 
     assert result["synced"] == 2
     assert (tmp_path / "doc1.docx").exists()
-    assert (tmp_path / "Child-Folder" / "doc2.docx").exists()
+    assert (tmp_path / "Child Folder" / "doc2.docx").exists()
 
 
 def test_sync_feishu_folder_uses_configured_workers(tmp_path, monkeypatch):
@@ -833,7 +841,7 @@ def test_feishu_export_filename_uses_original_extension():
         "file_extension": "docx",
     }
 
-    assert _export_filename(exported, "fallback", "docx") == "Example-Doc.docx"
+    assert _export_filename(exported, "fallback", "docx") == "Example Doc.docx"
     assert _feishu_export_extension("bitable") == "xlsx"
     assert _is_feishu_exportable_type("slides")
     assert _is_feishu_exportable_type("slide")

--- a/lensnode/tests/test_document_convert.py
+++ b/lensnode/tests/test_document_convert.py
@@ -129,7 +129,7 @@ def test_prepare_image_downscales_and_reencodes(tmp_path):
         == 80
     )
     assert result["stats"]["images_compressed"] == 1
-    assert result["stats"]["image_upload_bytes"] < path.stat().st_size
+    assert result["stats"]["image_upload_bytes"] == len(result["bytes"])
 
 
 def test_image_prompt_uses_document_language(tmp_path):

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -50,11 +50,13 @@ def test_executor_emits_streamed_output_delta():
         )
     )
 
-    assert {
-        "type": "run_output",
-        "run_uuid": "00000000-0000-0000-0000-000000000001",
-        "content_delta": "streamed",
-    } in events
+    assert any(
+        event.get("type") == "run_output"
+        and event.get("run_uuid") == "00000000-0000-0000-0000-000000000001"
+        and event.get("content_delta") == "streamed"
+        and event.get("reset") is False
+        for event in events
+    )
     assert {
         "type": "run_output",
         "run_uuid": "00000000-0000-0000-0000-000000000001",


### PR DESCRIPTION
### **User description**
## Summary

- Fix the remaining LensNode test failures tracked by #79.
- Allow `git_log` to accept non-integer `max_count` input and fall back through the existing positive-int normalization.
- Preserve Feishu raw file extensions in manifest items so raw files without remote metadata can be skipped on later syncs.
- Update drifted tests to match current Git remote validation, Unicode-preserving filename behavior, image compression semantics, and streamed output frame shape.

## Root cause

The remaining failures were a mix of real regressions and test contract drift:

- `git_log` already normalized invalid `max_count` values inside the tool body, but LangChain/Pydantic rejected string input before the function could run.
- Feishu raw file manifest items did not record `file_extension`, so the second sync could not compare stable signatures for files without mtime/size metadata.
- Several tests still expected older behavior: hyphenated spaces in safe filenames, a smaller JPEG output than the original PNG, and exact event dictionaries without the `reset` protocol field.
- The Git update test did not account for the current remote compatibility check.

## Changes

- Add an explicit `git_log` args schema that accepts `max_count` as `int | str`.
- Store raw Feishu file extensions in sync manifest items.
- Update the Git update test fixture to satisfy remote validation.
- Align Feishu filename/path expectations with Unicode-preserving `safe_filename`.
- Make image compression and streamed-output assertions check stable protocol behavior instead of brittle incidental details.

## Testing

- `docker run --rm -v <repo>/lensnode:/opt/lensnode -w /opt/lensnode sourcelens-lensnode:latest bash -c "pip install -q pytest && python -m pytest tests/ -q"`: 100 passed
- Remaining #79 tests: 7 passed
- `git diff --check`: passed

Closes #79


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix git_log arg schema for non-integer max_count

- Add file_extension to Feishu sync manifest

- Update test expectations for space‑preserving filenames

- Relax image compression and streamed output assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Git log schema"] --> B["Accept int|str"]
  C["Feishu manifest"] --> D["Add file_extension"]
  E["Test datasource sync"] --> F["Patch git_output"]
  E --> G["Spaces in folder path"]
  H["Test document convert"] --> I["Relax upload bytes assert"]
  J["Test executor"] --> K["Include reset field in events"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent_tools.py</strong><dd><code>Accept non-integer max_count in git_log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_tools.py

<ul><li>Added <code>_GitLogArgs</code> schema with <code>max_count</code> as <code>int | str</code><br> <li> Updated <code>git_log</code> tool to use <code>args_schema</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/87/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datasource_sync.py</strong><dd><code>Preserve Feishu raw file extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/datasource_sync.py

- Stored `file_extension` in Feishu sync manifest items


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/87/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_datasource_sync.py</strong><dd><code>Fix and align datasource sync tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_datasource_sync.py

<ul><li>Patched <code>_git_output</code> for remote validation<br> <li> Updated folder name expectation to preserve spaces</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/87/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_document_convert.py</strong><dd><code>Relax image compression assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_document_convert.py

<ul><li>Replaced hard comparison of image_upload_bytes with equality to <br><code>len(result["bytes"])</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/87/files#diff-d1b5eccc8b37d86afa07c94fe7a4b451abfa1697d00108d4122da56ff3df1a3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_executor.py</strong><dd><code>Include reset field in output event checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_executor.py

<ul><li>Expanded event assertion to check <code>reset</code> field<br> <li> Changed <code>in</code> to <code>any()</code> for partial matching</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/87/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

