### PR TITLE
docs(readme): move the product diagram right after the intro paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 **SourceLens** is Agentic RAG built on an AI coding agent harness — the same kind of harness behind tools like Cursor, Claude Code, or Codex, not those products themselves — running inside a sandboxed environment. Instead of embedding your files into a vector index ahead of time, SourceLens hands them directly to the agent harness, which reads, searches, and reasons over the file system on demand — turning any pile of documents or code into something you can just ask questions of.
 
+![What is SourceLens](docs/images/what_is_sourcelens.png)
+
+Instead of vector embeddings or keyword indexes, SourceLens uses AI coding agents running in a sandbox to directly read, navigate, and reason over the file system. This means the retrieval understands code structure, cross-file relationships, and semantic intent — not just surface-level text matching.
+
 ## Background
 
 Our first attempts at RAG used graphical workflow tools like Dify and n8n. They asked a lot of the people building on them, and the real difficulty was always upfront: splitting documents and embedding them before they ever reached a vector store. That prep work took real effort to get right, and even after all of it, recall accuracy stayed disappointing — answers would come back incomplete, sometimes missing the point that was in the document all along.
@@ -24,12 +28,6 @@ That's the idea behind SourceLens: instead of the embed-then-retrieve pipeline, 
 Most teams building a RAG knowledge base today go through some version of this same graphical-orchestration pipeline — tools like Dify, n8n, Coze, or FastGPT, wired up to a vector store. SourceLens's core goal is to drive the cost of standing up a working RAG system as close to zero as possible, without trading away answer quality.
 
 The underlying loop stays deliberately simple: a query triggers the agent to search, it synthesizes what it finds into a partial answer, and if that's not enough, it searches again and synthesizes again — repeating until it can answer with confidence. Skills and MCP integration are the planned path for extending what the agent can reach beyond the local file system, without changing that core loop.
-
-## How It Works
-
-![What is SourceLens](docs/images/what_is_sourcelens.png)
-
-Instead of vector embeddings or keyword indexes, SourceLens uses AI coding agents running in a sandbox to directly read, navigate, and reason over the file system. This means the retrieval understands code structure, cross-file relationships, and semantic intent — not just surface-level text matching.
 
 ## Why SourceLens
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,10 @@
 
 **SourceLens** 是一套基于 Harness 的 Agentic RAG（Agentic Retrieval-Augmented Generation）方案：底层由一套 AI 编程 agent harness 驱动（跟 Cursor、Claude Code、Codex 背后是同一类 harness，但并非直接集成这些产品本身），在沙箱环境中运行。它不需要提前把文件做 embedding 建成向量索引，而是直接把文档和代码交给 agent harness，由其在文件系统上按需读取、检索、推理——让任意一堆文档或代码都能直接拿来问问题。
 
+![What is SourceLens](docs/images/what_is_sourcelens.png)
+
+区别于向量嵌入或关键词索引，SourceLens 让 AI 编程 agent 在沙箱中直接读取、导航和推理文件系统。这意味着检索过程能够理解代码结构、跨文件关系和语义意图，而非仅停留在表层文本匹配。
+
 ## 项目背景
 
 我们最早做 RAG 用的是 Dify、n8n 这类图形化编排工具。这类工具对使用者的专业要求很高，而真正的难点始终在前期：文档要先拆分、做 embedding，才能存入向量库。这一步准备工作要做好并不容易，投入了不少精力之后，召回的准确率却始终不太理想——回答经常不完整，有时候明明文档里写着答案，却还是会被漏掉。
@@ -24,12 +28,6 @@
 现在大多数团队搭建 RAG 知识库，走的基本都是这一类图形化编排工具的路径——Dify、n8n、Coze（扣子）、FastGPT 之类的工具，接上一个向量库。SourceLens 的核心目标不一样：把搭建一套能跑起来的 RAG 系统的成本尽量压到接近于零，同时不牺牲回答质量。
 
 底层逻辑刻意保持简单：一个 Query 触发 agent 去检索，把找到的内容总结成阶段性答案；如果还不够，就再检索、再总结，如此循环，直到能够给出有把握的回答。未来会通过集成 Skills 和 MCP，在不改变这个核心循环的前提下，扩展 agent 能够触达的边界，不再局限于本地文件系统。
-
-## 工作流程
-
-![What is SourceLens](docs/images/what_is_sourcelens.png)
-
-区别于向量嵌入或关键词索引，SourceLens 让 AI 编程 agent 在沙箱中直接读取、导航和推理文件系统。这意味着检索过程能够理解代码结构、跨文件关系和语义意图，而非仅停留在表层文本匹配。
 
 ## 为什么选择 SourceLens
 


### PR DESCRIPTION
### **User description**
## Summary
- Move the `what_is_sourcelens.png` diagram (and its caption paragraph) to right after the bold intro paragraph, so it's visible immediately instead of further down past the whole Background story.
- Drop the now-empty "How It Works" heading — the image + caption cover the same ground right at the top.

## Test plan
- [ ] Render both README.md and README.zh-CN.md on GitHub and confirm the diagram appears right after the intro paragraph


___

### **PR Type**
Documentation


___

### **Description**
- Move product diagram right after the intro paragraph

- Remove the empty "How It Works" heading

- Apply same restructuring to both English and Chinese READMEs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Restructure README to surface diagram earlier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Moved the product diagram and its caption from the "How It Works" <br>section to right after the intro paragraph.<br> <li> Removed the now-empty "How It Works" heading.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/90/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>Synchronize Chinese README diagram placement and heading removal</code></dd></summary>
<hr>

README.zh-CN.md

<ul><li>Moved the product diagram and its caption from the "工作流程" section to <br>right after the intro paragraph.<br> <li> Removed the now-empty "工作流程" heading.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/90/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

