### PR TITLE
Add managed workspace data sources

### DIFF
--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -212,6 +212,8 @@ def dispatch_datasource_sync_async(datasource, task_id, trigger="scheduled"):
     ).get(
         pk=datasource.pk
     )
+    if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+        raise DataSourceDispatchError("DATASOURCE_SYNC_NOT_SUPPORTED")
     validate_datasource_lensnode(datasource.lensnode)
     config = datasource_runtime_config(datasource)
     sync_policy = datasource.sync_policy or {}

--- a/backend/lens/migrations/0028_datasource_managed_workspace.py
+++ b/backend/lens/migrations/0028_datasource_managed_workspace.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0027_run_feedback"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="datasource",
+            name="source_type",
+            field=models.CharField(
+                choices=[
+                    ("git", "Git"),
+                    ("feishu", "Feishu"),
+                    ("managed_workspace", "Managed Workspace"),
+                ],
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="datasource",
+            name="availability_checked_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="datasource",
+            name="availability_message",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="datasource",
+            name="availability_status",
+            field=models.CharField(
+                choices=[
+                    ("unknown", "Unknown"),
+                    ("available", "Available"),
+                    ("unavailable", "Unavailable"),
+                    ("error", "Error"),
+                ],
+                default="unknown",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/backend/lens/migrations/0029_datasource_managed_workspace.py
+++ b/backend/lens/migrations/0029_datasource_managed_workspace.py
@@ -3,7 +3,10 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("lens", "0027_run_feedback"),
+        (
+            "lens",
+            "0028_runexecution_agent_rounds_runexecution_run_timeout_s",
+        ),
     ]
 
     operations = [

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -366,15 +366,22 @@ class MCPServer(TimestampedUUIDModel):
 
 
 class DataSource(TimestampedUUIDModel):
-    """Independent synchronizer for external sources."""
+    """Cataloged external data resource bound to a LensNode."""
 
     class SourceType(models.TextChoices):
         GIT = "git", "Git"
         FEISHU = "feishu", "Feishu"
+        MANAGED_WORKSPACE = "managed_workspace", "Managed Workspace"
 
     class Status(models.TextChoices):
         ACTIVE = "active", "Active"
         DISABLED = "disabled", "Disabled"
+
+    class AvailabilityStatus(models.TextChoices):
+        UNKNOWN = "unknown", "Unknown"
+        AVAILABLE = "available", "Available"
+        UNAVAILABLE = "unavailable", "Unavailable"
+        ERROR = "error", "Error"
 
     name = models.CharField(max_length=160)
     source_type = models.CharField(max_length=32, choices=SourceType.choices)
@@ -397,6 +404,13 @@ class DataSource(TimestampedUUIDModel):
     )
     last_synced_at = models.DateTimeField(null=True, blank=True)
     last_error = models.TextField(blank=True, default="")
+    availability_status = models.CharField(
+        max_length=16,
+        choices=AvailabilityStatus.choices,
+        default=AvailabilityStatus.UNKNOWN,
+    )
+    availability_checked_at = models.DateTimeField(null=True, blank=True)
+    availability_message = models.TextField(blank=True, default="")
     status = models.CharField(
         max_length=16,
         choices=Status.choices,

--- a/backend/lens/periodic_tasks.py
+++ b/backend/lens/periodic_tasks.py
@@ -105,6 +105,9 @@ def _ensure_source_scheduled_task(datasource):
 def ensure_datasource_periodic_task(datasource):
     """Create missing Celery Beat and UI rows for a datasource sync."""
 
+    if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+        _disable_datasource_periodic_task(datasource)
+        return None
     if datasource.status == DataSource.Status.DISABLED:
         _disable_datasource_periodic_task(datasource)
         return None
@@ -163,6 +166,8 @@ def ensure_datasource_periodic_task(datasource):
 def estimate_datasource_next_run(datasource, record=None):
     """Return a best-effort next run time for datasource sync."""
 
+    if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+        return None
     if datasource.status == DataSource.Status.DISABLED:
         return None
 
@@ -287,7 +292,9 @@ def register_periodic_tasks():
             enabled=True,
         )
 
-    datasources = DataSource.objects.filter(status=DataSource.Status.ACTIVE)
+    datasources = DataSource.objects.filter(
+        status=DataSource.Status.ACTIVE,
+    ).exclude(source_type=DataSource.SourceType.MANAGED_WORKSPACE)
     for datasource in datasources:
         interval = datasource.sync_policy.get("interval_seconds", 3600)
         _ensure_source_scheduled_task(datasource)

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -15,6 +15,7 @@ from .assistant_lifecycle import (
 )
 from .attachments import ATTACHMENT_MAX_PER_MESSAGE
 from .datasource_services import (
+    check_datasource_path,
     DataSourceDispatchError,
     DataSourcePathError,
     normalize_workspace_target_path,
@@ -755,6 +756,7 @@ class DataSourceSerializer(serializers.ModelSerializer):
                 attrs["target_path"],
                 lensnode,
                 self.instance,
+                source_type,
             )
         except (DataSourcePathError, DataSourceDispatchError) as exc:
             raise serializers.ValidationError({"target_path": str(exc)})
@@ -764,7 +766,45 @@ class DataSourceSerializer(serializers.ModelSerializer):
             if "credential" in attrs
             else getattr(self.instance, "credential", None)
         )
-        if source_type == DataSource.SourceType.GIT:
+        if source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+            if credential is not None:
+                raise serializers.ValidationError(
+                    {
+                        "credential_uuid": (
+                            "Managed workspace does not use credentials"
+                        )
+                    }
+                )
+            if config:
+                raise serializers.ValidationError(
+                    {
+                        "config": (
+                            "Managed workspace does not use connection config"
+                        )
+                    }
+                )
+            if sync_policy:
+                raise serializers.ValidationError(
+                    {
+                        "sync_policy": (
+                            "Managed workspace does not use sync policy"
+                        )
+                    }
+                )
+            if self._managed_workspace_path_changed(
+                lensnode,
+                attrs["target_path"],
+                source_type,
+            ):
+                self._validate_managed_workspace_path(
+                    attrs,
+                    lensnode,
+                    source_type,
+                )
+            attrs["credential"] = None
+            attrs["config"] = {}
+            attrs["sync_policy"] = {}
+        elif source_type == DataSource.SourceType.GIT:
             _validate_datasource_credential_type(
                 credential,
                 {
@@ -789,10 +829,67 @@ class DataSourceSerializer(serializers.ModelSerializer):
             )
         else:
             raise serializers.ValidationError(
-                {"source_type": "source_type must be git or feishu"}
+                {"source_type": "Unsupported datasource source_type"}
             )
 
+        if (
+            source_type != DataSource.SourceType.MANAGED_WORKSPACE
+            and self.instance is not None
+            and self.instance.source_type
+            == DataSource.SourceType.MANAGED_WORKSPACE
+        ):
+            attrs["availability_status"] = (
+                DataSource.AvailabilityStatus.UNKNOWN
+            )
+            attrs["availability_checked_at"] = None
+            attrs["availability_message"] = ""
+
         return attrs
+
+    def _managed_workspace_path_changed(
+        self,
+        lensnode,
+        target_path,
+        source_type,
+    ):
+        """Return whether managed workspace availability must be checked."""
+
+        if self.instance is None:
+            return True
+        if self.instance.source_type != source_type:
+            return True
+        if self.instance.lensnode_id != lensnode.pk:
+            return True
+        try:
+            current_path = normalize_workspace_target_path(
+                self.instance.target_path,
+                lensnode.workspace_path,
+            )
+        except DataSourcePathError:
+            return True
+        return current_path != target_path
+
+    @staticmethod
+    def _validate_managed_workspace_path(attrs, lensnode, source_type):
+        """Require an existing directory for a managed workspace source."""
+
+        try:
+            result = check_datasource_path(
+                lensnode,
+                attrs["target_path"],
+                source_type,
+            )
+        except (DataSourcePathError, DataSourceDispatchError) as exc:
+            raise serializers.ValidationError({"target_path": str(exc)})
+        if not result.get("exists") or not result.get("is_directory"):
+            raise serializers.ValidationError(
+                {"target_path": "MANAGED_WORKSPACE_DIRECTORY_REQUIRED"}
+            )
+        attrs["availability_status"] = (
+            DataSource.AvailabilityStatus.AVAILABLE
+        )
+        attrs["availability_checked_at"] = timezone.now()
+        attrs["availability_message"] = str(result.get("message") or "")
 
     def get_credential_configured(self, datasource):
         """Return whether a datasource has a stored credential."""
@@ -907,6 +1004,9 @@ class DataSourceSerializer(serializers.ModelSerializer):
             "target_path",
             "last_synced_at",
             "last_error",
+            "availability_status",
+            "availability_checked_at",
+            "availability_message",
             "status",
             "created_at",
             "updated_at",
@@ -918,6 +1018,9 @@ class DataSourceSerializer(serializers.ModelSerializer):
             "current_sync",
             "sync_state",
             "last_error",
+            "availability_status",
+            "availability_checked_at",
+            "availability_message",
             "created_at",
             "updated_at",
         ]
@@ -1346,14 +1449,19 @@ def _validate_conversion_policy(conversion):
             )
 
 
-def _validate_unique_datasource_target_path(target_path, lensnode, instance):
-    """Reject an exact target path match on the same LensNode."""
+def _validate_unique_datasource_target_path(
+    target_path,
+    lensnode,
+    instance,
+    source_type,
+):
+    """Reject conflicting datasource paths on the same LensNode."""
 
     query = DataSource.objects.filter(lensnode=lensnode)
     if instance is not None:
         query = query.exclude(pk=instance.pk)
     target = PurePosixPath(target_path)
-    for datasource in query.only("target_path"):
+    for datasource in query.only("source_type", "target_path"):
         if not datasource.target_path:
             continue
         try:
@@ -1365,14 +1473,35 @@ def _validate_unique_datasource_target_path(target_path, lensnode, instance):
             )
         except DataSourcePathError:
             continue
-        if existing == target:
+        managed_overlap = (
+            source_type == DataSource.SourceType.MANAGED_WORKSPACE
+            or datasource.source_type
+            == DataSource.SourceType.MANAGED_WORKSPACE
+        )
+        paths_overlap = _paths_overlap(existing, target)
+        if existing == target or (managed_overlap and paths_overlap):
             raise serializers.ValidationError(
                 {
                     "target_path": (
-                        "Another datasource already uses this target path"
+                        "Another datasource uses an overlapping target path"
                     )
                 }
             )
+
+
+def _paths_overlap(first, second):
+    """Return whether either path contains the other path."""
+
+    try:
+        first.relative_to(second)
+        return True
+    except ValueError:
+        pass
+    try:
+        second.relative_to(first)
+        return True
+    except ValueError:
+        return False
 
 
 def _validate_datasource_credential_type(credential, auth_type):

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -137,6 +137,8 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
     datasource = DataSource.objects.select_related("lensnode").get(
         uuid=datasource_uuid
     )
+    if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+        return 0
     record = _get_or_create_source_sync_record(datasource)
     if datasource.status == DataSource.Status.DISABLED:
         if record.enabled:

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -24,7 +24,10 @@ from agentcore_metering.adapters.django.models import LLMConfig, LLMUsage
 from agentcore_task.adapters.django.models import TaskExecution
 
 from accounts.models import Role
-from lens.datasource_services import test_datasource_connection
+from lens.datasource_services import (
+    DataSourceDispatchError,
+    test_datasource_connection,
+)
 from lens.lensnode_auth import hash_lensnode_token
 from lens.models import (
     Assistant,
@@ -2653,6 +2656,30 @@ class LensApiTests(TestCase):
         )
 
     @patch("lens.views.lensnodes.check_datasource_path")
+    def test_check_managed_workspace_path_blocks_nested_datasource(
+        self,
+        check_path,
+    ):
+        response = self.client.post(
+            f"/api/lens/admin/lensnodes/{self.lensnode.uuid}/"
+            "check-datasource-path/",
+            {
+                "target_path": "/workspace/repo-cache/restored",
+                "source_type": "managed_workspace",
+                "config": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "blocked")
+        self.assertEqual(
+            response.data["message_code"],
+            "datasource_path_in_use",
+        )
+        check_path.assert_not_called()
+
+    @patch("lens.views.lensnodes.check_datasource_path")
     def test_check_datasource_path_allows_current_datasource_path(
         self,
         check_path,
@@ -2711,6 +2738,236 @@ class LensApiTests(TestCase):
         self.assertEqual(task.status, "PENDING")
         self.assertEqual(task.created_by, self.user)
         self.assertEqual(task.metadata["celery_task_id"], celery_task_id)
+
+    @patch("lens.serializers.check_datasource_path")
+    def test_managed_workspace_create_does_not_enqueue_sync(self, check_path):
+        check_path.return_value = {
+            "status": "available",
+            "exists": True,
+            "is_directory": True,
+            "message": "Managed workspace directory is available.",
+        }
+        payload = {
+            "name": "Restored Snapshot",
+            "source_type": "managed_workspace",
+            "lensnode_uuid": str(self.lensnode.uuid),
+            "target_path": "/workspace/restores/finance",
+            "config": {},
+            "sync_policy": {},
+        }
+
+        with patch(
+            "lens.views.datasources.source_sync_task.apply_async"
+        ) as apply_async:
+            with self.captureOnCommitCallbacks(execute=True):
+                response = self.client.post(
+                    "/api/lens/admin/datasources/",
+                    payload,
+                    format="json",
+                )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["availability_status"], "available")
+        self.assertNotIn("initial_sync_task_id", response.data)
+        apply_async.assert_not_called()
+        datasource = DataSource.objects.get(uuid=response.data["uuid"])
+        self.assertFalse(
+            ScheduledTask.objects.filter(target_id=datasource.uuid).exists()
+        )
+
+    @patch("lens.serializers.check_datasource_path")
+    def test_managed_workspace_create_requires_existing_directory(
+        self,
+        check_path,
+    ):
+        check_path.return_value = {
+            "status": "blocked",
+            "exists": False,
+            "is_directory": False,
+            "message": "Managed workspace directory does not exist.",
+        }
+
+        response = self.client.post(
+            "/api/lens/admin/datasources/",
+            {
+                "name": "Missing Snapshot",
+                "source_type": "managed_workspace",
+                "lensnode_uuid": str(self.lensnode.uuid),
+                "target_path": "/workspace/restores/missing",
+                "config": {},
+                "sync_policy": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["target_path"][0],
+            "MANAGED_WORKSPACE_DIRECTORY_REQUIRED",
+        )
+
+    def test_managed_workspace_rejects_path_outside_workspace(self):
+        response = self.client.post(
+            "/api/lens/admin/datasources/",
+            {
+                "name": "Outside Snapshot",
+                "source_type": "managed_workspace",
+                "lensnode_uuid": str(self.lensnode.uuid),
+                "target_path": "/etc/data",
+                "config": {},
+                "sync_policy": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["target_path"][0],
+            "LENS_SOURCE_TARGET_PATH_INVALID",
+        )
+
+    @patch("lens.serializers.check_datasource_path")
+    def test_managed_workspace_rejects_overlapping_datasource_path(
+        self,
+        check_path,
+    ):
+        response = self.client.post(
+            "/api/lens/admin/datasources/",
+            {
+                "name": "Managed Parent",
+                "source_type": "managed_workspace",
+                "lensnode_uuid": str(self.lensnode.uuid),
+                "target_path": "/workspace",
+                "config": {},
+                "sync_policy": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        check_path.assert_not_called()
+
+        response = self.client.post(
+            "/api/lens/admin/datasources/",
+            {
+                "name": "Managed Child",
+                "source_type": "managed_workspace",
+                "lensnode_uuid": str(self.lensnode.uuid),
+                "target_path": "/workspace/repo-cache/restored",
+                "config": {},
+                "sync_policy": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("overlapping", response.data["target_path"][0])
+        check_path.assert_not_called()
+
+    def test_managed_workspace_manual_sync_is_rejected(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        with patch(
+            "lens.views.datasources.source_sync_task.apply_async"
+        ) as apply_async:
+            response = self.client.post(
+                f"/api/lens/admin/datasources/{datasource.uuid}/sync/",
+                {},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.data["detail"],
+            "DATASOURCE_SYNC_NOT_SUPPORTED",
+        )
+        apply_async.assert_not_called()
+
+    @patch("lens.views.datasources.check_datasource_path")
+    def test_managed_workspace_refresh_updates_availability(self, check_path):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            availability_status=DataSource.AvailabilityStatus.AVAILABLE,
+        )
+        check_path.return_value = {
+            "status": "blocked",
+            "exists": False,
+            "is_directory": False,
+            "message": "Managed workspace directory does not exist.",
+        }
+
+        response = self.client.post(
+            f"/api/lens/admin/datasources/{datasource.uuid}/"
+            "refresh-availability/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["availability_status"], "unavailable")
+        datasource.refresh_from_db()
+        self.assertIsNotNone(datasource.availability_checked_at)
+
+        check_path.side_effect = DataSourceDispatchError("LENSNODE_OFFLINE")
+        response = self.client.post(
+            f"/api/lens/admin/datasources/{datasource.uuid}/"
+            "refresh-availability/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["availability_status"], "error")
+        self.assertEqual(
+            response.data["availability_message"],
+            "LENSNODE_OFFLINE",
+        )
+
+    @patch("lens.serializers.check_datasource_path")
+    def test_managed_workspace_metadata_update_skips_path_check(
+        self,
+        check_path,
+    ):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        response = self.client.patch(
+            f"/api/lens/admin/datasources/{datasource.uuid}/",
+            {"name": "Renamed Snapshot"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        check_path.assert_not_called()
+
+    def test_managed_workspace_delete_only_removes_catalog_record(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        with patch("lens.datasource_services._send_lensnode_command") as send:
+            response = self.client.delete(
+                f"/api/lens/admin/datasources/{datasource.uuid}/"
+            )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(DataSource.objects.filter(pk=datasource.pk).exists())
+        send.assert_not_called()
 
     def test_datasource_manual_sync_registers_task(self):
         with patch(

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -19,7 +19,10 @@ from core.management.commands.register_periodic_tasks import (
 )
 from core.periodic_registry import TASK_REGISTRY
 from lens.consumers import LensNodeConsumer
-from lens.datasource_services import dispatch_datasource_sync_async
+from lens.datasource_services import (
+    DataSourceDispatchError,
+    dispatch_datasource_sync_async,
+)
 from lens.execution import execute_answer_run
 from lens.lensnode_auth import issue_lensnode_token
 from lens.models import (
@@ -1287,6 +1290,34 @@ class LensServiceTests(TransactionTestCase):
             self.assertGreaterEqual(len(steps), 2)
             self.assertEqual(steps[0]["name"], "prepare")
             self.assertEqual(steps[-1]["name"], "dispatch")
+
+    def test_managed_workspace_sync_is_blocked_at_task_and_dispatch_layers(
+        self,
+    ):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        with patch("lens.tasks.dispatch_datasource_sync_async") as dispatch:
+            self.assertEqual(source_sync_task(str(datasource.uuid)), 0)
+
+        dispatch.assert_not_called()
+        self.assertFalse(
+            ScheduledTask.objects.filter(target_id=datasource.uuid).exists()
+        )
+        self.assertFalse(
+            TaskExecution.objects.filter(
+                metadata__datasource_uuid=str(datasource.uuid)
+            ).exists()
+        )
+        with self.assertRaises(DataSourceDispatchError):
+            dispatch_datasource_sync_async(
+                datasource,
+                task_id="managed-sync",
+            )
 
     def test_source_sync_task_reuses_registered_task_id(self):
         task_id = "manual-sync"

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -10,6 +10,11 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from lens.datasource_services import (
+    DataSourceDispatchError,
+    DataSourcePathError,
+    check_datasource_path,
+)
 from lens.models import DataSource, ScheduledTask
 from lens.periodic_tasks import ensure_datasource_periodic_task
 from lens.serializers import DataSourceSerializer
@@ -137,6 +142,8 @@ class DataSourceViewSet(BaseAdminViewSet):
 
         datasource = serializer.save()
         ensure_datasource_periodic_task(datasource)
+        if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+            return
         if datasource.status == DataSource.Status.DISABLED:
             return
         task_id = uuid_mod.uuid4().hex
@@ -161,6 +168,8 @@ class DataSourceViewSet(BaseAdminViewSet):
     def _enqueue_datasource_sync(datasource, task_id, trigger, user=None):
         """Register and enqueue one datasource sync task."""
 
+        if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+            raise ValueError("DATASOURCE_SYNC_NOT_SUPPORTED")
         if datasource.status == DataSource.Status.DISABLED:
             raise ValueError("DATASOURCE_DISABLED")
         celery_task_id = uuid_mod.uuid4().hex
@@ -185,6 +194,11 @@ class DataSourceViewSet(BaseAdminViewSet):
         """Enqueue datasource synchronization on its LensNode."""
 
         datasource = self.get_object()
+        if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+            return Response(
+                {"detail": "DATASOURCE_SYNC_NOT_SUPPORTED"},
+                status=status.HTTP_409_CONFLICT,
+            )
         if datasource.status == DataSource.Status.DISABLED:
             return Response(
                 {"detail": "DATASOURCE_DISABLED"},
@@ -228,6 +242,50 @@ class DataSourceViewSet(BaseAdminViewSet):
             datasource.status = next_status
             datasource.save(update_fields=["status", "updated_at"])
         ensure_datasource_periodic_task(datasource)
+        return Response(DataSourceSerializer(datasource).data)
+
+    @action(detail=True, methods=["post"], url_path="refresh-availability")
+    def refresh_availability(self, request, uuid=None):
+        """Refresh a managed workspace path without modifying its contents."""
+
+        datasource = self.get_object()
+        if datasource.source_type != DataSource.SourceType.MANAGED_WORKSPACE:
+            return Response(
+                {"detail": "DATASOURCE_AVAILABILITY_NOT_SUPPORTED"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        try:
+            result = check_datasource_path(
+                datasource.lensnode,
+                datasource.target_path,
+                datasource.source_type,
+            )
+        except (DataSourcePathError, DataSourceDispatchError) as exc:
+            datasource.availability_status = (
+                DataSource.AvailabilityStatus.ERROR
+            )
+            datasource.availability_message = str(exc)
+        else:
+            is_available = bool(
+                result.get("exists") and result.get("is_directory")
+            )
+            datasource.availability_status = (
+                DataSource.AvailabilityStatus.AVAILABLE
+                if is_available
+                else DataSource.AvailabilityStatus.UNAVAILABLE
+            )
+            datasource.availability_message = str(
+                result.get("message") or ""
+            )
+        datasource.availability_checked_at = timezone.now()
+        datasource.save(
+            update_fields=[
+                "availability_status",
+                "availability_checked_at",
+                "availability_message",
+                "updated_at",
+            ]
+        )
         return Response(DataSourceSerializer(datasource).data)
 
     @action(detail=True, methods=["get"], url_path="sync-tasks")

--- a/backend/lens/views/lensnodes.py
+++ b/backend/lens/views/lensnodes.py
@@ -1,5 +1,7 @@
 """LensNode enrollment, token, and datasource-path viewset."""
 
+from pathlib import PurePosixPath
+
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -181,6 +183,7 @@ class LensNodeViewSet(BaseAdminViewSet):
                 lensnode,
                 target_path,
                 request.data.get("datasource_uuid") or None,
+                request.data.get("source_type") or DataSource.SourceType.GIT,
             )
             if conflict is not None:
                 return Response(
@@ -237,7 +240,12 @@ class LensNodeViewSet(BaseAdminViewSet):
         return Response(result)
 
 
-def _datasource_target_path_conflict(lensnode, target_path, datasource_uuid):
+def _datasource_target_path_conflict(
+    lensnode,
+    target_path,
+    datasource_uuid,
+    source_type,
+):
     """Return another datasource using the same target path on this
     LensNode."""
 
@@ -248,16 +256,46 @@ def _datasource_target_path_conflict(lensnode, target_path, datasource_uuid):
         target_path,
         lensnode.workspace_path,
     )
-    for datasource in query.only("uuid", "name", "target_path"):
+    target = PurePosixPath(normalized_target)
+    for datasource in query.only(
+        "uuid",
+        "name",
+        "source_type",
+        "target_path",
+    ):
         if not datasource.target_path:
             continue
         try:
-            existing = normalize_workspace_target_path(
-                datasource.target_path,
-                lensnode.workspace_path,
+            existing = PurePosixPath(
+                normalize_workspace_target_path(
+                    datasource.target_path,
+                    lensnode.workspace_path,
+                )
             )
         except DataSourcePathError:
             continue
-        if existing == normalized_target:
+        managed_overlap = (
+            source_type == DataSource.SourceType.MANAGED_WORKSPACE
+            or datasource.source_type
+            == DataSource.SourceType.MANAGED_WORKSPACE
+        )
+        if existing == target or (
+            managed_overlap and _datasource_paths_overlap(existing, target)
+        ):
             return datasource
     return None
+
+
+def _datasource_paths_overlap(first, second):
+    """Return whether either datasource path contains the other."""
+
+    try:
+        first.relative_to(second)
+        return True
+    except ValueError:
+        pass
+    try:
+        second.relative_to(first)
+        return True
+    except ValueError:
+        return False

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -983,12 +983,22 @@
       "issueToken": "Issue",
       "revokeToken": "Revoke",
       "sync": "Sync",
+      "refreshAvailability": "Check path",
       "enableDatasource": "Enable",
       "disableDatasource": "Disable",
       "cancelSync": "Cancel Sync",
       "viewTask": "View Task",
       "addRow": "Add row",
       "removeRow": "Remove"
+    },
+    "availability": {
+      "title": "Availability",
+      "unknown": "Unknown",
+      "available": "Available",
+      "unavailable": "Unavailable",
+      "error": "Error",
+      "checkedAt": "Last checked",
+      "message": "Check result"
     },
     "fields": {
       "name": "Name",
@@ -1153,6 +1163,12 @@
       "gitDesc": "Sync one Git repository into the node workspace.",
       "feishu": "Feishu",
       "feishuDesc": "Sync Feishu documents or Drive folders into the node workspace.",
+      "managedWorkspace": "Managed Workspace",
+      "managedWorkspaceDesc": "Catalog an existing directory managed by an external system without modifying or synchronizing its contents.",
+      "managedNodeDesc": "Select the online LensNode that contains the externally managed directory.",
+      "managedPathDesc": "Select or enter an existing directory. SourceLens will only check and catalog it.",
+      "managedPathHint": "The directory must already exist under the selected node workspace. SourceLens will never create or modify it.",
+      "managedPathPlaceholder": "Existing workspace-relative path, e.g. restores/finance",
       "onlineNodeHint": "Only approved online nodes are shown.",
       "noOnlineNodes": "No online LensNode is available.",
       "gitRepoHint": "Copy the Git HTTPS URL; use HTTPS Token for private repositories.",
@@ -1265,7 +1281,9 @@
         "not_git_repo": "Directory is not empty and is not a Git repo.",
         "remote_mismatch": "Existing Git remote does not match repo URL.",
         "git_update": "Existing Git repository can be updated.",
-        "datasource_path_in_use": "This directory is already used by another datasource. Choose a different directory to avoid source data and incremental manifest conflicts."
+        "datasource_path_in_use": "This directory is already used by another datasource. Choose a different directory to avoid source data and incremental manifest conflicts.",
+        "managed_workspace_available": "Managed workspace directory is available.",
+        "managed_workspace_missing": "Managed workspace directory does not exist."
       },
       "feishuScopeDocuments": "Specific documents",
       "feishuScopeDriveFolder": "Drive folder",
@@ -1415,7 +1433,8 @@
       "syncFailed": "Failed to trigger sync task",
       "datasourceDisabled": "Data source is disabled; sync cannot start",
       "syncCancelled": "Sync task cancelled",
-      "syncCancelFailed": "Failed to cancel sync task"
+      "syncCancelFailed": "Failed to cancel sync task",
+      "availabilityRefreshed": "Path availability refreshed"
     },
     "visibility": {
       "public": "Public",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -983,12 +983,22 @@
       "issueToken": "签发",
       "revokeToken": "吊销",
       "sync": "同步",
+      "refreshAvailability": "检查路径",
       "enableDatasource": "启用",
       "disableDatasource": "禁用",
       "cancelSync": "取消同步",
       "viewTask": "查看任务",
       "addRow": "添加一行",
       "removeRow": "移除"
+    },
+    "availability": {
+      "title": "可用性",
+      "unknown": "未知",
+      "available": "可用",
+      "unavailable": "不可用",
+      "error": "错误",
+      "checkedAt": "上次检查",
+      "message": "检查结果"
     },
     "fields": {
       "name": "名称",
@@ -1153,6 +1163,12 @@
       "gitDesc": "同步一个 Git 仓库到节点工作区。",
       "feishu": "飞书",
       "feishuDesc": "同步飞书文档或 Drive 目录到节点工作区。",
+      "managedWorkspace": "托管工作区",
+      "managedWorkspaceDesc": "登记由外部系统维护的已有目录，不修改或同步目录内容。",
+      "managedNodeDesc": "选择包含外部托管目录的在线 LensNode。",
+      "managedPathDesc": "选择或输入一个已有目录，SourceLens 只会检查并登记该目录。",
+      "managedPathHint": "目录必须已存在于所选节点工作区内，SourceLens 绝不会创建或修改它。",
+      "managedPathPlaceholder": "工作区内已有的相对路径，例如 restores/finance",
       "onlineNodeHint": "只显示已审批且在线的节点。",
       "noOnlineNodes": "暂无在线节点，请先确认 LensNode 已连接。",
       "gitRepoHint": "复制 Git 仓库 HTTPS 地址；私有仓库选择 HTTPS Token。",
@@ -1265,7 +1281,9 @@
         "not_git_repo": "目录非空，且不是 Git 仓库。",
         "remote_mismatch": "已有 Git 仓库的远程地址与当前仓库 URL 不一致。",
         "git_update": "已有 Git 仓库可以更新。",
-        "datasource_path_in_use": "该目录已被其他数据源使用，请选择另一个目录，避免源数据和增量记录冲突。"
+        "datasource_path_in_use": "该目录已被其他数据源使用，请选择另一个目录，避免源数据和增量记录冲突。",
+        "managed_workspace_available": "托管工作区目录可用。",
+        "managed_workspace_missing": "托管工作区目录不存在。"
       },
       "feishuScopeDocuments": "指定文档",
       "feishuScopeDriveFolder": "Drive 目录",
@@ -1415,7 +1433,8 @@
       "syncFailed": "同步任务触发失败",
       "datasourceDisabled": "数据源已禁用，不能触发同步",
       "syncCancelled": "同步任务已取消",
-      "syncCancelFailed": "同步任务取消失败"
+      "syncCancelFailed": "同步任务取消失败",
+      "availabilityRefreshed": "路径可用性已刷新"
     },
     "visibility": {
       "public": "公开",

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -311,6 +311,13 @@ export async function setDataSourceEnabled(uuid, enabled) {
   return unwrapResponse(response)
 }
 
+export async function refreshDataSourceAvailability(uuid) {
+  const response = await api.post(
+    `/lens/admin/datasources/${uuid}/refresh-availability/`
+  )
+  return unwrapResponse(response)
+}
+
 export async function cancelDataSourceSync(uuid) {
   const response = await api.post(
     `/lens/admin/datasources/${uuid}/cancel-sync/`

--- a/frontend/src/pages/lens/DataSourceDetailDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceDetailDrawer.vue
@@ -132,7 +132,10 @@
           </div>
         </section>
 
-        <section class="border-t border-line pt-6">
+        <section
+          v-if="datasource.source_type !== 'managed_workspace'"
+          class="border-t border-line pt-6"
+        >
           <h3 class="mb-4 text-sm font-semibold text-ink-900">
             {{ t('lensAdmin.datasourceDetail.sync') }}
           </h3>
@@ -153,7 +156,10 @@
           </dl>
         </section>
 
-        <section class="border-t border-line pt-6">
+        <section
+          v-if="datasource.source_type !== 'managed_workspace'"
+          class="border-t border-line pt-6"
+        >
           <h3 class="mb-4 text-sm font-semibold text-ink-900">
             {{ t('lensAdmin.datasourceDetail.retrieval') }}
           </h3>
@@ -680,6 +686,9 @@ function formatSourceType(sourceType) {
   if (sourceType === 'feishu') {
     return t('lensAdmin.datasourceWizard.feishu')
   }
+  if (sourceType === 'managed_workspace') {
+    return t('lensAdmin.datasourceWizard.managedWorkspace')
+  }
   return sourceType || emptyValue
 }
 
@@ -753,6 +762,25 @@ const datasourceConnectionDetails = computed(() => {
   const row = props.datasource
   if (!row) return []
   const config = row.config || {}
+  if (row.source_type === 'managed_workspace') {
+    return [
+      detailItem(t('lensAdmin.fields.type'), formatSourceType(row.source_type)),
+      detailItem(
+        t('lensAdmin.fields.lensnode'),
+        row.lensnode_name || lensNodeName(row.lensnode)
+      ),
+      detailItem(t('lensAdmin.fields.targetPath'), row.target_path, true),
+      detailItem(
+        t('lensAdmin.availability.title'),
+        t(`lensAdmin.availability.${row.availability_status || 'unknown'}`)
+      ),
+      detailItem(
+        t('lensAdmin.availability.checkedAt'),
+        formatDateTime(row.availability_checked_at)
+      ),
+      detailItem(t('lensAdmin.availability.message'), row.availability_message)
+    ]
+  }
   if (row.source_type === 'git') {
     const repositories = dataSourceRepositories(row)
     const items = [

--- a/frontend/src/pages/lens/DataSourceFormDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceFormDrawer.vue
@@ -39,7 +39,7 @@
       </template>
     </div>
 
-    <div v-if="wizardStep === 1" class="space-y-5">
+    <div v-if="activeStepKey === 'basic'" class="space-y-5">
       <p class="text-sm text-ink-500">
         {{ t('lensAdmin.datasourceWizard.step1Desc') }}
       </p>
@@ -72,9 +72,15 @@
       </FormRow>
     </div>
 
-    <div v-else-if="wizardStep === 2" class="space-y-5">
+    <div v-else-if="activeStepKey === 'node'" class="space-y-5">
       <p class="text-sm text-ink-500">
-        {{ t('lensAdmin.datasourceWizard.step2Desc') }}
+        {{
+          t(
+            isManagedWorkspace
+              ? 'lensAdmin.datasourceWizard.managedNodeDesc'
+              : 'lensAdmin.datasourceWizard.step2Desc'
+          )
+        }}
       </p>
       <FormRow :label="t('lensAdmin.fields.lensnode')" required>
         <select v-model="form.lensnode_uuid" class="form-input" required>
@@ -101,7 +107,7 @@
       </div>
     </div>
 
-    <div v-else-if="wizardStep === 3" class="space-y-5">
+    <div v-else-if="activeStepKey === 'connection'" class="space-y-5">
       <p class="text-sm text-ink-500">
         {{ t('lensAdmin.datasourceWizard.step3Desc') }}
       </p>
@@ -436,12 +442,27 @@
       </div>
     </div>
 
-    <div v-else-if="wizardStep === 4" class="space-y-5">
+    <div v-else-if="activeStepKey === 'sync'" class="space-y-5">
       <p class="text-sm text-ink-500">
-        {{ t('lensAdmin.datasourceWizard.step4Desc') }}
+        {{
+          t(
+            isManagedWorkspace
+              ? 'lensAdmin.datasourceWizard.managedPathDesc'
+              : 'lensAdmin.datasourceWizard.step4Desc'
+          )
+        }}
       </p>
       <FormRow :label="t('lensAdmin.fields.targetPath')" required>
         <div class="space-y-3">
+          <input
+            v-if="isManagedWorkspace"
+            v-model="form.workspace_relative_path"
+            class="form-input font-mono"
+            :placeholder="
+              t('lensAdmin.datasourceWizard.managedPathPlaceholder')
+            "
+            @change="$emit('check-path')"
+          />
           <div
             class="rounded-md border border-line bg-surface-sunken px-3 py-2"
           >
@@ -489,6 +510,7 @@
                 {{ workspaceRoot }}
               </div>
               <button
+                v-if="!isManagedWorkspace"
                 class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-ink-500 hover:bg-surface-sunken hover:text-ink-900"
                 type="button"
                 :title="t('lensAdmin.datasourceWizard.createAtWorkspace')"
@@ -499,7 +521,7 @@
             </div>
             <div class="max-h-64 overflow-y-auto p-2">
               <div
-                v-if="creatingDirectoryParent === ''"
+                v-if="!isManagedWorkspace && creatingDirectoryParent === ''"
                 class="flex gap-1 px-2 py-1"
               >
                 <span class="h-7 w-7 shrink-0" />
@@ -572,6 +594,7 @@
                     <span class="truncate">{{ dir.name }}</span>
                   </button>
                   <button
+                    v-if="!isManagedWorkspace"
                     class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-ink-500 hover:bg-surface-sunken hover:text-ink-900"
                     type="button"
                     :title="t('lensAdmin.datasourceWizard.createTargetDir')"
@@ -581,7 +604,10 @@
                   </button>
                 </div>
                 <div
-                  v-if="creatingDirectoryParent === dir.relative"
+                  v-if="
+                    !isManagedWorkspace &&
+                    creatingDirectoryParent === dir.relative
+                  "
                   class="ml-5 flex gap-1 border-l border-line pl-10"
                 >
                   <input
@@ -644,6 +670,7 @@
                         <span class="truncate">{{ child.name }}</span>
                       </button>
                       <button
+                        v-if="!isManagedWorkspace"
                         class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-ink-500 hover:bg-surface-sunken hover:text-ink-900"
                         type="button"
                         :title="t('lensAdmin.datasourceWizard.createTargetDir')"
@@ -653,7 +680,10 @@
                       </button>
                     </div>
                     <div
-                      v-if="creatingDirectoryParent === child.relative"
+                      v-if="
+                        !isManagedWorkspace &&
+                        creatingDirectoryParent === child.relative
+                      "
                       class="ml-8 flex gap-1"
                     >
                       <input
@@ -690,13 +720,19 @@
         </div>
         <p class="mt-1 text-xs text-ink-500">
           {{
-            isGitOrganizationMode
-              ? t('lensAdmin.datasourceWizard.gitOrganizationPathHint')
-              : t('lensAdmin.datasourceWizard.pathHint')
+            isManagedWorkspace
+              ? t('lensAdmin.datasourceWizard.managedPathHint')
+              : isGitOrganizationMode
+                ? t('lensAdmin.datasourceWizard.gitOrganizationPathHint')
+                : t('lensAdmin.datasourceWizard.pathHint')
           }}
         </p>
       </FormRow>
-      <FormRow :label="t('lensAdmin.fields.syncPolicy')" required>
+      <FormRow
+        v-if="!isManagedWorkspace"
+        :label="t('lensAdmin.fields.syncPolicy')"
+        required
+      >
         <select v-model="syncPolicyMode" class="form-input w-56">
           <option value="interval">
             {{ t('lensAdmin.datasourceWizard.syncPolicyInterval') }}
@@ -707,7 +743,7 @@
         </select>
       </FormRow>
       <FormRow
-        v-if="syncPolicyMode === 'interval'"
+        v-if="!isManagedWorkspace && syncPolicyMode === 'interval'"
         :label="t('lensAdmin.fields.syncInterval')"
         required
       >
@@ -721,7 +757,7 @@
           {{ t('lensAdmin.datasourceWizard.intervalHint') }}
         </p>
       </FormRow>
-      <div v-else class="grid gap-4 md:grid-cols-2">
+      <div v-else-if="!isManagedWorkspace" class="grid gap-4 md:grid-cols-2">
         <FormRow :label="t('lensAdmin.fields.cron')" required>
           <input
             v-model="syncCron"
@@ -786,7 +822,7 @@
       </section>
     </div>
 
-    <div v-else-if="wizardStep === 5" class="space-y-5">
+    <div v-else-if="activeStepKey === 'conversion'" class="space-y-5">
       <p class="text-sm text-ink-500">
         {{ t('lensAdmin.datasourceWizard.step5Desc') }}
       </p>
@@ -1100,10 +1136,10 @@
         </div>
         <div class="flex items-center gap-3">
           <span class="text-xs text-ink-400">
-            {{ wizardStep }} / {{ WIZARD_STEP_COUNT }}
+            {{ wizardStep }} / {{ wizardStepCount }}
           </span>
           <BaseButton
-            v-if="wizardStep < WIZARD_STEP_COUNT"
+            v-if="wizardStep < wizardStepCount"
             variant="primary"
             :disabled="!canProceedWizard"
             @click="nextWizardStep"
@@ -1117,7 +1153,7 @@
             :disabled="
               !canProceedWizard ||
               pathResult?.status === 'blocked' ||
-              connectionResult?.status !== 'success'
+              (!isManagedWorkspace && connectionResult?.status !== 'success')
             "
             @click="$emit('save')"
           >
@@ -1192,7 +1228,6 @@ const emit = defineEmits([
 ])
 
 const { t } = useI18n()
-const WIZARD_STEP_COUNT = 5
 const wizardStep = ref(1)
 const creatingDirectoryParent = ref(null)
 const expandedDirectories = ref(new Set())
@@ -1358,6 +1393,11 @@ const sourceTypes = computed(() => [
     value: 'feishu',
     label: t('lensAdmin.datasourceWizard.feishu'),
     description: t('lensAdmin.datasourceWizard.feishuDesc')
+  },
+  {
+    value: 'managed_workspace',
+    label: t('lensAdmin.datasourceWizard.managedWorkspace'),
+    description: t('lensAdmin.datasourceWizard.managedWorkspaceDesc')
   }
 ])
 
@@ -1368,13 +1408,28 @@ const selectedSourceTypeDescription = computed(() => {
   return selected?.description || ''
 })
 
-const wizardStepsMeta = computed(() => [
-  { key: 'basic', title: t('lensAdmin.datasourceWizard.step1Title') },
-  { key: 'node', title: t('lensAdmin.datasourceWizard.step2Title') },
-  { key: 'connection', title: t('lensAdmin.datasourceWizard.step3Title') },
-  { key: 'sync', title: t('lensAdmin.datasourceWizard.step4Title') },
-  { key: 'conversion', title: t('lensAdmin.datasourceWizard.step5Title') }
-])
+const isManagedWorkspace = computed(
+  () => props.form.source_type === 'managed_workspace'
+)
+
+const wizardStepsMeta = computed(() => {
+  const steps = [
+    { key: 'basic', title: t('lensAdmin.datasourceWizard.step1Title') },
+    { key: 'node', title: t('lensAdmin.datasourceWizard.step2Title') },
+    { key: 'connection', title: t('lensAdmin.datasourceWizard.step3Title') },
+    { key: 'sync', title: t('lensAdmin.datasourceWizard.step4Title') },
+    { key: 'conversion', title: t('lensAdmin.datasourceWizard.step5Title') }
+  ]
+  if (isManagedWorkspace.value) {
+    return steps.filter((step) => ['basic', 'node', 'sync'].includes(step.key))
+  }
+  return steps
+})
+
+const wizardStepCount = computed(() => wizardStepsMeta.value.length)
+const activeStepKey = computed(
+  () => wizardStepsMeta.value[wizardStep.value - 1]?.key || 'basic'
+)
 
 const onlineLensNodes = computed(() =>
   props.lensnodes.filter(
@@ -1473,13 +1528,13 @@ const connectionResultMessage = computed(() => {
 })
 
 const canProceedWizard = computed(() => {
-  if (wizardStep.value === 1) {
+  if (activeStepKey.value === 'basic') {
     return !!props.form.name?.trim() && !!props.form.source_type
   }
-  if (wizardStep.value === 2) {
+  if (activeStepKey.value === 'node') {
     return !!props.form.lensnode_uuid
   }
-  if (wizardStep.value === 3) {
+  if (activeStepKey.value === 'connection') {
     if (props.connectionResult?.status !== 'success') {
       return false
     }
@@ -1499,6 +1554,9 @@ const canProceedWizard = computed(() => {
   }
   if (props.pathResult?.status === 'blocked' || !props.pathResult) {
     return false
+  }
+  if (isManagedWorkspace.value) {
+    return props.pathResult?.status === 'available'
   }
   if (syncPolicyMode.value === 'crontab') {
     return (
@@ -1637,7 +1695,7 @@ function credentialScopeUrl(credential) {
 }
 
 function nextWizardStep() {
-  if (wizardStep.value < WIZARD_STEP_COUNT) wizardStep.value++
+  if (wizardStep.value < wizardStepCount.value) wizardStep.value++
 }
 
 function prevWizardStep() {

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -303,7 +303,18 @@
                     </div>
                   </td>
                   <td class="table-cell">
-                    <div class="space-y-1 text-xs text-ink-500">
+                    <div
+                      v-if="row.source_type === 'managed_workspace'"
+                      class="space-y-1 text-xs text-ink-500"
+                    >
+                      <div class="font-medium text-ink-700">
+                        {{ t('lensAdmin.availability.title') }}
+                      </div>
+                      <div>
+                        {{ formatDateTime(row.availability_checked_at) }}
+                      </div>
+                    </div>
+                    <div v-else class="space-y-1 text-xs text-ink-500">
                       <div class="font-mono text-ink-700">
                         {{ formatDataSourcePolicyLine(row.sync_policy) }}
                       </div>
@@ -320,6 +331,7 @@
                   <td class="table-cell" @click.stop>
                     <div class="flex flex-wrap gap-2">
                       <BaseButton
+                        v-if="row.source_type !== 'managed_workspace'"
                         size="sm"
                         variant="outline"
                         :disabled="
@@ -328,6 +340,14 @@
                         @click="sync(row)"
                       >
                         {{ t('lensAdmin.actions.sync') }}
+                      </BaseButton>
+                      <BaseButton
+                        v-else
+                        size="sm"
+                        variant="outline"
+                        @click="refreshAvailability(row)"
+                      >
+                        {{ t('lensAdmin.actions.refreshAvailability') }}
                       </BaseButton>
                       <BaseButton
                         size="sm"
@@ -428,6 +448,7 @@ import {
   listCredentials,
   listDataSources,
   listLensNodes,
+  refreshDataSourceAvailability,
   setDataSourceEnabled,
   syncDataSource,
   testLensNodeDataSourceConnection,
@@ -688,7 +709,20 @@ function datasourceSyncTags(row) {
       label: t('common.status.disabled'),
       class: syncTagClass('disabled')
     })
-  } else if (isDataSourceSyncing(row)) {
+  }
+  if (row.source_type === 'managed_workspace') {
+    const availability = row.availability_status || 'unknown'
+    tags.push({
+      key: 'availability',
+      label: t(`lensAdmin.availability.${availability}`),
+      class: syncTagClass(availability)
+    })
+    return tags
+  }
+  if (!isDataSourceEnabled(row)) {
+    return tags
+  }
+  if (isDataSourceSyncing(row)) {
     tags.push({
       key: 'running',
       label: t('lensAdmin.table.syncRunning'),
@@ -745,6 +779,9 @@ function formatSourceType(sourceType) {
   }
   if (sourceType === 'feishu') {
     return t('lensAdmin.datasourceWizard.feishu')
+  }
+  if (sourceType === 'managed_workspace') {
+    return t('lensAdmin.datasourceWizard.managedWorkspace')
   }
   return sourceType || emptyValue
 }
@@ -1100,6 +1137,8 @@ function handleDatasourceTypeChange(seed = null) {
       feishu_incremental: true,
       feishu_delete_missing: false
     }
+  } else {
+    datasourceConfig.value = {}
   }
 }
 
@@ -1127,7 +1166,10 @@ async function save() {
   saving.value = true
   formError.value = ''
   try {
-    if (!canSaveDatasource()) {
+    if (
+      form.value.source_type !== 'managed_workspace' &&
+      !canSaveDatasource()
+    ) {
       throw new Error(t('lensAdmin.datasourceWizard.connectionRequired'))
     }
     const uuid = form.value.uuid
@@ -1155,13 +1197,14 @@ async function save() {
 }
 
 function buildPayload() {
+  const managedWorkspace = form.value.source_type === 'managed_workspace'
   return {
     name: form.value.name,
     source_type: normalizedSourceType(form.value.source_type),
     lensnode_uuid: form.value.lensnode_uuid,
     target_path: datasourceTargetPath(),
-    config: buildDatasourceConfig(),
-    sync_policy: buildDatasourceSyncPolicy(),
+    config: managedWorkspace ? {} : buildDatasourceConfig(),
+    sync_policy: managedWorkspace ? {} : buildDatasourceSyncPolicy(),
     status: form.value.status || 'active',
     credential_uuid: shouldUseDatasourceCredential()
       ? form.value.credential_uuid
@@ -1667,6 +1710,16 @@ async function sync(row) {
     await load()
   } catch (error) {
     showError(extractErrorMessage(error, t('lensAdmin.messages.syncFailed')))
+  }
+}
+
+async function refreshAvailability(row) {
+  try {
+    await refreshDataSourceAvailability(row.uuid)
+    showSuccess(t('lensAdmin.messages.availabilityRefreshed'))
+    await load()
+  } catch (error) {
+    showError(extractErrorMessage(error, t('lensAdmin.messages.saveFailed')))
   }
 }
 

--- a/frontend/src/pages/lens/datasourceHelpers.js
+++ b/frontend/src/pages/lens/datasourceHelpers.js
@@ -51,6 +51,10 @@ export function syncTagClass(status) {
     running: 'border-warning-200 bg-warning-50 text-warning-700',
     not_synced: 'border-line bg-surface-sunken text-ink-600',
     disabled: 'border-line bg-surface-sunken text-ink-500',
+    available: 'border-success-200 bg-success-50 text-success-700',
+    unavailable: 'border-warning-200 bg-warning-50 text-warning-700',
+    error: 'border-danger-200 bg-danger-50 text-danger-700',
+    unknown: 'border-line bg-surface-sunken text-ink-500',
     policy: 'border-primary-200 bg-primary-50 text-primary-700'
   }
   return classes[status] || classes.not_synced

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -93,6 +93,18 @@ def inspect_datasource_path(command, workspace_path=WORKSPACE_ROOT):
     }
 
     if not target.exists():
+        if source_type == "managed_workspace":
+            result.update(
+                {
+                    "source_compatible": False,
+                    "status": "blocked",
+                    "message_code": "managed_workspace_missing",
+                    "message": (
+                        "Managed workspace directory does not exist."
+                    ),
+                }
+            )
+            return result
         result["will_create"] = True
         result["message_code"] = "will_create"
         result["message"] = "Directory will be created during first sync."
@@ -112,6 +124,10 @@ def inspect_datasource_path(command, workspace_path=WORKSPACE_ROOT):
     children = list(target.iterdir())
     result["is_empty"] = len(children) == 0
     result["is_git_repo"] = (target / ".git").is_dir()
+    if source_type == "managed_workspace":
+        result["message_code"] = "managed_workspace_available"
+        result["message"] = "Managed workspace directory is available."
+        return result
     if result["is_empty"]:
         result["message_code"] = "empty"
         result["message"] = "Directory is empty and can be used."

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -6,6 +6,7 @@ import pytest
 from lensnode.datasource_sync import (
     DataSourceSyncError,
     datasource_sync_workers,
+    inspect_datasource_path,
     _default_git_branch,
     _export_feishu_document,
     _export_filename,
@@ -36,6 +37,64 @@ def test_datasource_sync_workers_defaults_to_four():
     assert datasource_sync_workers({}) == 4
     assert datasource_sync_workers({"max_workers": "8"}) == 8
     assert datasource_sync_workers({"max_workers": "invalid"}) == 4
+
+
+def test_managed_workspace_path_must_exist(tmp_path):
+    """Managed workspace inspection never offers to create missing paths."""
+
+    result = inspect_datasource_path(
+        {
+            "source_type": "managed_workspace",
+            "target_path": str(tmp_path / "missing"),
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["message_code"] == "managed_workspace_missing"
+    assert result["will_create"] is False
+
+
+def test_managed_workspace_accepts_non_git_directory(tmp_path):
+    """Managed workspace inspection accepts externally populated content."""
+
+    target = tmp_path / "restored"
+    target.mkdir()
+    (target / "snapshot.txt").write_text("external data")
+
+    result = inspect_datasource_path(
+        {
+            "source_type": "managed_workspace",
+            "target_path": str(target),
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["status"] == "available"
+    assert result["message_code"] == "managed_workspace_available"
+    assert result["exists"] is True
+    assert result["is_directory"] is True
+
+
+def test_managed_workspace_rejects_symlink_outside_workspace(tmp_path):
+    """Managed workspace inspection resolves symlinks before validation."""
+
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    target = tmp_path / "outside-link"
+    target.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(
+        DataSourceSyncError,
+        match="LENS_SOURCE_TARGET_PATH_INVALID",
+    ):
+        inspect_datasource_path(
+            {
+                "source_type": "managed_workspace",
+                "target_path": str(target),
+            },
+            workspace_path=tmp_path,
+        )
 
 
 def test_git_auth_url_uses_inline_access_token():


### PR DESCRIPTION
### **User description**
## Summary

- add managed workspace as a data source type for externally maintained LensNode directories
- validate directory availability, workspace containment, symlink safety, and path overlap
- prevent managed workspaces from entering manual, periodic, Celery, or LensNode synchronization flows
- add availability refresh, admin UI creation and detail flows, and non-destructive deletion behavior

## Testing

- Django Lens API tests: 105 passed
- LensNode data source synchronization tests: 32 passed
- managed workspace synchronization guard tests passed
- Django migration drift check passed
- frontend production build passed
- frontend ESLint passed with no errors
- ego-browser user flow passed for create, availability refresh, disable/enable, details, and deletion while retaining external files

Closes #19


___

### **PR Type**
Enhancement


___

### **Description**
- Add managed workspace data source type for externally populated LensNode directories

- Validate directory existence, workspace containment, and path overlap; block sync operations

- Add availability refresh endpoint and non-destructive deletion

- Update admin UI with creation wizard, detail, and availability display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Admin["Admin UI"] --> API["Django API (CRUD, validation)"]
  API --> LensNode["LensNode directory inspect"]
  LensNode --> API
  API --> Catalog["DataSource catalog record"]
  Sync["Sync (Celery, Periodic, LensNode)"] -->|blocked| API
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>datasource_services.py</strong><dd><code>Block sync dispatch for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add managed workspace source type and availability fields</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>periodic_tasks.py</strong><dd><code>Exclude managed workspace from sync scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-b4f2328e7ea6c16451ba79cb137983af97f02a8cb9a5f22e0c05f81a732a0084">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add validation and path check for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+136/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Return early for managed workspace sync tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Add refresh-availability endpoint, block sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lensnodes.py</strong><dd><code>Update path conflict check for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-335cf862941c3741f4827fe24d51a2c0d40c4e682c65b7c9ee8a154f4f622a77">+44/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Handle managed workspace path inspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceDetailDrawer.vue</strong><dd><code>Show availability details for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-b0769411d4535ce440e95fe367c2d0996579d7fc5a79c1d0a6ff8475d210a523">+30/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceFormDrawer.vue</strong><dd><code>Adapt wizard steps for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-0b2ea6040d7c458a234eb3d290500ddb300a087019b6b58d947883cda373ec42">+89/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DataSources.vue</strong><dd><code>Add availability column and refresh button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-1a2dc840b5da820c7b8a16cb18fa4a424860f010974ced2df56948e3cde5c30a">+58/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add refreshAvailability API call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasourceHelpers.js</strong><dd><code>Add availability tag classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-2a4e96e3cf92d92f5e8ef916aa558e50b9ae852b47b7888e185b50169c26ca5e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0029_datasource_managed_workspace.py</strong><dd><code>Add migration for managed workspace fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-1702f0fb32210e8faadfcf76993c5590729eee85adc7ef90a12e391832357da0">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add API tests for managed workspace CRUD and availability</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+258/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add service tests for sync blocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_datasource_sync.py</strong><dd><code>Add lensnode tests for managed workspace path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English translations for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese translations for managed workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/165/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+21/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


