### PR TITLE
Make the development Turnstile bypass explicit

### DIFF
--- a/backend/accounts/services/turnstile.py
+++ b/backend/accounts/services/turnstile.py
@@ -31,6 +31,12 @@ def verify_token(token, remote_ip=None):
             - (True, []) when verification passes or is bypassed.
             - (False, [..]) with Cloudflare error codes on failure.
     """
+    if not getattr(settings, 'TURNSTILE_ENABLED', True):
+        logger.info(
+            "Turnstile verification is disabled by configuration."
+        )
+        return True, []
+
     secret = getattr(settings, 'TURNSTILE_SECRET_KEY', '')
     if not secret:
         logger.warning(

--- a/backend/accounts/tests/test_turnstile.py
+++ b/backend/accounts/tests/test_turnstile.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from accounts.services import turnstile
+
+
+class TurnstileVerificationTests(SimpleTestCase):
+    """Verify the explicit development bypass remains network-free."""
+
+    @override_settings(
+        TURNSTILE_ENABLED=False,
+        TURNSTILE_SECRET_KEY="configured-secret",
+    )
+    @patch("accounts.services.turnstile.urllib.request.urlopen")
+    def test_disabled_verification_bypasses_cloudflare(self, urlopen):
+        passed, errors = turnstile.verify_token("")
+
+        self.assertTrue(passed)
+        self.assertEqual(errors, [])
+        urlopen.assert_not_called()
+
+    @override_settings(
+        TURNSTILE_ENABLED=True,
+        TURNSTILE_SECRET_KEY="configured-secret",
+    )
+    def test_enabled_verification_rejects_a_missing_token(self):
+        passed, errors = turnstile.verify_token("")
+
+        self.assertFalse(passed)
+        self.assertEqual(errors, ["missing-input-response"])

--- a/backend/core/settings/accounts.py
+++ b/backend/core/settings/accounts.py
@@ -156,9 +156,15 @@ OTP_SEND_MAX_PER_IP_HOUR = int(os.getenv('OTP_SEND_MAX_PER_IP_HOUR', '20'))
 # Cloudflare Turnstile
 # ============================
 
-# Server-side secret used to verify Turnstile tokens. Empty disables the
-# check (development bypass).
+# Server-side secret used to verify Turnstile tokens. Required when the
+# check is enabled outside debug mode.
 TURNSTILE_SECRET_KEY = os.getenv('TURNSTILE_SECRET_KEY', '')
+
+# Explicit switch for local development. Only "false" disables the check.
+TURNSTILE_ENABLED = os.getenv(
+    'TURNSTILE_ENABLED',
+    'true',
+).strip().lower() != 'false'
 
 TURNSTILE_VERIFY_URL = (
     'https://challenges.cloudflare.com/turnstile/v0/siteverify'
@@ -167,7 +173,7 @@ TURNSTILE_VERIFY_URL = (
 # Fail fast in production: an empty secret silently bypasses human
 # verification on every login entry, so refuse to start without it unless
 # explicitly in debug mode.
-if not TURNSTILE_SECRET_KEY and (
+if TURNSTILE_ENABLED and not TURNSTILE_SECRET_KEY and (
     os.getenv('DJANGO_DEBUG', 'false').lower() != 'true'
 ):
     raise ImproperlyConfigured(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,9 @@ services:
       LENSNODE_NAME: ${LENSNODE_NAME:-local-dev-lensnode}
       LENSNODE_TOKEN: ${LENSNODE_TOKEN:-dev-lensnode-token}
       LENSNODE_WORKSPACE_PATH: /workspace
+      # Development login must not depend on the external Turnstile service.
+      TURNSTILE_ENABLED: "false"
+      TURNSTILE_SECRET_KEY: ""
     build:
       context: .
       dockerfile: Dockerfile
@@ -212,6 +215,9 @@ services:
     restart: unless-stopped
     env_file:
       - ./.env.dev
+    environment:
+      # Keep the development login flow aligned with the backend bypass.
+      VITE_TURNSTILE_SITE_KEY: ""
     volumes:
       - ./frontend/src:/app/src:ro
       - ./frontend/public:/app/public:ro

--- a/env.sample
+++ b/env.sample
@@ -151,7 +151,9 @@ OTP_SEND_MAX_PER_IP_HOUR=20
 # -----------------------------------------------------------------------------
 # Cloudflare Turnstile
 # -----------------------------------------------------------------------------
-# Backend secret key (empty disables verification — development bypass).
+# Keep enabled outside local development.
+TURNSTILE_ENABLED=true
+# Backend secret key (required when enabled outside debug mode).
 TURNSTILE_SECRET_KEY=
 # Frontend widget site key (build-time, VITE_ prefix).
 VITE_TURNSTILE_SITE_KEY=


### PR DESCRIPTION
## Summary

- Add an explicit TURNSTILE_ENABLED setting where only false disables server-side verification.
- Preserve fail-fast startup outside debug mode when verification is enabled without a secret.
- Disable both the backend check and frontend widget key in the development Compose stack.

Refs #142

## Test plan

- [x] Django focused suite: 67 tests passed
- [x] Development Compose configuration rendered successfully
- [x] Diff whitespace check passed