### PR TITLE
chore(frontend): fix llm admin lint failures

### DIFF
--- a/frontend/src/admin/api/llmAdmin.js
+++ b/frontend/src/admin/api/llmAdmin.js
@@ -128,7 +128,9 @@ export const llmAdminApi = {
       try {
         const data = await res.json()
         if (data?.detail) err.detail = data.detail
-      } catch (_) {}
+      } catch {
+        // Ignore non-JSON error bodies.
+      }
       if (callbacks.onError) callbacks.onError(err.detail || err.message)
       throw err
     }
@@ -136,7 +138,7 @@ export const llmAdminApi = {
     const decoder = new TextDecoder()
     let buffer = ''
     try {
-      while (true) {
+      for (;;) {
         const { done, value } = await reader.read()
         if (done) break
         buffer += decoder.decode(value, { stream: true })
@@ -165,7 +167,9 @@ export const llmAdminApi = {
               else if (!payload.ok && callbacks.onError)
                 callbacks.onError(payload.detail || 'Unknown error')
             }
-          } catch (_) {}
+          } catch {
+            // Ignore malformed stream events.
+          }
         }
       }
       if (buffer.trim()) {
@@ -181,7 +185,9 @@ export const llmAdminApi = {
               callbacks.onError
             )
               callbacks.onError(payload.detail || 'Unknown error')
-          } catch (_) {}
+          } catch {
+            // Ignore malformed trailing stream events.
+          }
         }
       }
     } catch (readErr) {


### PR DESCRIPTION
### **User description**
## Summary

Fix the four pre-existing ESLint errors in the LLM admin API client without
changing its runtime behavior.

## Problem

`frontend/src/admin/api/llmAdmin.js` contained four ESLint errors:

- Three empty `catch` blocks reported by `no-empty`.
- One intentional `while (true)` stream-reading loop reported by
  `no-constant-condition`.

These errors predated #63 and made new lint findings in this file harder to
identify.

## Changes

- Use optional catch binding for intentionally ignored parsing errors.
- Document why non-JSON error bodies and malformed SSE events are ignored.
- Replace the intentional `while (true)` loop with the equivalent `for (;;)`
  form.
- Preserve the existing HTTP error fallback and SSE processing behavior.

## Testing

- `npx eslint src/admin/api/llmAdmin.js --ignore-path .gitignore`
- `npx prettier --check src/admin/api/llmAdmin.js`
- `node --check src/admin/api/llmAdmin.js`
- `node --test tests/*.test.js` — 3 tests passed
- `git diff --check`

Closes #88.


___

### **PR Type**
Other


___

### **Description**
- Fix four pre-existing ESLint errors in llmAdmin.js

- Replace `while (true)` with `for (;;)` to satisfy `no-constant-condition`

- Remove unused catch parameter and add comments for ignored error branches

- Preserve all existing runtime behavior


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llmAdmin.js</strong><dd><code>Fix ESLint errors without runtime changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/api/llmAdmin.js

<ul><li>Replaced <code>while (true)</code> with <code>for (;;)</code> to avoid <code>no-constant-condition</code><br> <li> Removed unused catch parameter in three empty catch blocks<br> <li> Added explanatory comments for intentionally ignored parsing errors <br>and malformed events<br> <li> No runtime behavior changes</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/91/files#diff-16c97c3fd8d98b7e70381f3eddafff09055f42208acd7f87c12334c1f6229cac">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

