### PR TITLE
fix(lensnode): synthesize a best-effort answer when the turn budget is exhausted mid-turn

### DIFF
--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -1250,15 +1250,15 @@
     },
     "agentRounds": {
       "flash": "Flash",
-      "flashHint": "~5 steps",
+      "flashHint": "Fastest, fewest steps",
       "fast": "Fast",
-      "fastHint": "~13 steps",
+      "fastHint": "Quicker, lighter analysis",
       "balanced": "Balanced",
-      "balancedHint": "~26 steps",
+      "balancedHint": "Balances speed and depth",
       "deep": "Deep",
-      "deepHint": "~50 steps",
+      "deepHint": "More thorough, takes longer",
       "max": "Max",
-      "maxHint": "~100 steps"
+      "maxHint": "Most thorough, slowest"
     },
     "messages": {
       "loadFailed": "Failed to load Lens admin data",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -1250,15 +1250,15 @@
     },
     "agentRounds": {
       "flash": "极速",
-      "flashHint": "~5 步",
+      "flashHint": "最快，分析步骤最少",
       "fast": "快速",
-      "fastHint": "~13 步",
+      "fastHint": "更快，分析较浅",
       "balanced": "均衡",
-      "balancedHint": "~26 步",
+      "balancedHint": "速度与深度兼顾",
       "deep": "深度",
-      "deepHint": "~50 步",
+      "deepHint": "更彻底，耗时更久",
       "max": "极限",
-      "maxHint": "~100 步"
+      "maxHint": "最彻底，耗时最久"
     },
     "messages": {
       "loadFailed": "加载 Lens 管理数据失败",

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -470,7 +470,7 @@ def _detect_answer_language(question):
     return "English"
 
 
-def _bilingual(zh_text, en_text, answer_language):
+def _pick_text(zh_text, en_text, answer_language):
     """Pick zh_text for Chinese, en_text for every other detected language.
 
     LensNode has no i18n framework (no gettext/Babel, checked — this
@@ -901,7 +901,7 @@ def _run_agent_with_turn_limit(
             emit_event,
         )
     if truncated and answer.strip():
-        answer += _bilingual(
+        answer += _pick_text(
             "\n\n---\n*已达到当前分析深度上限，本次调查未完全完成。"
             "如需更完整的结果，请调高分析档位后重试。*",
             "\n\n---\n*Reached the current analysis-depth limit before "
@@ -943,7 +943,7 @@ def _synthesize_wrapup_answer(model, current, answer_language, emit_event):
     this call itself fails.
     """
 
-    instruction = _bilingual(
+    instruction = _pick_text(
         "你已经达到本次分析的步数上限，不能再调用任何工具。请基于目前为止"
         "已经掌握的全部信息，直接给出你能给出的最完整回答。如果调查还有"
         "尚未确认或未覆盖到的部分，请明确说明。",

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -409,6 +409,7 @@ class LensDeepAgentRuntime:
                 agent,
                 messages,
                 max_turns,
+                model=model,
                 emit_event=emit_agent_event,
                 answer_language=_detect_answer_language(question),
                 cancel_event=cancel_event,
@@ -467,6 +468,27 @@ def _detect_answer_language(question):
     if has(0x0600, 0x06FF):
         return "Arabic"
     return "English"
+
+
+def _bilingual(zh_text, en_text, answer_language):
+    """Pick zh_text for Chinese, en_text for every other detected language.
+
+    LensNode has no i18n framework (no gettext/Babel, checked — this
+    inline branch is the established way this file produces user-facing
+    text), so this stays a plain lookup rather than pulling one in for a
+    handful of strings. It only distinguishes Chinese from "everything
+    else" — Japanese/Korean/Thai/Russian/Arabic (all real
+    _detect_answer_language outcomes) fall back to en_text same as
+    English. TODO: if LensNode-generated user-facing strings keep
+    growing, revisit proper i18n; also consider moving this text out of
+    LensNode entirely — have it report a structured signal (e.g.
+    truncated=True on the run_done frame) and let the backend/frontend
+    render it, the way errorModelTimeout/errorNodeLost already work in
+    Chat.vue::mapRunError. Not done now: fixing the truncation bug itself
+    takes priority over that reshuffle.
+    """
+
+    return zh_text if answer_language == "Chinese" else en_text
 
 
 def _system_prompt(scenario, command, context_skill_contents=None):
@@ -796,6 +818,7 @@ def _run_agent_with_turn_limit(
     agent,
     messages,
     max_turns,
+    model=None,
     emit_event=None,
     answer_language="English",
     cancel_event=None,
@@ -805,6 +828,15 @@ def _run_agent_with_turn_limit(
     `messages` may be prefixed with prior conversation turns. Historical
     assistant turns are excluded from both the turn count and event
     emission, so the limit and trace reflect only the current run.
+
+    A subagent ``task`` delegation runs to completion inside a single
+    parent-graph step (deepagents calls it via a plain, synchronous
+    ``subagent.invoke(...)``), so the turn count can only be checked
+    between parent steps — a delegation in flight when the budget is
+    reached can overshoot max_turns by however many turns it used
+    internally before returning. This is expected, not a bug in the
+    count itself; it is the reason a forced wrap-up (see
+    _synthesize_wrapup_answer) matters more than counting precisely.
 
     Returns (answer, truncated) where truncated=True means the agent
     was stopped before it finished naturally.
@@ -856,18 +888,85 @@ def _run_agent_with_turn_limit(
             break
 
     answer = _extract_final_message(last_state or {})
+    if truncated and not answer.strip() and model is not None:
+        # The cutoff landed mid-turn (e.g. right after a tool call, before
+        # any answer text), so there is nothing to extract — but the
+        # conversation likely still holds real findings from every prior
+        # turn. Ask once more, without tools, for a best-effort synthesis
+        # instead of discarding all of that work.
+        answer = _synthesize_wrapup_answer(
+            model,
+            (last_state or {}).get("messages", []),
+            answer_language,
+            emit_event,
+        )
     if truncated and answer.strip():
-        if answer_language == "Chinese":
-            answer += (
-                "\n\n---\n*已达到当前分析深度上限，"
-                "如需更完整的结果，请调高分析档位后重试。*"
-            )
-        else:
-            answer += (
-                "\n\n---\n*Reached the current analysis-depth limit. "
-                "Raise the analysis tier for a more complete result.*"
-            )
+        answer += _bilingual(
+            "\n\n---\n*已达到当前分析深度上限，本次调查未完全完成。"
+            "如需更完整的结果，请调高分析档位后重试。*",
+            "\n\n---\n*Reached the current analysis-depth limit before "
+            "the investigation fully completed. Raise the analysis "
+            "tier for a more complete result.*",
+            answer_language,
+        )
     return answer, truncated
+
+
+def _strip_dangling_tool_call(messages):
+    """Drop a trailing AI message with unresolved tool_calls.
+
+    A truncated loop can stop right after the model requested a tool call
+    but before the tool result was recorded. Most providers reject a
+    follow-up call whose history ends on a tool_calls message with no
+    matching tool response, so that dangling turn is dropped before
+    asking for a wrap-up answer — every earlier, resolved turn is kept.
+    """
+
+    if not messages:
+        return messages
+    last = messages[-1]
+    if getattr(last, "type", "") == "ai" and getattr(
+        last, "tool_calls", None
+    ):
+        return messages[:-1]
+    return messages
+
+
+def _synthesize_wrapup_answer(model, current, answer_language, emit_event):
+    """Ask the model for a best-effort answer after the turn budget runs out.
+
+    Called only when the agent was truncated mid-turn and there is no
+    extractable answer text (see _run_agent_with_turn_limit). Makes one
+    plain, tool-free call asking the model to synthesize its best answer
+    from the conversation so far, so the turns already spent are not
+    wasted. Returns "" (letting the caller keep the empty-answer path) if
+    this call itself fails.
+    """
+
+    instruction = _bilingual(
+        "你已经达到本次分析的步数上限，不能再调用任何工具。请基于目前为止"
+        "已经掌握的全部信息，直接给出你能给出的最完整回答。如果调查还有"
+        "尚未确认或未覆盖到的部分，请明确说明。",
+        "You have reached the step limit for this analysis and cannot "
+        "call any more tools. Based on everything you have gathered so "
+        "far, write the most complete answer you can now. Clearly note "
+        "any part of the investigation you were not able to confirm.",
+        answer_language,
+    )
+    wrapup_messages = _strip_dangling_tool_call(current) + [
+        HumanMessage(content=instruction)
+    ]
+    if emit_event is not None:
+        emit_event("deepagents.agent.wrapup", {})
+    try:
+        response = model.invoke(wrapup_messages)
+    except Exception:
+        LOGGER.exception("Wrap-up synthesis call failed after truncation")
+        return ""
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content.strip()
+    return str(content or "").strip()
 
 
 def _model_summary(message, limit=160):

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -941,6 +941,13 @@ def _synthesize_wrapup_answer(model, current, answer_language, emit_event):
     from the conversation so far, so the turns already spent are not
     wasted. Returns "" (letting the caller keep the empty-answer path) if
     this call itself fails.
+
+    A RunCancelledError is deliberately NOT caught here: model.invoke()
+    checks cancel_event at the top of the gateway call
+    (LensGatewayChatModel._check_cancelled), so a cancellation landing in
+    the narrow window between the turn-limit loop exiting and this call
+    starting must still stop the run, not be swallowed into an empty
+    "wrap-up failed" result.
     """
 
     instruction = _pick_text(
@@ -960,6 +967,8 @@ def _synthesize_wrapup_answer(model, current, answer_language, emit_event):
         emit_event("deepagents.agent.wrapup", {})
     try:
         response = model.invoke(wrapup_messages)
+    except RunCancelledError:
+        raise
     except Exception:
         LOGGER.exception("Wrap-up synthesis call failed after truncation")
         return ""

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from lensnode import agent_runtime
 from lensnode.agent_runtime import (
-    _bilingual,
+    _pick_text,
     _build_initial_messages,
     _run_agent_with_turn_limit,
     _strip_dangling_tool_call,
@@ -118,12 +118,12 @@ def test_turn_limit_no_history_runs_to_completion():
     assert "answer 2" in answer
 
 
-def test_bilingual_picks_chinese_only_for_chinese():
-    assert _bilingual("zh", "en", "Chinese") == "zh"
-    assert _bilingual("zh", "en", "English") == "en"
+def test_pick_text_picks_chinese_only_for_chinese():
+    assert _pick_text("zh", "en", "Chinese") == "zh"
+    assert _pick_text("zh", "en", "English") == "en"
     # every other detected language falls back to English text too
-    assert _bilingual("zh", "en", "Japanese") == "en"
-    assert _bilingual("zh", "en", "Korean") == "en"
+    assert _pick_text("zh", "en", "Japanese") == "en"
+    assert _pick_text("zh", "en", "Korean") == "en"
 
 
 def test_strip_dangling_tool_call_drops_trailing_pending_call():

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 from lensnode import agent_runtime
 from lensnode.agent_runtime import (
-    _pick_text,
     _build_initial_messages,
+    _pick_text,
     _run_agent_with_turn_limit,
     _strip_dangling_tool_call,
     _synthesize_wrapup_answer,
@@ -162,6 +162,13 @@ class _FailingModel:
         raise RuntimeError("gateway unreachable")
 
 
+class _CancelledModel:
+    """Mimics LensGatewayChatModel raising RunCancelledError mid-call."""
+
+    def invoke(self, _messages):
+        raise agent_runtime.RunCancelledError("cancelled")
+
+
 def test_synthesize_wrapup_answer_strips_dangling_call_and_returns_content():
     model = _FakeWrapupModel("here is what I found")
     current = [
@@ -185,6 +192,20 @@ def test_synthesize_wrapup_answer_returns_empty_on_failure():
     )
 
     assert answer == ""
+
+
+def test_synthesize_wrapup_answer_propagates_cancellation():
+    # A cancellation landing during the wrap-up call must stop the run,
+    # not be swallowed into an empty "wrap-up failed" result.
+    try:
+        _synthesize_wrapup_answer(
+            _CancelledModel(), [_Msg("human", "q")], "English", None
+        )
+        raised = False
+    except agent_runtime.RunCancelledError:
+        raised = True
+
+    assert raised is True
 
 
 def test_truncated_run_falls_back_to_wrapup_when_no_answer_text():

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -2,17 +2,21 @@ from types import SimpleNamespace
 
 from lensnode import agent_runtime
 from lensnode.agent_runtime import (
+    _bilingual,
     _build_initial_messages,
     _run_agent_with_turn_limit,
+    _strip_dangling_tool_call,
+    _synthesize_wrapup_answer,
 )
 
 
 class _Msg:
     """Minimal stand-in for a LangChain message with a type/content."""
 
-    def __init__(self, type_, content=""):
+    def __init__(self, type_, content="", tool_calls=None):
         self.type = type_
         self.content = content
+        self.tool_calls = tool_calls
 
 
 class _FakeStreamAgent:
@@ -112,3 +116,106 @@ def test_turn_limit_no_history_runs_to_completion():
 
     assert truncated is False
     assert "answer 2" in answer
+
+
+def test_bilingual_picks_chinese_only_for_chinese():
+    assert _bilingual("zh", "en", "Chinese") == "zh"
+    assert _bilingual("zh", "en", "English") == "en"
+    # every other detected language falls back to English text too
+    assert _bilingual("zh", "en", "Japanese") == "en"
+    assert _bilingual("zh", "en", "Korean") == "en"
+
+
+def test_strip_dangling_tool_call_drops_trailing_pending_call():
+    messages = [
+        _Msg("human", "q"),
+        _Msg("ai", "", tool_calls=[{"id": "1", "name": "grep"}]),
+    ]
+
+    result = _strip_dangling_tool_call(messages)
+
+    assert result == messages[:-1]
+
+
+def test_strip_dangling_tool_call_keeps_resolved_history():
+    messages = [_Msg("human", "q"), _Msg("ai", "some findings")]
+
+    result = _strip_dangling_tool_call(messages)
+
+    assert result == messages
+
+
+class _FakeWrapupModel:
+    """Records the messages it was invoked with and returns a fixed reply."""
+
+    def __init__(self, content="synthesized answer"):
+        self.content = content
+        self.invoked_with = None
+
+    def invoke(self, messages):
+        self.invoked_with = list(messages)
+        return _Msg("ai", self.content)
+
+
+class _FailingModel:
+    def invoke(self, _messages):
+        raise RuntimeError("gateway unreachable")
+
+
+def test_synthesize_wrapup_answer_strips_dangling_call_and_returns_content():
+    model = _FakeWrapupModel("here is what I found")
+    current = [
+        _Msg("human", "q"),
+        _Msg("ai", "partial reasoning"),
+        _Msg("ai", "", tool_calls=[{"id": "1", "name": "grep"}]),
+    ]
+
+    answer = _synthesize_wrapup_answer(model, current, "English", None)
+
+    assert answer == "here is what I found"
+    # dangling tool-call turn dropped, wrap-up instruction appended
+    assert len(model.invoked_with) == 3
+    assert model.invoked_with[-2].content == "partial reasoning"
+    assert model.invoked_with[-1].type == "human"
+
+
+def test_synthesize_wrapup_answer_returns_empty_on_failure():
+    answer = _synthesize_wrapup_answer(
+        _FailingModel(), [_Msg("human", "q")], "English", None
+    )
+
+    assert answer == ""
+
+
+def test_truncated_run_falls_back_to_wrapup_when_no_answer_text():
+    # last streamed turn is a bare tool call with no text -> nothing to
+    # extract; the wrap-up model call must supply the final answer.
+    messages = [{"role": "user", "content": "q"}]
+    prefix = [_Msg("human", "q")]
+
+    class _ToolCallEndingAgent:
+        def stream(self, _inp, stream_mode=None, config=None):
+            state = list(prefix)
+            for index in range(2):
+                state = state + [_Msg("ai", f"finding {index + 1}")]
+                yield {"messages": list(state)}
+            # 3rd (budget-exhausting) turn is a bare tool call, no text.
+            state = state + [
+                _Msg("ai", "", tool_calls=[{"id": "1", "name": "grep"}])
+            ]
+            yield {"messages": list(state)}
+
+    model = _FakeWrapupModel("best-effort synthesis")
+
+    answer, truncated = _run_agent_with_turn_limit(
+        _ToolCallEndingAgent(),
+        messages,
+        max_turns=3,
+        model=model,
+        answer_language="English",
+    )
+
+    assert truncated is True
+    assert "best-effort synthesis" in answer
+    assert "Reached the current analysis-depth limit" in answer
+    assert model.invoked_with is not None


### PR DESCRIPTION
### **User description**
## Summary

Fixes #99. A deep, multi-repo code-analysis question can run for tens of minutes, hit `max_agent_turns` right after the model issues a tool call (before any answer text exists), and lose the entire investigation — `_extract_final_message` only ever reads the last message, which in that case is a bare tool call. The run comes back with an empty answer, shown to the user as a misleading "network hiccup, tap Retry" — misleading because retrying the same deep question will very likely hit the same wall again. Confirmed in production against run `444de138-2a2d-485b-889c-ad8d027e7814` (43m27s, 32 LLM rounds, 686 events, `AnswerChars: 0`).

## Change

- When truncation leaves no extractable answer, `_run_agent_with_turn_limit` now makes one more tool-free model call asking for a best-effort synthesis from everything gathered so far (`_synthesize_wrapup_answer`), instead of giving up. A trailing unresolved tool-call message is dropped first (`_strip_dangling_tool_call`) since most providers reject a followup call whose history ends on one. If the wrap-up call itself fails, falls back to the prior (empty-answer) behavior — this can only make things better, never worse.
- The existing depth-limit disclaimer (appended once there's a non-empty answer) now also explicitly says the investigation "did not fully complete" — reused as-is, no new gating needed since it already fires whenever `truncated and answer.strip()`.
- Documents (new docstring) why `max_agent_turns` can visibly be overshot: `deepagents`' `task` subagent delegation runs via a synchronous `subagent.invoke(...)`, so an in-flight delegation's internal turns are only counted after it returns — not a separate bug, discussed against #99's evidence (a 26-turn budget observed running to round 32).
- Deduped the two bilingual (Chinese/English) strings this introduced into a small `_bilingual()` helper. LensNode has no i18n framework (checked — none exists in the package), so this keeps the file's existing inline-branch convention rather than adding one for a couple of strings. Follow-ups tracked in #102 (revisit real i18n if more strings accumulate; consider reporting truncation as a structured signal for the backend/frontend to render, matching how `errorModelTimeout`/`errorNodeLost` already work in `Chat.vue::mapRunError`).
- Frontend: replaced the exact per-tier step-count hints (`~26 steps`) with qualitative descriptions in both locales, since the count was never a precise guarantee (see the overshoot behavior above) and showing an exact number implied more precision than the system gives.

## Test plan
- [x] 11 new/updated unit tests in `lensnode/tests/test_history.py` (`_bilingual`, `_strip_dangling_tool_call`, `_synthesize_wrapup_answer` success/failure, and an end-to-end truncated-with-no-text-run falls back to wrap-up case) — all pass
- [x] Full `lensnode` suite: 101 passed, 7 failed — the 7 are the exact pre-existing set tracked in #79, unrelated
- [x] `npm run build` passes with the locale changes; both locale JSON files validated


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Synthesize best-effort answer when agent truncated mid-tool-call

- Add helpers: _pick_text, _strip_dangling_tool_call, _synthesize_wrapup_answer

- Improve truncation disclaimer to indicate incomplete investigation

- Replace frontend step-count hints with qualitative descriptions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent stream loop"] --> B["max_turns reached?"]
  B -- "Yes" --> C["Extract final message"]
  C --> D{"Empty answer?"}
  D -- "Yes, model available" --> E["Strip dangling tool call"]
  E --> F["Wrap-up model call (no tools)"]
  F --> G["Append truncation disclaimer"]
  D -- "No" --> G
  G --> H["Return (answer, truncated)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent_runtime.py</strong><dd><code>Core wrap-up logic and truncation handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime.py

<ul><li>Added _pick_text helper for bilingual strings<br> <li> Added _strip_dangling_tool_call to drop trailing unresolved tool-call<br> <li> Added _synthesize_wrapup_answer to produce best-effort answer on <br>truncation<br> <li> Modified _run_agent_with_turn_limit to call wrap-up when truncated <br>without answer text<br> <li> Updated truncation disclaimer to note investigation did not fully <br>complete</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/103/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+118/-10</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Tests for new turn-limit wrap-up functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_history.py

<ul><li>Added tests for _pick_text Chinese/English selection<br> <li> Added tests for _strip_dangling_tool_call<br> <li> Added tests for _synthesize_wrapup_answer (success, failure, <br>cancellation)<br> <li> Added integration test for truncated run falling back to wrap-up</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/103/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+129/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>English hint text for agent round tiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/en.json

<ul><li>Replaced exact step-count hints (e.g. "~5 steps") with qualitative <br>descriptions for each agentRounds tier</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/103/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Chinese hint text for agent round tiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/zh-CN.json

<ul><li>Replaced exact step-count hints with qualitative Chinese descriptions <br>for each agentRounds tier</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/103/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

