### PR TITLE
Harden active-run recovery and LensNode gateway lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,6 +274,9 @@ requirements-dev.txt
 # Stoneforge internal tooling
 .stoneforge/
 
+# Serena local project state
+.serena/
+
 # uv lock file (project uses pip)
 uv.lock
 /.stoneforge/.worktrees/

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -837,6 +837,7 @@ def lensnode_cleanup_task():
     RunExecution.objects.filter(
         run__status=Run.Status.FAILED,
         status__in=[
+            RunExecution.Status.QUEUED,
             RunExecution.Status.DISPATCHED,
             RunExecution.Status.RUNNING,
         ],

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
-from lens.models import Assistant, LensNode, Run, Session
+from lens.models import Assistant, LensNode, Run, RunExecution, Session
 from lens.services import (
     create_execution_run,
     reconcile_lensnode_active_runs,
@@ -118,6 +118,22 @@ class RunLifecycleTests(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, Run.Status.FAILED)
         self.assertEqual(run.error, "LENS_RUN_TIMEOUT")
+
+    def test_idle_reaper_fails_queued_execution_snapshot(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=10),
+            timedelta(minutes=10),
+        )
+        self.assertEqual(run.execution.status, RunExecution.Status.QUEUED)
+
+        lensnode_cleanup_task()
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.execution.status, RunExecution.Status.FAILED)
+        self.assertIsNotNone(run.execution.finished_at)
 
     def test_idle_reaper_keeps_long_but_active_run(self):
         # Long-running (90 min, past the old 1h cap) but still streaming

--- a/docs/design-assistant-run-timeout.md
+++ b/docs/design-assistant-run-timeout.md
@@ -70,10 +70,15 @@ use English comments and docstrings with a 79-character line limit.
 
 ## Boundaries
 
-- Always: snapshot the resolved duration and keep existing Runs immutable.
+- Always: snapshot the resolved duration when the Run is created and keep
+  that timeout immutable.
 - Always: retain an eventual hard wall-clock deadline for runaway execution.
 - Never: use `LENSNODE_REQUEST_TIMEOUT_S` as the Run wall-clock fallback.
-- Never: let later Assistant edits change an in-flight Run.
+- Never: let later Assistant analysis-level edits change an existing Run's
+  timeout.
+- Compatibility: refresh Skill package metadata immediately before dispatch.
+  SourceLens does not retain historical Skill packages, so a package hash
+  frozen while queued could no longer be downloadable after a Skill update.
 - Out of scope: transport timeout renaming, retry policy, and timeout UI error
   copy.
 

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2439,6 +2439,9 @@ async function selectSession(session, updateRoute = true) {
   }
   if (!isCurrentLoad()) return
   messages.value = loadedMessages
+  // Session history is ready for display. An active run's SSE can stay open
+  // for minutes, so it must not keep the whole chat behind the page loader.
+  booted.value = true
   if (sessionChanged) {
     question.value = ''
     if (composerRef.value) composerRef.value.style.height = 'auto'

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const chatSource = () =>
+  readFile(new URL('../src/pages/lens/Chat.vue', import.meta.url), 'utf8')
+
+test('reveals loaded chat before waiting for active run recovery', async () => {
+  const source = await chatSource()
+  const messagesLoaded = source.indexOf('messages.value = loadedMessages')
+  const resumeActiveRun = source.indexOf(
+    'await maybeResumeActiveRun(session.uuid)',
+    messagesLoaded
+  )
+  const chatRevealed = source.indexOf('booted.value = true', messagesLoaded)
+
+  assert.notEqual(messagesLoaded, -1)
+  assert.notEqual(resumeActiveRun, -1)
+  assert.ok(chatRevealed > messagesLoaded)
+  assert.ok(chatRevealed < resumeActiveRun)
+})

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -678,7 +678,12 @@ class LensSummarizationMiddleware(SummarizationMiddleware):
 
 
 def _build_summarization_middleware(
-    config, model_ref, emit_event, cancel_event=None, run_uuid=""
+    config,
+    model_ref,
+    emit_event,
+    cancel_event=None,
+    run_uuid="",
+    http_client=None,
 ):
     """Build context-compaction middleware, or None when disabled.
 
@@ -703,6 +708,7 @@ def _build_summarization_middleware(
         request_timeout_s=config.request_timeout_s,
         tls_skip_verify=getattr(config, "tls_skip_verify", False),
         tls_ca_file=getattr(config, "tls_ca_file", None),
+        http_client=http_client,
         cancel_event=cancel_event,
         run_uuid=run_uuid,
     )
@@ -767,8 +773,9 @@ def _apply_offload_thresholds(config):
 class LensDeepAgentRuntime:
     """Run a real LangChain Deep Agents execution for one LensNode command."""
 
-    def __init__(self, config):
+    def __init__(self, config, http_client=None):
         self.config = config
+        self.http_client = http_client
 
     async def answer(
         self,
@@ -874,6 +881,7 @@ class LensDeepAgentRuntime:
                     self.config, "tls_skip_verify", False
                 ),
                 tls_ca_file=getattr(self.config, "tls_ca_file", None),
+                http_client=self.http_client,
                 emit_output=emit_output,
                 on_activity=on_activity,
                 cancel_event=cancel_event,
@@ -1079,6 +1087,7 @@ class LensDeepAgentRuntime:
                 emit_agent_event,
                 cancel_event,
                 run_uuid=run_uuid,
+                http_client=self.http_client,
             )
             middleware = _agent_middleware(
                 command,

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -245,6 +245,7 @@ def _sync_context(command, target):
         ),
         "ai_gateway_url": command.get("ai_gateway_url") or "",
         "lensnode_token": command.get("lensnode_token") or "",
+        "gateway_http_client": command.get("gateway_http_client"),
         "tls_skip_verify": bool(command.get("tls_skip_verify", False)),
         "tls_ca_file": command.get("tls_ca_file") or None,
         "vision_model_ref": conversion.get("vision_model_ref") or "",

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -1708,6 +1708,7 @@ def describe_image_bytes(image_bytes, mime_type, context):
         token=token,
         tls_skip_verify=context.get("tls_skip_verify", False),
         tls_ca_file=context.get("tls_ca_file"),
+        http_client=context.get("gateway_http_client"),
     )
     return result.get("content") or "", result.get("usage") or {}
 

--- a/lensnode/lensnode/executor.py
+++ b/lensnode/lensnode/executor.py
@@ -168,8 +168,8 @@ TASKS = [
 class LensNodeExecutor:
     """Translate LensNode protocol commands into Deep Agents execution."""
 
-    def __init__(self, config):
-        self.agent = LensDeepAgentRuntime(config)
+    def __init__(self, config, http_client=None):
+        self.agent = LensDeepAgentRuntime(config, http_client=http_client)
 
     async def execute(self, command, emit):
         """Execute one run_start command and emit protocol frames."""

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -5,6 +5,7 @@ import re
 import threading
 import time
 from collections import Counter, deque
+from contextlib import nullcontext
 from typing import Any, Optional, Sequence
 
 import httpx
@@ -138,6 +139,23 @@ _COMPLETED_PLAN_FINAL_INSTRUCTION = (
 )
 
 
+def _http_client_context(
+    http_client,
+    *,
+    timeout,
+    tls_skip_verify=False,
+    tls_ca_file=None,
+):
+    """Return an injected shared client or a compatible owned client."""
+
+    if http_client is not None:
+        return nullcontext(http_client)
+    return httpx.Client(
+        timeout=timeout,
+        verify=create_ssl_context(tls_skip_verify, tls_ca_file),
+    )
+
+
 class LensGatewayChatModel(BaseChatModel):
     """LangChain chat model that delegates calls to the control plane."""
 
@@ -147,6 +165,7 @@ class LensGatewayChatModel(BaseChatModel):
     request_timeout_s: int = 120
     tls_skip_verify: bool = False
     tls_ca_file: str | None = None
+    http_client: Optional[Any] = None
     emit_output: Optional[Any] = None
     # Called on EVERY gateway SSE event (reasoning/tool-call tokens,
     # heartbeats, done) to prove transport liveness to the run watchdog.
@@ -300,17 +319,17 @@ class LensGatewayChatModel(BaseChatModel):
 
         payload["return_message"] = True
         start = time.monotonic()
-        with httpx.Client(
+        with _http_client_context(
+            self.http_client,
             timeout=self.request_timeout_s,
-            verify=create_ssl_context(
-                self.tls_skip_verify,
-                self.tls_ca_file,
-            ),
+            tls_skip_verify=self.tls_skip_verify,
+            tls_ca_file=self.tls_ca_file,
         ) as client:
             response = client.post(
                 self.ai_gateway_url,
                 headers={"Authorization": f"Bearer {self.token}"},
                 json=payload,
+                timeout=self.request_timeout_s,
             )
             response.raise_for_status()
             data = response.json()
@@ -341,18 +360,18 @@ class LensGatewayChatModel(BaseChatModel):
 
         start = time.monotonic()
         done_received = False
-        with httpx.Client(
+        with _http_client_context(
+            self.http_client,
             timeout=self.request_timeout_s,
-            verify=create_ssl_context(
-                self.tls_skip_verify,
-                self.tls_ca_file,
-            ),
+            tls_skip_verify=self.tls_skip_verify,
+            tls_ca_file=self.tls_ca_file,
         ) as client:
             with client.stream(
                 "POST",
                 self.ai_gateway_url,
                 headers={"Authorization": f"Bearer {self.token}"},
                 json={**payload, "stream": True},
+                timeout=self.request_timeout_s,
             ) as response:
                 response.raise_for_status()
                 buffer = ""
@@ -1122,6 +1141,7 @@ def describe_image_result(
     token,
     tls_skip_verify=False,
     tls_ca_file=None,
+    http_client=None,
 ):
     """Describe one image and return content plus usage."""
 
@@ -1144,14 +1164,17 @@ def describe_image_result(
             }
         ],
     }
-    with httpx.Client(
+    with _http_client_context(
+        http_client,
         timeout=120,
-        verify=create_ssl_context(tls_skip_verify, tls_ca_file),
+        tls_skip_verify=tls_skip_verify,
+        tls_ca_file=tls_ca_file,
     ) as client:
         response = client.post(
             ai_gateway_url,
             headers={"Authorization": f"Bearer {token}"},
             json=payload,
+            timeout=120,
         )
         response.raise_for_status()
         data = response.json()

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -6,6 +6,7 @@ import os
 import signal
 from urllib.parse import urlencode
 
+import httpx
 from websockets.asyncio.client import connect
 
 from .config import load_config
@@ -33,7 +34,19 @@ class LensNodeClient:
     def __init__(self, config):
         self.config = config
         self.ssl_context = create_config_ssl_context(config)
-        self.executor = LensNodeExecutor(config)
+        self.gateway_http_client = httpx.Client(
+            timeout=config.request_timeout_s,
+            verify=self.ssl_context,
+            limits=httpx.Limits(
+                max_connections=100,
+                max_keepalive_connections=20,
+                keepalive_expiry=60.0,
+            ),
+        )
+        self.executor = LensNodeExecutor(
+            config,
+            http_client=self.gateway_http_client,
+        )
         self.stopping = asyncio.Event()
         # Set while draining on shutdown/upgrade: stop accepting new runs and
         # stop heartbeating (a heartbeat would flip the node back to ONLINE
@@ -174,18 +187,21 @@ class LensNodeClient:
                 "lensnode_name": self.config.name,
             }
         )
-        await self._drain_running_tasks()
-        await self._flush_outbox()
-        self.stopping.set()
-        if self.websocket is not None:
-            await self.websocket.close()
-        for task in list(self.running_tasks.values()):
-            task.cancel()
-        if self.running_tasks:
-            await asyncio.gather(
-                *self.running_tasks.values(),
-                return_exceptions=True,
-            )
+        try:
+            await self._drain_running_tasks()
+            await self._flush_outbox()
+            self.stopping.set()
+            if self.websocket is not None:
+                await self.websocket.close()
+            for task in list(self.running_tasks.values()):
+                task.cancel()
+            if self.running_tasks:
+                await asyncio.gather(
+                    *self.running_tasks.values(),
+                    return_exceptions=True,
+                )
+        finally:
+            self.gateway_http_client.close()
 
     async def _drain_running_tasks(self):
         """Wait for in-flight runs to finish, bounded by the drain timeout."""
@@ -529,6 +545,7 @@ class LensNodeClient:
                 **message,
                 "ai_gateway_url": self.config.ai_gateway_url,
                 "lensnode_token": self.config.token,
+                "gateway_http_client": self.gateway_http_client,
                 "tls_skip_verify": getattr(
                     self.config, "tls_skip_verify", False
                 ),

--- a/lensnode/tests/test_drain.py
+++ b/lensnode/tests/test_drain.py
@@ -66,6 +66,7 @@ def test_drain_lets_in_flight_run_finish_then_stops():
         assert client.draining.is_set()
         assert client.stopping.is_set()
         assert ws.closed
+        assert client.gateway_http_client.is_closed
         # Draining was announced so the control plane stops routing here.
         assert "node_draining" in _sent_types(ws)
 

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -84,6 +84,63 @@ def test_streaming_touches_activity_on_every_event(monkeypatch):
     assert client_options["verify"].verify_mode == ssl.CERT_REQUIRED
 
 
+def test_gateway_calls_reuse_injected_http_client(monkeypatch):
+    requests = []
+
+    def handler(request):
+        payload = json.loads(request.read())
+        requests.append(payload)
+        if payload.get("stream"):
+            return httpx.Response(200, content=SSE_BODY.encode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "message": {"content": "Hello"},
+                "usage": {"total_tokens": 5},
+            },
+        )
+
+    shared_client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(
+        "lensnode.gateway_model.httpx.Client",
+        lambda *args, **kwargs: pytest.fail(
+            "Gateway call created a per-request HTTP client"
+        ),
+    )
+    try:
+        sync_model = LensGatewayChatModel(
+            model_ref="model-ref",
+            ai_gateway_url="http://gateway/ai/",
+            token="token",
+            http_client=shared_client,
+        )
+        stream_model = LensGatewayChatModel(
+            model_ref="model-ref",
+            ai_gateway_url="http://gateway/ai/",
+            token="token",
+            emit_output=lambda _content: None,
+            http_client=shared_client,
+        )
+
+        sync_model._generate([HumanMessage(content="sync")])
+        stream_model._generate([HumanMessage(content="stream")])
+        image_result = describe_image_result(
+            b"image",
+            "Describe this image.",
+            "image/png",
+            model_ref="vision-model",
+            ai_gateway_url="http://gateway/ai/",
+            token="token",
+            http_client=shared_client,
+        )
+
+        assert len(requests) == 3
+        assert image_result["content"] == "Hello"
+        assert not shared_client.is_closed
+    finally:
+        shared_client.close()
+
+
 def test_tool_call_turn_does_not_publish_intermediate_text(monkeypatch):
     body = (
         'data: {"type": "token", "kind": "content", '
@@ -882,7 +939,7 @@ def test_image_gateway_request_uses_configured_tls_context(monkeypatch):
     assert client_options["verify"].verify_mode == ssl.CERT_NONE
 
 
-def test_summarization_model_receives_tls_configuration():
+def test_summarization_model_receives_gateway_client_and_tls_configuration():
     config = SimpleNamespace(
         summary_trigger_tokens=1000,
         summary_keep_tokens=500,
@@ -893,11 +950,17 @@ def test_summarization_model_receives_tls_configuration():
         tls_ca_file="/ignored/ca.crt",
     )
 
-    middleware = _build_summarization_middleware(
-        config,
-        "summary-model",
-        lambda *args: None,
-    )
+    shared_client = httpx.Client(transport=httpx.MockTransport(lambda _: None))
+    try:
+        middleware = _build_summarization_middleware(
+            config,
+            "summary-model",
+            lambda *args: None,
+            http_client=shared_client,
+        )
 
-    assert middleware.model.tls_skip_verify is True
-    assert middleware.model.tls_ca_file == "/ignored/ca.crt"
+        assert middleware.model.http_client is shared_client
+        assert middleware.model.tls_skip_verify is True
+        assert middleware.model.tls_ca_file == "/ignored/ca.crt"
+    finally:
+        shared_client.close()


### PR DESCRIPTION
### **User description**
## Summary

- reuse a process-scoped LensNode HTTP client across synchronous, streaming, summarization, and vision Gateway calls
- close shared Gateway resources after graceful drain and preserve request-level timeout and TLS behavior
- reveal loaded chat history before active Run SSE recovery completes
- reconcile queued execution snapshots when stale Runs are failed
- clarify timeout snapshot boundaries and keep local Serena state out of version control

Closes #172

## Test plan

- [x] `docker exec sourcelens-api-dev python manage.py test lens.tests.test_run_lifecycle` (11 tests)
- [x] `lensnode/.venv/bin/pytest -q lensnode/tests` (266 tests)
- [x] `npm run test:unit` (98 tests)
- [x] ESLint on the affected frontend files
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser task space 28: return from the admin console to a chat with an active queued Run; session history and active Run state remain visible without a page-level loader or console errors


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Reuse shared HTTP client across LensNode gateway calls.

- Close client after graceful drain, preserve per-request timeouts.

- Reveal loaded chat history before active-run SSE recovery.

- Mark queued execution snapshots failed on reaping.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  client["LensNode HTTP client"] -->|shared| gateway["Gateway calls"]
  shutdown["LensNode shutdown"] -->|drain| close["Close client"]
  chat["Chat page"] -->|load messages| reveal["Reveal before SSE"]
  reaper["Idle reaper"] -->|fail queued| snapshot["RunExecution snapshots"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tasks.py</strong><dd><code>Add QUEUED status to reaper snapshot filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Reveal chat before active-run SSE recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_run_lifecycle.py</strong><dd><code>Test idle reaper fails queued execution snapshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_drain.py</strong><dd><code>Assert shared client is closed after stop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-7a8e3a7bc0056f4c38c6864bfb2918f40a1fd9f2f2b24467cf560ba1d845434c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gateway_model.py</strong><dd><code>Test reuse of injected HTTP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+71/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatBootstrap.test.js</strong><dd><code>Test order of chat reveal vs SSE recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Pass http_client to summarization and runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Add gateway_http_client to sync context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document_convert.py</strong><dd><code>Use http_client from context for image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>executor.py</strong><dd><code>Accept http_client parameter and forward</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-09da87f66493ac6ca403c68c259713dfe47d390711eb1ae828c477954e2a79d5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway_model.py</strong><dd><code>Inject shared HTTP client for all calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+35/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Create shared client and close on stop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+30/-13</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>design-assistant-run-timeout.md</strong><dd><code>Clarify timeout snapshot boundaries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/173/files#diff-10cab818f8cc7bc10bc4accdef4cf782e180df274ad1fa700c03547871a9cd47">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

