### PR TITLE
fix(lens): restore the mobile chat session drawer

### DIFF
--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test'
+
+async function mockChat(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+    localStorage.setItem('userLanguage', 'en')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+
+    const payloads = {
+      '/api/v1/auth/user': {
+        username: 'tester',
+        features: ['workspace'],
+        permissions: []
+      },
+      '/api/lens/assistants/': [
+        {
+          uuid: 'assistant-1',
+          slug: 'drawer-test',
+          name: 'Drawer Test',
+          status: 'active'
+        }
+      ],
+      '/api/lens/shares/': [],
+      '/api/lens/sessions/': [
+        { uuid: 'session-1', title: 'First session' },
+        { uuid: 'session-2', title: 'Second session' }
+      ],
+      '/api/lens/sessions/session-1/messages/': [],
+      '/api/lens/sessions/session-2/messages/': [
+        {
+          uuid: 'message-2',
+          role: 'assistant',
+          content: 'Second session response',
+          created_at: '2026-07-24T08:00:00Z'
+        }
+      ]
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payloads[path] ?? [] })
+    })
+  })
+}
+
+async function sidebarBox(page) {
+  return page.locator('.sidebar').evaluate((element) => {
+    const rect = element.getBoundingClientRect()
+    return { x: rect.x, width: rect.width }
+  })
+}
+
+test('mobile session drawer opens, selects sessions, and closes', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockChat(page)
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: -320 })
+
+  await page.getByRole('button', { name: 'Recent' }).click()
+  await expect(page.locator('.sidebar')).toHaveClass(/sidebar-open/)
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 320 })
+
+  const secondSession = page
+    .locator('.session-item')
+    .filter({ hasText: 'Second session' })
+  await expect(secondSession).toBeVisible()
+  await secondSession.click()
+  await expect(page).toHaveURL(/session=session-2/)
+  await expect(page.getByText('Second session response')).toBeAttached()
+
+  await page.locator('.sidebar').getByRole('button', { name: 'Close' }).click()
+  await expect(page.locator('.sidebar')).not.toHaveClass(/sidebar-open/)
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: -320 })
+
+  await page.getByRole('button', { name: 'Recent' }).click()
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0 })
+  await page
+    .locator('div.fixed.inset-0.z-20')
+    .click({ position: { x: 380, y: 400 } })
+  await expect(page.locator('.sidebar')).not.toHaveClass(/sidebar-open/)
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: -320 })
+})
+
+test('desktop sidebar still expands and collapses', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await mockChat(page)
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+  await page.getByRole('button', { name: 'Collapse' }).click()
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 64 })
+  await page.locator('.sidebar-collapse-btn[aria-label="Expand"]').click()
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+})

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -3076,8 +3076,8 @@ onBeforeUnmount(() => {
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
   }
 
-  .sidebar-open {
-    @apply translate-x-0;
+  .sidebar.sidebar-open {
+    transform: translateX(0);
   }
 
   .side-head {


### PR DESCRIPTION
### **User description**
## Summary

Fix the mobile chat session drawer remaining completely off-screen after the
Recent button is clicked.

Closes #84.

## Root cause

The mobile sidebar base state and open state both applied translate utilities
through selectors with the same specificity. In the affected runtime, the
sidebar received `sidebar-open`, but the base `translateX(-100%)` remained the
final computed transform.

As a result, the 320px drawer stayed at `x = -320` even though its Vue state
was open.

## Changes

- Use a more specific `.sidebar.sidebar-open` selector on mobile.
- Explicitly set `transform: translateX(0)` for the open state.
- Add Playwright regression coverage for:
  - Opening the drawer through the Recent button.
  - Selecting an existing session.
  - Closing through the close control.
  - Closing through the backdrop.
  - Preserving desktop expanded and collapsed sidebar behavior.

## Testing

- [x] Playwright mobile and desktop drawer regression: 2 passed
- [x] Manual ego lite verification at 390 x 844
- [x] Drawer opens at `x = 0` with a 320px width
- [x] Existing session selection updates the session URL
- [x] Close control dismisses the drawer
- [x] Backdrop dismisses the drawer
- [x] Desktop sidebar expands at 264px and collapses at 64px
- [x] Frontend production build
- [x] Prettier check
- [x] JavaScript syntax check
- [x] `git diff --check`

## PR Type

Bug fix, Tests


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix mobile chat session drawer off-screen

- Harden CSS selector and set explicit transform

- Add Playwright regression tests for drawer open/close and desktop sidebar


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chat.vue"] --> B["Fix CSS specificity"]
  B --> C["Sidebar translates to 0"]
  D["e2e test"] --> E["Mobile drawer opens/closes"]
  D --> F["Desktop sidebar unchanged"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Fix mobile sidebar CSS specificity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Replace generic <code>.sidebar-open</code> selector with <code>.sidebar.sidebar-open</code> to <br>increase specificity<br> <li> Use explicit <code>transform: translateX(0)</code> instead of Tailwind utility to <br>override base <code>-translate-x-full</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/97/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-mobile-drawer.spec.js</strong><dd><code>Add Playwright regression tests for drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-mobile-drawer.spec.js

<ul><li>Add test for mobile drawer open via Recent button, session selection, <br>close via close button and backdrop<br> <li> Add desktop sidebar expand/collapse regression test<br> <li> Mock API responses for user, assistants, shares, sessions, and <br>messages</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/97/files#diff-cb89d191cc946ddb676d704f3a7398dba03f09b1e45585cd92e06cefb093cdaa">+104/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

