### PR TITLE
Stabilize chat progress replay and completion cues

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -628,13 +628,22 @@ def build_run_history(run):
     current turn, newest-first up to the caps, then returned in
     chronological order. A Message stores only final content (never tool
     traces), so the carried history stays compact and the agent context
-    cannot blow up from a long session.
+    cannot blow up from a long session. Capability-unavailable fallback
+    answers are omitted because their boundary decision applies only to
+    that request; the user message remains available for follow-up context.
     """
 
+    blocked_runs = Run.objects.filter(
+        session=run.session,
+        termination_detail__reason="capability_unavailable",
+        output_message_id__isnull=False,
+    )
     messages = Message.objects.filter(
         session=run.session,
         sequence__lt=run.input_message.sequence,
         role__in=[Message.Role.USER, Message.Role.ASSISTANT],
+    ).exclude(
+        pk__in=blocked_runs.values("output_message_id")
     ).order_by("-sequence")
     history = []
     total_chars = 0

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -170,6 +170,69 @@ class LensServiceTests(TransactionTestCase):
             ],
         )
 
+    def test_build_run_history_skips_capability_unavailable_answer(self):
+        blocked = create_execution_run(
+            session=self.session,
+            question="Create an order",
+            enqueue=False,
+        )
+        blocked.output_message.content = "Capability unavailable"
+        blocked.output_message.save(update_fields=["content"])
+        finish_lensnode_run(
+            blocked.uuid,
+            Run.Status.DONE,
+            outcome=Run.Outcome.BLOCKED,
+            termination_detail={
+                "reason": "capability_unavailable",
+                "capability": "skill",
+            },
+        )
+        current = create_execution_run(
+            session=self.session,
+            question="List orders",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(
+            history,
+            [{"role": "user", "content": "Create an order"}],
+        )
+
+    def test_build_run_history_ignores_blocked_run_without_output(self):
+        answered = create_execution_run(
+            session=self.session,
+            question="Explain order states",
+            enqueue=False,
+        )
+        answered.output_message.content = "Order states explained"
+        answered.output_message.save(update_fields=["content"])
+        blocked = create_execution_run(
+            session=self.session,
+            question="Create an order",
+            enqueue=False,
+        )
+        blocked.termination_detail = {"reason": "capability_unavailable"}
+        blocked.save(update_fields=["termination_detail"])
+        blocked.output_message.delete()
+        current = create_execution_run(
+            session=self.session,
+            question="Continue",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(
+            history,
+            [
+                {"role": "user", "content": "Explain order states"},
+                {"role": "assistant", "content": "Order states explained"},
+                {"role": "user", "content": "Create an order"},
+            ],
+        )
+
     def test_rewrite_query_passthrough_without_preprocess_model(self):
         run = create_execution_run(
             session=self.session, question="how to deploy?", enqueue=False

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -221,7 +221,7 @@
       "stop": "Stop",
       "runStopped": "Execution stopped.",
       "runSubmitted": "Run submitted.",
-      "tabAnswerCompleted": "({count}) Answer completed · SourceLens",
+      "tabAnswerCompleted": "Answer completed",
       "submitFailed": "Failed to submit query.",
       "waitingForResult": "Still waiting for execution result.",
       "thinking": "Analyzing project context",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -221,7 +221,7 @@
       "stop": "停止",
       "runStopped": "已停止执行。",
       "runSubmitted": "Run 已提交。",
-      "tabAnswerCompleted": "({count}) 回答已完成 · SourceLens",
+      "tabAnswerCompleted": "回答已完成",
       "submitFailed": "提交查询失败。",
       "waitingForResult": "仍在等待执行结果。",
       "thinking": "正在分析项目内容",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -430,10 +430,24 @@
                       <div
                         v-if="structuredProgress(message._runtimeState).hasPlan"
                         class="runtime-plan-step runtime-task-row"
+                        :class="{
+                          'is-active-ancestor': isActiveProgressAncestor(
+                            task,
+                            task.stages
+                          )
+                        }"
                       >
                         <span
                           class="runtime-plan-status"
-                          :class="`is-${task.status}`"
+                          :class="[
+                            `is-${task.status}`,
+                            {
+                              'is-active-ancestor': isActiveProgressAncestor(
+                                task,
+                                task.stages
+                              )
+                            }
+                          ]"
                           aria-hidden="true"
                         >
                           {{ progressStatusIcon(task.status) }}
@@ -445,10 +459,26 @@
                         :key="stage.id"
                         class="runtime-workflow-stage"
                       >
-                        <div class="runtime-plan-step runtime-stage-row">
+                        <div
+                          class="runtime-plan-step runtime-stage-row"
+                          :class="{
+                            'is-active-ancestor': isActiveProgressAncestor(
+                              stage,
+                              stage.steps
+                            )
+                          }"
+                        >
                           <span
                             class="runtime-plan-status"
-                            :class="`is-${stage.status}`"
+                            :class="[
+                              `is-${stage.status}`,
+                              {
+                                'is-active-ancestor': isActiveProgressAncestor(
+                                  stage,
+                                  stage.steps
+                                )
+                              }
+                            ]"
                             aria-hidden="true"
                           >
                             {{ progressStatusIcon(stage.status) }}
@@ -815,10 +845,24 @@
                       <div
                         v-if="liveStructuredProgress.hasPlan"
                         class="runtime-plan-step runtime-task-row"
+                        :class="{
+                          'is-active-ancestor': isActiveProgressAncestor(
+                            task,
+                            task.stages
+                          )
+                        }"
                       >
                         <span
                           class="runtime-plan-status"
-                          :class="`is-${task.status}`"
+                          :class="[
+                            `is-${task.status}`,
+                            {
+                              'is-active-ancestor': isActiveProgressAncestor(
+                                task,
+                                task.stages
+                              )
+                            }
+                          ]"
                           aria-hidden="true"
                         >
                           {{ progressStatusIcon(task.status) }}
@@ -830,10 +874,26 @@
                         :key="stage.id"
                         class="runtime-workflow-stage"
                       >
-                        <div class="runtime-plan-step runtime-stage-row">
+                        <div
+                          class="runtime-plan-step runtime-stage-row"
+                          :class="{
+                            'is-active-ancestor': isActiveProgressAncestor(
+                              stage,
+                              stage.steps
+                            )
+                          }"
+                        >
                           <span
                             class="runtime-plan-status"
-                            :class="`is-${stage.status}`"
+                            :class="[
+                              `is-${stage.status}`,
+                              {
+                                'is-active-ancestor': isActiveProgressAncestor(
+                                  stage,
+                                  stage.steps
+                                )
+                              }
+                            ]"
                             aria-hidden="true"
                           >
                             {{ progressStatusIcon(stage.status) }}
@@ -1249,10 +1309,12 @@ import { useLensStore } from '@/store/lens'
 import { usePreferencesStore } from '@/store/preferences'
 import { useUserStore } from '@/store/user'
 import {
+  answerCompletionTitle,
   clearUnreadSession,
   handleTerminalRun,
   pollRunUntilTerminal,
   readUnreadSessions,
+  shouldReviewUnreadSession,
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
 import {
@@ -1261,11 +1323,13 @@ import {
   calculateRunElapsedSeconds,
   createRuntimeState,
   getMessageTimestamp,
+  isActiveProgressAncestor,
   scrollConversationToBottomAfterRender,
   selectLiveProgressText,
   selectStructuredProgress,
   summarizePlanProgress,
   summarizeStageProgress,
+  terminalSyncEvent,
   workflowProgressSource
 } from '@/pages/lens/runtimeEvents'
 import {
@@ -1306,7 +1370,7 @@ const MAX_IMAGE_BYTES = 10 * 1024 * 1024
 const IMAGE_MIME = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
 const RUN_POLL_INTERVAL_MS = 3000
 const RUN_POLL_MAX_ATTEMPTS = 160
-const BASE_DOCUMENT_TITLE = 'SourceLens'
+const BASE_DOCUMENT_TITLE = document.title || 'SourceLens'
 const streamError = ref('')
 const failedRunError = ref(null)
 const queuePosition = ref(null)
@@ -1327,6 +1391,7 @@ const runtimeState = ref(createRuntimeState())
 const liveActivityScrollRef = ref(null)
 const elapsedSeconds = ref(0)
 let elapsedTimer = null
+let reviewingUnreadSession = false
 
 const publicAssistant = ref(null)
 const showLoginModal = ref(false)
@@ -1871,12 +1936,14 @@ function sleep(ms) {
 
 function refreshUnreadSessions() {
   unreadSessions.value = readUnreadSessions(window.localStorage)
-  const unreadCount = preferencesStore.answerCompletionIndicator
-    ? Object.keys(unreadSessions.value).length
-    : 0
-  document.title = unreadCount
-    ? t('lens.chat.tabAnswerCompleted', { count: unreadCount })
-    : BASE_DOCUMENT_TITLE
+  const hasUnread =
+    preferencesStore.answerCompletionIndicator &&
+    Object.keys(unreadSessions.value).length > 0
+  document.title = answerCompletionTitle({
+    baseTitle: BASE_DOCUMENT_TITLE,
+    completionLabel: t('lens.chat.tabAnswerCompleted'),
+    hasUnread
+  })
 }
 
 function sessionHasUnreadAnswer(sessionUuid) {
@@ -1898,11 +1965,21 @@ function handleCompletionStorage(event) {
 }
 
 function handleCompletionVisibility() {
-  if (document.visibilityState !== 'visible') return
   const sessionUuid = selectedSessionUuid.value
-  if (sessionUuid && unreadSessions.value[sessionUuid]) {
-    void selectSession({ uuid: sessionUuid }, false)
+  if (
+    reviewingUnreadSession ||
+    !shouldReviewUnreadSession({
+      documentRef: document,
+      selectedSessionUuid: sessionUuid,
+      unreadSessions: unreadSessions.value
+    })
+  ) {
+    return
   }
+  reviewingUnreadSession = true
+  void selectSession({ uuid: sessionUuid }, false).finally(() => {
+    reviewingUnreadSession = false
+  })
 }
 
 function startCompletionTracking(run, sessionUuid) {
@@ -2420,12 +2497,9 @@ function handleEvent(event) {
     if (event.type === 'sync') {
       event.steps?.forEach((step) => handleStepEvent(step, event.ts))
     }
-    if (isTerminalRunStatus(event.status)) {
-      runtimeState.value = applyRuntimeEvent(runtimeState.value, {
-        type: 'done',
-        outcome: event.outcome,
-        termination_detail: event.termination_detail
-      })
+    const terminalEvent = terminalSyncEvent(event)
+    if (terminalEvent) {
+      runtimeState.value = applyRuntimeEvent(runtimeState.value, terminalEvent)
     }
   }
   if (event.type === 'queue_position') {
@@ -2758,6 +2832,7 @@ watch(
 
 onMounted(async () => {
   window.addEventListener('storage', handleCompletionStorage)
+  window.addEventListener('focus', handleCompletionVisibility)
   document.addEventListener('visibilitychange', handleCompletionVisibility)
   refreshUnreadSessions()
   if (window.innerWidth < 1024) {
@@ -2772,6 +2847,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('storage', handleCompletionStorage)
+  window.removeEventListener('focus', handleCompletionVisibility)
   document.removeEventListener('visibilitychange', handleCompletionVisibility)
   document.title = BASE_DOCUMENT_TITLE
   completionTrackers.forEach((tracker) => {
@@ -3390,6 +3466,16 @@ onBeforeUnmount(() => {
   color: transparent;
   font-size: 0;
   animation: spin 0.75s linear infinite;
+}
+
+.runtime-plan-step.is-active-ancestor {
+  color: #74521e;
+  font-weight: 600;
+}
+
+.runtime-plan-status.is-in_progress.is-active-ancestor {
+  border: 0;
+  animation: none;
 }
 
 .runtime-plan-status.is-completed {

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -52,6 +52,20 @@ export function getMessageTimestamp(message) {
   return message?.created_at || ''
 }
 
+export function terminalSyncEvent(event) {
+  if (
+    event?.type !== 'sync' ||
+    !['done', 'failed', 'cancelled'].includes(event.status)
+  ) {
+    return null
+  }
+  return {
+    type: event.status === 'done' ? 'done' : 'error',
+    outcome: event.outcome,
+    termination_detail: event.termination_detail
+  }
+}
+
 export async function scrollConversationToBottomAfterRender(
   getElement,
   waitForRender
@@ -75,6 +89,7 @@ export function createRuntimeState() {
     stageRevision: 0,
     activities: [],
     activityRevision: 0,
+    activityAttempts: {},
     capabilityBlock: null,
     executionFailure: null,
     artifacts: [],
@@ -211,8 +226,14 @@ function appendStructuredActivity(state, payload) {
   const existing = exactExisting || semanticExisting
   const taskId = existing?.taskId || currentTaskId
   const stageKind = existing?.stageKind || payload.stage_kind
+  const activityId = existing?.id || id
+  const attempts = {
+    ...(state.activityAttempts[activityId] || {}),
+    [id]: payload.status
+  }
+  const attemptStatuses = Object.values(attempts)
   const activity = {
-    id: existing?.id || id,
+    id: activityId,
     taskId,
     stageId: `${taskId}:${stageKind}`,
     stageKind,
@@ -220,10 +241,7 @@ function appendStructuredActivity(state, payload) {
       existing?.kind && existing.kind !== 'querying_data'
         ? existing.kind
         : payload.kind,
-    status:
-      existing?.status === 'completed' && payload.status === 'in_progress'
-        ? existing.status
-        : payload.status,
+    status: attemptStatuses.includes('completed') ? 'completed' : 'in_progress',
     ...(existing?.startDate || startDate
       ? { startDate: existing?.startDate || startDate }
       : {}),
@@ -244,6 +262,10 @@ function appendStructuredActivity(state, payload) {
   return {
     ...state,
     activityRevision: state.activityRevision + 1,
+    activityAttempts: {
+      ...state.activityAttempts,
+      [activityId]: attempts
+    },
     activities: capActivities(activities)
   }
 }
@@ -251,6 +273,16 @@ function appendStructuredActivity(state, payload) {
 function closeRuntimeProgress(state, status) {
   const activities = state.activities.map((item) => {
     if (!item.structured || item.status !== 'in_progress') return item
+    const attemptStatuses = Object.values(state.activityAttempts[item.id] || {})
+    if (attemptStatuses.includes('completed')) {
+      return { ...item, status: 'completed' }
+    }
+    if (
+      attemptStatuses.length > 0 &&
+      attemptStatuses.every((attemptStatus) => attemptStatus === 'failed')
+    ) {
+      return { ...item, status: 'failed' }
+    }
     return { ...item, status }
   })
   const stages = state.stages.map((item) => {
@@ -431,6 +463,14 @@ function workflowNodeStatus(items) {
   }
   if (items.some((item) => item.status === 'failed')) return 'failed'
   return items.length > 0 ? 'completed' : 'pending'
+}
+
+export function isActiveProgressAncestor(node, children) {
+  return (
+    node?.status === 'in_progress' &&
+    Array.isArray(children) &&
+    children.some((child) => child?.status === 'in_progress')
+  )
 }
 
 export function buildWorkflowTree(plan, activities) {
@@ -632,11 +672,16 @@ export function applyRuntimeEvent(state, event) {
   if (event.event_type === 'plan.updated') {
     const revision = Math.max(Number(payload.revision || 0), 0)
     if (revision < current.planRevision) return current
-    const currentPlanById = new Map(current.plan.map((item) => [item.id, item]))
-    const plan = normalizePlanSteps(payload.steps).map((item) => {
-      const existing = currentPlanById.get(item.id)
-      return existing ? { ...item, title: existing.title } : item
-    })
+    const incomingPlanById = new Map(
+      normalizePlanSteps(payload.steps).map((item) => [item.id, item])
+    )
+    const plan =
+      current.plan.length === 0
+        ? [...incomingPlanById.values()]
+        : current.plan.map((item) => ({
+            ...item,
+            status: incomingPlanById.get(item.id)?.status || item.status
+          }))
     return {
       ...current,
       plan,

--- a/frontend/src/utils/answerCompletionNotifications.js
+++ b/frontend/src/utils/answerCompletionNotifications.js
@@ -20,6 +20,25 @@ export function readUnreadSessions(storage) {
   return readObject(storage, UNREAD_STORAGE_KEY)
 }
 
+export function answerCompletionTitle({
+  baseTitle,
+  completionLabel,
+  hasUnread
+}) {
+  return hasUnread ? `🔔 ${completionLabel} · ${baseTitle}` : baseTitle
+}
+
+export function shouldReviewUnreadSession({
+  documentRef,
+  selectedSessionUuid,
+  unreadSessions
+}) {
+  return (
+    documentRef?.visibilityState === 'visible' &&
+    Boolean(selectedSessionUuid && unreadSessions?.[selectedSessionUuid])
+  )
+}
+
 function markUnreadSession(storage, sessionUuid, runUuid) {
   const unread = readUnreadSessions(storage)
   if (unread[sessionUuid] === runUuid) {

--- a/frontend/tests/answerCompletionNotifications.test.js
+++ b/frontend/tests/answerCompletionNotifications.test.js
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  answerCompletionTitle,
   clearUnreadSession,
   handleTerminalRun,
   pollRunUntilTerminal,
-  readUnreadSessions
+  readUnreadSessions,
+  shouldReviewUnreadSession
 } from '../src/utils/answerCompletionNotifications.js'
 
 class MemoryStorage {
@@ -36,6 +38,46 @@ function completionOptions(overrides = {}) {
     ...overrides
   }
 }
+
+test('uses a bell instead of an unread count in the browser title', () => {
+  assert.equal(
+    answerCompletionTitle({
+      baseTitle: 'SourceLens',
+      completionLabel: 'Answer completed',
+      hasUnread: true
+    }),
+    '🔔 Answer completed · SourceLens'
+  )
+  assert.equal(
+    answerCompletionTitle({
+      baseTitle: 'SourceLens',
+      completionLabel: 'Answer completed',
+      hasUnread: false
+    }),
+    'SourceLens'
+  )
+})
+
+test('reviews the selected unread conversation once the page is visible', () => {
+  const unreadSessions = { 'session-a': 'run-1' }
+
+  assert.equal(
+    shouldReviewUnreadSession({
+      documentRef: { visibilityState: 'visible' },
+      selectedSessionUuid: 'session-a',
+      unreadSessions
+    }),
+    true
+  )
+  assert.equal(
+    shouldReviewUnreadSession({
+      documentRef: { visibilityState: 'hidden' },
+      selectedSessionUuid: 'session-a',
+      unreadSessions
+    }),
+    false
+  )
+})
 
 test('marks a completed non-selected conversation unread', () => {
   const options = completionOptions()

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -8,6 +8,7 @@ import {
   calculateRunElapsedSeconds,
   createRuntimeState,
   getMessageTimestamp,
+  isActiveProgressAncestor,
   normalizePlanSteps,
   normalizeStages,
   scrollConversationToBottomAfterRender,
@@ -16,6 +17,7 @@ import {
   selectStructuredProgress,
   summarizeStageProgress,
   summarizePlanProgress,
+  terminalSyncEvent,
   workflowProgressSource
 } from '../src/pages/lens/runtimeEvents.js'
 
@@ -512,6 +514,39 @@ test('does not build placeholder workflow nodes from model rounds', () => {
   assert.deepEqual(tasks, [])
 })
 
+test('identifies active ancestors without suppressing parallel leaves', () => {
+  const activeSteps = [
+    { id: 'query-primary', status: 'in_progress' },
+    { id: 'query-secondary', status: 'in_progress' }
+  ]
+  const activeStage = {
+    id: 'order-query',
+    status: 'in_progress',
+    steps: activeSteps
+  }
+  const activeTask = {
+    id: 'query-orders',
+    status: 'in_progress',
+    stages: [activeStage]
+  }
+
+  assert.equal(isActiveProgressAncestor(activeTask, activeTask.stages), true)
+  assert.equal(isActiveProgressAncestor(activeStage, activeStage.steps), true)
+  for (const step of activeSteps) {
+    assert.equal(isActiveProgressAncestor(step, []), false)
+  }
+})
+
+test('keeps an active node animated when none of its children are active', () => {
+  const activeStage = { id: 'order-query', status: 'in_progress' }
+  const completedSteps = [
+    { id: 'check-login', status: 'completed' },
+    { id: 'query-orders', status: 'completed' }
+  ]
+
+  assert.equal(isActiveProgressAncestor(activeStage, completedSteps), false)
+})
+
 test('uses a business task fallback instead of a placeholder task', () => {
   const tasks = buildWorkflowTree(
     [],
@@ -697,6 +732,67 @@ test('coalesces a failed step with a successful semantic retry', () => {
   assert.equal(steps[0].status, 'completed')
 })
 
+test('keeps a recoverable semantic failure active until the run ends', () => {
+  let state = createRuntimeState()
+  for (const status of ['in_progress', 'failed']) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload: {
+        id: 'analysis-attempt-1',
+        stage_kind: 'result_analysis',
+        kind: 'analyzing_results',
+        status
+      }
+    })
+  }
+
+  assert.equal(state.activities[0].status, 'in_progress')
+
+  state = applyRuntimeEvent(state, { type: 'done', outcome: 'partial' })
+
+  assert.equal(state.activities[0].status, 'failed')
+})
+
+test('does not downgrade a successful semantic retry after a later failure', () => {
+  let state = createRuntimeState()
+  for (const [id, status] of [
+    ['analysis-attempt-1', 'completed'],
+    ['analysis-attempt-2', 'in_progress'],
+    ['analysis-attempt-2', 'failed']
+  ]) {
+    state = applyRuntimeEvent(state, {
+      event_type: 'activity.recorded',
+      visibility: 'user',
+      payload: {
+        id,
+        stage_kind: 'result_analysis',
+        kind: 'analyzing_results',
+        status
+      }
+    })
+  }
+
+  assert.equal(state.activities[0].status, 'completed')
+})
+
+test('waits for a terminal SSE payload before closing live progress', () => {
+  assert.equal(terminalSyncEvent({ type: 'status', status: 'done' }), null)
+  assert.deepEqual(
+    terminalSyncEvent({
+      type: 'sync',
+      status: 'done',
+      outcome: 'partial',
+      termination_detail: { reason: 'token_budget_wrapup' }
+    }),
+    {
+      type: 'done',
+      outcome: 'partial',
+      termination_detail: { reason: 'token_budget_wrapup' }
+    }
+  )
+})
+
 test('attaches final summary to the last real plan task', () => {
   let state = applyRuntimeEvent(createRuntimeState(), {
     event_type: 'plan.updated',
@@ -775,6 +871,38 @@ test('keeps plan task titles stable across later revisions', () => {
 
   assert.equal(state.plan[0].title, '查询订单')
   assert.equal(state.plan[0].status, 'completed')
+})
+
+test('keeps the initial plan shape when later revisions append tasks', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 1,
+      steps: [
+        { id: 'step-1', title: 'Query orders', status: 'in_progress' },
+        { id: 'step-2', title: 'Summarize results', status: 'pending' }
+      ]
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'plan.updated',
+    visibility: 'user',
+    payload: {
+      revision: 2,
+      steps: [
+        { id: 'step-1', title: 'Query orders', status: 'completed' },
+        { id: 'step-2', title: 'Summarize results', status: 'in_progress' },
+        { id: 'step-3', title: 'Check totals', status: 'pending' }
+      ]
+    }
+  })
+
+  assert.deepEqual(state.plan, [
+    { id: 'step-1', title: 'Query orders', status: 'completed' },
+    { id: 'step-2', title: 'Summarize results', status: 'in_progress' }
+  ])
 })
 
 test('moves trailing stages to tasks completed by a batched revision', () => {


### PR DESCRIPTION
## Summary

- Keep capability-unavailable fallback answers out of later Run history while retaining the user question.
- Aggregate semantic retry attempts and wait for complete terminal synchronization before closing progress.
- Preserve the initial plan shape and render only the deepest active node as animated.
- Use a bell-based completion title and review unread sessions on visibility or focus recovery.

Refs #142
Closes #137
Follow-up to #120

## Test plan

- [x] Django focused suite: 67 tests passed
- [x] Frontend unit suite: 83 tests passed
- [x] Read-only ESLint passed for affected frontend files
- [x] Frontend production build passed
- [x] ego-browser task space 27 checked live and replayed progress, deepest-node animation, terminal spinner cleanup, completion-title recovery, and browser console/network health
- [x] Diff whitespace check passed