### PR TITLE
fix(deploy): loosen the ASGI server's WS ping tolerance

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -50,6 +50,8 @@ start_gunicorn() {
         exec daphne core.asgi:application \
             --bind 0.0.0.0 \
             --port 8000 \
+            --ping-interval ${UVICORN_WS_PING_INTERVAL:-45} \
+            --ping-timeout ${UVICORN_WS_PING_TIMEOUT:-30} \
             --access-log $ACCESS_LOG
     fi
     log "Starting Uvicorn ASGI workers (API_WORKERS=${API_WORKERS:-3})..."
@@ -62,6 +64,8 @@ start_gunicorn() {
         --limit-max-requests ${UVICORN_MAX_REQUESTS:-10000} \
         --timeout-keep-alive ${UVICORN_KEEPALIVE:-75} \
         --timeout-graceful-shutdown ${UVICORN_GRACEFUL_TIMEOUT:-120} \
+        --ws-ping-interval ${UVICORN_WS_PING_INTERVAL:-45} \
+        --ws-ping-timeout ${UVICORN_WS_PING_TIMEOUT:-30} \
         --access-log \
         --no-server-header \
         --log-level ${API_LOG_LEVEL:-info}


### PR DESCRIPTION
### **User description**
## Summary

Fix direction A from #92. `uvicorn`'s `--ws-ping-interval`/`--ws-ping-timeout` were unset in `docker/entrypoint.sh`, defaulting to 20s/20s. A long Deep Agent run (observed: 2–4 minutes) can keep the LensNode client's asyncio event loop busy long enough to miss answering a ping within that window. The server then force-closes the control-plane WebSocket with `1011 keepalive ping timeout` mid-run, triggering a reconnect race that can discard the run's already-computed answer (full evidence chain in #92).

- Add `--ws-ping-interval`/`--ws-ping-timeout` to the default uvicorn startup, and the equivalent `--ping-interval`/`--ping-timeout` to the `ASGI_SERVER=daphne` fallback path.
- Configurable via `UVICORN_WS_PING_INTERVAL` (default 45) / `UVICORN_WS_PING_TIMEOUT` (default 30).
- Confirmed the app has exactly one WebSocket route (`/ws/lens/lensnodes/` — the frontend chat UI streams over SSE, not WS), so this only affects LensNode control-channel timing, nothing else.

This is a mitigation, not the full fix — it reduces how often the false-positive disconnect happens, but doesn't close the reconnect-reconcile race itself (fix direction B, tracked separately in #92 pending more discussion on the exact approach).

## Test plan
- [x] `uvicorn --help` confirms both flags exist and accept the values used
- [x] Started `uvicorn core.asgi:application --ws-ping-interval 45 --ws-ping-timeout 30 ...` directly against the real app — starts cleanly, no errors
- [x] `bash -n docker/entrypoint.sh` — syntax OK
- [ ] Deploy to production and confirm no new `LENSNODE_RECONNECT_ORPHANED`/`LENSNODE_DISCONNECTED` runs show up under normal long-run load


___

### **PR Type**
Bug fix


___

### **Description**
- Add WS ping interval/timeout to uvicorn and daphne

- Reduce false disconnect during long agent runs

- Configurable via UVICORN_WS_PING_INTERVAL/UVICORN_WS_PING_TIMEOUT


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Add WS ping configuration to ASGI server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/entrypoint.sh

<ul><li>Added --ping-interval/--ping-timeout to daphne fallback path<br> <li> Added --ws-ping-interval/--ws-ping-timeout to uvicorn path<br> <li> Default interval 45s, timeout 30s; configurable via environment <br>variables</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/93/files#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

