### PR TITLE
Restore total time in agent activity summaries

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1368,6 +1368,8 @@ import {
   applyRuntimeEvent,
   calculateRunElapsedSeconds,
   createRuntimeState,
+  formatActivityProgressText,
+  formatDuration,
   getMessageTimestamp,
   isActiveProgressAncestor,
   scrollConversationToBottomAfterRender,
@@ -1604,13 +1606,6 @@ const runtimePhaseText = computed(() => {
   return known.has(phase) ? t(`lens.chat.runtime.phase.${phase}`) : null
 })
 
-function formatDuration(seconds) {
-  if (seconds == null) return ''
-  const s = Math.round(seconds)
-  if (s < 60) return `${s}s`
-  return `${Math.floor(s / 60)}m ${s % 60}s`
-}
-
 const elapsedText = computed(() => {
   if (elapsedSeconds.value === 0) return null
   return formatDuration(elapsedSeconds.value)
@@ -1684,16 +1679,11 @@ function structuredProgressText(
     return stageProgressText(source.items, durationSeconds, terminal)
   }
   if (progress.kind === 'activity') {
-    const count = progress.items.reduce(
-      (total, item) => total + Number(item.count || 1),
-      0
-    )
-    return t(
-      terminal
-        ? 'lens.chat.runtime.activityCompleted'
-        : 'lens.chat.runtime.activityProgress',
-      { count }
-    )
+    return formatActivityProgressText(progress.items, {
+      durationSeconds,
+      terminal,
+      translate: t
+    })
   }
   return ''
 }

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -45,6 +45,33 @@ export function calculateRunElapsedSeconds(run, nowMs = Date.now()) {
   return Math.max(0, Math.floor((finishedMs - createdMs) / 1000))
 }
 
+export function formatDuration(seconds) {
+  if (seconds == null) return ''
+  const roundedSeconds = Math.round(seconds)
+  if (roundedSeconds < 60) return `${roundedSeconds}s`
+  return `${Math.floor(roundedSeconds / 60)}m ${roundedSeconds % 60}s`
+}
+
+export function formatActivityProgressText(
+  activities,
+  { durationSeconds = null, terminal = false, translate }
+) {
+  const count = activities.reduce(
+    (total, item) => total + Number(item.count || 1),
+    0
+  )
+  let text = translate(
+    terminal
+      ? 'lens.chat.runtime.activityCompleted'
+      : 'lens.chat.runtime.activityProgress',
+    { count }
+  )
+  if (durationSeconds != null) {
+    text += ` · ${formatDuration(durationSeconds)}`
+  }
+  return text
+}
+
 export function getMessageTimestamp(message) {
   if (message?.role === 'assistant' && message.completed_at) {
     return message.completed_at

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -7,6 +7,7 @@ import {
   buildWorkflowTree,
   calculateRunElapsedSeconds,
   createRuntimeState,
+  formatActivityProgressText,
   getMessageTimestamp,
   isActiveProgressAncestor,
   normalizePlanSteps,
@@ -98,6 +99,16 @@ test('returns zero for missing, invalid or future run timestamps', () => {
     calculateRunElapsedSeconds({ created_at: '2026-07-27T05:00:01.000Z' }, now),
     0
   )
+})
+
+test('includes total time in completed agent activity summaries', () => {
+  const text = formatActivityProgressText([{ count: 5 }, { count: 6 }], {
+    durationSeconds: 74.4,
+    terminal: true,
+    translate: (_key, { count }) => `Completed ${count} activities`
+  })
+
+  assert.equal(text, 'Completed 11 activities · 1m 14s')
 })
 
 test('reduces route, phase, plan and capability events', () => {


### PR DESCRIPTION
### **User description**
## Summary
- restore the total run duration beside completed Agent activity counts
- reuse one duration formatter across live and historical progress summaries
- add regression coverage for aggregated activity counts and duration text

Closes #159

## Test plan
- [x] `npm run test:unit` (95 tests)
- [x] ESLint on the three affected frontend files
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser task space 38: desktop and 390px mobile activity summaries


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restore total run duration in agent activity summaries

- Extract shared formatDuration and formatActivityProgressText to runtimeEvents.js

- Add regression test for activity duration display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Chat.vue] -->|extract formatDuration| B[runtimeEvents.js]
  B -->|export formatActivityProgressText| A
  C[runtimeEvents.test.js] -->|test formatActivityProgressText| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Use shared activity progress formatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Removed local <code>formatDuration</code> function<br> <li> Imported shared <code>formatDuration</code> and <code>formatActivityProgressText</code><br> <li> Replaced inline activity progress text generation with <br><code>formatActivityProgressText</code> including duration</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/162/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+7/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeEvents.js</strong><dd><code>Extract duration formatting and activity progress text</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/runtimeEvents.js

<ul><li>Exported <code>formatDuration</code> as a reusable utility<br> <li> Added <code>formatActivityProgressText</code> that appends duration text when <br>provided</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/162/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeEvents.test.js</strong><dd><code>Add regression test for activity duration display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/runtimeEvents.test.js

<ul><li>Added regression test for <code>formatActivityProgressText</code> with duration and <br>terminal flag</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/162/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

