### PR TITLE
fix(lens): add Q&A review detail drawer

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -2196,3 +2196,17 @@ class SharedQAAdminSerializer(serializers.ModelSerializer):
         """Return a short plain-text preview of the answer."""
 
         return _answer_snippet(obj.answer)
+
+
+class SharedQAAdminDetailSerializer(SharedQAAdminSerializer):
+    """Admin moderation detail with the complete Q&A content."""
+
+    class Meta(SharedQAAdminSerializer.Meta):
+        fields = SharedQAAdminSerializer.Meta.fields + [
+            "question",
+            "answer",
+        ]
+        read_only_fields = SharedQAAdminSerializer.Meta.read_only_fields + [
+            "question",
+            "answer",
+        ]

--- a/backend/lens/tests/test_shared_qa.py
+++ b/backend/lens/tests/test_shared_qa.py
@@ -658,12 +658,62 @@ class SharedQAApiTests(TestCase):
         token = self._share().data["token"]
         share = SharedQA.objects.get(token=token)
         self.client.force_authenticate(self.owner)
+        detail = self.client.get(
+            f"/api/lens/admin/shares/{share.uuid}/",
+        )
         resp = self.client.patch(
             f"/api/lens/admin/shares/{share.uuid}/",
             {"is_listed": True},
             format="json",
         )
+        self.assertEqual(detail.status_code, 403)
         self.assertEqual(resp.status_code, 403)
+
+    def test_admin_detail_returns_complete_content_for_all_states(self):
+        token = self._share().data["token"]
+        share = SharedQA.objects.get(token=token)
+        self.client.force_authenticate(self.admin)
+
+        states = [
+            (False, SharedQA.Status.PUBLISHED),
+            (True, SharedQA.Status.PUBLISHED),
+            (False, SharedQA.Status.HIDDEN),
+            (True, SharedQA.Status.HIDDEN),
+        ]
+        for is_listed, share_status in states:
+            with self.subTest(
+                is_listed=is_listed,
+                status=share_status,
+            ):
+                SharedQA.objects.filter(pk=share.pk).update(
+                    is_listed=is_listed,
+                    status=share_status,
+                )
+                before_views = share.view_count
+                resp = self.client.get(
+                    f"/api/lens/admin/shares/{share.uuid}/",
+                )
+
+                self.assertEqual(resp.status_code, 200)
+                self.assertEqual(resp.data["question"], "What is X?")
+                self.assertEqual(resp.data["answer"], "X is a thing.")
+                self.assertEqual(resp.data["published_by"], "qa-owner")
+                self.assertEqual(resp.data["is_listed"], is_listed)
+                self.assertEqual(resp.data["status"], share_status)
+                share.refresh_from_db()
+                self.assertEqual(share.view_count, before_views)
+
+    def test_admin_list_omits_complete_content(self):
+        self._share()
+        self.client.force_authenticate(self.admin)
+
+        resp = self.client.get("/api/lens/admin/shares/")
+
+        self.assertEqual(resp.status_code, 200)
+        row = _results(resp.data)[0]
+        self.assertIn("answer_snippet", row)
+        self.assertNotIn("question", row)
+        self.assertNotIn("answer", row)
 
     def test_owner_can_rename_share(self):
         token = self._share().data["token"]

--- a/backend/lens/views/shares.py
+++ b/backend/lens/views/shares.py
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 
 from lens.models import Assistant, SharedQA, SharedQAFile
 from lens.serializers import (
+    SharedQAAdminDetailSerializer,
     SharedQAAdminSerializer,
     SharedQAListSerializer,
     SharedQAMineSerializer,
@@ -69,6 +70,13 @@ class AdminSharedQAViewSet(BaseAdminViewSet):
     queryset = SharedQA.objects.all().select_related("published_by")
     serializer_class = SharedQAAdminSerializer
     http_method_names = ["get", "patch", "head", "options"]
+
+    def get_serializer_class(self):
+        """Return complete Q&A content only for the detail endpoint."""
+
+        if self.action == "retrieve":
+            return SharedQAAdminDetailSerializer
+        return SharedQAAdminSerializer
 
     def get_queryset(self):
         """Filter by listed/status for the moderation queue."""

--- a/frontend/e2e/access-control/qa-review.spec.js
+++ b/frontend/e2e/access-control/qa-review.spec.js
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test'
+
+import { asRole } from './helpers.js'
+
+test('admin reviews Q&A content and moderates it from the drawer', async ({
+  page
+}) => {
+  const share = {
+    uuid: '00000000-0000-0000-0000-000000000026',
+    token: 'review-detail-token',
+    title: 'Review detail fixture',
+    question: 'What content should the reviewer inspect?',
+    answer: 'The complete answer must stay visible during moderation.',
+    answer_snippet: 'Complete moderation answer.',
+    assistant_name: 'Review Assistant',
+    assistant_slug: 'review-assistant',
+    assistant_visibility: 'public',
+    is_listed: false,
+    status: 'published',
+    published_by: 'review-author',
+    view_count: 7,
+    published_at: '2026-07-22T08:00:00Z',
+    created_at: '2026-07-22T08:00:00Z'
+  }
+  const patches = []
+
+  await page.route('**/api/lens/admin/shares/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const isDetail = url.pathname.endsWith(`/${share.uuid}/`)
+
+    if (request.method() === 'PATCH' && isDetail) {
+      const payload = request.postDataJSON()
+      patches.push(payload)
+      Object.assign(share, payload)
+      await route.fulfill({ json: share })
+      return
+    }
+
+    if (request.method() === 'GET' && isDetail) {
+      await route.fulfill({ json: share })
+      return
+    }
+
+    const listed = url.searchParams.get('listed')
+    const status = url.searchParams.get('status')
+    const matchesListed = listed === null || String(share.is_listed) === listed
+    const matchesStatus = !status || share.status === status
+    await route.fulfill({
+      json: {
+        count: matchesListed && matchesStatus ? 1 : 0,
+        results: matchesListed && matchesStatus ? [share] : []
+      }
+    })
+  })
+
+  await asRole(page, 'admin')
+  await page.goto('/management/lens/shares')
+
+  await page.locator('tbody tr').click()
+  const drawer = page.getByRole('dialog', { name: /Q&A detail|问答详情/ })
+  await expect(
+    drawer.getByText('What content should the reviewer inspect?')
+  ).toBeVisible()
+  await expect(
+    drawer.getByText('The complete answer must stay visible during moderation.')
+  ).toBeVisible()
+
+  await drawer.getByRole('button', { name: /Approve|通过上榜/ }).click()
+  await expect(
+    drawer.getByRole('button', { name: /Remove from list|撤下列表/ })
+  ).toBeVisible()
+
+  await drawer.getByRole('button', { name: /Done|完成/ }).click()
+  await page.getByRole('button', { name: /^(Listed|已上榜)$/ }).click()
+  await page.locator('tbody tr').click()
+  await expect(
+    drawer.getByText('What content should the reviewer inspect?')
+  ).toBeVisible()
+
+  await drawer.getByRole('button', { name: /Take down|下架/ }).click()
+  await expect(
+    drawer.getByRole('button', { name: /Restore|恢复/ })
+  ).toBeVisible()
+
+  await drawer.getByRole('button', { name: /Done|完成/ }).click()
+  await page.getByRole('button', { name: /^(Hidden|已下架)$/ }).click()
+  await page.locator('tbody tr').click()
+  await expect(
+    drawer.getByText('The complete answer must stay visible during moderation.')
+  ).toBeVisible()
+
+  await drawer.getByRole('button', { name: /Restore|恢复/ }).click()
+  await expect(
+    drawer.getByRole('button', { name: /Remove from list|撤下列表/ })
+  ).toBeVisible()
+
+  expect(patches).toEqual([
+    { is_listed: true },
+    { status: 'hidden' },
+    { status: 'published' }
+  ])
+})

--- a/frontend/src/admin/pages/lens/ShareReview.vue
+++ b/frontend/src/admin/pages/lens/ShareReview.vue
@@ -73,7 +73,8 @@
                 <tr
                   v-for="row in pagedRows"
                   :key="row.uuid"
-                  class="transition-colors hover:bg-gray-50"
+                  class="cursor-pointer transition-colors hover:bg-gray-50"
+                  @click="openDetail(row)"
                 >
                   <td class="table-cell">
                     <div
@@ -130,8 +131,15 @@
                     {{ formatDate(row.published_at, 'yyyy-MM-dd HH:mm') }}
                   </td>
                   <td class="table-cell text-gray-500">{{ row.view_count }}</td>
-                  <td class="table-cell">
+                  <td class="table-cell" @click.stop>
                     <div class="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        class="text-xs text-gray-500 hover:text-primary-600"
+                        @click="openDetail(row)"
+                      >
+                        {{ t('lens.qa.viewDetail') }}
+                      </button>
                       <a
                         :href="qaShareUrl(row.token)"
                         target="_blank"
@@ -189,6 +197,104 @@
           />
         </div>
       </div>
+
+      <BaseDrawer
+        :show="drawerOpen"
+        :title="t('lens.qa.detailTitle')"
+        :subtitle="detail?.title || ''"
+        width="2xl"
+        @close="closeDetail"
+      >
+        <BaseLoading v-if="detailLoading" />
+        <div v-else-if="detail" class="space-y-6 pt-1">
+          <dl class="grid grid-cols-1 gap-x-4 gap-y-3 text-sm sm:grid-cols-2">
+            <div>
+              <dt class="text-gray-500">{{ t('lens.qa.assistant') }}</dt>
+              <dd class="mt-0.5 text-gray-900">
+                {{ detail.assistant_name || '-' }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-gray-500">{{ t('lens.qa.publishedBy') }}</dt>
+              <dd class="mt-0.5 text-gray-900">
+                {{ detail.published_by || '-' }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-gray-500">{{ t('lens.qa.publishedAt') }}</dt>
+              <dd class="mt-0.5 text-gray-900">
+                {{ formatDate(detail.published_at, 'yyyy-MM-dd HH:mm') }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-gray-500">{{ t('lens.qa.views') }}</dt>
+              <dd class="mt-0.5 text-gray-900">{{ detail.view_count }}</dd>
+            </div>
+          </dl>
+
+          <section>
+            <h3 class="mb-2 text-sm font-semibold text-gray-900">
+              {{ t('lens.qa.question') }}
+            </h3>
+            <div
+              class="whitespace-pre-wrap rounded-lg bg-gray-50 p-4 text-sm text-gray-800"
+            >
+              {{ detail.question || '-' }}
+            </div>
+          </section>
+
+          <section>
+            <h3 class="mb-2 text-sm font-semibold text-gray-900">
+              {{ t('lens.qa.answer') }}
+            </h3>
+            <MarkdownRenderer :content="detail.answer || ''" />
+          </section>
+        </div>
+
+        <template v-if="detail" #footer>
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <BaseButton
+              v-if="!detail.is_listed && detail.status === 'published'"
+              variant="primary"
+              size="sm"
+              :loading="actionLoading"
+              @click="apply(detail, { is_listed: true })"
+            >
+              {{ t('lens.qa.approve') }}
+            </BaseButton>
+            <BaseButton
+              v-if="detail.is_listed && detail.status === 'published'"
+              variant="outline"
+              size="sm"
+              :loading="actionLoading"
+              @click="apply(detail, { is_listed: false })"
+            >
+              {{ t('lens.qa.unlist') }}
+            </BaseButton>
+            <BaseButton
+              v-if="detail.status === 'published'"
+              variant="danger"
+              size="sm"
+              :loading="actionLoading"
+              @click="apply(detail, { status: 'hidden' })"
+            >
+              {{ t('lens.qa.hide') }}
+            </BaseButton>
+            <BaseButton
+              v-if="detail.status === 'hidden'"
+              variant="outline"
+              size="sm"
+              :loading="actionLoading"
+              @click="apply(detail, { status: 'published' })"
+            >
+              {{ t('lens.qa.restore') }}
+            </BaseButton>
+            <BaseButton variant="secondary" size="sm" @click="closeDetail">
+              {{ t('lens.qa.done') }}
+            </BaseButton>
+          </div>
+        </template>
+      </BaseDrawer>
     </div>
   </AdminLayout>
 </template>
@@ -200,9 +306,11 @@ import { useI18n } from 'vue-i18n'
 
 import AdminLayout from '@/admin/layout/AdminLayout.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
+import BaseDrawer from '@/components/ui/BaseDrawer.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
 import PaginationBar from '@/components/ui/PaginationBar.vue'
-import { listAdminShares, updateAdminShare } from '@/api/lens'
+import { getAdminShare, listAdminShares, updateAdminShare } from '@/api/lens'
 import { formatDate } from '@/utils/formatting'
 import { qaShareUrl } from '@/utils/lens'
 import { useToast } from '@/composables/useToast'
@@ -215,6 +323,11 @@ const loading = ref(true)
 const activeTab = ref('pending')
 const currentPage = ref(1)
 const pageSize = ref(20)
+const drawerOpen = ref(false)
+const selectedUuid = ref(null)
+const detail = ref(null)
+const detailLoading = ref(false)
+const actionLoading = ref(false)
 
 const tabs = computed(() => [
   { key: 'pending', label: t('lens.qa.tabPending') },
@@ -275,13 +388,45 @@ function setTab(key) {
   load()
 }
 
+async function openDetail(row) {
+  selectedUuid.value = row.uuid
+  drawerOpen.value = true
+  detail.value = null
+  await loadDetail()
+}
+
+function closeDetail() {
+  drawerOpen.value = false
+  selectedUuid.value = null
+  detail.value = null
+}
+
+async function loadDetail() {
+  if (!selectedUuid.value) return
+  detailLoading.value = true
+  try {
+    detail.value = await getAdminShare(selectedUuid.value)
+  } catch {
+    detail.value = null
+    showError(t('lens.qa.detailFailed'))
+  } finally {
+    detailLoading.value = false
+  }
+}
+
 async function apply(row, payload) {
+  actionLoading.value = true
   try {
     await updateAdminShare(row.uuid, payload)
     showSuccess(t('lens.qa.actionDone'))
-    load()
+    await load()
+    if (drawerOpen.value && selectedUuid.value === row.uuid) {
+      await loadDetail()
+    }
   } catch {
     showError(t('lens.qa.shareFailed'))
+  } finally {
+    actionLoading.value = false
   }
 }
 

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -475,6 +475,11 @@ export async function listAdminShares(params = {}) {
   return unwrapResponse(response)
 }
 
+export async function getAdminShare(uuid) {
+  const response = await api.get(`/lens/admin/shares/${uuid}/`)
+  return unwrapResponse(response)
+}
+
 export async function updateAdminShare(uuid, payload) {
   const response = await api.patch(`/lens/admin/shares/${uuid}/`, payload)
   return unwrapResponse(response)

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -123,6 +123,7 @@
       "previewFile": "Preview {name}",
       "downloadFile": "Download {name}",
       "detailTitle": "Q&A detail",
+      "detailFailed": "Failed to load Q&A details",
       "assistant": "Assistant",
       "views": "Views",
       "ctaTitle": "Have a similar question?",
@@ -159,6 +160,7 @@
       "hide": "Take down",
       "restore": "Restore",
       "preview": "Preview",
+      "viewDetail": "View details",
       "publishedBy": "Publisher",
       "publishedAt": "Published",
       "actionDone": "Updated"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -123,6 +123,7 @@
       "previewFile": "预览 {name}",
       "downloadFile": "下载 {name}",
       "detailTitle": "问答详情",
+      "detailFailed": "问答详情加载失败",
       "assistant": "助手",
       "views": "查看数",
       "ctaTitle": "想问类似问题？",
@@ -159,6 +160,7 @@
       "hide": "下架",
       "restore": "恢复",
       "preview": "预览",
+      "viewDetail": "查看详情",
       "publishedBy": "发布人",
       "publishedAt": "发布时间",
       "actionDone": "已更新"


### PR DESCRIPTION
### **User description**
## Summary

- add an admin-only Q&A detail response that includes the complete question and answer
- open shared Q&A records in an in-page review drawer for pending, listed, and hidden states
- keep approve, unlist, take-down, and restore actions available from the detail view
- preserve the public preview action and keep full content out of the admin list response

## Root cause

The review table only exposed a short answer snippet and linked to the public share page. Pending and hidden shares are not accessible through that public route, so reviewers could not inspect the content before moderating it.

## Validation

- `python manage.py test lens.tests.test_shared_qa` (33 tests passed)
- Prettier check for the changed frontend files
- ESLint check for the changed Vue and JavaScript files
- `npm run build`
- `BASE_URL=http://localhost:8000 playwright test e2e/access-control/qa-review.spec.js --config=playwright.access.config.cjs` (1 test passed)
- desktop and 390px browser verification, including long-answer scrolling and all moderation actions

Closes #26


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add admin-only detail endpoint with full Q&A content

- Open shared Q&A in an in-page review drawer

- Keep approve/unlist/hide/restore actions in drawer

- Add backend, frontend, and e2e tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ShareReview["ShareReview.vue"] --> |"click row"| openDetail["openDetail()"]
  openDetail --> |"GET /api/lens/admin/shares/:uuid/"| Backend["AdminSharedQAViewSet.retrieve"]
  Backend --> |"SharedQAAdminDetailSerializer"| Detail["Full Q&A content"]
  Detail --> Drawer["BaseDrawer"]
  Drawer --> |"moderation actions"| apply["apply()"]
  apply --> |"PATCH /api/lens/admin/shares/:uuid/"| Backend
  Backend --> |"update state"| Drawer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Add detail serializer with full Q&A content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shares.py</strong><dd><code>Return detail serializer for retrieve action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-71900dccaadf063e99cb73d6b7a06fa818bf4cbe4ee50018488d441b03afcc65">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ShareReview.vue</strong><dd><code>Add right-side drawer for Q&A review</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-1c41598417355cdc78248a58622d628210f52898531e2314e54c7a99541881e4">+149/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add getAdminShare API function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English locale strings for detail drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese locale strings for detail drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_shared_qa.py</strong><dd><code>Add tests for detail endpoint and list omission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-c776a2e7bf9a896d41f4933eb5f3b072cb5a1e1eb0e693642766f0f74d87bdb2">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qa-review.spec.js</strong><dd><code>Add e2e test for review drawer moderation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/157/files#diff-a9e2706d61db244c06e9571be7d1183aa5971943da46a3e3c304053ab67a489c">+103/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

