### PR TITLE
fix(admin): make create drawers dismissible and show field validation

### DIFF
--- a/frontend/e2e/access-control/management.spec.js
+++ b/frontend/e2e/access-control/management.spec.js
@@ -190,6 +190,111 @@ test.describe('Management: exact user filters', () => {
   })
 })
 
+test.describe('Management: create drawers', () => {
+  const drawers = [
+    {
+      path: '/management/users',
+      title: 'Create User',
+      errors: ['Username is required', 'Password is required'],
+      fieldLabel: 'Username',
+      postPath: '/api/v1/management/users/'
+    },
+    {
+      path: '/management/groups',
+      title: 'Create Group',
+      errors: ['Group name is required'],
+      fieldLabel: 'Group name',
+      postPath: '/api/v1/management/groups/'
+    }
+  ]
+
+  test.beforeEach(async ({ page }) => {
+    await asRole(page, 'admin')
+  })
+
+  for (const drawer of drawers) {
+    test(`${drawer.title} supports every dismissal action`, async ({
+      page
+    }) => {
+      await page.goto(drawer.path)
+
+      await page.getByRole('button', { name: drawer.title }).click()
+      const dialog = page.getByRole('dialog', { name: drawer.title })
+      await expect(dialog).toBeVisible()
+      await dialog.getByRole('button', { name: 'Cancel' }).click()
+      await expect(
+        page.getByRole('dialog', { name: drawer.title })
+      ).toBeHidden()
+
+      await page.getByRole('button', { name: drawer.title }).click()
+      await dialog.getByRole('button', { name: 'Close' }).click()
+      await expect(
+        page.getByRole('dialog', { name: drawer.title })
+      ).toBeHidden()
+
+      await page.getByRole('button', { name: drawer.title }).click()
+      await page.keyboard.press('Escape')
+      await expect(
+        page.getByRole('dialog', { name: drawer.title })
+      ).toBeHidden()
+    })
+
+    test(`${drawer.title} shows field errors without posting`, async ({
+      page
+    }) => {
+      const posts = []
+      page.on('request', (request) => {
+        const path = new URL(request.url()).pathname
+        if (request.method() === 'POST' && path === drawer.postPath) {
+          posts.push(request.url())
+        }
+      })
+
+      await page.setViewportSize({ width: 900, height: 700 })
+      await page.goto(drawer.path)
+      await page.getByRole('button', { name: drawer.title }).click()
+      const dialog = page.getByRole('dialog', { name: drawer.title })
+      const confirmButton = dialog.getByRole('button', { name: 'Confirm' })
+      await confirmButton.click()
+
+      for (const error of drawer.errors) {
+        const message = page.getByText(error, { exact: true })
+        await expect(message).toBeVisible()
+        await expect(message).toBeInViewport()
+      }
+      await expect(confirmButton).toBeInViewport()
+      expect(posts).toEqual([])
+
+      await dialog.getByLabel(drawer.fieldLabel).fill('fixed value')
+      await expect(
+        page.getByText(drawer.errors[0], { exact: true })
+      ).toBeHidden()
+    })
+  }
+
+  test('shared drawer supports every dismissal action', async ({ page }) => {
+    await page.goto('/management/lens/assistants')
+
+    const createButton = page.getByRole('button', {
+      name: 'Create Assistant'
+    })
+    const dialog = page.getByRole('dialog', { name: 'Create Assistant' })
+
+    await createButton.click()
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+    await expect(dialog).toBeHidden()
+
+    await createButton.click()
+    await dialog.getByRole('button', { name: 'Close' }).click()
+    await expect(dialog).toBeHidden()
+
+    await createButton.click()
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+  })
+})
+
 test.describe('Management: deleting a group revokes its assistant grants', () => {
   test('group deletion cascades AssistantAccess', async ({ request }) => {
     const baseline = (await privateGrants(request)).map((g) => ({

--- a/frontend/src/admin/pages/Management/Groups.vue
+++ b/frontend/src/admin/pages/Management/Groups.vue
@@ -133,16 +133,22 @@
         :subtitle="form.name || ''"
         @close="closeModal"
       >
-        <form id="group-form" class="space-y-4" @submit.prevent="submitGroup">
+        <form
+          id="group-form"
+          class="space-y-4"
+          novalidate
+          @submit.prevent="submitGroup"
+        >
           <p v-if="submitError" class="text-sm text-danger-700">
             {{ submitError }}
           </p>
-          <div>
-            <label class="mb-1 block text-sm font-medium text-ink-700">{{
-              t('management.groupName')
-            }}</label>
-            <input v-model="form.name" type="text" class="form-input" />
-          </div>
+          <BaseInput
+            v-model="form.name"
+            :label="t('management.groupName')"
+            :error="formErrors.name"
+            required
+            @update:model-value="formErrors.name = ''"
+          />
           <div>
             <label class="mb-1 block text-sm font-medium text-ink-700">{{
               t('management.members')
@@ -182,8 +188,7 @@
             <BaseButton
               variant="primary"
               :loading="submitLoading"
-              type="submit"
-              form="group-form"
+              @click="submitGroup"
             >
               {{ t('common.confirm') }}
             </BaseButton>
@@ -232,6 +237,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AdminLayout from '@/admin/layout/AdminLayout.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
+import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import PaginationBar from '@/components/ui/PaginationBar.vue'
 import BaseDrawer from '@/components/ui/BaseDrawer.vue'
@@ -257,6 +263,7 @@ const mode = ref('create')
 const editingGroupId = ref(null)
 const submitLoading = ref(false)
 const submitError = ref(null)
+const formErrors = ref({ name: '' })
 const form = ref({ name: '', user_ids: [] })
 
 const totalPages = computed(() =>
@@ -274,12 +281,14 @@ function closeModal() {
   editingGroupId.value = null
   submitError.value = null
   submitLoading.value = false
+  formErrors.value = { name: '' }
   form.value = { name: '', user_ids: [] }
 }
 
 function openCreateModal() {
   mode.value = 'create'
   form.value = { name: '', user_ids: [] }
+  formErrors.value = { name: '' }
   showModal.value = true
 }
 
@@ -292,6 +301,7 @@ function memberIdsForGroup(groupId) {
 function openEditModal(group) {
   mode.value = 'edit'
   editingGroupId.value = group.id
+  formErrors.value = { name: '' }
   form.value = {
     name: group.name || '',
     user_ids: memberIdsForGroup(group.id)
@@ -330,9 +340,10 @@ async function confirmDelete() {
 
 async function submitGroup() {
   submitError.value = null
+  formErrors.value = { name: '' }
   const name = (form.value.name || '').trim()
   if (!name) {
-    submitError.value = t('management.groupNameRequired')
+    formErrors.value.name = t('management.groupNameRequired')
     return
   }
 
@@ -411,9 +422,5 @@ onMounted(async () => {
 
 .table-cell {
   @apply px-4 py-4 text-sm text-ink-700;
-}
-
-.form-input {
-  @apply w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20;
 }
 </style>

--- a/frontend/src/admin/pages/Management/Users.vue
+++ b/frontend/src/admin/pages/Management/Users.vue
@@ -215,28 +215,36 @@
         :subtitle="form.username || ''"
         @close="closeModal"
       >
-        <form id="user-form" class="space-y-4" @submit.prevent="submitUser">
+        <form
+          id="user-form"
+          class="space-y-4"
+          novalidate
+          @submit.prevent="submitUser"
+        >
           <p v-if="submitError" class="text-sm text-danger-700">
             {{ submitError }}
           </p>
-          <div>
-            <label class="mb-1 block text-sm font-medium text-ink-700">{{
-              t('dashboard.username')
-            }}</label>
-            <input v-model="form.username" type="text" class="form-input" />
-          </div>
-          <div>
-            <label class="mb-1 block text-sm font-medium text-ink-700">{{
-              t('dashboard.email')
-            }}</label>
-            <input v-model="form.email" type="email" class="form-input" />
-          </div>
-          <div v-if="mode === 'create'">
-            <label class="mb-1 block text-sm font-medium text-ink-700">{{
-              t('password.reset.newPassword')
-            }}</label>
-            <input v-model="form.password" type="password" class="form-input" />
-          </div>
+          <BaseInput
+            v-model="form.username"
+            :label="t('dashboard.username')"
+            :error="formErrors.username"
+            required
+            @update:model-value="formErrors.username = ''"
+          />
+          <BaseInput
+            v-model="form.email"
+            type="email"
+            :label="t('dashboard.email')"
+          />
+          <BaseInput
+            v-if="mode === 'create'"
+            v-model="form.password"
+            type="password"
+            :label="t('password.reset.newPassword')"
+            :error="formErrors.password"
+            required
+            @update:model-value="formErrors.password = ''"
+          />
           <div>
             <label class="mb-1 block text-sm font-medium text-ink-700">{{
               t('management.selectGroups')
@@ -293,8 +301,7 @@
             <BaseButton
               variant="primary"
               :loading="submitLoading"
-              type="submit"
-              form="user-form"
+              @click="submitUser"
             >
               {{ t('common.confirm') }}
             </BaseButton>
@@ -313,6 +320,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AdminLayout from '@/admin/layout/AdminLayout.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
+import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import PaginationBar from '@/components/ui/PaginationBar.vue'
 import BaseDrawer from '@/components/ui/BaseDrawer.vue'
@@ -344,6 +352,7 @@ const mode = ref('create')
 const editingUserId = ref(null)
 const submitLoading = ref(false)
 const submitError = ref(null)
+const formErrors = ref({ username: '', password: '' })
 
 const groupOptions = ref([])
 
@@ -385,18 +394,21 @@ function closeModal() {
   submitError.value = null
   submitLoading.value = false
   editingUserId.value = null
+  formErrors.value = { username: '', password: '' }
   form.value = createEmptyForm()
 }
 
 function openCreateModal() {
   mode.value = 'create'
   form.value = createEmptyForm()
+  formErrors.value = { username: '', password: '' }
   showModal.value = true
 }
 
 function openEditModal(user) {
   mode.value = 'edit'
   editingUserId.value = user.id
+  formErrors.value = { username: '', password: '' }
   form.value = {
     username: user.username || '',
     email: user.email || '',
@@ -426,6 +438,7 @@ async function loadOptions() {
 
 async function submitUser() {
   submitError.value = null
+  formErrors.value = { username: '', password: '' }
   const payload = {
     username: (form.value.username || '').trim(),
     email: (form.value.email || '').trim(),
@@ -435,17 +448,17 @@ async function submitUser() {
   }
 
   if (!payload.username) {
-    submitError.value = t('management.usernameRequired')
-    return
+    formErrors.value.username = t('management.usernameRequired')
   }
 
   if (mode.value === 'create') {
     payload.password = (form.value.password || '').trim()
     if (!payload.password) {
-      submitError.value = t('management.passwordRequired')
-      return
+      formErrors.value.password = t('management.passwordRequired')
     }
   }
+
+  if (formErrors.value.username || formErrors.value.password) return
 
   submitLoading.value = true
   try {

--- a/frontend/src/components/ui/BaseDrawer.vue
+++ b/frontend/src/components/ui/BaseDrawer.vue
@@ -8,7 +8,13 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-if="show" class="fixed inset-0 z-50 flex justify-end">
+      <div
+        v-if="show"
+        class="fixed inset-0 z-50 flex justify-end"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="title"
+      >
         <div class="fixed inset-0 bg-black/40" @click="handleBackdropClick" />
         <Transition
           enter-active-class="transition-transform duration-300 ease-out"
@@ -44,7 +50,8 @@
               <button
                 type="button"
                 class="ml-3 flex-shrink-0 rounded-md p-1.5 text-ink-400 transition-colors hover:bg-surface-sunken hover:text-ink-600 focus:outline-none"
-                @click="$emit('close')"
+                :aria-label="t('common.close')"
+                @click="requestClose"
               >
                 <svg
                   class="h-5 w-5"
@@ -81,7 +88,10 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -105,6 +115,32 @@ const widthClass = computed(() => {
 })
 
 function handleBackdropClick() {
-  if (props.closeOnBackdrop) emit('close')
+  if (props.closeOnBackdrop) requestClose()
 }
+
+function handleKeydown(event) {
+  if (event.key !== 'Escape' || !props.show) return
+  event.preventDefault()
+  requestClose()
+}
+
+function requestClose() {
+  emit('close')
+}
+
+watch(
+  () => props.show,
+  (show) => {
+    if (typeof window === 'undefined') return
+    const action = show ? 'addEventListener' : 'removeEventListener'
+    window[action]('keydown', handleKeydown)
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', handleKeydown)
+  }
+})
 </script>


### PR DESCRIPTION
### **User description**
## Summary

Fix the admin create drawers so they can be dismissed consistently and invalid
submissions provide visible field-level feedback.

The fix covers the Users and Groups management pages and adds shared drawer
regression coverage through the Assistant create flow.

## Root cause

`BaseDrawer` supported close events from the header and backdrop, but did not
handle the Escape key or expose dialog semantics.

The Users and Groups create forms also relied on an externally associated
submit button and stored validation failures in one form-level error. Required
fields were therefore not identified individually, and the dismissal and
validation paths had no dedicated regression coverage.

## Changes

- Add Escape-key dismissal to `BaseDrawer`
- Register the keyboard listener only while the drawer is visible
- Remove the listener when the drawer closes or unmounts
- Route backdrop and header close actions through one shared close handler
- Add dialog semantics and an accessible label for the close button
- Render field-level validation for user username, create-mode password, and
  group name
- Validate all missing required user fields in one submission
- Clear individual field errors when the user edits that field
- Reset validation state when create/edit drawers open or close
- Invoke the management form submit handlers directly from Confirm
- Disable native browser validation so button and Enter submission use the
  same application validation flow
- Preserve existing server-side error handling and API payloads

## Tests

Added Playwright regression coverage for:

- Create User and Create Group dismissal through Cancel, header close, and
  Escape
- Field-level feedback for invalid empty submissions
- No create request for invalid input
- Clearing field feedback after input
- Create Assistant dismissal through all three paths as shared drawer coverage
- Validation feedback and footer visibility at a 900 x 700 viewport

Validation completed:

- Frontend production build passed
- Issue-specific Playwright tests: 5 passed
- Full management Playwright suite: 12 passed
- Manual ego lite verification passed for Users and Groups
- Prettier passed
- ESLint passed
- `git diff --check` passed

## Compatibility

- No backend or API changes
- No database migration required
- Existing create and edit payloads remain unchanged
- Existing server-side error handling remains in place

Closes #82


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix drawer dismissal (Cancel, Close, Escape)

- Add field-level validation for empty submissions

- Add Playwright regression tests for Users, Groups, and Assistant drawers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Admin Create Drawer bug"] --> B["BaseDrawer: add Escape key & shared close handler"]
  A --> C["Users & Groups: replace raw inputs with BaseInput"]
  A --> D["Users & Groups: validate fields, clear on edit"]
  A --> E["Playwright: add tests for dismissal & validation"]
  B --> F["<code>@close</code> emitted on Cancel, Close icon, Escape"]
  C --> G["<code>novalidate</code>, direct @click on Confirm"]
  D --> H["formErrors reactive object, early return on invalid"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseDrawer.vue</strong><dd><code>Enhance drawer with Escape dismissal and accessibility</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/BaseDrawer.vue

<ul><li>Add Escape key listener (add/remove based on show) and expose shared <br>close handler<br> <li> Add <code>role="dialog"</code>, <code>aria-modal</code>, and <code>aria-label</code> for accessibility<br> <li> Route backdrop click through shared close handler</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/101/files#diff-9179f20c96236a212c5eb8b5f85b8f2690570886366191e6365fc58666c4c7b4">+40/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Groups.vue</strong><dd><code>Add field-level validation and proper submission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/pages/Management/Groups.vue

<ul><li>Replace inline input with <code>BaseInput</code> supporting error display<br> <li> Add <code>formErrors</code> reactive object and clear on edit/close/open<br> <li> Add <code>novalidate</code> to form and move submit from <code>type="submit"</code> to <code>@click</code><br> <li> Remove unused <code>.form-input</code> CSS class</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/101/files#diff-0d6ca0089db600204daad8a5eabd59d85aa6e6bc0746701d57447bd8fab96992">+21/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Users.vue</strong><dd><code>Add per-field validation and refactor form submission</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/pages/Management/Users.vue

<ul><li>Replace inline inputs with <code>BaseInput</code> (username, email, password)<br> <li> Add <code>formErrors</code> for username and password validation<br> <li> Validate both required fields, return early if any error<br> <li> Add <code>novalidate</code>, remove <code>type="submit"</code> and direct footer button to <br><code>submitUser</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/101/files#diff-bd17c5feba4852cd6103733e18ec32304f0c2f48fcf10c9612260b209f19ed88">+38/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>management.spec.js</strong><dd><code>Add Playwright tests for drawer dismissal and validation</code>&nbsp; </dd></summary>
<hr>

frontend/e2e/access-control/management.spec.js

<ul><li>Add test suite for create drawers: Users, Groups, and Assistant<br> <li> Test dismissal via Cancel, Close icon, Escape<br> <li> Test field errors, no POST on invalid, and error clearing after input<br> <li> Verify dialog visibility and in-viewport assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/101/files#diff-f74f2bb90d1cb05642cf9248c229d784791ef289f182eb5d88fbd39fc651cb5f">+105/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

