### PR TITLE
Show truthful hierarchical General Chat progress

### DIFF
--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -1,5 +1,7 @@
 """Sanitize LensNode runtime events before exposing them to end users."""
 
+from datetime import datetime
+
 PUBLIC_EVENT_TYPES = {
     "artifact.created",
     "capability.blocked",
@@ -51,6 +53,20 @@ PUBLIC_STAGE_STATUSES = {
     "completed",
     "failed",
     "skipped",
+}
+
+TOOL_ACTIVITY_STATUSES = {
+    "done": "completed",
+    "failed": "failed",
+    "invoke": "in_progress",
+    "start": "in_progress",
+    "timeout": "failed",
+}
+
+MODEL_ACTIVITY_STATUSES = {
+    "done": "completed",
+    "failed": "failed",
+    "start": "in_progress",
 }
 
 PUBLIC_TERMINATION_REASONS = {
@@ -141,6 +157,180 @@ def sanitize_loaded_mcps(items):
 
 def _text(value, limit=240):
     return str(value or "")[:limit]
+
+
+def _safe_activity_id(value):
+    activity_id = _text(value, 64).strip()
+    if not activity_id:
+        return ""
+    if not activity_id.isascii() or not all(
+        char.isalnum() or char in "-_" for char in activity_id
+    ):
+        return ""
+    return activity_id
+
+
+def _date_argument(arguments, name):
+    """Return one ISO date from an allowlisted command argument."""
+
+    if not isinstance(arguments, list):
+        return ""
+    try:
+        index = arguments.index(name)
+        value = str(arguments[index + 1])
+    except (IndexError, ValueError):
+        return ""
+    if value == "[REDACTED]" or len(value) > 64:
+        return ""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.date().isoformat()
+    except ValueError:
+        return ""
+
+
+def _contains_command(arguments, *parts):
+    if not isinstance(arguments, list):
+        return False
+    normalized = [str(item).strip().lower() for item in arguments]
+    expected = list(parts)
+    width = len(expected)
+    return any(
+        normalized[index : index + width] == expected
+        for index in range(len(normalized) - width + 1)
+    )
+
+
+def _tool_activity_kind(tool_name, item):
+    """Return a safe semantic kind derived from an observed tool event."""
+
+    if tool_name == "run_skill_artifact":
+        arguments = item.get("args_redacted")
+        if _contains_command(arguments, "order", "list"):
+            return "query_orders"
+        if (
+            _contains_command(arguments, "order")
+            and isinstance(arguments, list)
+            and any(
+                str(argument).strip().lower() in {"--help", "-h", "help"}
+                for argument in arguments
+            )
+        ):
+            return "reading_order_commands"
+        if _contains_command(arguments, "order", "get"):
+            return "get_order_detail"
+        if _contains_command(
+            arguments,
+            "auth",
+            "status",
+        ) or _contains_command(arguments, "version"):
+            return "checking_capability"
+        return "querying_data"
+    if tool_name == "analyze_structured_output":
+        operation = str(item.get("operation") or "").strip().lower()
+        if operation == "count":
+            return "count_results"
+        if operation == "group_count":
+            return "group_results"
+        return "analyzing_results"
+    if tool_name in {"inspect_saved_output", "run_skill_transform"}:
+        return "analyzing_results"
+    if tool_name == "call_skill_api":
+        return "querying_data"
+    return ""
+
+
+def _activity_stage_kind(activity_kind):
+    """Return the safe stage that owns one General Chat step."""
+
+    if activity_kind in {
+        "checking_capability",
+        "get_order_detail",
+        "query_orders",
+        "reading_order_commands",
+    }:
+        return "order_query"
+    if activity_kind in {
+        "analyzing_results",
+        "count_results",
+        "group_results",
+    }:
+        return "result_analysis"
+    return "data_query"
+
+
+def _sanitize_tool_activity(item):
+    """Return one replayable activity without raw model/tool arguments."""
+
+    if item.get("runtime_scope") != "general_chat":
+        return None
+    agent_event = _text(item.get("agent_event"), 128)
+    if not agent_event.startswith("tool."):
+        return None
+    body = agent_event[5:]
+    tool_name, separator, suffix = body.rpartition(".")
+    status = TOOL_ACTIVITY_STATUSES.get(suffix)
+    if not separator or not status:
+        return None
+    activity_id = _safe_activity_id(item.get("invocation_id"))
+    kind = _tool_activity_kind(tool_name, item)
+    if not activity_id or not kind:
+        return None
+    payload = {
+        "id": activity_id,
+        "kind": kind,
+        "stage_kind": _activity_stage_kind(kind),
+        "status": status,
+    }
+    if kind == "query_orders" and status == "in_progress":
+        arguments = item.get("args_redacted")
+        start_date = _date_argument(
+            arguments,
+            "--start-time",
+        ) or _date_argument(arguments, "--start")
+        end_date = _date_argument(
+            arguments,
+            "--end-time",
+        ) or _date_argument(arguments, "--end")
+        if start_date:
+            payload["start_date"] = start_date
+        if end_date:
+            payload["end_date"] = end_date
+    return {
+        "event_type": "activity.recorded",
+        "visibility": "user",
+        "payload": payload,
+    }
+
+
+def _sanitize_model_activity(item):
+    """Return one safe, replayable General Chat model-round step."""
+
+    if item.get("runtime_scope") != "general_chat":
+        return None
+    agent_event = _text(item.get("agent_event"), 128)
+    prefix = "model.round."
+    if not agent_event.startswith(prefix):
+        return None
+    status = MODEL_ACTIVITY_STATUSES.get(agent_event[len(prefix) :])
+    activity_id = _safe_activity_id(item.get("invocation_id"))
+    if not activity_id or not status:
+        return None
+    try:
+        round_number = min(max(int(item.get("round") or 1), 1), 100)
+    except (TypeError, ValueError):
+        round_number = 1
+    return {
+        "event_type": "activity.recorded",
+        "visibility": "user",
+        "payload": {
+            "id": activity_id,
+            "kind": "analyzing_request",
+            "stage_kind": "reasoning",
+            "status": status,
+            "round": round_number,
+        },
+    }
 
 
 def sanitize_termination_detail(detail):
@@ -271,6 +461,12 @@ def sanitize_runtime_event(item):
             "visibility": "user",
             "payload": _sanitize_payload(event_type, item.get("payload")),
         }
+    model_activity = _sanitize_model_activity(item)
+    if model_activity is not None:
+        return model_activity
+    tool_activity = _sanitize_tool_activity(item)
+    if tool_activity is not None:
+        return tool_activity
     agent_event = _text(item.get("agent_event"), 128)
     activity = _text(item.get("activity"), 64)
     if not agent_event and not activity:

--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -63,6 +63,15 @@ TOOL_ACTIVITY_STATUSES = {
     "timeout": "failed",
 }
 
+BUSINESS_ACTIVITY_KINDS = {
+    "analyzing_results",
+    "count_results",
+    "get_order_detail",
+    "group_results",
+    "query_orders",
+    "querying_data",
+}
+
 PUBLIC_TERMINATION_REASONS = {
     "capability_unavailable",
     "execution_failed",
@@ -245,6 +254,12 @@ def _tool_activity_kind(tool_name, item):
 
     if tool_name == "run_skill_artifact":
         arguments = item.get("args_redacted")
+        if _contains_command(arguments, "auth", "status"):
+            return "checking_authentication"
+        if _contains_command(arguments, "auth", "login"):
+            return "authenticating"
+        if _contains_command(arguments, "version"):
+            return "checking_tool"
         if _contains_command(arguments, "order", "list"):
             return "query_orders"
         if (
@@ -258,12 +273,6 @@ def _tool_activity_kind(tool_name, item):
             return "reading_order_commands"
         if _contains_command(arguments, "order", "get"):
             return "get_order_detail"
-        if _contains_command(
-            arguments,
-            "auth",
-            "status",
-        ) or _contains_command(arguments, "version"):
-            return "checking_capability"
         return "querying_data"
     if tool_name == "analyze_structured_output":
         operation = str(item.get("operation") or "").strip().lower()
@@ -283,12 +292,17 @@ def _activity_stage_kind(activity_kind):
     """Return the safe stage that owns one General Chat step."""
 
     if activity_kind in {
-        "checking_capability",
         "get_order_detail",
         "query_orders",
-        "reading_order_commands",
     }:
         return "order_query"
+    if activity_kind in {
+        "authenticating",
+        "checking_authentication",
+        "checking_tool",
+        "reading_order_commands",
+    }:
+        return "preparation"
     if activity_kind in {
         "analyzing_results",
         "count_results",
@@ -500,8 +514,88 @@ def public_step_detail(detail):
     if not isinstance(detail, dict):
         return {"events": []}
     events = []
+    activity_by_id = {}
+    has_business_result = False
+    summary_context = {}
+    summary_started = False
     for item in detail.get("events") or []:
+        agent_event = _text(item.get("agent_event"), 128)
+        if (
+            item.get("runtime_scope") == "general_chat"
+            and agent_event == "model.round.start"
+            and has_business_result
+            and not summary_started
+        ):
+            events.append(
+                _summary_activity_event("in_progress", summary_context)
+            )
+            summary_started = True
+            continue
+        if (
+            item.get("runtime_scope") == "general_chat"
+            and agent_event == "deepagents.runtime.done"
+            and has_business_result
+            and _positive_int(item.get("answer_chars"))
+        ):
+            events.append(
+                _summary_activity_event("completed", summary_context)
+            )
+            continue
         event = sanitize_runtime_event(item)
-        if event is not None:
-            events.append(event)
+        if event is None:
+            continue
+        if event.get("event_type") == "activity.recorded":
+            payload = event["payload"]
+            activity_id = payload["id"]
+            previous = activity_by_id.get(activity_id)
+            if previous is not None:
+                for key in (
+                    "kind",
+                    "stage_kind",
+                    "start_date",
+                    "end_date",
+                    "order_ref",
+                ):
+                    if previous.get(key):
+                        payload[key] = previous[key]
+            activity_by_id[activity_id] = dict(payload)
+            if (
+                payload.get("status") == "completed"
+                and payload.get("kind") in BUSINESS_ACTIVITY_KINDS
+            ):
+                has_business_result = True
+                summary_context = {
+                    key: payload[key]
+                    for key in ("order_ref",)
+                    if payload.get(key)
+                }
+        events.append(event)
     return {"events": events}
+
+
+def _positive_int(value):
+    """Return a non-negative int for one internal counter."""
+
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _summary_activity_event(status, context):
+    """Return one generic final-result activity with safe context only."""
+
+    payload = {
+        "id": "summarize-results",
+        "kind": "summarizing_results",
+        "stage_kind": "result_analysis",
+        "status": status,
+    }
+    order_reference = _safe_order_reference(context.get("order_ref"))
+    if order_reference:
+        payload["order_ref"] = order_reference
+    return {
+        "event_type": "activity.recorded",
+        "visibility": "user",
+        "payload": payload,
+    }

--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -63,12 +63,6 @@ TOOL_ACTIVITY_STATUSES = {
     "timeout": "failed",
 }
 
-MODEL_ACTIVITY_STATUSES = {
-    "done": "completed",
-    "failed": "failed",
-    "start": "in_progress",
-}
-
 PUBLIC_TERMINATION_REASONS = {
     "capability_unavailable",
     "execution_failed",
@@ -189,6 +183,51 @@ def _date_argument(arguments, name):
         return ""
 
 
+def _safe_order_reference(value):
+    """Return one allowlisted business reference without raw CLI context."""
+
+    reference = str(value or "").strip()
+    if (
+        not reference
+        or len(reference) > 64
+        or not reference.isascii()
+        or not reference[0].isalnum()
+        or any(
+            not (char.isalnum() or char in "._-")
+            for char in reference
+        )
+    ):
+        return ""
+    return reference
+
+
+def _argument_after(arguments, *parts):
+    """Return the argument after one exact command or option sequence."""
+
+    if not isinstance(arguments, list):
+        return ""
+    normalized = [str(item).strip().lower() for item in arguments]
+    expected = list(parts)
+    width = len(expected)
+    for index in range(len(normalized) - width + 1):
+        if normalized[index : index + width] != expected:
+            continue
+        try:
+            return str(arguments[index + width])
+        except IndexError:
+            return ""
+    return ""
+
+
+def _order_reference_argument(arguments):
+    """Return an allowlisted order reference from supported CLI shapes."""
+
+    value = _argument_after(arguments, "order", "get")
+    if not value:
+        value = _argument_after(arguments, "--code")
+    return _safe_order_reference(value)
+
+
 def _contains_command(arguments, *parts):
     if not isinstance(arguments, list):
         return False
@@ -296,40 +335,16 @@ def _sanitize_tool_activity(item):
             payload["start_date"] = start_date
         if end_date:
             payload["end_date"] = end_date
+    if kind in {"query_orders", "get_order_detail"}:
+        order_reference = _order_reference_argument(
+            item.get("args_redacted")
+        )
+        if order_reference:
+            payload["order_ref"] = order_reference
     return {
         "event_type": "activity.recorded",
         "visibility": "user",
         "payload": payload,
-    }
-
-
-def _sanitize_model_activity(item):
-    """Return one safe, replayable General Chat model-round step."""
-
-    if item.get("runtime_scope") != "general_chat":
-        return None
-    agent_event = _text(item.get("agent_event"), 128)
-    prefix = "model.round."
-    if not agent_event.startswith(prefix):
-        return None
-    status = MODEL_ACTIVITY_STATUSES.get(agent_event[len(prefix) :])
-    activity_id = _safe_activity_id(item.get("invocation_id"))
-    if not activity_id or not status:
-        return None
-    try:
-        round_number = min(max(int(item.get("round") or 1), 1), 100)
-    except (TypeError, ValueError):
-        round_number = 1
-    return {
-        "event_type": "activity.recorded",
-        "visibility": "user",
-        "payload": {
-            "id": activity_id,
-            "kind": "analyzing_request",
-            "stage_kind": "reasoning",
-            "status": status,
-            "round": round_number,
-        },
     }
 
 
@@ -461,13 +476,15 @@ def sanitize_runtime_event(item):
             "visibility": "user",
             "payload": _sanitize_payload(event_type, item.get("payload")),
         }
-    model_activity = _sanitize_model_activity(item)
-    if model_activity is not None:
-        return model_activity
+    agent_event = _text(item.get("agent_event"), 128)
+    if (
+        item.get("runtime_scope") == "general_chat"
+        and agent_event.startswith("model.round.")
+    ):
+        return None
     tool_activity = _sanitize_tool_activity(item)
     if tool_activity is not None:
         return tool_activity
-    agent_event = _text(item.get("agent_event"), 128)
     activity = _text(item.get("activity"), 64)
     if not agent_event and not activity:
         return None

--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -233,6 +233,8 @@ def _order_reference_argument(arguments):
 
     value = _argument_after(arguments, "order", "get")
     if not value:
+        value = _argument_after(arguments, "order", "view")
+    if not value:
         value = _argument_after(arguments, "--code")
     return _safe_order_reference(value)
 
@@ -260,8 +262,6 @@ def _tool_activity_kind(tool_name, item):
             return "authenticating"
         if _contains_command(arguments, "version"):
             return "checking_tool"
-        if _contains_command(arguments, "order", "list"):
-            return "query_orders"
         if (
             _contains_command(arguments, "order")
             and isinstance(arguments, list)
@@ -271,7 +271,11 @@ def _tool_activity_kind(tool_name, item):
             )
         ):
             return "reading_order_commands"
-        if _contains_command(arguments, "order", "get"):
+        if _contains_command(arguments, "order", "list"):
+            return "query_orders"
+        if _contains_command(
+            arguments, "order", "get"
+        ) or _contains_command(arguments, "order", "view"):
             return "get_order_detail"
         return "querying_data"
     if tool_name == "analyze_structured_output":
@@ -517,20 +521,8 @@ def public_step_detail(detail):
     activity_by_id = {}
     has_business_result = False
     summary_context = {}
-    summary_started = False
     for item in detail.get("events") or []:
         agent_event = _text(item.get("agent_event"), 128)
-        if (
-            item.get("runtime_scope") == "general_chat"
-            and agent_event == "model.round.start"
-            and has_business_result
-            and not summary_started
-        ):
-            events.append(
-                _summary_activity_event("in_progress", summary_context)
-            )
-            summary_started = True
-            continue
         if (
             item.get("runtime_scope") == "general_chat"
             and agent_event == "deepagents.runtime.done"

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -49,7 +49,6 @@ from .runtime_events import (
     public_step_detail,
     sanitize_loaded_mcps,
     sanitize_loaded_skills,
-    sanitize_runtime_event,
     sanitize_termination_detail,
 )
 from .services import create_execution_run
@@ -1805,10 +1804,7 @@ class MessageSerializer(serializers.ModelSerializer):
             return None
         steps = []
         for step in run.steps.all():
-            for item in (step.detail or {}).get("events", []):
-                event = sanitize_runtime_event(item)
-                if event is not None:
-                    steps.append(event)
+            steps.extend(public_step_detail(step.detail)["events"])
         if not steps and not run.outcome:
             return None
         duration = None

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -728,6 +728,81 @@ class LensServiceTests(TransactionTestCase):
 
         self.assertIsNone(event)
 
+    def test_order_help_is_preparation_not_a_business_query(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "runtime_scope": "general_chat",
+            "invocation_id": "order-list-help",
+            "args_redacted": ["order", "list", "--help"],
+        })
+
+        self.assertEqual(
+            event["payload"],
+            {
+                "id": "order-list-help",
+                "kind": "reading_order_commands",
+                "stage_kind": "preparation",
+                "status": "in_progress",
+            },
+        )
+
+    def test_order_view_is_an_order_detail_operation(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "runtime_scope": "general_chat",
+            "invocation_id": "order-view",
+            "args_redacted": [
+                "order",
+                "view",
+                "HWINSTAD2025071509",
+            ],
+        })
+
+        self.assertEqual(event["payload"]["kind"], "get_order_detail")
+        self.assertEqual(
+            event["payload"]["order_ref"],
+            "HWINSTAD2025071509",
+        )
+
+    def test_general_chat_does_not_guess_summary_before_later_tools(self):
+        detail = public_step_detail({
+            "events": [
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "order-query",
+                    "args_redacted": [
+                        "order",
+                        "get",
+                        "HWINSTAD2025071509",
+                    ],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "order-query",
+                },
+                {
+                    "agent_event": "model.round.start",
+                    "runtime_scope": "general_chat",
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "order-help",
+                    "args_redacted": ["order", "--help"],
+                },
+            ]
+        })
+
+        kinds = [
+            item["payload"]["kind"]
+            for item in detail["events"]
+            if item.get("event_type") == "activity.recorded"
+        ]
+
+        self.assertNotIn("summarizing_results", kinds)
+
     def test_general_chat_public_path_uses_real_operation_stages(self):
         detail = public_step_detail({
             "events": [
@@ -786,6 +861,11 @@ class LensServiceTests(TransactionTestCase):
                     "invocation_id": "model-round-4",
                     "round": 4,
                 },
+                {
+                    "agent_event": "deepagents.runtime.done",
+                    "runtime_scope": "general_chat",
+                    "answer_chars": 120,
+                },
             ]
         })
 
@@ -823,7 +903,7 @@ class LensServiceTests(TransactionTestCase):
                 "result_analysis",
             ],
         )
-        self.assertEqual(activities[-1]["status"], "in_progress")
+        self.assertEqual(activities[-1]["status"], "completed")
         self.assertEqual(
             activities[-1]["order_ref"],
             "HWINSTAD2025071509",

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -631,10 +631,53 @@ class LensServiceTests(TransactionTestCase):
 
         self.assertEqual(detail["payload"]["kind"], "get_order_detail")
         self.assertEqual(
+            detail["payload"]["order_ref"],
+            "ORDER-123",
+        )
+        self.assertEqual(
             command_help["payload"]["kind"],
             "reading_order_commands",
         )
-        self.assertNotIn("ORDER-123", str(detail))
+
+    def test_order_list_by_code_exposes_only_safe_order_reference(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "lookup-123",
+            "args_redacted": [
+                "--profile",
+                "default",
+                "order",
+                "list",
+                "--code",
+                "HWINSTAD2025071509",
+                "--token",
+                "[REDACTED]",
+            ],
+        })
+
+        self.assertEqual(
+            event["payload"]["order_ref"],
+            "HWINSTAD2025071509",
+        )
+        self.assertNotIn("profile", str(event).lower())
+        self.assertNotIn("token", str(event).lower())
+
+    def test_order_reference_rejects_non_identifier_arguments(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "lookup-unsafe",
+            "args_redacted": [
+                "order",
+                "get",
+                "../../private-order",
+            ],
+        })
+
+        self.assertNotIn("order_ref", event["payload"])
 
     def test_structured_analysis_activity_exposes_allowlisted_operation(self):
         event = sanitize_runtime_event({
@@ -673,7 +716,7 @@ class LensServiceTests(TransactionTestCase):
             },
         )
 
-    def test_general_chat_model_round_is_a_safe_replayable_step(self):
+    def test_general_chat_model_round_is_not_user_visible(self):
         event = sanitize_runtime_event({
             "agent_event": "model.round.start",
             "runtime_scope": "general_chat",
@@ -682,21 +725,7 @@ class LensServiceTests(TransactionTestCase):
             "summary": "private model reasoning",
         })
 
-        self.assertEqual(
-            event,
-            {
-                "event_type": "activity.recorded",
-                "visibility": "user",
-                "payload": {
-                    "id": "model-round-2",
-                    "kind": "analyzing_request",
-                    "stage_kind": "reasoning",
-                    "status": "in_progress",
-                    "round": 2,
-                },
-            },
-        )
-        self.assertNotIn("private", str(event["payload"]).lower())
+        self.assertIsNone(event)
 
     def test_termination_detail_uses_fixed_public_contract(self):
         detail = sanitize_termination_detail({

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -547,6 +547,157 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(event["payload"], {})
         self.assertNotIn("secret-token", str(event))
 
+    def test_order_query_activity_exposes_safe_real_parameters(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "activity-123",
+            "skill": "license-cli",
+            "artifact": "income",
+            "args_redacted": [
+                "--profile",
+                "default",
+                "order",
+                "list",
+                "--start",
+                "2026-07-20T00:00:00+08:00",
+                "--end",
+                "2026-07-26T23:59:59+08:00",
+                "--token",
+                "[REDACTED]",
+            ],
+        })
+
+        self.assertEqual(event["event_type"], "activity.recorded")
+        self.assertEqual(event["visibility"], "user")
+        self.assertEqual(
+            event["payload"],
+            {
+                "id": "activity-123",
+                "kind": "query_orders",
+                "stage_kind": "order_query",
+                "status": "in_progress",
+                "start_date": "2026-07-20",
+                "end_date": "2026-07-26",
+            },
+        )
+        self.assertNotIn("token", str(event).lower())
+        self.assertNotIn("profile", str(event).lower())
+        self.assertNotIn("run_skill_artifact", str(event))
+
+    def test_completed_tool_activity_preserves_only_pairing_fields(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.done",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "activity-123",
+            "stdout_ref": "/large_tool_results/private.txt",
+            "summary": "license-cli/income · rc=0",
+        })
+
+        self.assertEqual(
+            event["payload"],
+            {
+                "id": "activity-123",
+                "kind": "querying_data",
+                "stage_kind": "data_query",
+                "status": "completed",
+            },
+        )
+        self.assertNotIn("stdout", str(event))
+
+    def test_order_detail_and_command_help_have_real_activity_kinds(self):
+        detail = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "detail-123",
+            "args_redacted": [
+                "--profile",
+                "default",
+                "order",
+                "get",
+                "ORDER-123",
+            ],
+        })
+        command_help = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "help-123",
+            "args_redacted": ["order", "get", "--help"],
+        })
+
+        self.assertEqual(detail["payload"]["kind"], "get_order_detail")
+        self.assertEqual(
+            command_help["payload"]["kind"],
+            "reading_order_commands",
+        )
+        self.assertNotIn("ORDER-123", str(detail))
+
+    def test_structured_analysis_activity_exposes_allowlisted_operation(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.analyze_structured_output.start",
+            "activity": "running_tool",
+            "runtime_scope": "general_chat",
+            "invocation_id": "analysis-123",
+            "operation": "count",
+            "input_ref": "/large_tool_results/private.txt",
+        })
+
+        self.assertEqual(
+            event["payload"],
+            {
+                "id": "analysis-123",
+                "kind": "count_results",
+                "stage_kind": "result_analysis",
+                "status": "in_progress",
+            },
+        )
+        self.assertNotIn("input_ref", str(event))
+
+    def test_non_general_chat_tool_event_keeps_original_public_shape(self):
+        event = sanitize_runtime_event({
+            "agent_event": "tool.run_skill_artifact.start",
+            "activity": "running_tool",
+            "invocation_id": "activity-123",
+            "args_redacted": ["order", "list"],
+        })
+
+        self.assertEqual(
+            event,
+            {
+                "agent_event": "tool.run_skill_artifact.start",
+                "activity": "running_tool",
+            },
+        )
+
+    def test_general_chat_model_round_is_a_safe_replayable_step(self):
+        event = sanitize_runtime_event({
+            "agent_event": "model.round.start",
+            "runtime_scope": "general_chat",
+            "invocation_id": "model-round-2",
+            "round": 2,
+            "summary": "private model reasoning",
+        })
+
+        self.assertEqual(
+            event,
+            {
+                "event_type": "activity.recorded",
+                "visibility": "user",
+                "payload": {
+                    "id": "model-round-2",
+                    "kind": "analyzing_request",
+                    "stage_kind": "reasoning",
+                    "status": "in_progress",
+                    "round": 2,
+                },
+            },
+        )
+        self.assertNotIn("private", str(event["payload"]).lower())
+
     def test_termination_detail_uses_fixed_public_contract(self):
         detail = sanitize_termination_detail({
             "reason": "secret-token",

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -38,10 +38,11 @@ from lens.periodic_tasks import (
     register_periodic_tasks,
 )
 from lens.runtime_events import (
+    public_step_detail,
     sanitize_runtime_event,
     sanitize_termination_detail,
 )
-from lens.serializers import RunSerializer
+from lens.serializers import MessageSerializer, RunSerializer
 from lens.services import (
     _build_sync_event,
     _step_sequence,
@@ -726,6 +727,215 @@ class LensServiceTests(TransactionTestCase):
         })
 
         self.assertIsNone(event)
+
+    def test_general_chat_public_path_uses_real_operation_stages(self):
+        detail = public_step_detail({
+            "events": [
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "tool-version",
+                    "args_redacted": ["version"],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "tool-version",
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "auth-status",
+                    "args_redacted": ["auth", "status"],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "auth-status",
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "auth-login",
+                    "args_redacted": ["auth", "login"],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "auth-login",
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "order-query",
+                    "args_redacted": [
+                        "order",
+                        "list",
+                        "--code",
+                        "HWINSTAD2025071509",
+                    ],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "order-query",
+                },
+                {
+                    "agent_event": "model.round.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "model-round-4",
+                    "round": 4,
+                },
+            ]
+        })
+
+        activities = [
+            item["payload"]
+            for item in detail["events"]
+            if item.get("event_type") == "activity.recorded"
+        ]
+
+        self.assertEqual(
+            [item["kind"] for item in activities],
+            [
+                "checking_tool",
+                "checking_tool",
+                "checking_authentication",
+                "checking_authentication",
+                "authenticating",
+                "authenticating",
+                "query_orders",
+                "query_orders",
+                "summarizing_results",
+            ],
+        )
+        self.assertEqual(
+            [item["stage_kind"] for item in activities],
+            [
+                "preparation",
+                "preparation",
+                "preparation",
+                "preparation",
+                "preparation",
+                "preparation",
+                "order_query",
+                "order_query",
+                "result_analysis",
+            ],
+        )
+        self.assertEqual(activities[-1]["status"], "in_progress")
+        self.assertEqual(
+            activities[-1]["order_ref"],
+            "HWINSTAD2025071509",
+        )
+
+    def test_general_chat_summary_completes_without_order_assumptions(self):
+        detail = public_step_detail({
+            "events": [
+                {
+                    "agent_event": "tool.run_skill_artifact.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "ticket-query",
+                    "args_redacted": ["ticket", "search", "INC-123"],
+                },
+                {
+                    "agent_event": "tool.run_skill_artifact.done",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "ticket-query",
+                },
+                {
+                    "agent_event": "model.round.start",
+                    "runtime_scope": "general_chat",
+                    "invocation_id": "model-round-2",
+                    "round": 2,
+                },
+                {
+                    "agent_event": "deepagents.runtime.done",
+                    "runtime_scope": "general_chat",
+                    "answer_chars": 120,
+                },
+            ]
+        })
+
+        activities = [
+            item["payload"]
+            for item in detail["events"]
+            if item.get("event_type") == "activity.recorded"
+        ]
+
+        self.assertEqual(activities[0]["kind"], "querying_data")
+        self.assertNotIn("order_ref", activities[0])
+        self.assertEqual(
+            activities[-1],
+            {
+                "id": "summarize-results",
+                "kind": "summarizing_results",
+                "stage_kind": "result_analysis",
+                "status": "completed",
+            },
+        )
+
+    def test_message_history_replays_inferred_general_chat_summary(self):
+        run = create_execution_run(
+            session=self.session,
+            question="Find ticket INC-123",
+            enqueue=False,
+        )
+        RunStep.objects.create(
+            run=run,
+            step_type=RunStep.StepType.GENERAL_CHAT,
+            sequence=3,
+            status=RunStep.Status.DONE,
+            detail={
+                "events": [
+                    {
+                        "agent_event": (
+                            "tool.run_skill_artifact.start"
+                        ),
+                        "runtime_scope": "general_chat",
+                        "invocation_id": "ticket-query",
+                        "args_redacted": [
+                            "ticket",
+                            "search",
+                            "INC-123",
+                        ],
+                    },
+                    {
+                        "agent_event": (
+                            "tool.run_skill_artifact.done"
+                        ),
+                        "runtime_scope": "general_chat",
+                        "invocation_id": "ticket-query",
+                    },
+                    {
+                        "agent_event": "model.round.start",
+                        "runtime_scope": "general_chat",
+                    },
+                    {
+                        "agent_event": "deepagents.runtime.done",
+                        "runtime_scope": "general_chat",
+                        "answer_chars": 120,
+                    },
+                ]
+            },
+        )
+
+        thinking = MessageSerializer(run.output_message).data["thinking"]
+        activities = [
+            item["payload"]
+            for item in thinking["steps"]
+            if item.get("event_type") == "activity.recorded"
+        ]
+
+        self.assertEqual(
+            activities[-1],
+            {
+                "id": "summarize-results",
+                "kind": "summarizing_results",
+                "stage_kind": "result_analysis",
+                "status": "completed",
+            },
+        )
 
     def test_termination_detail_uses_fixed_public_contract(self):
         detail = sanitize_termination_detail({

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -262,24 +262,29 @@
         },
         "pathStep": {
           "query_orders": "Query orders from {startDate} to {endDate}",
+          "query_orders_ref": "Query order {orderRef}",
           "get_order_detail": "Retrieve order details",
+          "get_order_detail_ref": "Retrieve order {orderRef} details",
           "reading_order_commands": "Read order command instructions",
           "checking_capability": "Confirm order query capability",
           "querying_data": "Query business data",
           "count_results": "Count matching orders",
           "group_results": "Group order results",
-          "analyzing_results": "Summarize and analyze results",
-          "analyzing_request": "Round {round}: analyze and choose the next step"
+          "analyzing_results": "Summarize and analyze results"
         },
         "workflow": {
           "task": {
-            "execute_request": "Handle the current request"
+            "get_order_detail": "Query order details",
+            "get_order_detail_ref": "Query order {orderRef} details",
+            "query_orders": "Query orders",
+            "query_orders_ref": "Query order {orderRef}",
+            "analyze_results": "Analyze query results",
+            "query_data": "Query business data"
           },
           "stage": {
             "order_query": "Order query",
             "data_query": "Business data query",
-            "result_analysis": "Result analysis",
-            "reasoning": "Analysis"
+            "result_analysis": "Result analysis"
           }
         },
         "recovery": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -243,6 +243,8 @@
         "stageProgressCurrent": "Completed {completed}/{total} · Current: {currentTitle}",
         "stageCompleted": "Completed {completed}/{total}",
         "stageEnded": "Ended {completed}/{total}",
+        "activityProgress": "Recorded {count} activities",
+        "activityCompleted": "Completed {count} activities",
         "blockedTitle": "Capability unavailable",
         "executionFailedTitle": "Capability execution failed",
         "artifactTitle": "Artifact ready",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -303,7 +303,7 @@
           "verification": "No verified result was returned. Review the runtime details and retry."
         },
         "phase": {
-          "analyzing": "Understanding the request",
+          "analyzing": "Analyzing the question",
           "planning": "Planning the work",
           "executing": "Executing the plan",
           "answering": "Preparing the answer",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -258,6 +258,28 @@
           "searchingSources": "Searching relevant sources",
           "usingCapability": "Running the required operation"
         },
+        "pathStep": {
+          "query_orders": "Query orders from {startDate} to {endDate}",
+          "get_order_detail": "Retrieve order details",
+          "reading_order_commands": "Read order command instructions",
+          "checking_capability": "Confirm order query capability",
+          "querying_data": "Query business data",
+          "count_results": "Count matching orders",
+          "group_results": "Group order results",
+          "analyzing_results": "Summarize and analyze results",
+          "analyzing_request": "Round {round}: analyze and choose the next step"
+        },
+        "workflow": {
+          "task": {
+            "execute_request": "Handle the current request"
+          },
+          "stage": {
+            "order_query": "Order query",
+            "data_query": "Business data query",
+            "result_analysis": "Result analysis",
+            "reasoning": "Analysis"
+          }
+        },
         "recovery": {
           "capability": "Use an assistant that supports this operation or ask an administrator to bind the required capability.",
           "configuration": "Ask an administrator to configure or authorize this capability, then retry.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -267,10 +267,15 @@
           "get_order_detail_ref": "Retrieve order {orderRef} details",
           "reading_order_commands": "Read order command instructions",
           "checking_capability": "Confirm order query capability",
+          "checking_tool": "Confirm the execution tool is available",
+          "checking_authentication": "Confirm login status",
+          "authenticating": "Sign in to the business system",
           "querying_data": "Query business data",
           "count_results": "Count matching orders",
           "group_results": "Group order results",
-          "analyzing_results": "Summarize and analyze results"
+          "analyzing_results": "Summarize and analyze results",
+          "summarizing_results": "Summarize the result",
+          "summarizing_order": "Summarize order {orderRef} details"
         },
         "workflow": {
           "task": {
@@ -282,9 +287,10 @@
             "query_data": "Query business data"
           },
           "stage": {
+            "preparation": "Execution preparation",
             "order_query": "Order query",
             "data_query": "Business data query",
-            "result_analysis": "Result analysis"
+            "result_analysis": "Result summary"
           }
         },
         "recovery": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -243,6 +243,8 @@
         "stageProgressCurrent": "已完成 {completed}/{total} · 当前：{currentTitle}",
         "stageCompleted": "已完成 {completed}/{total}",
         "stageEnded": "已结束 {completed}/{total}",
+        "activityProgress": "已记录 {count} 项活动",
+        "activityCompleted": "已完成 {count} 项活动",
         "blockedTitle": "所需能力当前不可用",
         "executionFailedTitle": "能力执行失败",
         "artifactTitle": "交付文件已生成",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -303,7 +303,7 @@
           "verification": "本次执行未返回可验证结果，请查看运行详情后重试。"
         },
         "phase": {
-          "analyzing": "正在理解请求",
+          "analyzing": "正在分析问题",
           "planning": "正在制定计划",
           "executing": "正在执行计划",
           "answering": "正在整理回答",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -262,24 +262,29 @@
         },
         "pathStep": {
           "query_orders": "查询 {startDate} 至 {endDate} 的订单",
+          "query_orders_ref": "查询订单 {orderRef}",
           "get_order_detail": "获取订单详情",
+          "get_order_detail_ref": "获取订单 {orderRef} 详情",
           "reading_order_commands": "读取订单命令说明",
           "checking_capability": "确认订单查询能力",
           "querying_data": "查询业务数据",
           "count_results": "统计符合条件的订单",
           "group_results": "按类型汇总订单",
-          "analyzing_results": "汇总并分析结果",
-          "analyzing_request": "第 {round} 轮：分析问题并确定下一步"
+          "analyzing_results": "汇总并分析结果"
         },
         "workflow": {
           "task": {
-            "execute_request": "处理当前问题"
+            "get_order_detail": "查询订单详情",
+            "get_order_detail_ref": "查询订单 {orderRef} 详情",
+            "query_orders": "查询订单",
+            "query_orders_ref": "查询订单 {orderRef}",
+            "analyze_results": "分析查询结果",
+            "query_data": "查询业务数据"
           },
           "stage": {
             "order_query": "订单查询",
             "data_query": "业务数据查询",
-            "result_analysis": "结果分析",
-            "reasoning": "分析处理"
+            "result_analysis": "结果分析"
           }
         },
         "recovery": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -267,10 +267,15 @@
           "get_order_detail_ref": "获取订单 {orderRef} 详情",
           "reading_order_commands": "读取订单命令说明",
           "checking_capability": "确认订单查询能力",
+          "checking_tool": "确认执行工具可用",
+          "checking_authentication": "确认登录状态",
+          "authenticating": "登录业务系统",
           "querying_data": "查询业务数据",
           "count_results": "统计符合条件的订单",
           "group_results": "按类型汇总订单",
-          "analyzing_results": "汇总并分析结果"
+          "analyzing_results": "汇总并分析结果",
+          "summarizing_results": "总结处理结果",
+          "summarizing_order": "总结订单 {orderRef} 详情"
         },
         "workflow": {
           "task": {
@@ -282,9 +287,10 @@
             "query_data": "查询业务数据"
           },
           "stage": {
+            "preparation": "执行准备",
             "order_query": "订单查询",
             "data_query": "业务数据查询",
-            "result_analysis": "结果分析"
+            "result_analysis": "结果整理"
           }
         },
         "recovery": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -258,6 +258,28 @@
           "searchingSources": "正在搜索相关资料",
           "usingCapability": "正在执行所需操作"
         },
+        "pathStep": {
+          "query_orders": "查询 {startDate} 至 {endDate} 的订单",
+          "get_order_detail": "获取订单详情",
+          "reading_order_commands": "读取订单命令说明",
+          "checking_capability": "确认订单查询能力",
+          "querying_data": "查询业务数据",
+          "count_results": "统计符合条件的订单",
+          "group_results": "按类型汇总订单",
+          "analyzing_results": "汇总并分析结果",
+          "analyzing_request": "第 {round} 轮：分析问题并确定下一步"
+        },
+        "workflow": {
+          "task": {
+            "execute_request": "处理当前问题"
+          },
+          "stage": {
+            "order_query": "订单查询",
+            "data_query": "业务数据查询",
+            "result_analysis": "结果分析",
+            "reasoning": "分析处理"
+          }
+        },
         "recovery": {
           "capability": "请改用支持该操作的助手，或联系管理员绑定所需能力。",
           "configuration": "请联系管理员配置或授权该能力，然后重试。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -392,7 +392,8 @@
                     <span class="runtime-card-title">
                       {{
                         progressTitle(
-                          structuredProgress(message._runtimeState).kind
+                          structuredProgress(message._runtimeState).kind,
+                          structuredProgress(message._runtimeState).items
                         )
                       }}
                     </span>
@@ -410,6 +411,64 @@
                     </span>
                   </summary>
                   <div
+                    v-if="
+                      structuredProgress(message._runtimeState).kind ===
+                      'workflow'
+                    "
+                    class="runtime-workflow"
+                  >
+                    <div
+                      v-for="task in structuredProgress(message._runtimeState)
+                        .tasks"
+                      :key="task.id"
+                      class="runtime-workflow-task"
+                    >
+                      <div class="runtime-plan-step runtime-task-row">
+                        <span
+                          class="runtime-plan-status"
+                          :class="`is-${task.status}`"
+                          aria-hidden="true"
+                        >
+                          {{ progressStatusIcon(task.status) }}
+                        </span>
+                        <span>{{ workflowTaskTitle(task) }}</span>
+                      </div>
+                      <div
+                        v-for="stage in task.stages"
+                        :key="stage.id"
+                        class="runtime-workflow-stage"
+                      >
+                        <div class="runtime-plan-step runtime-stage-row">
+                          <span
+                            class="runtime-plan-status"
+                            :class="`is-${stage.status}`"
+                            aria-hidden="true"
+                          >
+                            {{ progressStatusIcon(stage.status) }}
+                          </span>
+                          <span>{{ workflowStageTitle(stage.kind) }}</span>
+                        </div>
+                        <div class="runtime-workflow-steps">
+                          <div
+                            v-for="step in stage.steps"
+                            :key="step.id"
+                            class="runtime-plan-step runtime-step-row"
+                          >
+                            <span
+                              class="runtime-plan-status"
+                              :class="`is-${step.status}`"
+                              aria-hidden="true"
+                            >
+                              {{ progressStatusIcon(step.status) }}
+                            </span>
+                            <span>{{ workflowStepTitle(step) }}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
                     v-for="item in structuredProgress(message._runtimeState)
                       .items"
                     :key="item.id"
@@ -445,7 +504,7 @@
                         class="runtime-node-activity"
                       >
                         <span class="runtime-activity-indicator">✓</span>
-                        <span>{{ activityLabel(activity.kind, item) }}</span>
+                        <span>{{ activityLabel(activity.kind) }}</span>
                         <span
                           v-if="activity.count > 1"
                           class="runtime-activity-count"
@@ -703,9 +762,75 @@
                   aria-live="polite"
                 >
                   <div class="runtime-card-title">
-                    {{ progressTitle(liveStructuredProgress.kind) }}
+                    {{
+                      progressTitle(
+                        liveStructuredProgress.kind,
+                        liveStructuredProgress.items
+                      )
+                    }}
                   </div>
                   <div
+                    v-if="liveStructuredProgress.kind === 'workflow'"
+                    class="runtime-workflow"
+                  >
+                    <div
+                      v-for="task in liveStructuredProgress.tasks"
+                      :key="task.id"
+                      class="runtime-workflow-task"
+                    >
+                      <div class="runtime-plan-step runtime-task-row">
+                        <span
+                          class="runtime-plan-status"
+                          :class="`is-${task.status}`"
+                          aria-hidden="true"
+                        >
+                          {{ progressStatusIcon(task.status) }}
+                        </span>
+                        <span>{{ workflowTaskTitle(task) }}</span>
+                      </div>
+                      <div
+                        v-for="stage in task.stages"
+                        :key="stage.id"
+                        class="runtime-workflow-stage"
+                      >
+                        <div class="runtime-plan-step runtime-stage-row">
+                          <span
+                            class="runtime-plan-status"
+                            :class="`is-${stage.status}`"
+                            aria-hidden="true"
+                          >
+                            {{ progressStatusIcon(stage.status) }}
+                          </span>
+                          <span>{{ workflowStageTitle(stage.kind) }}</span>
+                        </div>
+                        <div
+                          :ref="
+                            stage.status === 'in_progress'
+                              ? 'liveActivityScrollRef'
+                              : undefined
+                          "
+                          class="runtime-workflow-steps"
+                        >
+                          <div
+                            v-for="step in stage.steps"
+                            :key="step.id"
+                            class="runtime-plan-step runtime-step-row"
+                          >
+                            <span
+                              class="runtime-plan-status"
+                              :class="`is-${step.status}`"
+                              aria-hidden="true"
+                            >
+                              {{ progressStatusIcon(step.status) }}
+                            </span>
+                            <span>{{ workflowStepTitle(step) }}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
                     v-for="item in liveStructuredProgress.items"
                     :key="item.id"
                     class="runtime-plan-node"
@@ -751,7 +876,7 @@
                         >
                           {{ isCurrentActivity(activity, item) ? '' : '✓' }}
                         </span>
-                        <span>{{ activityLabel(activity.kind, item) }}</span>
+                        <span>{{ activityLabel(activity.kind) }}</span>
                         <span
                           v-if="activity.count > 1"
                           class="runtime-activity-count"
@@ -762,7 +887,13 @@
                     </div>
                   </div>
                   <div class="runtime-progress-footer">
-                    <span>{{ liveProgressText }}</span>
+                    <span>
+                      {{
+                        liveStructuredProgress.kind === 'workflow'
+                          ? structuredProgressText(runtimeState)
+                          : liveProgressText
+                      }}
+                    </span>
                     <span v-if="elapsedText"> · {{ elapsedText }}</span>
                   </div>
                 </div>
@@ -1053,8 +1184,8 @@ import {
   calculateRunElapsedSeconds,
   createRuntimeState,
   getMessageTimestamp,
-  inferProgressLocale,
   scrollConversationToBottomAfterRender,
+  selectCurrentWorkflowStage,
   selectLiveProgressText,
   selectStructuredProgress,
   summarizePlanProgress,
@@ -1328,8 +1459,10 @@ function stageProgressText(stages, durationSeconds = null, terminal = false) {
 
 function structuredProgress(state) {
   return selectStructuredProgress({
+    route: state?.route,
     plan: state?.plan,
-    stages: state?.stages
+    stages: state?.stages,
+    activities: state?.activities
   })
 }
 
@@ -1345,13 +1478,64 @@ function structuredProgressText(
   if (progress.kind === 'stage') {
     return stageProgressText(progress.items, durationSeconds, terminal)
   }
+  if (progress.kind === 'workflow') {
+    const stages = progress.tasks.flatMap((task) => task.stages || [])
+    return stageProgressText(stages, durationSeconds, terminal)
+  }
   return ''
 }
 
-function progressTitle(kind) {
-  return kind === 'plan'
-    ? t('lens.chat.runtime.planTitle')
-    : t('lens.chat.runtime.stageTitle')
+function progressTitle(kind, items = []) {
+  if (kind === 'plan') return t('lens.chat.runtime.planTitle')
+  if (kind === 'workflow') {
+    const stage = selectCurrentWorkflowStage(items)
+    return stage
+      ? workflowStageTitle(stage.kind)
+      : t('lens.chat.runtime.planTitle')
+  }
+  return t('lens.chat.runtime.stageTitle')
+}
+
+const PATH_KINDS = new Set([
+  'query_orders',
+  'get_order_detail',
+  'reading_order_commands',
+  'checking_capability',
+  'querying_data',
+  'count_results',
+  'group_results',
+  'analyzing_results',
+  'analyzing_request'
+])
+function safePathKind(item) {
+  let kind = PATH_KINDS.has(item?.kind) ? item.kind : 'querying_data'
+  if (kind === 'query_orders' && (!item.startDate || !item.endDate)) {
+    kind = 'querying_data'
+  }
+  return kind
+}
+
+function workflowTaskTitle(task) {
+  return task.title || t('lens.chat.runtime.workflow.task.execute_request')
+}
+
+function workflowStageTitle(kind) {
+  const known = new Set([
+    'order_query',
+    'data_query',
+    'result_analysis',
+    'reasoning'
+  ])
+  const safeKind = known.has(kind) ? kind : 'data_query'
+  return t(`lens.chat.runtime.workflow.stage.${safeKind}`)
+}
+
+function workflowStepTitle(item) {
+  return t(`lens.chat.runtime.pathStep.${safePathKind(item)}`, {
+    startDate: item?.startDate,
+    endDate: item?.endDate,
+    round: item?.round
+  })
 }
 
 function progressStatusIcon(status) {
@@ -1372,7 +1556,7 @@ function nodeActivities(state, nodeId) {
   return activitiesForNode(state, nodeId)
 }
 
-function activityLabel(kind, item) {
+function activityLabel(kind) {
   const known = new Set([
     'analyzingResults',
     'findingCapability',
@@ -1384,11 +1568,7 @@ function activityLabel(kind, item) {
     'usingCapability'
   ])
   const safeKind = known.has(kind) ? kind : 'usingCapability'
-  return t(
-    `lens.chat.runtime.activity.${safeKind}`,
-    {},
-    { locale: inferProgressLocale(item?.title) }
-  )
+  return t(`lens.chat.runtime.activity.${safeKind}`)
 }
 
 function isCurrentActivity(activity, item) {
@@ -1417,7 +1597,9 @@ const liveStageProgressText = computed(() =>
 const liveProgressText = computed(() =>
   selectLiveProgressText({
     planProgressText: livePlanProgressText.value,
-    stageProgressText: liveStageProgressText.value,
+    stageProgressText: runtimeState.value.route
+      ? ''
+      : liveStageProgressText.value,
     phaseText: runtimePhaseText.value,
     fallbackText: liveStatusText.value
   })
@@ -2099,6 +2281,13 @@ function handleEvent(event) {
     if (event.status !== 'queued') queuePosition.value = null
     if (event.type === 'sync') {
       event.steps?.forEach((step) => handleStepEvent(step, event.ts))
+    }
+    if (isTerminalRunStatus(event.status)) {
+      runtimeState.value = applyRuntimeEvent(runtimeState.value, {
+        type: 'done',
+        outcome: event.outcome,
+        termination_detail: event.termination_detail
+      })
     }
   }
   if (event.type === 'queue_position') {
@@ -2955,6 +3144,39 @@ onBeforeUnmount(() => {
   align-items: flex-start;
   gap: 0.5rem;
   padding: 0.18rem 0;
+}
+
+.runtime-workflow-task + .runtime-workflow-task {
+  margin-top: 0.3rem;
+}
+
+.runtime-task-row {
+  color: #334155;
+  font-weight: 600;
+}
+
+.runtime-workflow-stage {
+  margin-left: 1.45rem;
+  border-left: 1px solid #dbe3ec;
+  padding-left: 0.65rem;
+}
+
+.runtime-stage-row {
+  color: #475569;
+  font-weight: 500;
+}
+
+.runtime-workflow-steps {
+  max-height: 6.5rem;
+  margin-left: 1.35rem;
+  overflow-y: auto;
+  color: #64748b;
+  font-size: 0.72rem;
+  scrollbar-width: thin;
+}
+
+.runtime-step-row {
+  padding: 0.12rem 0;
 }
 
 .runtime-node-activities {

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1585,10 +1585,14 @@ const PATH_KINDS = new Set([
   'get_order_detail',
   'reading_order_commands',
   'checking_capability',
+  'checking_tool',
+  'checking_authentication',
+  'authenticating',
   'querying_data',
   'count_results',
   'group_results',
-  'analyzing_results'
+  'analyzing_results',
+  'summarizing_results'
 ])
 function safePathKind(item) {
   let kind = PATH_KINDS.has(item?.kind) ? item.kind : 'querying_data'
@@ -1627,7 +1631,12 @@ function workflowTaskTitle(task) {
 }
 
 function workflowStageTitle(kind) {
-  const known = new Set(['order_query', 'data_query', 'result_analysis'])
+  const known = new Set([
+    'preparation',
+    'order_query',
+    'data_query',
+    'result_analysis'
+  ])
   const safeKind = known.has(kind) ? kind : 'data_query'
   return t(`lens.chat.runtime.workflow.stage.${safeKind}`)
 }
@@ -1638,6 +1647,8 @@ function workflowStepTitle(item) {
     kind = 'get_order_detail_ref'
   } else if (kind === 'query_orders' && item?.orderRef) {
     kind = 'query_orders_ref'
+  } else if (kind === 'summarizing_results' && item?.orderRef) {
+    kind = 'summarizing_order'
   }
   return t(`lens.chat.runtime.pathStep.${kind}`, {
     startDate: item?.startDate,

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1588,37 +1588,61 @@ const PATH_KINDS = new Set([
   'querying_data',
   'count_results',
   'group_results',
-  'analyzing_results',
-  'analyzing_request'
+  'analyzing_results'
 ])
 function safePathKind(item) {
   let kind = PATH_KINDS.has(item?.kind) ? item.kind : 'querying_data'
-  if (kind === 'query_orders' && (!item.startDate || !item.endDate)) {
+  if (
+    kind === 'query_orders' &&
+    (!item.startDate || !item.endDate) &&
+    !item.orderRef
+  ) {
     kind = 'querying_data'
   }
   return kind
 }
 
 function workflowTaskTitle(task) {
-  return task.title || t('lens.chat.runtime.workflow.task.execute_request')
+  if (task.title) return task.title
+  if (task.kind === 'get_order_detail') {
+    return t(
+      `lens.chat.runtime.workflow.task.${
+        task.orderRef ? 'get_order_detail_ref' : 'get_order_detail'
+      }`,
+      { orderRef: task.orderRef }
+    )
+  }
+  if (task.kind === 'query_orders') {
+    return t(
+      `lens.chat.runtime.workflow.task.${
+        task.orderRef ? 'query_orders_ref' : 'query_orders'
+      }`,
+      { orderRef: task.orderRef }
+    )
+  }
+  if (task.kind === 'analyze_results') {
+    return t('lens.chat.runtime.workflow.task.analyze_results')
+  }
+  return t('lens.chat.runtime.workflow.task.query_data')
 }
 
 function workflowStageTitle(kind) {
-  const known = new Set([
-    'order_query',
-    'data_query',
-    'result_analysis',
-    'reasoning'
-  ])
+  const known = new Set(['order_query', 'data_query', 'result_analysis'])
   const safeKind = known.has(kind) ? kind : 'data_query'
   return t(`lens.chat.runtime.workflow.stage.${safeKind}`)
 }
 
 function workflowStepTitle(item) {
-  return t(`lens.chat.runtime.pathStep.${safePathKind(item)}`, {
+  let kind = safePathKind(item)
+  if (kind === 'get_order_detail' && item?.orderRef) {
+    kind = 'get_order_detail_ref'
+  } else if (kind === 'query_orders' && item?.orderRef) {
+    kind = 'query_orders_ref'
+  }
+  return t(`lens.chat.runtime.pathStep.${kind}`, {
     startDate: item?.startDate,
     endDate: item?.endDate,
-    round: item?.round
+    orderRef: item?.orderRef
   })
 }
 

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -468,6 +468,30 @@
                     </div>
                   </div>
                   <div
+                    v-else-if="
+                      structuredProgress(message._runtimeState).kind ===
+                      'activity'
+                    "
+                    class="runtime-node-activities runtime-standalone-activities"
+                  >
+                    <div
+                      v-for="activity in structuredProgress(
+                        message._runtimeState
+                      ).items"
+                      :key="activity.id"
+                      class="runtime-node-activity"
+                    >
+                      <span class="runtime-activity-indicator">✓</span>
+                      <span>{{ activityLabel(activity.kind) }}</span>
+                      <span
+                        v-if="activity.count > 1"
+                        class="runtime-activity-count"
+                      >
+                        ×{{ activity.count }}
+                      </span>
+                    </div>
+                  </div>
+                  <div
                     v-else
                     v-for="item in structuredProgress(message._runtimeState)
                       .items"
@@ -830,6 +854,44 @@
                     </div>
                   </div>
                   <div
+                    v-else-if="liveStructuredProgress.kind === 'activity'"
+                    ref="liveActivityScrollRef"
+                    class="runtime-node-activities runtime-standalone-activities"
+                  >
+                    <div
+                      v-for="activity in liveStructuredProgress.items"
+                      :key="activity.id"
+                      class="runtime-node-activity"
+                    >
+                      <span
+                        class="runtime-activity-indicator"
+                        :class="{
+                          'is-current': isCurrentStandaloneActivity(
+                            activity,
+                            liveStructuredProgress.items
+                          )
+                        }"
+                        aria-hidden="true"
+                      >
+                        {{
+                          isCurrentStandaloneActivity(
+                            activity,
+                            liveStructuredProgress.items
+                          )
+                            ? ''
+                            : '✓'
+                        }}
+                      </span>
+                      <span>{{ activityLabel(activity.kind) }}</span>
+                      <span
+                        v-if="activity.count > 1"
+                        class="runtime-activity-count"
+                      >
+                        ×{{ activity.count }}
+                      </span>
+                    </div>
+                  </div>
+                  <div
                     v-else
                     v-for="item in liveStructuredProgress.items"
                     :key="item.id"
@@ -889,7 +951,9 @@
                   <div class="runtime-progress-footer">
                     <span>
                       {{
-                        liveStructuredProgress.kind === 'workflow'
+                        ['workflow', 'activity'].includes(
+                          liveStructuredProgress.kind
+                        )
                           ? structuredProgressText(runtimeState)
                           : liveProgressText
                       }}
@@ -1310,6 +1374,12 @@ const assistantDescription = computed(
     ''
 )
 
+const isGeneralChatAssistant = computed(
+  () =>
+    (selectedAssistant.value || publicAssistant.value)?.selected_task ===
+    'general_chat'
+)
+
 // The top header turns the assistant name into a switcher only when an
 // authenticated user has more than one assistant to choose from. Mirror the
 // switcher's own visibility rule (active assistants only) so the header never
@@ -1462,7 +1532,8 @@ function structuredProgress(state) {
     route: state?.route,
     plan: state?.plan,
     stages: state?.stages,
-    activities: state?.activities
+    activities: state?.activities,
+    standaloneActivities: !isGeneralChatAssistant.value
   })
 }
 
@@ -1482,11 +1553,24 @@ function structuredProgressText(
     const stages = progress.tasks.flatMap((task) => task.stages || [])
     return stageProgressText(stages, durationSeconds, terminal)
   }
+  if (progress.kind === 'activity') {
+    const count = progress.items.reduce(
+      (total, item) => total + Number(item.count || 1),
+      0
+    )
+    return t(
+      terminal
+        ? 'lens.chat.runtime.activityCompleted'
+        : 'lens.chat.runtime.activityProgress',
+      { count }
+    )
+  }
   return ''
 }
 
 function progressTitle(kind, items = []) {
   if (kind === 'plan') return t('lens.chat.runtime.planTitle')
+  if (kind === 'activity') return t('lens.chat.agentActivity')
   if (kind === 'workflow') {
     const stage = selectCurrentWorkflowStage(items)
     return stage
@@ -1574,6 +1658,10 @@ function activityLabel(kind) {
 function isCurrentActivity(activity, item) {
   const latest = runtimeState.value.activities.at(-1)
   return item.status === 'in_progress' && latest?.id === activity.id
+}
+
+function isCurrentStandaloneActivity(activity, items) {
+  return isRunActive.value && items.at(-1)?.id === activity.id
 }
 
 watch(
@@ -3188,6 +3276,10 @@ onBeforeUnmount(() => {
   color: #64748b;
   font-size: 0.71rem;
   scrollbar-width: thin;
+}
+
+.runtime-standalone-activities {
+  margin-left: 0;
 }
 
 .runtime-node-activity {

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -393,7 +393,7 @@
                       {{
                         progressTitle(
                           structuredProgress(message._runtimeState).kind,
-                          structuredProgress(message._runtimeState).items
+                          structuredProgress(message._runtimeState).hasPlan
                         )
                       }}
                     </span>
@@ -422,8 +422,15 @@
                         .tasks"
                       :key="task.id"
                       class="runtime-workflow-task"
+                      :class="{
+                        'is-direct': !structuredProgress(message._runtimeState)
+                          .hasPlan
+                      }"
                     >
-                      <div class="runtime-plan-step runtime-task-row">
+                      <div
+                        v-if="structuredProgress(message._runtimeState).hasPlan"
+                        class="runtime-plan-step runtime-task-row"
+                      >
                         <span
                           class="runtime-plan-status"
                           :class="`is-${task.status}`"
@@ -789,7 +796,7 @@
                     {{
                       progressTitle(
                         liveStructuredProgress.kind,
-                        liveStructuredProgress.items
+                        liveStructuredProgress.hasPlan
                       )
                     }}
                   </div>
@@ -801,8 +808,14 @@
                       v-for="task in liveStructuredProgress.tasks"
                       :key="task.id"
                       class="runtime-workflow-task"
+                      :class="{
+                        'is-direct': !liveStructuredProgress.hasPlan
+                      }"
                     >
-                      <div class="runtime-plan-step runtime-task-row">
+                      <div
+                        v-if="liveStructuredProgress.hasPlan"
+                        class="runtime-plan-step runtime-task-row"
+                      >
                         <span
                           class="runtime-plan-status"
                           :class="`is-${task.status}`"
@@ -1249,11 +1262,11 @@ import {
   createRuntimeState,
   getMessageTimestamp,
   scrollConversationToBottomAfterRender,
-  selectCurrentWorkflowStage,
   selectLiveProgressText,
   selectStructuredProgress,
   summarizePlanProgress,
-  summarizeStageProgress
+  summarizeStageProgress,
+  workflowProgressSource
 } from '@/pages/lens/runtimeEvents'
 import {
   cancelRun,
@@ -1550,8 +1563,11 @@ function structuredProgressText(
     return stageProgressText(progress.items, durationSeconds, terminal)
   }
   if (progress.kind === 'workflow') {
-    const stages = progress.tasks.flatMap((task) => task.stages || [])
-    return stageProgressText(stages, durationSeconds, terminal)
+    const source = workflowProgressSource(progress.tasks, progress.hasPlan)
+    if (source.kind === 'plan') {
+      return planProgressText(source.items, durationSeconds, terminal)
+    }
+    return stageProgressText(source.items, durationSeconds, terminal)
   }
   if (progress.kind === 'activity') {
     const count = progress.items.reduce(
@@ -1568,14 +1584,13 @@ function structuredProgressText(
   return ''
 }
 
-function progressTitle(kind, items = []) {
+function progressTitle(kind, hasPlan = false) {
   if (kind === 'plan') return t('lens.chat.runtime.planTitle')
   if (kind === 'activity') return t('lens.chat.agentActivity')
   if (kind === 'workflow') {
-    const stage = selectCurrentWorkflowStage(items)
-    return stage
-      ? workflowStageTitle(stage.kind)
-      : t('lens.chat.runtime.planTitle')
+    return t(
+      hasPlan ? 'lens.chat.runtime.planTitle' : 'lens.chat.runtime.stageTitle'
+    )
   }
   return t('lens.chat.runtime.stageTitle')
 }
@@ -3282,6 +3297,10 @@ onBeforeUnmount(() => {
   margin-left: 1.45rem;
   border-left: 1px solid #dbe3ec;
   padding-left: 0.65rem;
+}
+
+.runtime-workflow-task.is-direct .runtime-workflow-stage {
+  margin-left: 0;
 }
 
 .runtime-stage-row {

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -15,14 +15,12 @@ const STRUCTURED_ACTIVITY_KINDS = new Set([
   'querying_data',
   'count_results',
   'group_results',
-  'analyzing_results',
-  'analyzing_request'
+  'analyzing_results'
 ])
 const WORKFLOW_STAGE_KINDS = new Set([
   'order_query',
   'data_query',
-  'result_analysis',
-  'reasoning'
+  'result_analysis'
 ])
 
 export function calculateRunElapsedSeconds(run, nowMs = Date.now()) {
@@ -163,6 +161,12 @@ function normalizeActivityDate(value) {
   return parsed.toISOString().slice(0, 10) === date ? date : ''
 }
 
+function normalizeOrderReference(value) {
+  const reference = String(value || '').trim()
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(reference)) return ''
+  return reference
+}
+
 function appendStructuredActivity(state, payload) {
   if (!payload || typeof payload !== 'object') return state
   const id = String(payload.id || '')
@@ -178,7 +182,7 @@ function appendStructuredActivity(state, payload) {
   )
   const startDate = normalizeActivityDate(payload.start_date)
   const endDate = normalizeActivityDate(payload.end_date)
-  const round = Math.min(Math.max(Number(payload.round || 0), 0), 100)
+  const orderRef = normalizeOrderReference(payload.order_ref)
   const activeTask = state.plan.find((item) => item.status === 'in_progress')
   const taskId = existing?.taskId || activeTask?.id || 'task-execute'
   const stageKind = existing?.stageKind || payload.stage_kind
@@ -195,12 +199,14 @@ function appendStructuredActivity(state, payload) {
       existing?.status === 'completed' && payload.status === 'in_progress'
         ? existing.status
         : payload.status,
-    ...(existing?.round || round ? { round: existing?.round || round } : {}),
     ...(existing?.startDate || startDate
       ? { startDate: existing?.startDate || startDate }
       : {}),
     ...(existing?.endDate || endDate
       ? { endDate: existing?.endDate || endDate }
+      : {}),
+    ...(existing?.orderRef || orderRef
+      ? { orderRef: existing?.orderRef || orderRef }
       : {}),
     structured: true
   }
@@ -355,13 +361,19 @@ export function buildWorkflowTree(plan, activities) {
     stages: []
   }))
   const taskById = new Map(tasks.map((item) => [item.id, item]))
-  for (const step of Array.isArray(activities) ? activities : []) {
+  const structuredActivities = (
+    Array.isArray(activities) ? activities : []
+  ).filter((item) => item?.structured)
+  const visibleActivities = structuredActivities.filter(
+    (item) => item.kind !== 'analyzing_request'
+  )
+  for (const step of visibleActivities) {
     if (!step?.structured || !step.taskId || !step.stageId) continue
     let task = taskById.get(step.taskId)
     if (!task) {
       task = {
         id: step.taskId,
-        kind: 'execute_request',
+        kind: 'query_data',
         order: tasks.length + 1,
         status: 'pending',
         stages: []
@@ -388,6 +400,32 @@ export function buildWorkflowTree(plan, activities) {
     }
     if (!task.title) {
       task.status = workflowNodeStatus(task.stages)
+      const steps = task.stages.flatMap((stage) => stage.steps || [])
+      const detailStep = steps.find((step) => step.kind === 'get_order_detail')
+      const queryStep = steps.find((step) => step.kind === 'query_orders')
+      if (detailStep) {
+        task.kind = 'get_order_detail'
+        task.orderRef = detailStep.orderRef || ''
+      } else if (queryStep) {
+        task.kind = 'query_orders'
+        task.orderRef = queryStep.orderRef || ''
+      } else if (
+        steps.some((step) =>
+          ['count_results', 'group_results', 'analyzing_results'].includes(
+            step.kind
+          )
+        )
+      ) {
+        task.kind = 'analyze_results'
+      } else if (
+        steps.some((step) =>
+          ['checking_capability', 'reading_order_commands'].includes(step.kind)
+        )
+      ) {
+        task.kind = 'query_orders'
+      } else {
+        task.kind = 'query_data'
+      }
     }
   }
   return tasks

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -6,6 +6,24 @@ const STAGE_STATUSES = new Set([
   'failed',
   'skipped'
 ])
+const ACTIVITY_STATUSES = new Set(['in_progress', 'completed', 'failed'])
+const STRUCTURED_ACTIVITY_KINDS = new Set([
+  'query_orders',
+  'get_order_detail',
+  'reading_order_commands',
+  'checking_capability',
+  'querying_data',
+  'count_results',
+  'group_results',
+  'analyzing_results',
+  'analyzing_request'
+])
+const WORKFLOW_STAGE_KINDS = new Set([
+  'order_query',
+  'data_query',
+  'result_analysis',
+  'reasoning'
+])
 
 export function calculateRunElapsedSeconds(run, nowMs = Date.now()) {
   const createdMs = Date.parse(run?.created_at || '')
@@ -22,10 +40,6 @@ export function getMessageTimestamp(message) {
     return message.completed_at
   }
   return message?.created_at || ''
-}
-
-export function inferProgressLocale(title) {
-  return /[\u3400-\u9fff]/.test(String(title || '')) ? 'zh-CN' : 'en'
 }
 
 export async function scrollConversationToBottomAfterRender(
@@ -127,11 +141,98 @@ function appendActivity(state, kind) {
   return {
     ...state,
     activityRevision,
-    activities: [
+    activities: capActivities([
       ...state.activities,
       { id: activityRevision, nodeId, kind, count: 1 }
-    ].slice(-20)
+    ])
   }
+}
+
+function capActivities(activities) {
+  const structured = activities.filter((item) => item.structured).slice(-120)
+  const generic = activities.filter((item) => !item.structured).slice(-20)
+  return activities.filter(
+    (item) => structured.includes(item) || generic.includes(item)
+  )
+}
+
+function normalizeActivityDate(value) {
+  const date = String(value || '')
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return ''
+  const parsed = new Date(`${date}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toISOString().slice(0, 10) === date ? date : ''
+}
+
+function appendStructuredActivity(state, payload) {
+  if (!payload || typeof payload !== 'object') return state
+  const id = String(payload.id || '')
+    .trim()
+    .slice(0, 64)
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) return state
+  if (!STRUCTURED_ACTIVITY_KINDS.has(payload.kind)) return state
+  if (!WORKFLOW_STAGE_KINDS.has(payload.stage_kind)) return state
+  if (!ACTIVITY_STATUSES.has(payload.status)) return state
+
+  const existing = state.activities.find(
+    (item) => item.structured && item.id === id
+  )
+  const startDate = normalizeActivityDate(payload.start_date)
+  const endDate = normalizeActivityDate(payload.end_date)
+  const round = Math.min(Math.max(Number(payload.round || 0), 0), 100)
+  const activeTask = state.plan.find((item) => item.status === 'in_progress')
+  const taskId = existing?.taskId || activeTask?.id || 'task-execute'
+  const stageKind = existing?.stageKind || payload.stage_kind
+  const activity = {
+    id,
+    taskId,
+    stageId: `${taskId}:${stageKind}`,
+    stageKind,
+    kind:
+      existing?.kind && existing.kind !== 'querying_data'
+        ? existing.kind
+        : payload.kind,
+    status:
+      existing?.status === 'completed' && payload.status === 'in_progress'
+        ? existing.status
+        : payload.status,
+    ...(existing?.round || round ? { round: existing?.round || round } : {}),
+    ...(existing?.startDate || startDate
+      ? { startDate: existing?.startDate || startDate }
+      : {}),
+    ...(existing?.endDate || endDate
+      ? { endDate: existing?.endDate || endDate }
+      : {}),
+    structured: true
+  }
+  const activities = existing
+    ? state.activities.map((item) =>
+        item.structured && item.id === id ? activity : item
+      )
+    : [...state.activities, activity]
+  return {
+    ...state,
+    activityRevision: state.activityRevision + 1,
+    activities: capActivities(activities)
+  }
+}
+
+function closeRuntimeProgress(state, status) {
+  const activities = state.activities.map((item) => {
+    if (!item.structured || item.status !== 'in_progress') return item
+    return { ...item, status }
+  })
+  const stages = state.stages.map((item) => {
+    if (item.status === 'in_progress') return { ...item, status }
+    if (item.status === 'pending') return { ...item, status: 'skipped' }
+    return item
+  })
+  const plan = state.plan.map((item) => {
+    if (item.status === 'in_progress') return { ...item, status }
+    if (item.status === 'pending') return { ...item, status: 'skipped' }
+    return item
+  })
+  return { ...state, activities, stages, plan }
 }
 
 export function activitiesForNode(state, nodeId) {
@@ -240,7 +341,72 @@ export function selectLiveProgressText({
   )
 }
 
-export function selectStructuredProgress({ plan, stages }) {
+function workflowNodeStatus(items) {
+  if (items.some((item) => item.status === 'in_progress')) {
+    return 'in_progress'
+  }
+  if (items.some((item) => item.status === 'failed')) return 'failed'
+  return items.length > 0 ? 'completed' : 'pending'
+}
+
+export function buildWorkflowTree(plan, activities) {
+  const tasks = (Array.isArray(plan) ? plan : []).map((item, index) => ({
+    ...item,
+    order: index + 1,
+    stages: []
+  }))
+  const taskById = new Map(tasks.map((item) => [item.id, item]))
+  for (const step of Array.isArray(activities) ? activities : []) {
+    if (!step?.structured || !step.taskId || !step.stageId) continue
+    let task = taskById.get(step.taskId)
+    if (!task) {
+      task = {
+        id: step.taskId,
+        kind: 'execute_request',
+        order: tasks.length + 1,
+        status: 'pending',
+        stages: []
+      }
+      tasks.push(task)
+      taskById.set(task.id, task)
+    }
+    let stage = task.stages.find((item) => item.id === step.stageId)
+    if (!stage) {
+      stage = {
+        id: step.stageId,
+        kind: step.stageKind,
+        order: task.stages.length + 1,
+        status: 'pending',
+        steps: []
+      }
+      task.stages.push(stage)
+    }
+    stage.steps.push(step)
+  }
+  for (const task of tasks) {
+    for (const stage of task.stages) {
+      stage.status = workflowNodeStatus(stage.steps)
+    }
+    if (!task.title) {
+      task.status = workflowNodeStatus(task.stages)
+    }
+  }
+  return tasks
+}
+
+export function selectStructuredProgress({ route, plan, stages, activities }) {
+  if (route) {
+    const tasks = buildWorkflowTree(plan, activities)
+    if (tasks.length > 0) {
+      return {
+        kind: 'workflow',
+        hasPlan: Array.isArray(plan) && plan.length > 0,
+        items: tasks,
+        tasks
+      }
+    }
+    return { kind: null, items: [] }
+  }
   if (Array.isArray(plan) && plan.length > 0) {
     return { kind: 'plan', items: plan }
   }
@@ -248,6 +414,19 @@ export function selectStructuredProgress({ plan, stages }) {
     return { kind: 'stage', items: stages }
   }
   return { kind: null, items: [] }
+}
+
+export function selectCurrentWorkflowStage(tasks) {
+  const stages = (Array.isArray(tasks) ? tasks : []).flatMap(
+    (task) => task.stages || []
+  )
+  if (stages.length === 0) return null
+  for (const status of ['in_progress', 'failed']) {
+    for (let index = stages.length - 1; index >= 0; index -= 1) {
+      if (stages[index]?.status === status) return stages[index]
+    }
+  }
+  return stages.at(-1) || null
 }
 
 export function applyRuntimeEvent(state, event) {
@@ -259,7 +438,7 @@ export function applyRuntimeEvent(state, event) {
   ) {
     const terminationDetail =
       event.termination_detail || current.terminationDetail
-    return {
+    const terminal = {
       ...current,
       outcome: event.outcome || current.outcome,
       terminationDetail,
@@ -272,6 +451,20 @@ export function applyRuntimeEvent(state, event) {
           ? { ...terminationDetail }
           : current.executionFailure
     }
+    if (event.type === 'done') {
+      const status = event.outcome === 'completed' ? 'completed' : 'failed'
+      return closeRuntimeProgress(terminal, status)
+    }
+    if (event.type === 'error') {
+      return closeRuntimeProgress(terminal, 'failed')
+    }
+    return terminal
+  }
+  if (
+    event?.visibility === 'user' &&
+    event.event_type === 'activity.recorded'
+  ) {
+    return appendStructuredActivity(current, event.payload)
   }
   const activityKind = activityKindForEvent(event)
   if (activityKind) return appendActivity(current, activityKind)

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -125,8 +125,7 @@ function activeNodeId(state) {
 }
 
 function appendActivity(state, kind) {
-  const nodeId = activeNodeId(state)
-  if (!nodeId) return state
+  const nodeId = activeNodeId(state) || 'legacy-runtime'
   const last = state.activities[state.activities.length - 1]
   if (last?.nodeId === nodeId && last.kind === kind) {
     return {
@@ -394,7 +393,13 @@ export function buildWorkflowTree(plan, activities) {
   return tasks
 }
 
-export function selectStructuredProgress({ route, plan, stages, activities }) {
+export function selectStructuredProgress({
+  route,
+  plan,
+  stages,
+  activities,
+  standaloneActivities = false
+}) {
   if (route) {
     const tasks = buildWorkflowTree(plan, activities)
     if (tasks.length > 0) {
@@ -412,6 +417,12 @@ export function selectStructuredProgress({ route, plan, stages, activities }) {
   }
   if (Array.isArray(stages) && stages.length > 0) {
     return { kind: 'stage', items: stages }
+  }
+  if (standaloneActivities) {
+    const items = (Array.isArray(activities) ? activities : []).filter(
+      (item) => !item.structured
+    )
+    if (items.length > 0) return { kind: 'activity', items }
   }
   return { kind: null, items: [] }
 }

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -12,16 +12,28 @@ const STRUCTURED_ACTIVITY_KINDS = new Set([
   'get_order_detail',
   'reading_order_commands',
   'checking_capability',
+  'checking_tool',
+  'checking_authentication',
+  'authenticating',
   'querying_data',
   'count_results',
   'group_results',
-  'analyzing_results'
+  'analyzing_results',
+  'summarizing_results'
 ])
 const WORKFLOW_STAGE_KINDS = new Set([
+  'preparation',
   'order_query',
   'data_query',
   'result_analysis'
 ])
+
+const WORKFLOW_STAGE_ORDER = {
+  preparation: 1,
+  order_query: 2,
+  data_query: 2,
+  result_analysis: 3
+}
 
 export function calculateRunElapsedSeconds(run, nowMs = Date.now()) {
   const createdMs = Date.parse(run?.created_at || '')
@@ -398,6 +410,14 @@ export function buildWorkflowTree(plan, activities) {
     for (const stage of task.stages) {
       stage.status = workflowNodeStatus(stage.steps)
     }
+    task.stages.sort(
+      (left, right) =>
+        (WORKFLOW_STAGE_ORDER[left.kind] || 99) -
+        (WORKFLOW_STAGE_ORDER[right.kind] || 99)
+    )
+    task.stages.forEach((stage, index) => {
+      stage.order = index + 1
+    })
     if (!task.title) {
       task.status = workflowNodeStatus(task.stages)
       const steps = task.stages.flatMap((stage) => stage.steps || [])
@@ -409,6 +429,8 @@ export function buildWorkflowTree(plan, activities) {
       } else if (queryStep) {
         task.kind = 'query_orders'
         task.orderRef = queryStep.orderRef || ''
+      } else if (steps.some((step) => step.kind === 'querying_data')) {
+        task.kind = 'query_data'
       } else if (
         steps.some((step) =>
           ['count_results', 'group_results', 'analyzing_results'].includes(

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -189,17 +189,30 @@ function appendStructuredActivity(state, payload) {
   if (!WORKFLOW_STAGE_KINDS.has(payload.stage_kind)) return state
   if (!ACTIVITY_STATUSES.has(payload.status)) return state
 
-  const existing = state.activities.find(
+  const exactExisting = state.activities.find(
     (item) => item.structured && item.id === id
   )
   const startDate = normalizeActivityDate(payload.start_date)
   const endDate = normalizeActivityDate(payload.end_date)
   const orderRef = normalizeOrderReference(payload.order_ref)
   const activeTask = state.plan.find((item) => item.status === 'in_progress')
-  const taskId = existing?.taskId || activeTask?.id || 'task-execute'
+  const currentTaskId =
+    activeTask?.id || state.plan.at(-1)?.id || 'task-execute'
+  const semanticExisting = state.activities.find(
+    (item) =>
+      item.structured &&
+      item.taskId === currentTaskId &&
+      item.stageKind === payload.stage_kind &&
+      item.kind === payload.kind &&
+      (item.startDate || '') === startDate &&
+      (item.endDate || '') === endDate &&
+      (item.orderRef || '') === orderRef
+  )
+  const existing = exactExisting || semanticExisting
+  const taskId = existing?.taskId || currentTaskId
   const stageKind = existing?.stageKind || payload.stage_kind
   const activity = {
-    id,
+    id: existing?.id || id,
     taskId,
     stageId: `${taskId}:${stageKind}`,
     stageKind,
@@ -220,11 +233,12 @@ function appendStructuredActivity(state, payload) {
     ...(existing?.orderRef || orderRef
       ? { orderRef: existing?.orderRef || orderRef }
       : {}),
+    planRevision: existing?.planRevision ?? state.planRevision,
     structured: true
   }
   const activities = existing
     ? state.activities.map((item) =>
-        item.structured && item.id === id ? activity : item
+        item.structured && item.id === existing.id ? activity : item
       )
     : [...state.activities, activity]
   return {
@@ -301,6 +315,59 @@ export function normalizePlanSteps(steps) {
         status
       }
     ]
+  })
+}
+
+// A batched revision can complete pending tasks after their work already ran.
+function alignBatchedPlanActivities(state, plan) {
+  const previousPlanById = new Map(state.plan.map((item) => [item.id, item]))
+  const advancedTasks = plan.filter(
+    (item) =>
+      item.status === 'completed' &&
+      previousPlanById.get(item.id)?.status === 'pending'
+  )
+  const previousActive = state.plan.find(
+    (item) => item.status === 'in_progress'
+  )
+  if (!previousActive || advancedTasks.length === 0) {
+    return state.activities
+  }
+
+  const stageKinds = []
+  for (const item of state.activities) {
+    if (
+      !item.structured ||
+      item.taskId !== previousActive.id ||
+      item.planRevision !== state.planRevision ||
+      stageKinds.includes(item.stageKind)
+    ) {
+      continue
+    }
+    stageKinds.push(item.stageKind)
+  }
+  if (stageKinds.length < advancedTasks.length) return state.activities
+
+  const trailingKinds = stageKinds.slice(-advancedTasks.length)
+  const targetTaskByStage = new Map(
+    trailingKinds.map((stageKind, index) => [
+      stageKind,
+      advancedTasks[index].id
+    ])
+  )
+  return state.activities.map((item) => {
+    const taskId = targetTaskByStage.get(item.stageKind)
+    if (
+      !taskId ||
+      item.taskId !== previousActive.id ||
+      item.planRevision !== state.planRevision
+    ) {
+      return item
+    }
+    return {
+      ...item,
+      taskId,
+      stageId: `${taskId}:${item.stageKind}`
+    }
   })
 }
 
@@ -453,6 +520,16 @@ export function buildWorkflowTree(plan, activities) {
   return tasks
 }
 
+export function workflowProgressSource(tasks, hasPlan = false) {
+  if (hasPlan) return { kind: 'plan', items: tasks }
+  return {
+    kind: 'stage',
+    items: (Array.isArray(tasks) ? tasks : []).flatMap(
+      (task) => task.stages || []
+    )
+  }
+}
+
 export function selectStructuredProgress({
   route,
   plan,
@@ -555,10 +632,16 @@ export function applyRuntimeEvent(state, event) {
   if (event.event_type === 'plan.updated') {
     const revision = Math.max(Number(payload.revision || 0), 0)
     if (revision < current.planRevision) return current
+    const currentPlanById = new Map(current.plan.map((item) => [item.id, item]))
+    const plan = normalizePlanSteps(payload.steps).map((item) => {
+      const existing = currentPlanById.get(item.id)
+      return existing ? { ...item, title: existing.title } : item
+    })
     return {
       ...current,
-      plan: normalizePlanSteps(payload.steps),
-      planRevision: revision
+      plan,
+      planRevision: revision,
+      activities: alignBatchedPlanActivities(current, plan)
     }
   }
   if (event.event_type === 'stage.updated') {

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -15,7 +15,8 @@ import {
   selectLiveProgressText,
   selectStructuredProgress,
   summarizeStageProgress,
-  summarizePlanProgress
+  summarizePlanProgress,
+  workflowProgressSource
 } from '../src/pages/lens/runtimeEvents.js'
 
 test('waits for the conversation to render before scrolling to the bottom', async () => {
@@ -425,6 +426,7 @@ test('records and completes a replayable real order-query activity', () => {
       status: 'completed',
       startDate: '2026-07-20',
       endDate: '2026-07-26',
+      planRevision: 0,
       structured: true
     }
   ])
@@ -621,6 +623,217 @@ test('keeps non-order assistants on their actual generic operation path', () => 
   assert.equal(
     tasks[0].stages.some((stage) => stage.kind === 'order_query'),
     false
+  )
+})
+
+test('coalesces repeated steps with the same public operation context', () => {
+  let state = createRuntimeState()
+  for (const payload of [
+    {
+      id: 'order-get-help',
+      stage_kind: 'preparation',
+      kind: 'reading_order_commands',
+      status: 'completed'
+    },
+    {
+      id: 'order-list-help',
+      stage_kind: 'preparation',
+      kind: 'reading_order_commands',
+      status: 'completed'
+    }
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload
+    })
+  }
+
+  const steps = buildWorkflowTree([], state.activities)[0].stages[0].steps
+
+  assert.equal(steps.length, 1)
+  assert.equal(steps[0].kind, 'reading_order_commands')
+  assert.equal(steps[0].status, 'completed')
+})
+
+test('coalesces a failed step with a successful semantic retry', () => {
+  let state = createRuntimeState()
+  for (const payload of [
+    {
+      id: 'analysis-attempt-1',
+      stage_kind: 'result_analysis',
+      kind: 'analyzing_results',
+      status: 'in_progress'
+    },
+    {
+      id: 'analysis-attempt-1',
+      stage_kind: 'result_analysis',
+      kind: 'analyzing_results',
+      status: 'failed'
+    },
+    {
+      id: 'analysis-attempt-2',
+      stage_kind: 'result_analysis',
+      kind: 'analyzing_results',
+      status: 'in_progress'
+    },
+    {
+      id: 'analysis-attempt-2',
+      stage_kind: 'result_analysis',
+      kind: 'analyzing_results',
+      status: 'completed'
+    }
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload
+    })
+  }
+
+  const steps = buildWorkflowTree([], state.activities)[0].stages[0].steps
+
+  assert.equal(steps.length, 1)
+  assert.equal(steps[0].status, 'completed')
+})
+
+test('attaches final summary to the last real plan task', () => {
+  let state = applyRuntimeEvent(createRuntimeState(), {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 1,
+      steps: [
+        { id: 'step-1', title: '查询订单', status: 'completed' },
+        { id: 'step-2', title: '生成报告', status: 'completed' }
+      ]
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'summarize-results',
+      stage_kind: 'result_analysis',
+      kind: 'summarizing_results',
+      status: 'completed'
+    }
+  })
+
+  const tasks = buildWorkflowTree(state.plan, state.activities)
+
+  assert.equal(tasks.length, 2)
+  assert.equal(tasks[1].stages[0].steps[0].kind, 'summarizing_results')
+})
+
+test('uses plan tasks for the progress count when a plan exists', () => {
+  const tasks = [
+    { id: 'step-1', status: 'completed', stages: [{}] },
+    { id: 'step-2', status: 'completed', stages: [{}] },
+    { id: 'step-3', status: 'completed', stages: [{}] },
+    { id: 'step-4', status: 'in_progress', stages: [] }
+  ]
+
+  const source = workflowProgressSource(tasks, true)
+  const progress = summarizePlanProgress(source.items)
+
+  assert.equal(source.kind, 'plan')
+  assert.equal(progress.completed, 3)
+  assert.equal(progress.total, 4)
+})
+
+test('keeps plan task titles stable across later revisions', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 1,
+      steps: [
+        {
+          id: 'step-1',
+          title: '查询订单',
+          status: 'in_progress'
+        }
+      ]
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 2,
+      steps: [
+        {
+          id: 'step-1',
+          title: '重新命名后的任务',
+          status: 'completed'
+        }
+      ]
+    }
+  })
+
+  assert.equal(state.plan[0].title, '查询订单')
+  assert.equal(state.plan[0].status, 'completed')
+})
+
+test('moves trailing stages to tasks completed by a batched revision', () => {
+  let state = applyRuntimeEvent(createRuntimeState(), {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 2,
+      steps: [
+        { id: 'step-1', title: '登录', status: 'completed' },
+        { id: 'step-2', title: '查询订单', status: 'in_progress' },
+        { id: 'step-3', title: '统计订单', status: 'pending' },
+        { id: 'step-4', title: '生成报告', status: 'pending' }
+      ]
+    }
+  })
+  for (const payload of [
+    {
+      id: 'query-orders',
+      stage_kind: 'order_query',
+      kind: 'query_orders',
+      status: 'completed'
+    },
+    {
+      id: 'count-orders',
+      stage_kind: 'result_analysis',
+      kind: 'count_results',
+      status: 'completed'
+    }
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload
+    })
+  }
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 3,
+      steps: [
+        { id: 'step-1', title: '登录', status: 'completed' },
+        { id: 'step-2', title: '查询订单', status: 'completed' },
+        { id: 'step-3', title: '统计订单', status: 'completed' },
+        { id: 'step-4', title: '生成报告', status: 'in_progress' }
+      ]
+    }
+  })
+
+  const tasks = buildWorkflowTree(state.plan, state.activities)
+
+  assert.deepEqual(
+    tasks[1].stages.map((stage) => stage.kind),
+    ['order_query']
+  )
+  assert.deepEqual(
+    tasks[2].stages.map((stage) => stage.kind),
+    ['result_analysis']
   )
 })
 

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -430,23 +430,46 @@ test('records and completes a replayable real order-query activity', () => {
   ])
 })
 
-test('records each General Chat model round as one nested step', () => {
+test('hides model rounds when real General Chat operations exist', () => {
   let state = applyRuntimeEvent(createRuntimeState(), {
     event_type: 'route.selected',
     visibility: 'user',
     payload: { route: 'direct_execute' }
   })
-  for (const status of ['in_progress', 'completed']) {
+  for (let round = 1; round <= 3; round += 1) {
+    for (const status of ['in_progress', 'completed']) {
+      state = applyRuntimeEvent(state, {
+        event_type: 'activity.recorded',
+        visibility: 'user',
+        payload: {
+          id: `model-round-${round}`,
+          kind: 'analyzing_request',
+          stage_kind: 'reasoning',
+          status,
+          round
+        }
+      })
+    }
+  }
+  for (const payload of [
+    {
+      id: 'capability-1',
+      kind: 'checking_capability',
+      stage_kind: 'order_query',
+      status: 'completed'
+    },
+    {
+      id: 'detail-1',
+      kind: 'get_order_detail',
+      stage_kind: 'order_query',
+      status: 'completed',
+      order_ref: 'HWINSTAD2025071509'
+    }
+  ]) {
     state = applyRuntimeEvent(state, {
       event_type: 'activity.recorded',
       visibility: 'user',
-      payload: {
-        id: 'model-round-1',
-        kind: 'analyzing_request',
-        stage_kind: 'reasoning',
-        status,
-        round: 1
-      }
+      payload
     })
   }
 
@@ -457,10 +480,54 @@ test('records each General Chat model round as one nested step', () => {
     activities: state.activities
   })
   assert.equal(progress.kind, 'workflow')
-  assert.equal(progress.tasks[0].kind, 'execute_request')
-  assert.equal(progress.tasks[0].stages[0].kind, 'reasoning')
-  assert.equal(progress.tasks[0].stages[0].steps[0].round, 1)
-  assert.equal(progress.tasks[0].stages[0].steps[0].status, 'completed')
+  assert.equal(progress.tasks.length, 1)
+  assert.equal(progress.tasks[0].kind, 'get_order_detail')
+  assert.equal(progress.tasks[0].orderRef, 'HWINSTAD2025071509')
+  assert.deepEqual(
+    progress.tasks[0].stages.map((stage) => stage.kind),
+    ['order_query']
+  )
+  assert.deepEqual(
+    progress.tasks[0].stages[0].steps.map((step) => step.kind),
+    ['checking_capability', 'get_order_detail']
+  )
+})
+
+test('does not build placeholder workflow nodes from model rounds', () => {
+  const activities = [1, 2, 3].map((round) => ({
+    id: `model-round-${round}`,
+    taskId: 'task-execute',
+    stageId: 'task-execute:reasoning',
+    stageKind: 'reasoning',
+    kind: 'analyzing_request',
+    status: 'completed',
+    round,
+    structured: true
+  }))
+
+  const tasks = buildWorkflowTree([], activities)
+
+  assert.deepEqual(tasks, [])
+})
+
+test('uses a business task fallback instead of a placeholder task', () => {
+  const tasks = buildWorkflowTree(
+    [],
+    [
+      {
+        id: 'query-1',
+        taskId: 'task-execute',
+        stageId: 'task-execute:data_query',
+        stageKind: 'data_query',
+        kind: 'querying_data',
+        status: 'completed',
+        structured: true
+      }
+    ]
+  )
+
+  assert.equal(tasks.length, 1)
+  assert.equal(tasks[0].kind, 'query_data')
 })
 
 test('accepts real order-detail and command-discovery activities', () => {
@@ -535,11 +602,12 @@ test('closes every legacy and General Chat spinner at terminal failure', () => {
     event_type: 'activity.recorded',
     visibility: 'user',
     payload: {
-      id: 'model-round-1',
-      kind: 'analyzing_request',
-      stage_kind: 'reasoning',
+      id: 'query-1',
+      kind: 'query_orders',
+      stage_kind: 'order_query',
       status: 'in_progress',
-      round: 1
+      start_date: '2026-07-20',
+      end_date: '2026-07-26'
     }
   })
   state = applyRuntimeEvent(state, { type: 'error' })
@@ -586,7 +654,7 @@ test('generic activity cannot evict a real path from the bounded history', () =>
   assert.equal(activitiesForNode(state, 'execute').length, 20)
 })
 
-test('keeps the complete bounded General Chat hierarchy across many rounds', () => {
+test('keeps model rounds out of the bounded General Chat hierarchy', () => {
   let state = createRuntimeState()
   for (let index = 1; index <= 30; index += 1) {
     state = applyRuntimeEvent(state, {
@@ -602,7 +670,7 @@ test('keeps the complete bounded General Chat hierarchy across many rounds', () 
     })
   }
 
-  assert.equal(state.activities.filter((item) => item.structured).length, 30)
+  assert.equal(state.activities.filter((item) => item.structured).length, 0)
 })
 
 test('keeps raw tool activity out of the primary progress text', () => {

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -530,6 +530,100 @@ test('uses a business task fallback instead of a placeholder task', () => {
   assert.equal(tasks[0].kind, 'query_data')
 })
 
+test('builds preparation, operation and summary from real activities', () => {
+  let state = createRuntimeState()
+  for (const payload of [
+    {
+      id: 'tool-version',
+      stage_kind: 'preparation',
+      kind: 'checking_tool',
+      status: 'completed'
+    },
+    {
+      id: 'auth-status',
+      stage_kind: 'preparation',
+      kind: 'checking_authentication',
+      status: 'completed'
+    },
+    {
+      id: 'auth-login',
+      stage_kind: 'preparation',
+      kind: 'authenticating',
+      status: 'completed'
+    },
+    {
+      id: 'order-query',
+      stage_kind: 'order_query',
+      kind: 'query_orders',
+      status: 'completed',
+      order_ref: 'HWINSTAD2025071509'
+    },
+    {
+      id: 'summarize-results',
+      stage_kind: 'result_analysis',
+      kind: 'summarizing_results',
+      status: 'completed',
+      order_ref: 'HWINSTAD2025071509'
+    }
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload
+    })
+  }
+  const tasks = buildWorkflowTree([], state.activities)
+
+  assert.equal(tasks[0].kind, 'query_orders')
+  assert.deepEqual(
+    tasks[0].stages.map((stage) => stage.kind),
+    ['preparation', 'order_query', 'result_analysis']
+  )
+  assert.deepEqual(
+    tasks[0].stages.map((stage) => stage.steps.map((step) => step.kind)),
+    [
+      ['checking_tool', 'checking_authentication', 'authenticating'],
+      ['query_orders'],
+      ['summarizing_results']
+    ]
+  )
+})
+
+test('keeps non-order assistants on their actual generic operation path', () => {
+  let state = createRuntimeState()
+  for (const payload of [
+    {
+      id: 'ticket-query',
+      stage_kind: 'data_query',
+      kind: 'querying_data',
+      status: 'completed'
+    },
+    {
+      id: 'summarize-results',
+      stage_kind: 'result_analysis',
+      kind: 'summarizing_results',
+      status: 'completed'
+    }
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload
+    })
+  }
+  const tasks = buildWorkflowTree([], state.activities)
+
+  assert.equal(tasks[0].kind, 'query_data')
+  assert.deepEqual(
+    tasks[0].stages.map((stage) => stage.kind),
+    ['data_query', 'result_analysis']
+  )
+  assert.equal(
+    tasks[0].stages.some((stage) => stage.kind === 'order_query'),
+    false
+  )
+})
+
 test('accepts real order-detail and command-discovery activities', () => {
   let state = createRuntimeState()
   for (const [id, kind] of [

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -318,6 +318,50 @@ test('isolates General Chat workflow trees from legacy progress modes', () => {
   )
 })
 
+test('shows standalone legacy activities without plan or stage nodes', () => {
+  let state = createRuntimeState()
+  for (const agent_event of [
+    'tool.search_workspace.start',
+    'tool.read_workspace_file.start'
+  ]) {
+    state = applyRuntimeEvent(state, { agent_event })
+  }
+
+  assert.deepEqual(
+    state.activities.map((item) => ({
+      nodeId: item.nodeId,
+      kind: item.kind
+    })),
+    [
+      { nodeId: 'legacy-runtime', kind: 'searchingSources' },
+      { nodeId: 'legacy-runtime', kind: 'readingSources' }
+    ]
+  )
+  assert.deepEqual(
+    selectStructuredProgress({
+      route: null,
+      plan: [],
+      stages: [],
+      activities: state.activities,
+      standaloneActivities: true
+    }),
+    {
+      kind: 'activity',
+      items: state.activities
+    }
+  )
+  assert.deepEqual(
+    selectStructuredProgress({
+      route: 'direct_execute',
+      plan: [],
+      stages: [],
+      activities: state.activities,
+      standaloneActivities: true
+    }),
+    { kind: null, items: [] }
+  )
+})
+
 test('uses the active real operation as the General Chat stage', () => {
   const tasks = buildWorkflowTree(
     [],

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -4,13 +4,14 @@ import test from 'node:test'
 import {
   activitiesForNode,
   applyRuntimeEvent,
+  buildWorkflowTree,
   calculateRunElapsedSeconds,
   createRuntimeState,
   getMessageTimestamp,
-  inferProgressLocale,
   normalizePlanSteps,
   normalizeStages,
   scrollConversationToBottomAfterRender,
+  selectCurrentWorkflowStage,
   selectLiveProgressText,
   selectStructuredProgress,
   summarizeStageProgress,
@@ -60,11 +61,6 @@ test('uses run completion time for assistant messages', () => {
     }),
     createdAt
   )
-})
-
-test('uses the progress node language for nested activity labels', () => {
-  assert.equal(inferProgressLocale('执行并分析所需操作'), 'zh-CN')
-  assert.equal(inferProgressLocale('Execute required operations'), 'en')
 })
 
 test('restores active run elapsed time from its server creation time', () => {
@@ -255,7 +251,7 @@ test('shows real plan completion before lower-level execution details', () => {
   )
 })
 
-test('shows real direct-execution stages before raw tool details', () => {
+test('keeps the legacy stage status for non-General Chat modes', () => {
   assert.equal(
     selectLiveProgressText({
       stageProgressText: 'Completed 1/3 · Execute required operations',
@@ -268,22 +264,301 @@ test('shows real direct-execution stages before raw tool details', () => {
   )
 })
 
-test('uses plans before stages and stages before generic fallback', () => {
+test('isolates General Chat workflow trees from legacy progress modes', () => {
   const stages = [{ id: 'execute', title: 'Execute', status: 'in_progress' }]
   const plan = [{ id: 'step-1', title: 'Inspect', status: 'in_progress' }]
+  const activities = [
+    {
+      id: 'activity-1',
+      taskId: 'step-1',
+      stageId: 'step-1:order_query',
+      stageKind: 'order_query',
+      kind: 'query_orders',
+      status: 'in_progress',
+      startDate: '2026-07-20',
+      endDate: '2026-07-26',
+      structured: true
+    }
+  ]
 
-  assert.deepEqual(selectStructuredProgress({ plan, stages }), {
+  const general = selectStructuredProgress({
+    route: 'plan_execute',
+    plan,
+    activities,
+    stages
+  })
+  assert.equal(general.kind, 'workflow')
+  assert.equal(general.hasPlan, true)
+  assert.equal(general.tasks[0].stages[0].steps[0].id, 'activity-1')
+  assert.deepEqual(selectStructuredProgress({ plan, activities, stages }), {
     kind: 'plan',
     items: plan
   })
-  assert.deepEqual(selectStructuredProgress({ plan: [], stages }), {
+  assert.deepEqual(selectStructuredProgress({ plan: [], activities, stages }), {
     kind: 'stage',
     items: stages
   })
-  assert.deepEqual(selectStructuredProgress({ plan: [], stages: [] }), {
-    kind: null,
-    items: []
+  assert.deepEqual(
+    selectStructuredProgress({ plan: [], activities: [], stages }),
+    {
+      kind: 'stage',
+      items: stages
+    }
+  )
+  assert.deepEqual(
+    selectStructuredProgress({
+      plan: [],
+      activities: [],
+      stages: []
+    }),
+    {
+      kind: null,
+      items: []
+    }
+  )
+})
+
+test('uses the active real operation as the General Chat stage', () => {
+  const tasks = buildWorkflowTree(
+    [],
+    [
+      {
+        id: 'capability-1',
+        taskId: 'task-execute',
+        stageId: 'task-execute:order_query',
+        stageKind: 'order_query',
+        kind: 'checking_capability',
+        status: 'completed',
+        structured: true
+      },
+      {
+        id: 'orders-1',
+        taskId: 'task-execute',
+        stageId: 'task-execute:data_query',
+        stageKind: 'data_query',
+        kind: 'query_orders',
+        status: 'in_progress',
+        structured: true
+      }
+    ]
+  )
+
+  assert.equal(selectCurrentWorkflowStage(tasks).kind, 'data_query')
+})
+
+test('records and completes a replayable real order-query activity', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'activity-123',
+      kind: 'query_orders',
+      stage_kind: 'order_query',
+      status: 'in_progress',
+      start_date: '2026-07-20',
+      end_date: '2026-07-26'
+    }
   })
+  state = applyRuntimeEvent(state, {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'activity-123',
+      kind: 'querying_data',
+      stage_kind: 'data_query',
+      status: 'completed'
+    }
+  })
+
+  assert.deepEqual(state.activities, [
+    {
+      id: 'activity-123',
+      taskId: 'task-execute',
+      stageId: 'task-execute:order_query',
+      stageKind: 'order_query',
+      kind: 'query_orders',
+      status: 'completed',
+      startDate: '2026-07-20',
+      endDate: '2026-07-26',
+      structured: true
+    }
+  ])
+})
+
+test('records each General Chat model round as one nested step', () => {
+  let state = applyRuntimeEvent(createRuntimeState(), {
+    event_type: 'route.selected',
+    visibility: 'user',
+    payload: { route: 'direct_execute' }
+  })
+  for (const status of ['in_progress', 'completed']) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload: {
+        id: 'model-round-1',
+        kind: 'analyzing_request',
+        stage_kind: 'reasoning',
+        status,
+        round: 1
+      }
+    })
+  }
+
+  const progress = selectStructuredProgress({
+    route: state.route,
+    plan: state.plan,
+    stages: state.stages,
+    activities: state.activities
+  })
+  assert.equal(progress.kind, 'workflow')
+  assert.equal(progress.tasks[0].kind, 'execute_request')
+  assert.equal(progress.tasks[0].stages[0].kind, 'reasoning')
+  assert.equal(progress.tasks[0].stages[0].steps[0].round, 1)
+  assert.equal(progress.tasks[0].stages[0].steps[0].status, 'completed')
+})
+
+test('accepts real order-detail and command-discovery activities', () => {
+  let state = createRuntimeState()
+  for (const [id, kind] of [
+    ['help-123', 'reading_order_commands'],
+    ['detail-123', 'get_order_detail']
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload: {
+        id,
+        kind,
+        stage_kind: 'order_query',
+        status: 'in_progress'
+      }
+    })
+  }
+
+  assert.deepEqual(
+    state.activities.map((item) => item.kind),
+    ['reading_order_commands', 'get_order_detail']
+  )
+})
+
+test('drops invalid activity dates and fails open work on partial completion', () => {
+  let state = applyRuntimeEvent(createRuntimeState(), {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'activity-123',
+      kind: 'query_orders',
+      stage_kind: 'order_query',
+      status: 'in_progress',
+      start_date: '2026-02-30',
+      end_date: '2026-03-01'
+    }
+  })
+  state = applyRuntimeEvent(state, { type: 'done', outcome: 'partial' })
+
+  assert.equal(state.activities[0].startDate, undefined)
+  assert.equal(state.activities[0].endDate, '2026-03-01')
+  assert.equal(state.activities[0].status, 'failed')
+})
+
+test('closes every legacy and General Chat spinner at terminal failure', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 1,
+      steps: [
+        { id: 'one', title: 'Query orders', status: 'in_progress' },
+        { id: 'two', title: 'Summarize', status: 'pending' }
+      ]
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'stage.updated',
+    visibility: 'user',
+    payload: {
+      id: 'query',
+      title: 'Query orders',
+      status: 'in_progress',
+      order: 1,
+      revision: 1
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'model-round-1',
+      kind: 'analyzing_request',
+      stage_kind: 'reasoning',
+      status: 'in_progress',
+      round: 1
+    }
+  })
+  state = applyRuntimeEvent(state, { type: 'error' })
+
+  assert.deepEqual(
+    state.plan.map((item) => item.status),
+    ['failed', 'skipped']
+  )
+  assert.equal(state.stages[0].status, 'failed')
+  assert.equal(state.activities[0].status, 'failed')
+})
+
+test('generic activity cannot evict a real path from the bounded history', () => {
+  let state = applyRuntimeEvent(createRuntimeState(), {
+    event_type: 'activity.recorded',
+    visibility: 'user',
+    payload: {
+      id: 'activity-123',
+      kind: 'get_order_detail',
+      stage_kind: 'order_query',
+      status: 'completed'
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'stage.updated',
+    visibility: 'user',
+    payload: {
+      id: 'execute',
+      title: 'Execute',
+      status: 'in_progress',
+      revision: 1
+    }
+  })
+  for (let index = 0; index < 25; index += 1) {
+    state = applyRuntimeEvent(state, {
+      agent_event:
+        index % 2 === 0
+          ? 'tool.read_file.invoke'
+          : 'tool.search_workspace.invoke'
+    })
+  }
+
+  assert.equal(state.activities.filter((item) => item.structured).length, 1)
+  assert.equal(activitiesForNode(state, 'execute').length, 20)
+})
+
+test('keeps the complete bounded General Chat hierarchy across many rounds', () => {
+  let state = createRuntimeState()
+  for (let index = 1; index <= 30; index += 1) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload: {
+        id: `model-round-${index}`,
+        kind: 'analyzing_request',
+        stage_kind: 'reasoning',
+        status: 'completed',
+        round: index
+      }
+    })
+  }
+
+  assert.equal(state.activities.filter((item) => item.structured).length, 30)
 })
 
 test('keeps raw tool activity out of the primary progress text', () => {

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -31,6 +31,7 @@ from .gateway_model import (
 )
 from .logging_utils import elapsed_since, task_log, utc_now
 from .mcp_tools import build_deferred_mcp_tools, load_mcp_tools
+from .runtime_modes import runtime_mode_for
 from .runtime_resources import (
     cleanup_runtime_resources,
     prepare_runtime_resources,
@@ -50,6 +51,7 @@ class _NoTaskMiddleware(AgentMiddleware):
 
     def __init__(self, emit_event=None):
         self.emit_event = emit_event
+        self.model_round = 0
 
     @staticmethod
     def _filter_tools(tools):
@@ -65,7 +67,14 @@ class _NoTaskMiddleware(AgentMiddleware):
         request = request.override(
             tools=self._filter_tools(request.tools)
         )
-        return handler(request)
+        invocation_id = self._start_model_round()
+        try:
+            result = handler(request)
+        except Exception:
+            self._finish_model_round(invocation_id, "failed")
+            raise
+        self._finish_model_round(invocation_id, "done")
+        return result
 
     async def awrap_model_call(self, request, handler):
         """Filter asynchronous model requests."""
@@ -73,7 +82,42 @@ class _NoTaskMiddleware(AgentMiddleware):
         request = request.override(
             tools=self._filter_tools(request.tools)
         )
-        return await handler(request)
+        invocation_id = self._start_model_round()
+        try:
+            result = await handler(request)
+        except Exception:
+            self._finish_model_round(invocation_id, "failed")
+            raise
+        self._finish_model_round(invocation_id, "done")
+        return result
+
+    def _start_model_round(self):
+        """Emit the start of one real General Chat model round."""
+
+        self.model_round += 1
+        invocation_id = f"model-round-{self.model_round}"
+        if self.emit_event is not None:
+            self.emit_event(
+                "model.round.start",
+                {
+                    "invocation_id": invocation_id,
+                    "round": self.model_round,
+                },
+            )
+        return invocation_id
+
+    def _finish_model_round(self, invocation_id, suffix):
+        """Emit the terminal state for one General Chat model round."""
+
+        if self.emit_event is not None:
+            round_number = int(invocation_id.rsplit("-", 1)[-1])
+            self.emit_event(
+                f"model.round.{suffix}",
+                {
+                    "invocation_id": invocation_id,
+                    "round": round_number,
+                },
+            )
 
     def _deny_task_call(self, request):
         """Return a tool error without executing the subagent handler."""
@@ -574,11 +618,13 @@ class LensDeepAgentRuntime:
         started_at = utc_now()
         question = command.get("question", "")
         scenario = _scenario_for_task(command.get("task"))
+        runtime_mode = runtime_mode_for(command)
         model_ref = command.get("agent_model_ref")
         if not model_ref:
             raise ValueError("agent_model_ref is required for Deep Agents")
 
         def emit_agent_event(event, detail=None):
+            detail = runtime_mode.decorate_event(detail)
             message = task_log(event, details=_detail_lines(detail))
             LOGGER.info(message)
             if emit_progress is not None:
@@ -587,7 +633,7 @@ class LensDeepAgentRuntime:
                     {
                         "agent_event": event,
                         "activity": _activity_from_event(event),
-                        **(detail or {}),
+                        **detail,
                     },
                 )
 
@@ -618,14 +664,13 @@ class LensDeepAgentRuntime:
                 "human_tokens": self.config.offload_human_tokens,
             },
         )
-        if _is_general_chat(command):
+        if runtime_mode.general_chat:
             emit_user_event("phase.changed", {"phase": "analyzing"})
         resources = prepare_runtime_resources(
             self.config,
             command,
             emit_event=emit_agent_event,
         )
-        direct_stage_state = None
         try:
             run_uuid = str(command.get("run_uuid") or "")
             token_budget = _resolve_token_budget(self.config, command)
@@ -654,7 +699,7 @@ class LensDeepAgentRuntime:
                 ),
                 token_budget_wrapup_event=token_budget_wrapup_event,
             )
-            if _is_general_chat(command):
+            if runtime_mode.general_chat:
                 tools = build_general_chat_tools(
                     command,
                     resources,
@@ -696,7 +741,7 @@ class LensDeepAgentRuntime:
             capability_middleware = None
             capability_stop_event = None
             evidence_requirement = "none"
-            if _is_general_chat(command):
+            if runtime_mode.general_chat:
                 route_decision = _select_general_chat_route(
                     model,
                     question,
@@ -754,14 +799,32 @@ class LensDeepAgentRuntime:
                     }
                 if route_decision["route"] == "direct_answer":
                     emit_user_event("phase.changed", {"phase": "answering"})
-                    answer = _answer_general_chat_directly(
-                        model,
-                        command,
-                        _system_prompt(
-                            scenario,
+                    runtime_mode.emit_model_round(
+                        emit_agent_event,
+                        "start",
+                        1,
+                    )
+                    try:
+                        answer = _answer_general_chat_directly(
+                            model,
                             command,
-                            resources.context_skill_contents,
-                        ),
+                            _system_prompt(
+                                scenario,
+                                command,
+                                resources.context_skill_contents,
+                            ),
+                        )
+                    except Exception:
+                        runtime_mode.emit_model_round(
+                            emit_agent_event,
+                            "failed",
+                            1,
+                        )
+                        raise
+                    runtime_mode.emit_model_round(
+                        emit_agent_event,
+                        "done",
+                        1,
                     )
                     if not answer.strip():
                         raise EmptyAgentResponseError(
@@ -779,14 +842,6 @@ class LensDeepAgentRuntime:
                         "outcome": "completed",
                         "termination_detail": {},
                     }
-                if route_decision["route"] == "direct_execute":
-                    direct_stage_state = _create_direct_stage_state(
-                        _detect_answer_language(question)
-                    )
-                    _start_direct_stages(
-                        direct_stage_state,
-                        emit_agent_event,
-                    )
                 capability_stop_event = threading.Event()
                 capability_middleware = CapabilityBoundaryMiddleware(
                     emit_event=emit_agent_event,
@@ -813,12 +868,12 @@ class LensDeepAgentRuntime:
                 ),
                 "subagents": (
                     []
-                    if _is_general_chat(command)
+                    if runtime_mode.general_chat
                     else [_fast_subagent(mcp_middleware)]
                 ),
                 "name": f"lensnode-{command.get('task') or 'agent'}",
             }
-            if resources.skill_paths and not _is_general_chat(command):
+            if resources.skill_paths and not runtime_mode.general_chat:
                 kwargs["skills"] = resources.skill_paths
 
             summarizer = _build_summarization_middleware(
@@ -853,7 +908,7 @@ class LensDeepAgentRuntime:
                     "skill_count": len(resources.skill_paths),
                     "mcp_tool_count": len(mcp_tools),
                     "mcp_deferred": mcp_middleware is not None,
-                    "task_tool_enabled": not _is_general_chat(command),
+                    "task_tool_enabled": not runtime_mode.general_chat,
                     "mcp_config_path": str(resources.mcp_config_path),
                 },
             )
@@ -884,7 +939,6 @@ class LensDeepAgentRuntime:
                 wrapup_event=wrapup_event,
                 token_budget_wrapup_event=token_budget_wrapup_event,
                 capability_stop_event=capability_stop_event,
-                direct_stage_state=direct_stage_state,
             )
             if truncated:
                 emit_agent_event(
@@ -920,12 +974,6 @@ class LensDeepAgentRuntime:
                     question,
                     termination_detail,
                 )
-            if direct_stage_state is not None:
-                _finish_direct_stages(
-                    direct_stage_state,
-                    emit_agent_event,
-                    outcome=outcome,
-                )
             emit_user_event("phase.changed", {"phase": "completed"})
             return {
                 "answer": answer,
@@ -935,13 +983,6 @@ class LensDeepAgentRuntime:
                 "outcome": outcome,
                 "termination_detail": termination_detail,
             }
-        except Exception:
-            if direct_stage_state is not None:
-                _fail_direct_stages(
-                    direct_stage_state,
-                    emit_agent_event,
-                )
-            raise
         finally:
             cleanup_runtime_resources(resources)
 
@@ -1040,156 +1081,6 @@ def _pick_text(zh_text, en_text, answer_language):
     """
 
     return zh_text if answer_language == "Chinese" else en_text
-
-
-def _create_direct_stage_state(answer_language):
-    """Return state for explicit direct-execution progress events."""
-
-    return {
-        "answer_language": answer_language,
-        "revision": 0,
-        "tool_count": 0,
-        "stages": {
-            "understand": {
-                "title": _pick_text(
-                    "理解任务范围",
-                    "Understand request scope",
-                    answer_language,
-                ),
-                "order": 1,
-                "status": "pending",
-            },
-            "execute": {
-                "title": _pick_text(
-                    "执行并分析所需操作",
-                    "Execute and analyze required operations",
-                    answer_language,
-                ),
-                "order": 2,
-                "status": "pending",
-            },
-            "answer": {
-                "title": _pick_text(
-                    "整理最终结果",
-                    "Organize final result",
-                    answer_language,
-                ),
-                "order": 3,
-                "status": "pending",
-            },
-        },
-    }
-
-
-def _emit_direct_stage(state, emit_event, stage_id, status, summary=""):
-    """Emit one revisioned direct-execution stage update."""
-
-    stage = state["stages"][stage_id]
-    stage["status"] = status
-    state["revision"] += 1
-    payload = {
-        "id": stage_id,
-        "title": stage["title"],
-        "status": status,
-        "order": stage["order"],
-        "revision": state["revision"],
-    }
-    if summary:
-        payload["summary"] = summary
-    emit_event(
-        "workflow.stage.updated",
-        {
-            "event_type": "stage.updated",
-            "visibility": "user",
-            "payload": payload,
-        },
-    )
-
-
-def _start_direct_stages(state, emit_event):
-    """Expose the direct-execution stages after routing completes."""
-
-    _emit_direct_stage(state, emit_event, "understand", "completed")
-    _emit_direct_stage(state, emit_event, "execute", "in_progress")
-    _emit_direct_stage(state, emit_event, "answer", "pending")
-
-
-def _record_direct_tool_call(state, emit_event):
-    """Update the execution stage from one observed tool call."""
-
-    state["tool_count"] += 1
-    count = state["tool_count"]
-    summary = _pick_text(
-        f"已开始 {count} 项操作",
-        (
-            "Started 1 operation"
-            if count == 1
-            else f"Started {count} operations"
-        ),
-        state["answer_language"],
-    )
-    _emit_direct_stage(
-        state,
-        emit_event,
-        "execute",
-        "in_progress",
-        summary,
-    )
-
-
-def _finish_direct_stages(state, emit_event, *, outcome):
-    """Record truthful terminal states for a direct execution."""
-
-    language = state["answer_language"]
-    if outcome == "blocked":
-        execution_status = "failed"
-        summary = _pick_text(
-            "未能获得所需的执行证据",
-            "Could not obtain the required execution evidence",
-            language,
-        )
-    elif outcome == "partial":
-        execution_status = "failed"
-        summary = _pick_text(
-            "执行已结束，但结果不完整",
-            "Execution ended with partial results",
-            language,
-        )
-    else:
-        execution_status = "completed"
-        summary = _pick_text(
-            "所需操作已执行",
-            "Required operations were executed",
-            language,
-        )
-    _emit_direct_stage(
-        state,
-        emit_event,
-        "execute",
-        execution_status,
-        summary,
-    )
-    _emit_direct_stage(state, emit_event, "answer", "completed")
-
-
-def _fail_direct_stages(state, emit_event):
-    """Close open direct-execution stages after a runtime exception."""
-
-    language = state["answer_language"]
-    if state["stages"]["execute"]["status"] == "in_progress":
-        _emit_direct_stage(
-            state,
-            emit_event,
-            "execute",
-            "failed",
-            _pick_text(
-                "执行意外中止",
-                "Execution stopped unexpectedly",
-                language,
-            ),
-        )
-    if state["stages"]["answer"]["status"] == "pending":
-        _emit_direct_stage(state, emit_event, "answer", "skipped")
 
 
 def _system_prompt(
@@ -1928,7 +1819,6 @@ def _run_agent_with_turn_limit(
     wrapup_event=None,
     token_budget_wrapup_event=None,
     capability_stop_event=None,
-    direct_stage_state=None,
 ):
     """Stream agent events and stop after max_turns NEW AI turns.
 
@@ -1991,7 +1881,6 @@ def _run_agent_with_turn_limit(
                 seen_tool_calls,
                 emit_event,
                 plan_state=plan_state,
-                direct_stage_state=direct_stage_state,
             )
         ai_turns = sum(
             1
@@ -2312,7 +2201,6 @@ def _emit_new_tool_calls(
     emit_event,
     *,
     plan_state=None,
-    direct_stage_state=None,
 ):
     """Emit a progress event for each not-yet-seen agent tool call.
 
@@ -2351,11 +2239,6 @@ def _emit_new_tool_calls(
                     },
                 )
                 continue
-            if direct_stage_state is not None:
-                _record_direct_tool_call(
-                    direct_stage_state,
-                    emit_event,
-                )
             if (
                 plan_state is not None
                 and not plan_state.get("execution_phase_emitted")

--- a/lensnode/lensnode/runtime_modes.py
+++ b/lensnode/lensnode/runtime_modes.py
@@ -1,0 +1,72 @@
+"""Runtime-mode policies shared by the LensNode agent engine."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeMode:
+    """Define mode-specific progress behavior."""
+
+    name: str
+    general_chat: bool = False
+
+    def decorate_event(self, detail):
+        """Return internal event details for this runtime mode."""
+
+        return dict(detail or {})
+
+    def emit_model_round(self, emit_event, suffix, round_number):
+        """Keep legacy modes free of General Chat model-step events."""
+
+        del emit_event, suffix, round_number
+
+
+class GeneralChatMode(RuntimeMode):
+    """Enable General Chat's user-visible hierarchical execution path."""
+
+    def __init__(self):
+        super().__init__(
+            name="general_chat",
+            general_chat=True,
+        )
+
+    def decorate_event(self, detail):
+        """Mark events that may be projected into General Chat steps."""
+
+        return {**super().decorate_event(detail), "runtime_scope": self.name}
+
+    def emit_model_round(self, emit_event, suffix, round_number):
+        """Emit one real model-round boundary for General Chat."""
+
+        emit_event(
+            f"model.round.{suffix}",
+            {
+                "invocation_id": f"model-round-{round_number}",
+                "round": round_number,
+            },
+        )
+
+
+class DocumentQAMode(RuntimeMode):
+    """Preserve the existing document Q&A runtime behavior."""
+
+    def __init__(self):
+        super().__init__(name="document_qa")
+
+
+class CodeAnalysisMode(RuntimeMode):
+    """Preserve the existing code-analysis runtime behavior."""
+
+    def __init__(self):
+        super().__init__(name="code_analysis")
+
+
+def runtime_mode_for(command):
+    """Return the concrete runtime mode for one command."""
+
+    task = str((command or {}).get("task") or "")
+    if task == "general_chat":
+        return GeneralChatMode()
+    if task == "code_analysis":
+        return CodeAnalysisMode()
+    return DocumentQAMode()

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -165,88 +165,6 @@ def test_write_todos_emits_user_visible_normalized_plan():
     ]
 
 
-def test_direct_execution_stages_start_with_real_runtime_state():
-    events = []
-    state = agent_runtime._create_direct_stage_state("English")
-
-    agent_runtime._start_direct_stages(
-        state,
-        lambda name, detail: events.append((name, detail)),
-    )
-
-    assert [detail["payload"]["status"] for _, detail in events] == [
-        "completed",
-        "in_progress",
-        "pending",
-    ]
-    assert [detail["payload"]["order"] for _, detail in events] == [1, 2, 3]
-    assert [detail["payload"]["revision"] for _, detail in events] == [1, 2, 3]
-    assert all(name == "workflow.stage.updated" for name, _ in events)
-
-
-def test_direct_execution_stage_counts_actual_tool_calls():
-    events = []
-    state = agent_runtime._create_direct_stage_state("English")
-    agent_runtime._start_direct_stages(state, lambda *_args: None)
-    message = _Msg(
-        "ai",
-        tool_calls=[
-            {"id": "call-orders", "name": "call_skill_api", "args": {}},
-        ],
-    )
-
-    _emit_new_tool_calls(
-        [message],
-        set(),
-        lambda name, detail: events.append((name, detail)),
-        direct_stage_state=state,
-    )
-
-    stage_events = [
-        detail for name, detail in events if name == "workflow.stage.updated"
-    ]
-    assert state["tool_count"] == 1
-    assert stage_events[-1]["payload"]["id"] == "execute"
-    assert stage_events[-1]["payload"]["status"] == "in_progress"
-    assert stage_events[-1]["payload"]["summary"] == "Started 1 operation"
-
-
-def test_direct_execution_stages_record_blocked_outcome():
-    events = []
-    state = agent_runtime._create_direct_stage_state("English")
-    agent_runtime._start_direct_stages(state, lambda *_args: None)
-
-    agent_runtime._finish_direct_stages(
-        state,
-        lambda name, detail: events.append((name, detail)),
-        outcome="blocked",
-    )
-
-    payloads = [detail["payload"] for _, detail in events]
-    assert payloads[0]["id"] == "execute"
-    assert payloads[0]["status"] == "failed"
-    assert payloads[1]["id"] == "answer"
-    assert payloads[1]["status"] == "completed"
-
-
-def test_direct_execution_stages_do_not_mark_partial_work_completed():
-    events = []
-    state = agent_runtime._create_direct_stage_state("English")
-    agent_runtime._start_direct_stages(state, lambda *_args: None)
-
-    agent_runtime._finish_direct_stages(
-        state,
-        lambda name, detail: events.append((name, detail)),
-        outcome="partial",
-    )
-
-    payloads = [detail["payload"] for _, detail in events]
-    assert payloads[0]["id"] == "execute"
-    assert payloads[0]["status"] == "failed"
-    assert payloads[0]["summary"] == "Execution ended with partial results"
-    assert payloads[1]["status"] == "completed"
-
-
 def test_route_decision_parses_json_and_uses_safe_fallback():
     decision = _parse_route_decision(
         '```json\n{"intent":"action","complexity":"simple",'
@@ -916,6 +834,33 @@ def test_general_chat_middleware_removes_task_tool():
     )
 
     assert result == ["run_skill_artifact"]
+
+
+def test_general_chat_middleware_emits_each_model_round_as_one_step():
+    class Request:
+        tools = []
+
+        def override(self, **changes):
+            return SimpleNamespace(**changes)
+
+    events = []
+    middleware = agent_runtime._NoTaskMiddleware(
+        lambda name, detail: events.append((name, detail))
+    )
+
+    result = middleware.wrap_model_call(Request(), lambda _request: "answer")
+
+    assert result == "answer"
+    assert events == [
+        (
+            "model.round.start",
+            {"invocation_id": "model-round-1", "round": 1},
+        ),
+        (
+            "model.round.done",
+            {"invocation_id": "model-round-1", "round": 1},
+        ),
+    ]
 
 
 def test_general_chat_middleware_denies_task_execution():

--- a/lensnode/tests/test_runtime_modes.py
+++ b/lensnode/tests/test_runtime_modes.py
@@ -1,0 +1,41 @@
+from lensnode.runtime_modes import (
+    CodeAnalysisMode,
+    DocumentQAMode,
+    GeneralChatMode,
+    runtime_mode_for,
+)
+
+
+def test_runtime_modes_keep_general_chat_features_isolated():
+    general = runtime_mode_for({"task": "general_chat"})
+    document = runtime_mode_for({"task": "knowledge_qa"})
+    code = runtime_mode_for({"task": "code_analysis"})
+
+    assert isinstance(general, GeneralChatMode)
+    assert general.decorate_event({"value": 1}) == {
+        "value": 1,
+        "runtime_scope": "general_chat",
+    }
+    events = []
+    general.emit_model_round(
+        lambda name, detail: events.append((name, detail)),
+        "start",
+        1,
+    )
+    assert events == [
+        (
+            "model.round.start",
+            {"invocation_id": "model-round-1", "round": 1},
+        )
+    ]
+
+    assert isinstance(document, DocumentQAMode)
+    assert isinstance(code, CodeAnalysisMode)
+    for legacy in (document, code):
+        assert legacy.decorate_event({"value": 1}) == {"value": 1}
+        legacy.emit_model_round(
+            lambda name, detail: events.append((name, detail)),
+            "start",
+            1,
+        )
+    assert len(events) == 1


### PR DESCRIPTION
## Summary

- derive General Chat progress from persisted, allowlisted runtime operations instead of synthetic workflow placeholders
- render `Run → optional Plan → Task → Stage → Step`, coalescing duplicate operations and semantic retries while preserving real plan task boundaries
- keep raw tool details private, close terminal progress consistently, and localize labels from the active UI locale
- preserve Document Q&A and Code Analysis progress, including standalone activities when no plan or stage exists

Closes #135
Closes #132
Closes #133
Closes #134

## Test plan

- [x] `docker exec sourcelens-api-dev python manage.py test lens.tests.test_services` (63 passed)
- [x] `lensnode/.venv/bin/pytest lensnode/tests` (223 passed)
- [x] `npm run test:unit` (75 passed)
- [x] targeted ESLint for Chat progress files
- [x] `npm run build`
- [x] ego-browser task space 10: direct answer, direct execution, planned execution, retry coalescing, historical replay, terminal failure, Document Q&A, and Code Analysis flows