### PR TITLE
fix(lens): restore mobile settings access and isolate session drafts

### DIFF
--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -66,6 +66,17 @@ test('mobile session drawer opens, selects sessions, and closes', async ({
 
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: -320 })
 
+  const composer = page.locator('.composer-input')
+  const initialComposerHeight = await composer.evaluate(
+    (element) => element.getBoundingClientRect().height
+  )
+  await composer.fill('Session A draft\nsecond line\nthird line')
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => element.getBoundingClientRect().height)
+    )
+    .toBeGreaterThan(initialComposerHeight)
+
   await page.getByRole('button', { name: 'Recent' }).click()
   await expect(page.locator('.sidebar')).toHaveClass(/sidebar-open/)
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 320 })
@@ -77,6 +88,12 @@ test('mobile session drawer opens, selects sessions, and closes', async ({
   await secondSession.click()
   await expect(page).toHaveURL(/session=session-2/)
   await expect(page.getByText('Second session response')).toBeAttached()
+  await expect(composer).toHaveValue('')
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => element.getBoundingClientRect().height)
+    )
+    .toBe(initialComposerHeight)
 
   await page.locator('.sidebar').getByRole('button', { name: 'Close' }).click()
   await expect(page.locator('.sidebar')).not.toHaveClass(/sidebar-open/)

--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-async function mockChat(page) {
+async function mockChat(page, messageDelays = {}) {
   await page.addInitScript(() => {
     localStorage.setItem('access_token', 'test-token')
     localStorage.setItem('userLanguage', 'en')
@@ -30,7 +30,8 @@ async function mockChat(page) {
       '/api/lens/shares/': [],
       '/api/lens/sessions/': [
         { uuid: 'session-1', title: 'First session' },
-        { uuid: 'session-2', title: 'Second session' }
+        { uuid: 'session-2', title: 'Second session' },
+        { uuid: 'session-3', title: 'Third session' }
       ],
       '/api/lens/sessions/session-1/messages/': [],
       '/api/lens/sessions/session-2/messages/': [
@@ -40,7 +41,19 @@ async function mockChat(page) {
           content: 'Second session response',
           created_at: '2026-07-24T08:00:00Z'
         }
+      ],
+      '/api/lens/sessions/session-3/messages/': [
+        {
+          uuid: 'message-3',
+          role: 'assistant',
+          content: 'Third session response',
+          created_at: '2026-07-24T08:01:00Z'
+        }
       ]
+    }
+
+    if (messageDelays[path]) {
+      await new Promise((resolve) => setTimeout(resolve, messageDelays[path]))
     }
 
     await route.fulfill({
@@ -118,4 +131,53 @@ test('desktop sidebar still expands and collapses', async ({ page }) => {
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 64 })
   await page.locator('.sidebar-collapse-btn[aria-label="Expand"]').click()
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+})
+
+test('stale session responses do not replace a newer session draft', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockChat(page, {
+    '/api/lens/sessions/session-2/messages/': 1000
+  })
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  await page.getByRole('button', { name: 'Recent' }).click()
+  const slowResponse = page.waitForResponse((response) =>
+    response.url().includes('/sessions/session-2/messages/')
+  )
+  await page
+    .locator('.session-item')
+    .filter({ hasText: 'Second session' })
+    .click()
+  await page
+    .locator('.session-item')
+    .filter({ hasText: 'Third session' })
+    .click()
+
+  await expect(page).toHaveURL(/session=session-3/)
+  await expect(page.getByText('Third session response')).toBeAttached()
+  const composer = page.locator('.composer-input')
+  await composer.fill('Session C draft\nsecond line\nthird line')
+  const draftHeight = await composer.evaluate(
+    (element) => element.getBoundingClientRect().height
+  )
+
+  const response = await slowResponse
+  await response.finished()
+  await page.evaluate(
+    () =>
+      new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      )
+  )
+  await expect(page).toHaveURL(/session=session-3/)
+  await expect(page.getByText('Second session response')).not.toBeAttached()
+  await expect(page.getByText('Third session response')).toBeAttached()
+  await expect(composer).toHaveValue('Session C draft\nsecond line\nthird line')
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => element.getBoundingClientRect().height)
+    )
+    .toBe(draftHeight)
 })

--- a/frontend/e2e/lens-settings-responsive.spec.js
+++ b/frontend/e2e/lens-settings-responsive.spec.js
@@ -1,0 +1,304 @@
+import { expect, test } from '@playwright/test'
+
+const MOBILE_VIEWPORTS = [
+  { width: 320, height: 568 },
+  { width: 360, height: 800 },
+  { width: 375, height: 667 },
+  { width: 390, height: 844 },
+  { width: 412, height: 915 },
+  { width: 430, height: 932 }
+]
+
+const DESKTOP_VIEWPORTS = [
+  { width: 768, height: 800 },
+  { width: 1280, height: 800 }
+]
+
+const RESOURCE_SETTINGS_PATH = '/management/lens/resources/settings'
+const SETTINGS_PATH = '/management/lens/settings'
+
+function setting(key, value) {
+  return { key, value, description: key }
+}
+
+async function mockSettingsApis(page) {
+  const state = {
+    globalSettingsRequests: 0,
+    settingUpdates: [],
+    taskUpdates: []
+  }
+  const settings = [
+    setting('public_base_url', 'https://lens.example.com'),
+    setting('lensnode.image', 'oneprocloud/lensnode:test'),
+    setting('lensnode.defaults.timeout', 600),
+    setting('retention.run_days', 90),
+    setting('lensnode.health.offline_threshold_s', 120),
+    setting('lensnode_cleanup.interval_seconds', 3600),
+    setting('lensnode_health.interval_seconds', 60),
+    setting('run_retention.interval_seconds', 86400),
+    setting('lens.skills.generator_model_ref', 'model-1'),
+    setting('lens.datasource_sync.timeout_s', 360),
+    setting('lens.datasource_sync.workers', 4),
+    setting('lens.datasource_conversion.vision_model_ref', 'model-1'),
+    setting('lens.datasource_conversion.document_model_ref', 'model-1')
+  ]
+  const tasks = [
+    {
+      task_type: 'lensnode_cleanup',
+      enabled: true,
+      last_run_at: '2026-07-27T08:00:00Z',
+      last_status: 'success'
+    },
+    {
+      task_type: 'lensnode_health',
+      enabled: true,
+      last_run_at: '2026-07-27T08:01:00Z',
+      last_status: 'success'
+    },
+    {
+      task_type: 'run_retention',
+      enabled: false,
+      last_run_at: null,
+      last_status: null
+    }
+  ]
+
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'e2e-lens-settings')
+    localStorage.setItem('userLanguage', 'en')
+  })
+
+  await page.route('**://*/api/**', async (route) => {
+    const request = route.request()
+    const { pathname } = new URL(request.url())
+    const method = request.method()
+    let data = []
+
+    if (pathname === '/api/v1/auth/user') {
+      data = {
+        id: 1,
+        username: 'admin',
+        is_staff: true,
+        is_superuser: true,
+        permissions: []
+      }
+    } else if (pathname === '/api/lens/admin/global-settings/') {
+      state.globalSettingsRequests += 1
+      data = settings
+    } else if (pathname === '/api/lens/admin/global-settings/system-health/') {
+      if (method === 'PATCH') {
+        const payload = request.postDataJSON()
+        state.taskUpdates.push(payload)
+        const task = tasks.find((item) => item.task_type === payload.task_type)
+        task.enabled = payload.enabled
+        data = task
+      } else {
+        data = tasks
+      }
+    } else if (
+      pathname.startsWith('/api/lens/admin/global-settings/') &&
+      method === 'PATCH'
+    ) {
+      const payload = request.postDataJSON()
+      const key = decodeURIComponent(pathname.split('/').at(-2))
+      state.settingUpdates.push({ key, ...payload })
+      const current = settings.find((item) => item.key === key)
+      current.value = payload.value
+      data = current
+    } else if (pathname === '/api/v1/admin/llm-config/all/') {
+      data = [
+        { uuid: 'model-1', name: 'Primary model', model: 'gpt-5' },
+        { uuid: 'model-2', name: 'Backup model', model: 'gpt-4.1' }
+      ]
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data })
+    })
+  })
+
+  return state
+}
+
+async function openSettingsPage(page, path) {
+  await page.goto(path)
+  await expect(page.locator('.settings-table').first()).toBeVisible()
+  await expect(page.locator('.settings-input').first()).toBeVisible()
+}
+
+async function expectMobileLayout(page, includeTasks) {
+  const layout = await page.evaluate((hasTasks) => {
+    const root = document.documentElement
+    const main = document.querySelector('.layout-admin main')
+    const insideViewport = (element) => {
+      const rect = element.getBoundingClientRect()
+      return rect.left >= 0 && rect.right <= root.clientWidth + 0.5
+    }
+    const fitsOwnWidth = (element) =>
+      element.scrollWidth <= element.clientWidth + 1
+    const controls = [...document.querySelectorAll('.settings-input')]
+    const keys = [...document.querySelectorAll('.setting-key')]
+    const units = [...document.querySelectorAll('.settings-unit')].filter(
+      (element) => element.textContent.trim()
+    )
+    const tables = [...document.querySelectorAll('.settings-table')]
+    const firstRow = document.querySelector('.settings-table tbody tr')
+    const firstCells = firstRow.querySelectorAll('.table-cell')
+    const taskDetails = hasTasks
+      ? [...document.querySelectorAll('.task-detail')]
+      : []
+
+    return {
+      documentFits: root.scrollWidth === root.clientWidth,
+      mainFits: main.scrollWidth <= main.clientWidth + 1,
+      tablesFit: tables.every(fitsOwnWidth),
+      controlsFit: controls.every(insideViewport),
+      keysFit: keys.every(fitsOwnWidth),
+      unitsFit: units.every(insideViewport),
+      taskDetailsFit: taskDetails.every(insideViewport),
+      tableDisplay: getComputedStyle(tables[0]).display,
+      rowDisplay: getComputedStyle(firstRow).display,
+      cellDisplays: [...firstCells].map(
+        (cell) => getComputedStyle(cell).display
+      )
+    }
+  }, includeTasks)
+
+  expect(layout).toMatchObject({
+    documentFits: true,
+    mainFits: true,
+    tablesFit: true,
+    controlsFit: true,
+    keysFit: true,
+    unitsFit: true,
+    taskDetailsFit: true,
+    tableDisplay: 'block',
+    rowDisplay: 'block',
+    cellDisplays: ['block', 'block']
+  })
+
+  await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Save Changes' })).toBeVisible()
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`settings stay reachable at ${viewport.width}x${viewport.height}`, async ({
+    page
+  }) => {
+    await page.setViewportSize(viewport)
+    await mockSettingsApis(page)
+
+    await openSettingsPage(page, RESOURCE_SETTINGS_PATH)
+    await expectMobileLayout(page, false)
+
+    await openSettingsPage(page, SETTINGS_PATH)
+    await expectMobileLayout(page, true)
+    await expect(
+      page.locator('.scheduled-tasks input[type="checkbox"]')
+    ).toHaveCount(3)
+  })
+}
+
+test('resource settings controls edit, reset, save, and refresh on mobile', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 })
+  const state = await mockSettingsApis(page)
+  await openSettingsPage(page, RESOURCE_SETTINGS_PATH)
+
+  const timeout = page.locator('.settings-input[type="number"]').first()
+  const model = page.locator('.settings-table select').first()
+  await timeout.fill('12')
+  await model.selectOption('model-2')
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(timeout).toHaveValue('6')
+  await expect(model).toHaveValue('model-1')
+
+  await timeout.fill('10')
+  await model.selectOption('model-2')
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+  await expect.poll(() => state.settingUpdates.length).toBe(4)
+  expect(
+    state.settingUpdates.find(
+      (update) => update.key === 'lens.datasource_sync.timeout_s'
+    )?.value
+  ).toBe(600)
+
+  const requestsBeforeRefresh = state.globalSettingsRequests
+  await page.getByRole('button', { name: 'Refresh' }).click()
+  await expect
+    .poll(() => state.globalSettingsRequests)
+    .toBeGreaterThan(requestsBeforeRefresh)
+})
+
+test('global settings and scheduled tasks remain operable on mobile', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 })
+  const state = await mockSettingsApis(page)
+  await openSettingsPage(page, SETTINGS_PATH)
+
+  const publicUrl = page.locator('.settings-input[type="text"]').first()
+  const model = page.locator('.settings-table select').first()
+  await publicUrl.fill('https://changed.example.com')
+  await model.selectOption('model-2')
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(publicUrl).toHaveValue('https://lens.example.com')
+  await expect(model).toHaveValue('model-1')
+
+  await publicUrl.fill('https://saved.example.com')
+  await page.getByRole('button', { name: 'Save Changes' }).click()
+  await expect.poll(() => state.settingUpdates.length).toBe(9)
+  expect(
+    state.settingUpdates.find((update) => update.key === 'public_base_url')
+      ?.value
+  ).toBe('https://saved.example.com')
+
+  const cleanupToggle = page
+    .locator('.scheduled-tasks input[type="checkbox"]')
+    .first()
+  await expect(cleanupToggle).toBeChecked()
+  await cleanupToggle.click()
+  await expect
+    .poll(() => state.taskUpdates)
+    .toEqual([{ task_type: 'lensnode_cleanup', enabled: false }])
+  await expect(cleanupToggle).not.toBeChecked()
+})
+
+for (const viewport of DESKTOP_VIEWPORTS) {
+  test(`desktop tables remain unchanged at ${viewport.width}px`, async ({
+    page
+  }) => {
+    await page.setViewportSize(viewport)
+    await mockSettingsApis(page)
+
+    for (const path of [RESOURCE_SETTINGS_PATH, SETTINGS_PATH]) {
+      await openSettingsPage(page, path)
+      const layout = await page
+        .locator('.settings-table')
+        .first()
+        .evaluate((table) => {
+          const row = table.querySelector('tbody tr')
+          const cells = row.querySelectorAll('.table-cell')
+          const tableWidth = table.getBoundingClientRect().width
+          return {
+            tableDisplay: getComputedStyle(table).display,
+            rowDisplay: getComputedStyle(row).display,
+            cellDisplays: [...cells].map(
+              (cell) => getComputedStyle(cell).display
+            ),
+            firstColumnRatio:
+              cells[0].getBoundingClientRect().width / tableWidth
+          }
+        })
+
+      expect(layout.tableDisplay).toBe('table')
+      expect(layout.rowDisplay).toBe('table-row')
+      expect(layout.cellDisplays).toEqual(['table-cell', 'table-cell'])
+      expect(layout.firstColumnRatio).toBeGreaterThan(0.45)
+      expect(layout.firstColumnRatio).toBeLessThan(0.56)
+    }
+  })
+}

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1323,6 +1323,7 @@ const composerRef = ref(null)
 const scrollRef = ref(null)
 const seenStepEventCounts = new Map()
 const completionTrackers = new Map()
+let sessionLoadGeneration = 0
 const runtimeState = ref(createRuntimeState())
 const liveActivityScrollRef = ref(null)
 const elapsedSeconds = ref(0)
@@ -2302,19 +2303,27 @@ async function handlePrimaryAction() {
 }
 
 async function selectSession(session, updateRoute = true) {
+  const loadGeneration = ++sessionLoadGeneration
+  const isCurrentLoad = () =>
+    loadGeneration === sessionLoadGeneration &&
+    selectedSessionUuid.value === session.uuid
   const sessionChanged = selectedSessionUuid.value !== session.uuid
   mySharesOpen.value = false
   clearAttachments()
   selectedSessionUuid.value = session.uuid
+  let loadedMessages
   try {
-    messages.value = await listMessages(session.uuid)
+    loadedMessages = await listMessages(session.uuid)
   } catch (error) {
+    if (!isCurrentLoad()) return
     if ([403, 404].includes(error?.response?.status)) {
       showError(t('lens.chat.sessionAccessDenied'))
       return
     }
     throw error
   }
+  if (!isCurrentLoad()) return
+  messages.value = loadedMessages
   if (sessionChanged) {
     question.value = ''
     if (composerRef.value) composerRef.value.style.height = 'auto'
@@ -2328,7 +2337,9 @@ async function selectSession(session, updateRoute = true) {
     })
   }
   await nextTick(scrollToBottom)
+  if (!isCurrentLoad()) return
   await maybeResumeActiveRun(session.uuid)
+  if (!isCurrentLoad()) return
   if (clearUnreadSession(window.localStorage, session.uuid)) {
     refreshUnreadSessions()
   }

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1947,6 +1947,7 @@ async function handlePrimaryAction() {
 }
 
 async function selectSession(session, updateRoute = true) {
+  const sessionChanged = selectedSessionUuid.value !== session.uuid
   mySharesOpen.value = false
   clearAttachments()
   selectedSessionUuid.value = session.uuid
@@ -1958,6 +1959,10 @@ async function selectSession(session, updateRoute = true) {
       return
     }
     throw error
+  }
+  if (sessionChanged) {
+    question.value = ''
+    if (composerRef.value) composerRef.value.style.height = 'auto'
   }
   currentRun.value = null
   resetStreamState()

--- a/frontend/src/pages/lens/ResourceSettings.vue
+++ b/frontend/src/pages/lens/ResourceSettings.vue
@@ -51,7 +51,9 @@
                     {{ grp.title }}
                   </h3>
                 </div>
-                <table class="min-w-full table-fixed divide-y divide-line">
+                <table
+                  class="settings-table min-w-full table-fixed divide-y divide-line"
+                >
                   <colgroup>
                     <col class="w-[48%]" />
                     <col class="w-[52%]" />
@@ -69,23 +71,27 @@
                         <p class="mt-1 text-sm leading-6 text-ink-500">
                           {{ setting.description }}
                         </p>
-                        <p class="mt-1 font-mono text-xs text-ink-400">
+                        <p
+                          class="setting-key mt-1 font-mono text-xs text-ink-400"
+                        >
                           {{ setting.key }}
                         </p>
                       </td>
                       <td class="table-cell">
-                        <div class="flex w-full items-center justify-end gap-3">
+                        <div
+                          class="settings-control flex w-full items-center justify-end gap-3"
+                        >
                           <input
                             v-if="setting.type === 'number'"
                             v-model.number="settingsForm[setting.key]"
                             type="number"
                             min="1"
-                            class="w-full max-w-40 rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input w-full max-w-40 rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                           />
                           <select
                             v-else-if="setting.type === 'model_ref'"
                             v-model="settingsForm[setting.key]"
-                            class="w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                           >
                             <option value="">
                               {{ t('lensAdmin.placeholders.noModel') }}
@@ -102,10 +108,10 @@
                             v-else
                             v-model="settingsForm[setting.key]"
                             type="text"
-                            class="w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                             :placeholder="setting.placeholder"
                           />
-                          <span class="w-16 text-sm text-ink-500">
+                          <span class="settings-unit w-16 text-sm text-ink-500">
                             {{ setting.unit }}
                           </span>
                         </div>
@@ -329,5 +335,53 @@ onMounted(load)
 <style scoped>
 .table-cell {
   @apply px-4 py-4 text-sm text-ink-700;
+}
+
+@media (max-width: 767px) {
+  .settings-table,
+  .settings-table tbody {
+    display: block;
+    width: 100%;
+  }
+
+  .settings-table {
+    min-width: 100% !important;
+    table-layout: auto;
+  }
+
+  .settings-table colgroup {
+    display: none;
+  }
+
+  .settings-table tr,
+  .settings-table .table-cell {
+    display: block;
+    width: 100%;
+  }
+
+  .settings-table .table-cell:first-child {
+    @apply pb-2;
+  }
+
+  .settings-table .table-cell:last-child {
+    @apply pt-0;
+  }
+
+  .setting-key {
+    overflow-wrap: anywhere;
+  }
+
+  .settings-control {
+    @apply flex-col items-stretch gap-2;
+  }
+
+  .settings-control .settings-input {
+    min-width: 0;
+    max-width: none;
+  }
+
+  .settings-unit {
+    @apply w-auto;
+  }
 }
 </style>

--- a/frontend/src/pages/lens/Settings.vue
+++ b/frontend/src/pages/lens/Settings.vue
@@ -51,7 +51,9 @@
                     {{ grp.title }}
                   </h3>
                 </div>
-                <table class="min-w-full table-fixed divide-y divide-line">
+                <table
+                  class="settings-table min-w-full table-fixed divide-y divide-line"
+                >
                   <colgroup>
                     <col class="w-[48%]" />
                     <col class="w-[52%]" />
@@ -69,23 +71,27 @@
                         <p class="mt-1 text-sm leading-6 text-ink-500">
                           {{ setting.description }}
                         </p>
-                        <p class="mt-1 font-mono text-xs text-ink-400">
+                        <p
+                          class="setting-key mt-1 font-mono text-xs text-ink-400"
+                        >
                           {{ setting.key }}
                         </p>
                       </td>
                       <td class="table-cell">
-                        <div class="flex w-full items-center justify-end gap-3">
+                        <div
+                          class="settings-control flex w-full items-center justify-end gap-3"
+                        >
                           <input
                             v-if="setting.type === 'number'"
                             v-model.number="settingsForm[setting.key]"
                             type="number"
                             min="1"
-                            class="w-full max-w-40 rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input w-full max-w-40 rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                           />
                           <select
                             v-else-if="setting.type === 'model_ref'"
                             v-model="settingsForm[setting.key]"
-                            class="min-w-0 w-full max-w-lg rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input min-w-0 w-full max-w-lg rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                           >
                             <option value="">
                               {{ t('lensAdmin.placeholders.noModel') }}
@@ -103,9 +109,9 @@
                             v-model="settingsForm[setting.key]"
                             type="text"
                             :placeholder="setting.placeholder"
-                            class="min-w-0 w-full max-w-lg rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+                            class="settings-input min-w-0 w-full max-w-lg rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
                           />
-                          <span class="w-16 text-sm text-ink-500">
+                          <span class="settings-unit w-16 text-sm text-ink-500">
                             {{ setting.unit }}
                           </span>
                         </div>
@@ -116,7 +122,9 @@
               </div>
             </div>
 
-            <div class="mt-6 overflow-hidden rounded-lg border border-line">
+            <div
+              class="scheduled-tasks mt-6 overflow-hidden rounded-lg border border-line"
+            >
               <div class="border-b border-line px-4 py-3">
                 <h3 class="text-sm font-semibold text-ink-900">
                   {{ t('lensAdmin.tasks.title') }}
@@ -125,7 +133,9 @@
                   {{ t('lensAdmin.tasks.description') }}
                 </p>
               </div>
-              <table class="min-w-full divide-y divide-line">
+              <table
+                class="scheduled-tasks-table min-w-full divide-y divide-line"
+              >
                 <thead class="bg-surface-sunken">
                   <tr>
                     <th class="table-head">
@@ -155,11 +165,14 @@
                       <p class="mt-1 text-sm leading-6 text-ink-500">
                         {{ task.description }}
                       </p>
-                      <p class="mt-1 font-mono text-xs text-ink-400">
+                      <p class="task-key mt-1 font-mono text-xs text-ink-400">
                         {{ task.task_type }}
                       </p>
                     </td>
-                    <td class="table-cell">
+                    <td
+                      class="task-detail table-cell"
+                      :data-label="t('lensAdmin.tasks.enabled')"
+                    >
                       <label class="inline-flex items-center gap-2">
                         <input
                           :checked="task.enabled"
@@ -182,10 +195,16 @@
                         </span>
                       </label>
                     </td>
-                    <td class="table-cell text-sm text-ink-600">
+                    <td
+                      class="task-detail table-cell text-sm text-ink-600"
+                      :data-label="t('lensAdmin.tasks.lastRun')"
+                    >
                       {{ formatDateTime(task.last_run_at) }}
                     </td>
-                    <td class="table-cell">
+                    <td
+                      class="task-detail table-cell"
+                      :data-label="t('lensAdmin.tasks.lastStatus')"
+                    >
                       <StatusBadge :status="task.last_status || 'unknown'" />
                     </td>
                   </tr>
@@ -493,5 +512,90 @@ onMounted(load)
 
 .table-cell {
   @apply px-4 py-4 text-sm text-ink-700;
+}
+
+@media (max-width: 767px) {
+  .settings-table,
+  .settings-table tbody,
+  .scheduled-tasks-table,
+  .scheduled-tasks-table tbody {
+    display: block;
+    width: 100%;
+  }
+
+  .settings-table,
+  .scheduled-tasks-table {
+    min-width: 100% !important;
+    table-layout: auto;
+  }
+
+  .settings-table colgroup {
+    display: none;
+  }
+
+  .scheduled-tasks-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .settings-table tr,
+  .settings-table .table-cell,
+  .scheduled-tasks-table tr {
+    display: block;
+    width: 100%;
+  }
+
+  .settings-table .table-cell:first-child {
+    @apply pb-2;
+  }
+
+  .settings-table .table-cell:last-child {
+    @apply pt-0;
+  }
+
+  .setting-key,
+  .task-key {
+    overflow-wrap: anywhere;
+  }
+
+  .settings-control {
+    @apply flex-col items-stretch gap-2;
+  }
+
+  .settings-control .settings-input {
+    min-width: 0;
+    max-width: none;
+  }
+
+  .settings-unit {
+    @apply w-auto;
+  }
+
+  .scheduled-tasks {
+    @apply overflow-x-hidden;
+  }
+
+  .scheduled-tasks-table .table-cell {
+    display: block;
+    width: 100%;
+  }
+
+  .scheduled-tasks-table .task-detail {
+    display: grid;
+    grid-template-columns: minmax(5rem, 36%) minmax(0, 1fr);
+    @apply gap-3 border-t border-line py-3;
+  }
+
+  .scheduled-tasks-table .task-detail::before {
+    content: attr(data-label);
+    @apply text-xs font-semibold uppercase tracking-wide text-ink-500;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

- make Resource Settings and Lens Global Settings responsive at phone widths
- keep labels, descriptions, keys, units, inputs, selectors, and actions visible and operable
- preserve the existing two-column desktop layout at widths of 768px and above
- keep scheduled-task controls usable in the mobile layout
- clear an unsent composer draft and reset its height after switching to a different history session
- add responsive settings and chat-session regression coverage

## Root cause

The settings pages used fixed desktop table columns inside containers that hide overflow. On compact viewports, the control column extended outside the visible content area and was clipped.

The chat session switch path also reused the shared composer state. Loading another history session did not clear the previous session's unsent draft or reset the textarea height.

## Changes

- stack setting metadata and controls vertically below the desktop breakpoint
- allow setting keys and descriptions to wrap without creating document-level horizontal overflow
- use the available mobile width for inputs and selectors while keeping units associated with their controls
- provide mobile task detail blocks without changing the desktop task table
- detect successful switches to a different session UUID, then clear the draft and restore the composer height
- cover all requested mobile viewport sizes and desktop behavior with Playwright tests

## Acceptance criteria

- [x] All setting controls are fully visible and operable at 320-430px widths.
- [x] Labels, descriptions, and setting keys wrap without clipping.
- [x] Inputs and selectors use the available container width.
- [x] Units remain visibly associated with their controls.
- [x] Save, Reset, and Refresh remain reachable and touchable.
- [x] Scheduled-task controls on Lens Global Settings remain usable.
- [x] Neither page introduces unintended document-level horizontal scrolling.
- [x] The existing desktop layout remains unchanged at `>=768px`.
- [x] Responsive regression coverage is included for both settings pages.

## Verification

- Playwright responsive settings suite: 10 passed
- Playwright combined settings/chat suites: 14 passed
- ESLint: passed
- Prettier check: passed
- `git diff --check`: passed
- production frontend build: passed
- Ego Lite mobile verification: settings controls stayed within the viewport
- Ego Lite chat verification: switching from session A to B cleared the draft and reset the composer from 88px to 40px

## Compatibility

- no backend or API changes
- no database migrations
- desktop settings layout remains unchanged

Closes #127
