### PR TITLE
fix(admin): restore mobile sidebar navigation

### DIFF
--- a/frontend/e2e/access-control/admin-mobile-navigation.spec.js
+++ b/frontend/e2e/access-control/admin-mobile-navigation.spec.js
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+
+import { asRole } from './helpers.js'
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 }
+
+async function expectSidebarX(sidebar, expectedX) {
+  await expect
+    .poll(async () => Math.round((await sidebar.boundingBox()).x))
+    .toBe(expectedX)
+}
+
+test.describe('Admin mobile navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT)
+    await asRole(page, 'admin')
+    await page.addInitScript(() => {
+      window.localStorage.setItem('userLanguage', 'zh-CN')
+    })
+    await page.goto('/management/users')
+  })
+
+  test('opens, navigates, and closes the sidebar', async ({ page }) => {
+    const sidebar = page.locator('#admin-sidebar')
+    const openButton = page.locator('button[aria-controls="admin-sidebar"]')
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN')
+    await expect(openButton).toHaveAccessibleName('展开 SourceLens Admin')
+    await expect(openButton).toHaveAttribute('aria-expanded', 'false')
+    await expectSidebarX(sidebar, -256)
+
+    await openButton.click()
+
+    await expect(openButton).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.layout-admin-overlay')).toBeVisible()
+    await expectSidebarX(sidebar, 0)
+
+    await sidebar.locator('a[href="/management/groups"]').click()
+
+    await expect(page).toHaveURL(/\/management\/groups$/)
+    const navigatedSidebar = page.locator('#admin-sidebar')
+    const navigatedOpenButton = page.locator(
+      'button[aria-controls="admin-sidebar"]'
+    )
+    await expectSidebarX(navigatedSidebar, -256)
+    await expect(navigatedOpenButton).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('.layout-admin-overlay')).toBeHidden()
+
+    await navigatedOpenButton.click()
+    const closeButton = page.locator(
+      '#admin-sidebar button[aria-label="关闭 SourceLens Admin"]'
+    )
+    await expect(closeButton).toHaveAccessibleName('关闭 SourceLens Admin')
+    await closeButton.click()
+    await expectSidebarX(navigatedSidebar, -256)
+    await expect(navigatedOpenButton).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('.layout-admin-overlay')).toBeHidden()
+
+    await navigatedOpenButton.click()
+    await page
+      .locator('.layout-admin-overlay')
+      .click({ position: { x: 300, y: 400 } })
+    await expectSidebarX(navigatedSidebar, -256)
+    await expect(navigatedOpenButton).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('.layout-admin-overlay')).toBeHidden()
+  })
+
+  test('keeps the desktop sidebar visible', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+
+    await expect(
+      page.locator('button[aria-controls="admin-sidebar"]')
+    ).toBeHidden()
+    await expectSidebarX(page.locator('#admin-sidebar'), 0)
+  })
+})

--- a/frontend/src/admin/layout/AdminHeader.vue
+++ b/frontend/src/admin/layout/AdminHeader.vue
@@ -6,7 +6,11 @@
       <div class="flex justify-between items-center h-16">
         <div class="flex items-center gap-3">
           <button
-            @click="$emit('toggle-menu')"
+            type="button"
+            aria-controls="admin-sidebar"
+            :aria-expanded="showMobileMenu"
+            :aria-label="`${t('common.expand')} ${t('management.logoTitle')}`"
+            @click="$emit('open-menu')"
             class="lg:hidden p-2 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <svg
@@ -148,7 +152,14 @@ import { useUserStore } from '@/store/user'
 import { useUiStore } from '@/store/ui'
 import LanguageSwitcher from '@/components/ui/LanguageSwitcher.vue'
 
-defineEmits(['toggle-menu'])
+defineProps({
+  showMobileMenu: {
+    type: Boolean,
+    default: false
+  }
+})
+
+defineEmits(['open-menu'])
 
 const { t } = useI18n()
 const route = useRoute()

--- a/frontend/src/admin/layout/AdminLayout.vue
+++ b/frontend/src/admin/layout/AdminLayout.vue
@@ -5,7 +5,10 @@
       @close="showMobileMenu = false"
     />
     <div class="flex-1 flex min-w-0 flex-col overflow-hidden bg-ink-50">
-      <AdminHeader @toggle-menu="showMobileMenu = !showMobileMenu" />
+      <AdminHeader
+        :show-mobile-menu="showMobileMenu"
+        @open-menu="showMobileMenu = true"
+      />
       <main class="flex-1 min-w-0 overflow-y-auto bg-ink-50 px-4 py-3">
         <div :key="route.path" class="h-full min-h-0">
           <slot />

--- a/frontend/src/admin/layout/AdminSidebar.vue
+++ b/frontend/src/admin/layout/AdminSidebar.vue
@@ -15,6 +15,7 @@
   </Transition>
 
   <aside
+    id="admin-sidebar"
     :class="[
       'layout-admin-sidebar flex h-full w-64 flex-shrink-0 flex-col border-r border-ink-800 bg-ink-900 transition-transform duration-300 ease-in-out',
       isMobile ? 'fixed inset-y-0 left-0 z-50' : 'static',
@@ -37,6 +38,8 @@
       </router-link>
       <button
         v-if="isMobile"
+        type="button"
+        :aria-label="`${t('common.close')} ${t('management.logoTitle')}`"
         @click="$emit('close')"
         class="rounded-md p-2 text-ink-400 hover:bg-white/10 hover:text-white"
       >


### PR DESCRIPTION
### **User description**
## Summary

Fix the admin console mobile navigation so the sidebar opens through an explicit one-way event and exposes its state to assistive technologies.

Fixes #83.

## Problem

At a 390 x 844 viewport, the admin sidebar starts outside the viewport. The mobile navigation control must reliably open it, display a dismissible backdrop, and allow users to navigate between management pages.

The existing toggle and close controls also lacked accessible names and did not expose the sidebar expanded state.

## Changes

- Replace the ambiguous mobile menu toggle event with an explicit open event.
- Pass the sidebar open state to the admin header.
- Add a stable sidebar ID and connect it to the trigger with `aria-controls`.
- Expose the open state through `aria-expanded`.
- Add localized accessible names to the open and close controls.
- Add Playwright regression coverage for opening, closing, backdrop dismissal, route navigation, and unchanged desktop behavior.

## Testing

- [x] Admin mobile navigation Playwright tests: 2 passed
- [x] Verified with an administrator at 390 x 844 in zh-CN
- [x] Verified sidebar transition from `x = -256` to `x = 0`
- [x] Verified route navigation closes the sidebar
- [x] Verified close button and backdrop dismissal
- [x] Verified `aria-expanded` state changes
- [x] Verified desktop behavior at 1280 x 800
- [x] Production frontend build
- [x] Prettier check
- [x] `git diff --check`

## Scope

Frontend only. No API, database, migration, dependency, or deployment changes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace toggle event with explicit open event

- Add aria labels and expanded state for accessibility

- Add Playwright regression tests for mobile navigation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hamburger["Hamburger button click"] -->|"open-menu"| layout["AdminLayout sets showMobileMenu=true"]
  layout --> sidebar["AdminSidebar visible with backdrop"]
  sidebar -->|close| layout["AdminLayout sets showMobileMenu=false"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdminHeader.vue</strong><dd><code>Update mobile header event and accessibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/layout/AdminHeader.vue

<ul><li>Emit explicit 'open-menu' event instead of ambiguous 'toggle-menu'<br> <li> Accept showMobileMenu prop and expose aria-expanded state<br> <li> Add aria-controls and aria-label for accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/100/files#diff-72b027d627396e485c9cc13fc1b63078364fa57d249b1af9b940fef26d8e5334">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AdminLayout.vue</strong><dd><code>Fix sidebar open state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/layout/AdminLayout.vue

<ul><li>Wire showMobileMenu prop and open-menu event from AdminHeader<br> <li> Set sidebar state only on explicit open event</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/100/files#diff-be114c9e0de8e3af91253323967cad44fd6750c5c7e4eb0fa1b13db0b55108ec">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdminSidebar.vue</strong><dd><code>Add sidebar ID and close button label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/layout/AdminSidebar.vue

<ul><li>Add id="admin-sidebar" for aria-controls linking<br> <li> Add aria-label to close button</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/100/files#diff-68245495c461d476760afe3a8f4ca43037fde7fb7ad1a6e64bdc24b2c67dc8e1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-mobile-navigation.spec.js</strong><dd><code>Add mobile navigation Playwright tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/access-control/admin-mobile-navigation.spec.js

<ul><li>Test open, close, backdrop, route navigation at mobile viewport<br> <li> Verify desktop sidebar remains unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/100/files#diff-a51029184054236dcf50d9c491300cdfd4d72592a4e01ef35b9adca471d6bb91">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

