### PR TITLE
fix(admin): contain group member rows on compact phones

### DIFF
--- a/frontend/e2e/access-control/management.spec.js
+++ b/frontend/e2e/access-control/management.spec.js
@@ -272,6 +272,95 @@ test.describe('Management: create drawers', () => {
     })
   }
 
+  test('group member rows stay contained on compact phones', async ({
+    page,
+    request
+  }) => {
+    const usersResponse = await request.get(
+      '/api/v1/management/users/?page_size=1000',
+      { headers: ADMIN }
+    )
+    const originalUser = data(await usersResponse.json()).results.find(
+      (user) => user.id === USER_ID
+    )
+    const longUsername = `compact_member_${'x'.repeat(72)}`
+    const longEmail = `compact.${'long'.repeat(20)}@example.com`
+    let group
+
+    try {
+      const update = await request.patch(
+        `/api/v1/management/users/${USER_ID}/`,
+        {
+          headers: ADMIN,
+          data: { username: longUsername, email: longEmail }
+        }
+      )
+      expect(update.ok()).toBeTruthy()
+      group = await createGroup(request, [USER_ID])
+
+      await page.setViewportSize({ width: 320, height: 568 })
+      await page.goto('/management/groups')
+      await page.getByRole('button', { name: 'Create Group' }).click()
+
+      const createDialog = page.getByRole('dialog', { name: 'Create Group' })
+      const createSelector = createDialog.getByTestId('group-member-selector')
+      const createRow = createSelector.locator('label').filter({
+        hasText: longEmail
+      })
+      const checkbox = createRow.getByRole('checkbox')
+
+      await expect(createRow).toContainText(longUsername)
+      await expect(createRow).toContainText(longEmail)
+      await expect(createRow).toBeVisible()
+      await expect(createSelector).toBeVisible()
+      expect(
+        await createSelector.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth
+        )
+      ).toBe(true)
+
+      await checkbox.focus()
+      await page.keyboard.press('Space')
+      await expect(checkbox).toBeChecked()
+      await page.keyboard.press('Space')
+      await expect(checkbox).not.toBeChecked()
+
+      const checkboxes = createSelector.getByRole('checkbox')
+      await checkbox.check()
+      await checkboxes.nth(1).check()
+      await expect(checkbox).toBeChecked()
+      await expect(checkboxes.nth(1)).toBeChecked()
+
+      await createDialog.getByRole('button', { name: 'Cancel' }).click()
+      const groupRow = page.locator('tbody tr').filter({ hasText: group.name })
+      await groupRow.getByRole('button', { name: 'Edit' }).click()
+
+      const editDialog = page.getByRole('dialog', { name: 'Edit Group' })
+      const editSelector = editDialog.getByTestId('group-member-selector')
+      const editRow = editSelector.locator('label').filter({
+        hasText: longEmail
+      })
+
+      await expect(editRow.getByRole('checkbox')).toBeChecked()
+      expect(
+        await editSelector.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth
+        )
+      ).toBe(true)
+    } finally {
+      if (group) await deleteGroup(request, group.id)
+      if (originalUser) {
+        await request.patch(`/api/v1/management/users/${USER_ID}/`, {
+          headers: ADMIN,
+          data: {
+            username: originalUser.username,
+            email: originalUser.email
+          }
+        })
+      }
+    }
+  })
+
   test('shared drawer supports every dismissal action', async ({ page }) => {
     await page.goto('/management/lens/assistants')
 

--- a/frontend/src/admin/pages/Management/Groups.vue
+++ b/frontend/src/admin/pages/Management/Groups.vue
@@ -154,25 +154,30 @@
               t('management.members')
             }}</label>
             <div
+              data-testid="group-member-selector"
               class="max-h-60 space-y-1 overflow-y-auto rounded-lg border border-line bg-surface-sunken p-2"
             >
               <label
                 v-for="user in userOptions"
                 :key="user.id"
-                class="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-ink-700 hover:bg-surface"
+                class="flex cursor-pointer items-start gap-2 rounded px-2 py-1.5 text-sm text-ink-700 hover:bg-surface"
               >
                 <input
                   v-model="form.user_ids"
                   type="checkbox"
                   :value="user.id"
-                  class="h-4 w-4 rounded border-line text-brand-600 focus:ring-brand-500"
+                  class="mt-0.5 h-4 w-4 shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
                 />
-                <span class="font-medium">{{
-                  user.display_name || user.username
-                }}</span>
-                <span v-if="user.email" class="text-xs text-ink-400">{{
-                  user.email
-                }}</span>
+                <span class="min-w-0 flex-1">
+                  <span class="block break-words font-medium">{{
+                    user.display_name || user.username
+                  }}</span>
+                  <span
+                    v-if="user.email"
+                    class="block break-all text-xs text-ink-400"
+                    >{{ user.email }}</span
+                  >
+                </span>
               </label>
               <p
                 v-if="!userOptions.length"


### PR DESCRIPTION
## Summary

- keep group member checkboxes fixed while identity text shrinks within the drawer
- stack and wrap usernames and email addresses instead of creating horizontal overflow
- add a compact-mobile regression covering create and edit drawers, keyboard selection, and multiple members

## Testing

- Prettier check for the changed Vue and Playwright files
- ESLint for the changed Vue and Playwright files
- frontend production build
- Playwright access-control suite collection (13 tests)
- isolated Chromium geometry checks at 320x568, 390x844, and desktop widths

## Notes

Shared runtime overlay conflicts prevented loading this branch directly into localhost:8000. Browser geometry was therefore verified against the live page with the patch-equivalent DOM structure; the committed Playwright regression is included for synchronized CI execution.

Closes #128