### PR TITLE
Fix private GitHub repository discovery for user namespaces

### DIFF
--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -625,6 +625,16 @@ def _discover_github_projects(parsed, group_path, config):
     )
     if projects:
         return projects, attempts
+    authenticated_projects, authenticated_attempts = (
+        _discover_github_authenticated_user_projects(
+            api_base,
+            owner,
+            config,
+        )
+    )
+    attempts.extend(authenticated_attempts)
+    if authenticated_projects:
+        return authenticated_projects, attempts
     user_projects, user_attempts = _discover_github_owner_projects(
         api_base,
         owner,
@@ -648,6 +658,41 @@ def _github_api_base(parsed, config):
         return "https://api.github.com"
     base_url = parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
     return f"{base_url}/api/v3"
+
+
+def _discover_github_authenticated_user_projects(api_base, owner, config):
+    """Discover token-accessible repositories for a GitHub user owner."""
+
+    credentials = _load_credentials(config)
+    if not credentials.get("token"):
+        return None, []
+
+    projects = []
+    attempts = []
+    for page in range(1, 11):
+        url = (
+            f"{api_base}/user/repos?visibility=all"
+            "&affiliation=owner,collaborator,organization_member"
+            f"&per_page=100&page={page}"
+        )
+        payload, error_detail = _git_api_json(
+            url,
+            config,
+            auth_style="github",
+        )
+        attempts.append(_git_api_attempt("github", url, error_detail))
+        if not isinstance(payload, list):
+            return None if page == 1 else projects, attempts
+        if not payload:
+            break
+        projects.extend(
+            _github_project(item, api_base, "user")
+            for item in payload
+            if _github_repository_matches_owner(item, owner)
+        )
+        if len(payload) < 100:
+            break
+    return projects, attempts
 
 
 def _discover_github_owner_projects(api_base, owner, owner_type, config):
@@ -682,6 +727,15 @@ def _discover_github_owner_projects(api_base, owner, owner_type, config):
     if last_error and not projects:
         return None, attempts
     return projects, attempts
+
+
+def _github_repository_matches_owner(item, owner):
+    """Return whether a GitHub repository belongs to the requested owner."""
+
+    item_owner = (item.get("owner") or {}).get("login") or ""
+    if not item_owner:
+        item_owner, _, _ = str(item.get("full_name") or "").partition("/")
+    return item_owner.casefold() == str(owner or "").casefold()
 
 
 def _github_project(item, api_base, owner_type):

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -115,8 +115,74 @@ def test_discover_github_org_repositories(monkeypatch):
     )
 
 
-def test_discover_github_user_repositories_after_org_404(monkeypatch):
-    """GitHub user namespace URLs fall back from orgs to users."""
+def test_discover_github_user_private_repositories_after_org_404(
+    monkeypatch,
+):
+    """GitHub user namespaces include token-accessible private repos."""
+
+    calls = []
+
+    def fake_api(url, config, auth_style, timeout=30):
+        del config, timeout
+        calls.append((url, auth_style))
+        if "/orgs/" in url:
+            return None, 'HTTP 404: {"message":"Not Found"}'
+        if "/user/repos?" in url:
+            return [
+                {
+                    "name": "private-repo",
+                    "full_name": "CarltonXu/private-repo",
+                    "clone_url": (
+                        "https://github.com/CarltonXu/private-repo.git"
+                    ),
+                    "default_branch": "main",
+                    "private": True,
+                },
+                {
+                    "name": "shared-repo",
+                    "full_name": "Other/shared-repo",
+                    "clone_url": (
+                        "https://github.com/Other/shared-repo.git"
+                    ),
+                    "default_branch": "main",
+                    "private": True,
+                },
+            ], ""
+        return [], ""
+
+    monkeypatch.setattr("lensnode.datasource_sync._git_api_json", fake_api)
+    monkeypatch.setattr(
+        "lensnode.datasource_sync._git_repo_branches",
+        lambda repo_url, config: ["main"],
+    )
+
+    result = _discover_git_organization(
+        {
+            "repo_url": "https://github.com/CarltonXu/",
+            "provider": "github",
+            "auth_scheme": "token",
+            "access_token": "ghp_example",
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["details"]["owner_type"] == "user"
+    assert result["details"]["repositories"][0]["path"] == (
+        "CarltonXu/private-repo"
+    )
+    assert len(result["details"]["repositories"]) == 1
+    assert calls[0][0] == (
+        "https://api.github.com/orgs/CarltonXu/repos?per_page=100&page=1"
+    )
+    assert calls[1][0] == (
+        "https://api.github.com/user/repos?visibility=all"
+        "&affiliation=owner,collaborator,organization_member"
+        "&per_page=100&page=1"
+    )
+
+
+def test_discover_github_public_user_repositories_without_token(monkeypatch):
+    """Anonymous GitHub user discovery keeps the public endpoint fallback."""
 
     calls = []
 
@@ -144,18 +210,13 @@ def test_discover_github_user_repositories_after_org_404(monkeypatch):
         {
             "repo_url": "https://github.com/CarltonXu/",
             "provider": "github",
-            "auth_scheme": "token",
-            "access_token": "ghp_example",
+            "auth_scheme": "none",
         }
     )
 
     assert result["status"] == "success"
-    assert result["details"]["owner_type"] == "user"
     assert result["details"]["repositories"][0]["path"] == (
         "CarltonXu/dotfiles"
-    )
-    assert calls[0][0] == (
-        "https://api.github.com/orgs/CarltonXu/repos?per_page=100&page=1"
     )
     assert calls[1][0] == (
         "https://api.github.com/users/CarltonXu/repos?per_page=100&page=1"


### PR DESCRIPTION
### **User description**
## Summary
- query the authenticated GitHub user repository endpoint during user namespace discovery
- filter token-visible repositories to the requested owner so authorized private repositories are included
- preserve the public user repository fallback for configurations without a token
- cover private repository discovery, owner filtering, and anonymous fallback behavior

Closes #73

## Test plan
- [x] GitHub-focused datasource tests: 4 passed
- [x] Python syntax, diff whitespace, and added-line length checks
- [x] Full LensNode suite executed: 103 passed; 7 pre-existing failures remain and are tracked in #79


___

### **PR Type**
Bug fix


___

### **Description**
- Use authenticated endpoint for user private repos discovery

- Filter token-visible repos to the requested owner

- Preserve public fallback for anonymous configurations

- Add tests for private and public user discovery


___

### Diagram Walkthrough


```mermaid
flowchart LR
  namespace["User namespace"] --> org["Org repos endpoint"]
  org -->|"404 or empty"| auth["Authenticated /user/repos"]
  auth -->|"token available"| filter["Filter by owner"]
  auth -->|"no token"| public["Public user repos"]
  filter --> result["Repos"]
  public --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datasource_sync.py</strong><dd><code>Add authenticated user repository discovery for private repos</code></dd></summary>
<hr>

lensnode/lensnode/datasource_sync.py

<ul><li>Added <code>_discover_github_authenticated_user_projects</code> to fetch <br>token-accessible repos via <code>/user/repos</code>.<br> <li> Added <code>_github_repository_matches_owner</code> to filter repos by the <br>requested owner.<br> <li> Modified <code>_discover_github_projects</code> to attempt authenticated discovery <br>after org endpoint fails, before falling back to public user repos.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/104/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_datasource_sync.py</strong><dd><code>Add tests for authenticated and anonymous user discovery</code>&nbsp; </dd></summary>
<hr>

lensnode/tests/test_datasource_sync.py

<ul><li>Renamed test to <br><code>test_discover_github_user_private_repositories_after_org_404</code> to cover <br>authenticated private repo flow.<br> <li> Added <code>test_discover_github_public_user_repositories_without_token</code> for <br>anonymous fallback.<br> <li> Updated mock data to verify filtering and owner matching.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/104/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+69/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

