### PR TITLE
fix(lens): contain shared tables and admin viewport overflow

### DIFF
--- a/frontend/e2e/admin-layout-scroll.spec.js
+++ b/frontend/e2e/admin-layout-scroll.spec.js
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+
+const VIEWPORTS = [
+  { width: 1512, height: 945 },
+  { width: 1920, height: 1080 }
+]
+
+function assistant(index) {
+  return {
+    uuid: `assistant-${index}`,
+    name: `Assistant ${index}`,
+    slug: `assistant-${index}-with-a-long-display-name`,
+    lensnode: 'local-development-lensnode',
+    selected_task: 'knowledge_qa',
+    selected_dirs: [{ path: '/workspace/default' }],
+    status: 'active',
+    visibility: 'public',
+    skill_summary: { enabled: 1 },
+    mcp_summary: { enabled: 1 }
+  }
+}
+
+async function mockAdminApis(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'e2e-admin-layout')
+  })
+  await page.route('**://*/api/**', async (route) => {
+    const { pathname } = new URL(route.request().url())
+    let data = []
+
+    if (pathname === '/api/v1/auth/user') {
+      data = {
+        id: 1,
+        username: 'admin',
+        is_staff: true,
+        is_superuser: true,
+        permissions: []
+      }
+    } else if (pathname === '/api/lens/assistants/') {
+      data = Array.from({ length: 6 }, (_, index) => assistant(index + 1))
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data })
+    })
+  })
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`admin layout contains scrolling at ${viewport.width}x${viewport.height}`, async ({
+    page
+  }) => {
+    await page.setViewportSize(viewport)
+    await mockAdminApis(page)
+    await page.goto('/management/lens/assistants')
+    await expect(
+      page.getByRole('heading', { name: 'Assistants', exact: true })
+    ).toBeVisible()
+    await expect(page.locator('tbody tr')).toHaveCount(6)
+
+    const layout = await page.evaluate(() => {
+      const root = document.scrollingElement
+      const shell = document.querySelector('.layout-admin')
+      const main = shell.querySelector('main')
+      const shellRect = shell.getBoundingClientRect()
+
+      return {
+        rootClientHeight: root.clientHeight,
+        rootScrollHeight: root.scrollHeight,
+        shellTop: shellRect.top,
+        shellBottom: shellRect.bottom,
+        viewportHeight: window.innerHeight,
+        mainOverflowY: getComputedStyle(main).overflowY
+      }
+    })
+
+    expect(layout.rootScrollHeight).toBe(layout.rootClientHeight)
+    expect(layout.shellTop).toBe(0)
+    expect(layout.shellBottom).toBe(layout.viewportHeight)
+    expect(layout.mainOverflowY).toBe('auto')
+  })
+}

--- a/frontend/e2e/public-qa-layout.spec.js
+++ b/frontend/e2e/public-qa-layout.spec.js
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test'
+
+const SHARE_TOKEN = 'e2e-wide-table'
+const TABLE_MARKDOWN = `
+| Environment | Region | Provider | Instance type | Operating system | Database | Cache | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Production | Asia Pacific | OnePro Cloud | Memory optimized | Ubuntu 24.04 LTS | PostgreSQL 16 | Redis 7 | Healthy |
+`
+
+test('wide shared Q&A tables scroll without widening the page', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.route(`**/api/lens/public/qa/${SHARE_TOKEN}/`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          title: 'Wide table layout',
+          question: 'Wide table layout',
+          answer: TABLE_MARKDOWN,
+          published_at: '2026-07-24T00:00:00Z',
+          view_count: 1
+        }
+      })
+    })
+  })
+
+  await page.goto(`/lens/qa/${SHARE_TOKEN}`)
+  await expect(
+    page.getByRole('heading', { name: 'Wide table layout' })
+  ).toBeVisible()
+
+  const tableScroll = page.locator('.markdown-table-scroll')
+  await expect(tableScroll).toHaveCount(1)
+
+  const layout = await page.evaluate(() => {
+    const scroll = document.querySelector('.markdown-table-scroll')
+    return {
+      pageClientWidth: document.documentElement.clientWidth,
+      pageScrollWidth: document.documentElement.scrollWidth,
+      tableClientWidth: scroll.clientWidth,
+      tableScrollWidth: scroll.scrollWidth,
+      overflowX: getComputedStyle(scroll).overflowX
+    }
+  })
+
+  expect(layout.pageScrollWidth).toBe(layout.pageClientWidth)
+  expect(layout.tableScrollWidth).toBeGreaterThan(layout.tableClientWidth)
+  expect(layout.overflowX).toBe('auto')
+})
+
+test('shared Q&A tables retain their desktop styling', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.route(`**/api/lens/public/qa/${SHARE_TOKEN}/`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          title: 'Desktop table layout',
+          question: 'Desktop table layout',
+          answer: TABLE_MARKDOWN,
+          published_at: '2026-07-24T00:00:00Z',
+          view_count: 1
+        }
+      })
+    })
+  })
+
+  await page.goto(`/lens/qa/${SHARE_TOKEN}`)
+  await expect(
+    page.getByRole('heading', { name: 'Desktop table layout' })
+  ).toBeVisible()
+
+  const layout = await page.evaluate(() => {
+    const scroll = document.querySelector('.markdown-table-scroll')
+    const table = scroll.querySelector('table')
+    const scrollStyle = getComputedStyle(scroll)
+    const tableStyle = getComputedStyle(table)
+
+    return {
+      pageClientWidth: document.documentElement.clientWidth,
+      pageScrollWidth: document.documentElement.scrollWidth,
+      wrapperBorderWidth: scrollStyle.borderWidth,
+      wrapperPadding: scrollStyle.padding,
+      tableBorderCollapse: tableStyle.borderCollapse,
+      tableWidth: table.offsetWidth,
+      wrapperWidth: scroll.clientWidth
+    }
+  })
+
+  expect(layout.pageScrollWidth).toBe(layout.pageClientWidth)
+  expect(layout.wrapperBorderWidth).toBe('0px')
+  expect(layout.wrapperPadding).toBe('0px')
+  expect(layout.tableBorderCollapse).toBe('collapse')
+  expect(layout.tableWidth).toBeGreaterThanOrEqual(layout.wrapperWidth)
+})

--- a/frontend/src/admin/layout/AdminLayout.vue
+++ b/frontend/src/admin/layout/AdminLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="layout-admin flex h-screen w-full overflow-hidden bg-ink-50">
+  <div class="layout-admin fixed inset-0 flex w-full overflow-hidden bg-ink-50">
     <AdminSidebar
       :show-mobile-menu="showMobileMenu"
       @close="showMobileMenu = false"

--- a/frontend/src/components/ui/MarkdownRenderer.vue
+++ b/frontend/src/components/ui/MarkdownRenderer.vue
@@ -52,6 +52,11 @@ renderer.code = ({ text, lang }) => {
   return `<pre><code class="hljs language-${language}">${body}</code></pre>`
 }
 
+const renderTable = renderer.table.bind(renderer)
+renderer.table = (token) => {
+  return '<div class="markdown-table-scroll">' + renderTable(token) + '</div>'
+}
+
 // Open answer links in a new tab so clicking a doc link never replaces the
 // chat page. rel="noopener noreferrer" avoids the opened page accessing
 // window.opener. (sanitizeHtml already allows target/rel attributes.)
@@ -304,8 +309,12 @@ const renderedContent = computed(() => {
   @apply bg-gray-900;
 }
 
+.markdown-content :deep(.markdown-table-scroll) {
+  @apply my-4 w-full max-w-full overflow-x-auto;
+}
+
 .markdown-content :deep(table) {
-  @apply w-full border-collapse border border-gray-300 my-4;
+  @apply w-full border-collapse border border-gray-300;
 }
 
 .markdown-content :deep(th) {


### PR DESCRIPTION
### **User description**
## Summary

- Contain wide Markdown tables inside table-local horizontal scroll regions.
- Prevent shared Q&A tables from widening the mobile document.
- Lock the admin layout shell to the viewport so short displays do not create a second page-level scrollbar or bottom whitespace.
- Add Playwright regression coverage for mobile, desktop, laptop, and external-display viewport sizes.

## Root cause

Markdown tables were rendered directly without a horizontal overflow boundary. Their intrinsic width could therefore expand the shared Q&A document beyond the mobile viewport.

The admin shell used `h-screen` while remaining in normal document flow. On shorter effective viewports, overflow from the Assistants table was still included in the root document scrollable height. This created both an internal main-content scrollbar and a second page-level scrollbar, followed by blank space below the admin shell. Taller external-display viewports did not expose the problem.

## Changes

- Wrap each rendered Markdown table in a dedicated `overflow-x-auto` container.
- Preserve the existing full-width, collapsed-border desktop table styling.
- Fix the admin shell to the viewport with `fixed inset-0`.
- Keep vertical scrolling within the existing main-content and sidebar regions.
- Add shared Q&A layout tests at 390×844 and 1440×900.
- Add admin layout tests at 1512×945 and 1920×1080.

## Issue #85 acceptance criteria

- [x] Markdown tables are wrapped in a responsive horizontal scroll container.
- [x] The document width stays within the mobile viewport.
- [x] Wide table content remains readable through table-local scrolling.
- [x] Desktop table width, border collapse, spacing, and neutral wrapper styling are preserved.

## Testing

- [x] `BASE_URL=http://localhost:8000 npx playwright test e2e/admin-layout-scroll.spec.js e2e/public-qa-layout.spec.js --config=playwright.config.cjs --reporter=line` — 4 passed
- [x] `npm run test:unit` — 3 passed
- [x] `npm run build`
- [x] ESLint on the changed layout and test files
- [x] Prettier checks on the changed layout and test files
- [x] `git diff --check`
- [x] Ego Lite verification at 1512×945: root document 945/945, one right-side content scroller, zero bottom whitespace
- [x] Ego Lite verification at 1920×1080: root document 1080/1080, no extra right-side scrollbar, zero bottom whitespace

Closes #85


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Wrap Markdown tables in horizontal scroll container

- Fix admin shell to viewport with `fixed inset-0`

- Add Playwright regression tests for mobile and desktop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MarkdownRenderer --> WrapTable["Wrap table in .markdown-table-scroll"]
  WrapTable --> OverflowAuto["overflow-x-auto"]
  AdminLayout --> FixedInset0["fixed inset-0"]
  AdminLayout --> MainScroll["main overflow-y auto"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdminLayout.vue</strong><dd><code>Fix admin shell to viewport</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/layout/AdminLayout.vue

<ul><li>Changed <code>h-screen</code> to <code>fixed inset-0</code> to prevent viewport overflow<br> <li> Enables internal vertical scrolling within main content area</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/98/files#diff-be114c9e0de8e3af91253323967cad44fd6750c5c7e4eb0fa1b13db0b55108ec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarkdownRenderer.vue</strong><dd><code>Contain wide tables in scrollable wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/MarkdownRenderer.vue

<ul><li>Wrapped each Markdown table in a <code>div</code> with class <code>markdown-table-scroll</code><br> <li> Applied <code>overflow-x-auto</code> and constrained width to prevent page overflow<br> <li> Removed <code>my-4</code> from table style, now applied to wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/98/files#diff-8acab9a2284f91e2714ae018e98389ad38d85c55215ce785163b9cf790b4c5d3">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-layout-scroll.spec.js</strong><dd><code>Add admin layout scroll tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/admin-layout-scroll.spec.js

<ul><li>New Playwright test for admin layout at 1512×945 and 1920×1080<br> <li> Verifies root scroll height equals client height, shell fits viewport</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/98/files#diff-bc4911ecdac0091add9f00c0679059486a8bc50cbccf18c97d76a0489db5578a">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>public-qa-layout.spec.js</strong><dd><code>Add public QA layout tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/public-qa-layout.spec.js

<ul><li>New Playwright tests for shared Q&A table overflow on mobile and <br>desktop<br> <li> Checks page scroll width, table scroll container properties</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/98/files#diff-8109e9cb4e20a7aba7672d818a26ca2f6b4b3b974038b887c27f8efe09c27c05">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

