### PR TITLE
fix(lensnode): give reconnect-orphan detection a confirm grace window

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -163,33 +163,93 @@ def fail_active_runs_for_lensnode(lensnode_uuid):
 
 
 RECONCILE_GRACE_SECONDS = 60
+RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT = 20
+
+
+def get_reconcile_confirm_grace_seconds():
+    """Return how long a reconnect-unreported run waits before being failed.
+
+    A node's ``hello`` on reconnect reports its currently in-flight runs, but
+    LensNode redelivers ``run_done`` at-least-once through a durable outbox
+    (``LensNodeClient._send_loop``) — a run that finished during the drop is
+    legitimately absent from that snapshot while its already-computed answer
+    is still safely queued for delivery. Failing it immediately discards a
+    correct answer that was moments from arriving. This window gives the
+    normal completion path a chance to land first (see
+    lens.tasks.confirm_reconcile_orphan). Admin-tunable via the GlobalSetting
+    key ``lensnode.reconcile_confirm_grace_s``.
+    """
+
+    setting = GlobalSetting.objects.filter(
+        key="lensnode.reconcile_confirm_grace_s"
+    ).first()
+    try:
+        value = int(
+            setting.value
+            if setting
+            else RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT
+        )
+    except (TypeError, ValueError):
+        return RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT
+    return max(1, value)
+
+
+def schedule_reconcile_orphan_confirmation(run_uuid):
+    """Schedule the delayed check that fails a run if it's still non-terminal.
+
+    Called from reconcile_lensnode_active_runs for each candidate instead of
+    failing it inline, so a run that legitimately finished during the drop
+    gets a chance to reach a terminal state through the normal completion
+    path (see get_reconcile_confirm_grace_seconds) before being written off.
+
+    apply_async talks to the broker; wrap it so a broker hiccup can't raise
+    out of the consumer's hello handler — the periodic idle reaper
+    (lens.lensnode_cleanup) remains the backstop if scheduling fails.
+    """
+
+    from .tasks import confirm_reconcile_orphan
+
+    grace_s = get_reconcile_confirm_grace_seconds()
+    try:
+        confirm_reconcile_orphan.apply_async(
+            args=[str(run_uuid)],
+            countdown=grace_s,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to schedule reconcile-orphan confirmation for run %s; "
+            "it will be reaped by the idle sweep instead",
+            run_uuid,
+        )
 
 
 def reconcile_lensnode_active_runs(lensnode_uuid, active_run_uuids):
-    """Fail this node's non-terminal runs that it is no longer running.
+    """Schedule an orphan check for this node's runs it is no longer running.
 
-    On (re)connect a LensNode reports the runs it is actively executing.
-    Any RUNNING/STREAMING run assigned to the node that the node does not
-    claim was orphaned (e.g. the control plane restarted mid-answer and
-    the terminal frame was lost on the dropped socket); fail it now rather
-    than waiting for the idle reaper. A short grace window avoids racing a
-    run that was just dispatched but not yet started node-side.
+    On (re)connect a LensNode reports the runs it is actively executing. A
+    RUNNING/STREAMING run assigned to the node that the node does not claim
+    is a candidate orphan (e.g. the control plane restarted mid-answer and
+    the terminal frame was delayed on the dropped socket) — but LensNode
+    redelivers at-least-once on reconnect, so a run that just finished is
+    legitimately unreported while its result is still in flight. Rather than
+    failing candidates inline, this schedules a delayed confirmation per
+    candidate so the normal completion path gets a chance to resolve it
+    first (see schedule_reconcile_orphan_confirmation). A short grace window
+    on run age avoids even considering a run that was just dispatched but
+    not yet started node-side.
     """
 
     active = {str(value) for value in (active_run_uuids or [])}
     now = timezone.now()
-    orphaned = Run.objects.filter(
+    candidates = Run.objects.filter(
         lensnode__uuid=lensnode_uuid,
         status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
         started_at__lt=now - timedelta(seconds=RECONCILE_GRACE_SECONDS),
-    ).exclude(uuid__in=active)
-    count = orphaned.count()
-    orphaned.update(
-        status=Run.Status.FAILED,
-        error="LENSNODE_RECONNECT_ORPHANED",
-        finished_at=now,
-        updated_at=now,
-    )
+    ).exclude(uuid__in=active).values_list("uuid", flat=True)
+    count = 0
+    for run_uuid in candidates:
+        schedule_reconcile_orphan_confirmation(run_uuid)
+        count += 1
     return count
 
 

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -716,6 +716,45 @@ def check_lensnode_disconnect_grace_period(lensnode_uuid, disconnected_at_iso):
     fail_active_runs_for_lensnode(lensnode_uuid)
 
 
+@shared_task(
+    name="lens.confirm_reconcile_orphan",
+    queue="lens",
+    ignore_result=True,
+)
+def confirm_reconcile_orphan(run_uuid):
+    """Fail a run only if it's still non-terminal after the confirm window.
+
+    Scheduled (with a countdown) by
+    lens.services.schedule_reconcile_orphan_confirmation when a reconnecting
+    node's hello doesn't report the run as active. LensNode redelivers
+    run_done at-least-once through a durable outbox, so a run that finished
+    during the drop reaches a terminal state through the normal completion
+    path before this fires. The filtered update is atomic and inherently
+    idempotent — no episode-pinning needed (unlike
+    check_lensnode_disconnect_grace_period, which guards a shared,
+    overwritable LensNode.disconnected_at field): this only ever acts on the
+    one run_uuid it was scheduled for, and a run that already left
+    RUNNING/STREAMING simply won't match the filter.
+    """
+
+    now = timezone.now()
+    updated = Run.objects.filter(
+        uuid=run_uuid,
+        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+    ).update(
+        status=Run.Status.FAILED,
+        error="LENSNODE_RECONNECT_ORPHANED",
+        finished_at=now,
+        updated_at=now,
+    )
+    if updated:
+        logger.warning(
+            "Run %s still non-terminal after the reconcile confirm grace "
+            "window; marking it failed (LENSNODE_RECONNECT_ORPHANED)",
+            run_uuid,
+        )
+
+
 @shared_task(name="lens.lensnode_health", queue="lens")
 def lensnode_health_task():
     """Mark stale online LensNodes offline based on heartbeat age."""

--- a/backend/lens/tests/test_disconnect_grace.py
+++ b/backend/lens/tests/test_disconnect_grace.py
@@ -16,8 +16,10 @@ from lens.models import (
 )
 from lens.services import (
     LENSNODE_DISCONNECT_GRACE_SECONDS_DEFAULT,
+    RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT,
     create_execution_run,
     get_lensnode_disconnect_grace_seconds,
+    get_reconcile_confirm_grace_seconds,
 )
 from lens.tasks import check_lensnode_disconnect_grace_period
 
@@ -77,6 +79,16 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
             key="lensnode.disconnect_grace_s", value=42
         )
         self.assertEqual(get_lensnode_disconnect_grace_seconds(), 42)
+
+    def test_reconcile_confirm_grace_seconds_default_and_override(self):
+        self.assertEqual(
+            get_reconcile_confirm_grace_seconds(),
+            RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT,
+        )
+        GlobalSetting.objects.create(
+            key="lensnode.reconcile_confirm_grace_s", value=7
+        )
+        self.assertEqual(get_reconcile_confirm_grace_seconds(), 7)
 
     def test_check_fails_runs_when_still_offline(self):
         run = self._make_running_run()

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -12,7 +13,7 @@ from lens.services import (
     record_lensnode_run_event,
     touch_run_activity,
 )
-from lens.tasks import lensnode_cleanup_task
+from lens.tasks import confirm_reconcile_orphan, lensnode_cleanup_task
 
 User = get_user_model()
 
@@ -132,19 +133,28 @@ class RunLifecycleTests(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, Run.Status.STREAMING)
 
-    def test_reconcile_fails_orphaned_run(self):
+    def test_reconcile_schedules_confirmation_instead_of_failing_inline(self):
+        # LensNode redelivers run_done at-least-once through a durable
+        # outbox, so a run absent from a fresh hello's active list may just
+        # be finishing, not dead — reconcile must not fail it on the spot.
         run = self._run(
             Run.Status.STREAMING,
             timedelta(minutes=5),
             timedelta(minutes=5),
         )
 
-        count = reconcile_lensnode_active_runs(self.lensnode.uuid, [])
+        with patch(
+            "lens.tasks.confirm_reconcile_orphan.apply_async"
+        ) as apply_async:
+            count = reconcile_lensnode_active_runs(self.lensnode.uuid, [])
 
         run.refresh_from_db()
         self.assertEqual(count, 1)
-        self.assertEqual(run.status, Run.Status.FAILED)
-        self.assertEqual(run.error, "LENSNODE_RECONNECT_ORPHANED")
+        self.assertEqual(run.status, Run.Status.STREAMING)
+        self.assertTrue(apply_async.called)
+        kwargs = apply_async.call_args.kwargs
+        self.assertEqual(kwargs["args"][0], str(run.uuid))
+        self.assertIn("countdown", kwargs)
 
     def test_reconcile_keeps_claimed_and_fresh_runs(self):
         claimed = self._run(
@@ -158,11 +168,47 @@ class RunLifecycleTests(TestCase):
             timedelta(seconds=10),
         )
 
-        reconcile_lensnode_active_runs(
-            self.lensnode.uuid, [str(claimed.uuid)]
-        )
+        with patch(
+            "lens.tasks.confirm_reconcile_orphan.apply_async"
+        ) as apply_async:
+            reconcile_lensnode_active_runs(
+                self.lensnode.uuid, [str(claimed.uuid)]
+            )
 
         claimed.refresh_from_db()
         fresh.refresh_from_db()
         self.assertEqual(claimed.status, Run.Status.STREAMING)
         self.assertEqual(fresh.status, Run.Status.RUNNING)
+        apply_async.assert_not_called()
+
+    def test_confirm_reconcile_orphan_fails_still_running_run(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        confirm_reconcile_orphan(str(run.uuid))
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_RECONNECT_ORPHANED")
+
+    def test_confirm_reconcile_orphan_noops_if_already_terminal(self):
+        # The normal completion path (a late but durably-delivered run_done)
+        # won the race and finished the run before this fired.
+        run = self._run(
+            Run.Status.DONE,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        confirm_reconcile_orphan(str(run.uuid))
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.DONE)
+        self.assertEqual(run.error, "")
+
+    def test_confirm_reconcile_orphan_noops_for_unknown_run(self):
+        # Must not raise for a run_uuid that no longer exists.
+        confirm_reconcile_orphan(str(uuid.uuid4()))


### PR DESCRIPTION
### **User description**
## Summary

Fix direction B from #92 (fix direction A, WS ping tolerance, already merged in #93).

`reconcile_lensnode_active_runs` failed a RUNNING/STREAMING run the instant a reconnecting node's `hello` didn't report it as active. But LensNode redelivers `run_done` at-least-once through a durable outbox (`LensNodeClient._send_loop` in `lensnode/lensnode/main.py`) — a run that finished during the connection drop is legitimately absent from that one `hello` snapshot while its already-computed answer is still queued for delivery moments later. Failing it inline discarded correct, already-paid-for answers — full evidence chain (production log excerpts, timestamps) in #92.

## Change

`reconcile_lensnode_active_runs` now schedules a delayed confirmation per orphan candidate (`confirm_reconcile_orphan`, a Celery countdown task, default 20s, admin-tunable via `GlobalSetting` key `lensnode.reconcile_confirm_grace_s`) instead of failing it inline. The confirmation is a single filtered `UPDATE` gated on the run still being `RUNNING`/`STREAMING` — verified (not assumed) that this races safely against `finish_lensnode_run`'s `select_for_update` + terminal-state guard:
- If the normal completion path wins the race, my confirmation's filter no longer matches (status is already `DONE`) → no-op.
- If my confirmation wins (genuine orphan), `finish_lensnode_run` sees `TERMINAL_RUN_STATUSES` already set and returns early → doesn't overwrite.

No episode-pinning needed (unlike the sibling `check_lensnode_disconnect_grace_period`, which guards a shared, overwritable `LensNode.disconnected_at` field) — this task only ever acts on the one `run_uuid` it was scheduled for, and a run that already left `RUNNING`/`STREAMING` simply won't match the filter.

## Blast radius

- Only affects the reconnect-hello path. Doesn't touch the full-disconnect grace check (180s default) or the idle reaper (300s default) — all three filter on `status__in=[RUNNING, STREAMING]`, so whichever resolves a run first, the others naturally no-op on it.
- A genuine orphan now takes up to ~20s longer to be marked failed (was instant). Negligible against the other grace windows already in this system.
- Two accepted trade-offs, consistent with the existing sibling pattern (not new risk shapes introduced by this PR):
  - A flapping connection can schedule duplicate confirmation tasks for the same run across multiple `hello`s — harmless (idempotent, first-to-land wins) but adds some Celery task volume proportional to flapping.
  - This path now depends on the Celery broker being reachable at `hello` time; a broker hiccup is caught and logged, falling back to the idle reaper as backstop (same trade-off `schedule_lensnode_disconnect_grace_check` already accepts).

## Test plan
- [x] Updated `test_reconcile_fails_orphaned_run` → `test_reconcile_schedules_confirmation_instead_of_failing_inline`, updated `test_reconcile_keeps_claimed_and_fresh_runs` to assert no confirmation is scheduled for claimed/fresh runs
- [x] Added `test_confirm_reconcile_orphan_fails_still_running_run`, `test_confirm_reconcile_orphan_noops_if_already_terminal`, `test_confirm_reconcile_orphan_noops_for_unknown_run`
- [x] Added `test_reconcile_confirm_grace_seconds_default_and_override`
- [x] Full `lens` app suite: 154 tests, only the 3 pre-existing failures tracked in #77 (unrelated — verified by name/file, none touch this code path)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace immediate orphan fail with delayed confirm task

- Add `confirm_reconcile_orphan` Celery task with atomic filtered update

- Add tests for grace window settings, scheduling, and confirm task behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["reconcile_lensnode_active_runs"] --> B["schedule_reconcile_orphan_confirmation"]
  B --> C["Celery countdown (default 20s)"]
  C --> D["confirm_reconcile_orphan"]
  D --> E{"Run still RUNNING/STREAMING?"}
  E -- "Yes" --> F["Mark FAILED (LENSNODE_RECONNECT_ORPHANED)"]
  E -- "No" --> G["No-op (already terminal)"]
  B -- "Broker hiccup" --> H["Idle reaper backstop"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Delay orphan detection with configurable grace window</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/services.py

<ul><li>Changed <code>reconcile_lensnode_active_runs</code> to schedule a delayed <br>confirmation instead of failing runs inline.<br> <li> Added <code>schedule_reconcile_orphan_confirmation</code> and <br><code>get_reconcile_confirm_grace_seconds</code> helper functions.<br> <li> Grace window default 20s, configurable via <code>GlobalSetting</code> key <br><code>lensnode.reconcile_confirm_grace_s</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/95/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+77/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>New Celery task for deferred orphan confirmation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tasks.py

<ul><li>Added <code>confirm_reconcile_orphan</code> Celery task.<br> <li> Atomically fails a run only if still RUNNING/STREAMING; no-ops <br>otherwise.<br> <li> Idempotent, no shared-state locking needed.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/95/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_disconnect_grace.py</strong><dd><code>Test reconcile confirm grace seconds setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_disconnect_grace.py

<ul><li>Added test for <code>get_reconcile_confirm_grace_seconds</code> default and <br>override via <code>GlobalSetting</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/95/files#diff-4c30be79cc6bcad79aee8f4292034bf60ba45e1b95a1733ec8540c16b032949a">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_run_lifecycle.py</strong><dd><code>Update and extend tests for new orphan confirm behavior</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_run_lifecycle.py

<ul><li>Updated <br><code>test_reconcile_schedules_confirmation_instead_of_failing_inline</code> to <br>assert scheduling, not inline failure.<br> <li> Updated <code>test_reconcile_keeps_claimed_and_fresh_runs</code> to assert no <br>scheduling for claimed/fresh runs.<br> <li> Added tests for <code>confirm_reconcile_orphan</code>: fails still‑running, no‑op <br>on terminal, no‑op on unknown UUID.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/95/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+54/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

