### PR TITLE
fix(lens): align credential table and row actions

### DIFF
--- a/frontend/src/pages/lens/Credentials.vue
+++ b/frontend/src/pages/lens/Credentials.vue
@@ -141,7 +141,7 @@
             data-testid="credentials-list"
           >
             <table
-              class="credentials-table min-w-[66rem] table-fixed divide-y divide-line"
+              class="credentials-table w-full min-w-[66rem] table-fixed divide-y divide-line"
             >
               <colgroup>
                 <col class="w-44" />

--- a/frontend/src/pages/lens/components/RowActions.vue
+++ b/frontend/src/pages/lens/components/RowActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-wrap items-center gap-2">
+  <div class="flex flex-wrap items-center justify-end gap-2">
     <template v-if="confirming">
       <BaseButton size="sm" variant="danger" @click="confirmDelete">
         {{ t('common.confirm') }}


### PR DESCRIPTION
## Summary

- make the Credentials table fill the available container width on wide screens
- align shared Lens row actions to the right edge of their action column
- preserve the existing minimum table width and narrow-screen horizontal scrolling

## Scope

This is a layout-only change limited to:

- `frontend/src/pages/lens/Credentials.vue`
- `frontend/src/pages/lens/components/RowActions.vue`

It does not include the admin table-action standardization work.

## Testing

- `npm run test:unit` (75 passed)
- `npm run build`
- ESLint on both changed Vue files
- `git diff --check`
