### PR TITLE
Improve mobile chat action accessibility and touch targets

### DIFF
--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-async function mockChat(page, messageDelays = {}) {
-  await page.addInitScript(() => {
+async function mockChat(page, messageDelays = {}, language = 'en') {
+  await page.addInitScript((selectedLanguage) => {
     localStorage.setItem('access_token', 'test-token')
-    localStorage.setItem('userLanguage', 'en')
-  })
+    localStorage.setItem('userLanguage', selectedLanguage)
+  }, language)
 
   await page.route('**/api/**', async (route) => {
     const path = new URL(route.request().url()).pathname
@@ -24,7 +24,8 @@ async function mockChat(page, messageDelays = {}) {
           uuid: 'assistant-1',
           slug: 'drawer-test',
           name: 'Drawer Test',
-          status: 'active'
+          status: 'active',
+          multimodal_model_ref: 'vision-model'
         }
       ],
       '/api/lens/shares/': [],
@@ -39,6 +40,16 @@ async function mockChat(page, messageDelays = {}) {
           uuid: 'message-2',
           role: 'assistant',
           content: 'Second session response',
+          run: 'run-2',
+          feedback: 'positive',
+          output_files: [
+            {
+              uuid: 'file-1',
+              filename: 'report.pdf',
+              byte_size: 1024,
+              url: '/api/lens/output-files/file-1/content/'
+            }
+          ],
           created_at: '2026-07-24T08:00:00Z'
         }
       ],
@@ -56,6 +67,28 @@ async function mockChat(page, messageDelays = {}) {
       await new Promise((resolve) => setTimeout(resolve, messageDelays[path]))
     }
 
+    if (path.endsWith('/attachments/')) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { uuid: 'attachment-1' } })
+      })
+      return
+    }
+
+    if (path === '/api/lens/runs/run-2/share/') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            uuid: 'share-1',
+            token: 'shared-token',
+            title: 'Second session'
+          }
+        })
+      })
+      return
+    }
+
     await route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({ data: payloads[path] ?? [] })
@@ -68,6 +101,13 @@ async function sidebarBox(page) {
     const rect = element.getBoundingClientRect()
     return { x: rect.x, width: rect.width }
   })
+}
+
+async function expectMinimumTouchTarget(locator) {
+  const box = await locator.boundingBox()
+  expect(box).not.toBeNull()
+  expect(box.width).toBeGreaterThanOrEqual(44)
+  expect(box.height).toBeGreaterThanOrEqual(44)
 }
 
 test('mobile session drawer opens, selects sessions, and closes', async ({
@@ -131,6 +171,168 @@ test('desktop sidebar still expands and collapses', async ({ page }) => {
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 64 })
   await page.locator('.sidebar-collapse-btn[aria-label="Expand"]').click()
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+})
+
+test.describe('touch input accessibility', () => {
+  test.use({ hasTouch: true })
+
+  test('chat actions stay visible, accessible, and touchable', async ({
+    page
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockChat(page)
+    await page.goto('/lens/assistants/drawer-test/chat')
+
+    const recent = page.getByRole('button', { name: 'Recent' })
+    await expectMinimumTouchTarget(recent)
+    await recent.click()
+    const firstSession = page
+      .locator('.session-item')
+      .filter({ hasText: 'First session' })
+    const rename = firstSession.getByRole('button', { name: 'Rename' })
+    const remove = firstSession.getByRole('button', {
+      name: 'Delete session'
+    })
+
+    await expect(rename).toBeVisible()
+    await expect(remove).toBeVisible()
+    await expect(rename).toHaveCSS('opacity', '1')
+    await expect(remove).toHaveCSS('opacity', '1')
+    await expectMinimumTouchTarget(rename)
+    await expectMinimumTouchTarget(remove)
+
+    await remove.click()
+    const confirmDelete = firstSession.getByRole('button', {
+      name: 'Confirm delete'
+    })
+    const cancelDelete = firstSession.getByRole('button', { name: 'Cancel' })
+    await expectMinimumTouchTarget(confirmDelete)
+    await expectMinimumTouchTarget(cancelDelete)
+    await cancelDelete.click()
+
+    await page
+      .locator('.session-item')
+      .filter({ hasText: 'Second session' })
+      .click()
+    await page
+      .locator('.sidebar')
+      .getByRole('button', { name: 'Close' })
+      .click()
+
+    const copy = page.getByRole('button', { name: 'Copy' })
+    const share = page.getByRole('button', { name: 'Share' })
+    const retry = page.getByRole('button', { name: 'Retry' })
+    const upload = page.getByRole('button', { name: 'Upload image' })
+    const submit = page.getByRole('button', { name: 'Submit' })
+    const preview = page.getByRole('button', { name: 'Preview' })
+    const download = page.getByRole('button', { name: 'Download' })
+
+    for (const action of [
+      copy,
+      share,
+      retry,
+      upload,
+      submit,
+      preview,
+      download
+    ]) {
+      await expect(action).toBeVisible()
+      await expectMinimumTouchTarget(action)
+    }
+    await expect(page.locator('.message-feedback-status')).toHaveCount(0)
+    await expect(copy).toHaveAttribute('title', 'Copy')
+    await expect(share).toHaveAttribute('title', 'Share')
+    await expect(retry).toHaveAttribute('title', 'Retry')
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'mobile-test.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from('mobile image')
+    })
+    const removeImage = page.getByRole('button', { name: 'Remove image' })
+    const imagePreview = page.locator('.composer-thumb img')
+    await expect(removeImage).toBeVisible()
+    await expect(imagePreview).toHaveAttribute('src', /^blob:/)
+    await expect(removeImage).toHaveAttribute('title', 'Remove image')
+    await expectMinimumTouchTarget(removeImage)
+
+    await share.click()
+    const close = page.locator('.modal-close-btn')
+    const createLink = page.getByRole('button', { name: 'Create link' })
+    await expectMinimumTouchTarget(close)
+    await expectMinimumTouchTarget(createLink)
+    await createLink.click()
+    await expectMinimumTouchTarget(
+      page.getByRole('button', { name: 'Copy link' })
+    )
+    await expectMinimumTouchTarget(
+      page.getByRole('button', { name: 'Stop sharing' })
+    )
+    await expectMinimumTouchTarget(page.getByRole('button', { name: 'Done' }))
+  })
+
+  test('icon action names are localized in Simplified Chinese', async ({
+    page
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockChat(page, {}, 'zh-CN')
+    await page.goto('/lens/assistants/drawer-test/chat')
+
+    await page.getByRole('button', { name: '最近' }).click()
+    await page
+      .locator('.session-item')
+      .filter({ hasText: 'Second session' })
+      .click()
+
+    const localizedActions = [
+      ['复制', '复制'],
+      ['分享', '分享'],
+      ['重试', '重试'],
+      ['上传图片', '上传图片'],
+      ['预览', '预览'],
+      ['下载', '下载']
+    ]
+    for (const [name, title] of localizedActions) {
+      await expect(page.getByRole('button', { name })).toHaveAttribute(
+        'title',
+        title
+      )
+    }
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'mobile-test.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from('mobile image')
+    })
+    await expect(
+      page.getByRole('button', { name: '移除图片' })
+    ).toHaveAttribute('title', '移除图片')
+  })
+})
+
+test('desktop session actions retain compact hover behavior', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await mockChat(page)
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  const firstSession = page
+    .locator('.session-item')
+    .filter({ hasText: 'First session' })
+  const rename = firstSession.getByRole('button', { name: 'Rename' })
+  const remove = firstSession.getByRole('button', { name: 'Delete session' })
+
+  await expect(rename).toHaveCSS('opacity', '0')
+  await expect(remove).toHaveCSS('opacity', '0')
+  const renameBox = await rename.boundingBox()
+  const removeBox = await remove.boundingBox()
+  expect(renameBox).toMatchObject({ width: 24, height: 24 })
+  expect(removeBox).toMatchObject({ width: 24, height: 24 })
+
+  await firstSession.hover()
+  await expect(rename).toHaveCSS('opacity', '1')
+  await expect(remove).toHaveCSS('opacity', '1')
 })
 
 test('stale session responses do not replace a newer session draft', async ({

--- a/frontend/e2e/llm-stats-touch.spec.js
+++ b/frontend/e2e/llm-stats-touch.spec.js
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test'
+
+async function mockStats(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'e2e-llm-stats-touch')
+    localStorage.setItem('userLanguage', 'en')
+  })
+
+  await page.route('**://*/api/**', async (route) => {
+    const { pathname } = new URL(route.request().url())
+    let data = []
+
+    if (pathname === '/api/v1/auth/user') {
+      data = {
+        id: 1,
+        username: 'admin',
+        is_staff: true,
+        is_superuser: true,
+        permissions: []
+      }
+    } else if (pathname === '/api/v1/admin/users/') {
+      data = [{ id: 1, username: 'admin' }]
+    } else if (pathname === '/api/v1/admin/token-stats/') {
+      data = {
+        total_tokens: 0,
+        total_calls: 0,
+        total_cost_usd: 0,
+        by_model: [],
+        by_provider: [],
+        series: { items: [] }
+      }
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data })
+    })
+  })
+}
+
+async function expectMinimumTouchTarget(locator) {
+  const box = await locator.boundingBox()
+  expect(box).not.toBeNull()
+  expect(box.width).toBeGreaterThanOrEqual(44)
+  expect(box.height).toBeGreaterThanOrEqual(44)
+}
+
+test.describe('LLM Stats touch targets', () => {
+  test.use({ hasTouch: true })
+
+  test('filters and ranges remain touchable at the tablet breakpoint', async ({
+    page
+  }) => {
+    await page.setViewportSize({ width: 768, height: 1024 })
+    await mockStats(page)
+    await page.goto('/management/llm/stats')
+
+    await expect(
+      page.getByRole('main').getByRole('heading', {
+        name: 'Stats',
+        exact: true
+      })
+    ).toBeVisible()
+
+    const ranges = page.locator('.stats-granularity-btn')
+    await expect(ranges).toHaveCount(3)
+    for (const range of await ranges.all()) {
+      await expectMinimumTouchTarget(range)
+    }
+
+    await expectMinimumTouchTarget(page.locator('select').first())
+    const userSelectBox = await page.locator('select').first().boundingBox()
+    const filterSectionBox = await page
+      .locator('section[aria-label="Filters"]')
+      .boundingBox()
+    expect(userSelectBox).not.toBeNull()
+    expect(filterSectionBox).not.toBeNull()
+    expect(userSelectBox.width).toBeLessThanOrEqual(filterSectionBox.width)
+    await expectMinimumTouchTarget(page.locator('input[type="date"]'))
+    await expectMinimumTouchTarget(
+      page.getByRole('button', { name: 'Refresh' })
+    )
+
+    await ranges.nth(1).click()
+    await expectMinimumTouchTarget(page.locator('input[type="month"]'))
+
+    await ranges.nth(2).click()
+    await expectMinimumTouchTarget(page.locator('select').nth(1))
+  })
+})
+
+test('LLM Stats keeps compact controls for a desktop fine pointer', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await mockStats(page)
+  await page.goto('/management/llm/stats')
+
+  const rangeBox = await page
+    .locator('.stats-granularity-btn')
+    .first()
+    .boundingBox()
+  const refreshBox = await page
+    .getByRole('button', { name: 'Refresh' })
+    .boundingBox()
+
+  expect(rangeBox).not.toBeNull()
+  expect(refreshBox).not.toBeNull()
+  expect(rangeBox.height).toBeLessThan(44)
+  expect(refreshBox.height).toBeLessThan(44)
+})

--- a/frontend/e2e/management-users-mobile.spec.js
+++ b/frontend/e2e/management-users-mobile.spec.js
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+
+async function mockManagement(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'e2e-management-mobile')
+    localStorage.setItem('userLanguage', 'en')
+  })
+
+  await page.route('**://*/api/**', async (route) => {
+    const { pathname } = new URL(route.request().url())
+    let data = []
+
+    if (pathname === '/api/v1/auth/user') {
+      data = {
+        id: 1,
+        username: 'admin',
+        is_staff: true,
+        is_superuser: true,
+        permissions: []
+      }
+    } else if (pathname === '/api/v1/management/users/') {
+      data = {
+        count: 1,
+        results: [
+          {
+            id: 1,
+            username: 'admin',
+            email: 'admin@example.com',
+            is_active: true,
+            is_staff: true,
+            groups: []
+          }
+        ]
+      }
+    } else if (pathname === '/api/v1/management/groups/') {
+      data = { count: 0, results: [] }
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data })
+    })
+  })
+}
+
+test('user filters keep distinct rows and usable widths on mobile', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockManagement(page)
+  await page.goto('/management/users')
+
+  const username = page.getByTestId('username-filter-input')
+  const email = page.getByTestId('email-filter-input')
+  const search = page.getByTestId('user-filter-submit')
+  const reset = page.getByTestId('user-filter-reset')
+
+  await expect(username).toBeVisible()
+  await expect(email).toBeVisible()
+
+  const [usernameBox, emailBox, searchBox, resetBox] = await Promise.all([
+    username.boundingBox(),
+    email.boundingBox(),
+    search.boundingBox(),
+    reset.boundingBox()
+  ])
+
+  for (const box of [usernameBox, emailBox, searchBox, resetBox]) {
+    expect(box).not.toBeNull()
+    expect(box.width).toBeGreaterThanOrEqual(120)
+    expect(box.height).toBeGreaterThanOrEqual(44)
+  }
+  expect(usernameBox.y).toBe(emailBox.y)
+  expect(searchBox.y).toBe(resetBox.y)
+  expect(searchBox.y).toBeGreaterThan(usernameBox.y + usernameBox.height)
+})

--- a/frontend/src/admin/pages/LLM/Stats.vue
+++ b/frontend/src/admin/pages/LLM/Stats.vue
@@ -17,7 +17,7 @@
         <div
           class="flex w-full flex-none flex-wrap items-end gap-6 sm:w-auto sm:min-w-0 sm:flex-1"
         >
-          <div class="flex flex-col gap-1.5">
+          <div class="stats-user-filter flex flex-col gap-1.5">
             <label
               class="text-[10px] font-bold text-gray-400 uppercase tracking-wider ml-1"
             >
@@ -25,7 +25,7 @@
             </label>
             <select
               v-model="selectedUserId"
-              class="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 min-w-[140px] hover:border-gray-300 transition-colors"
+              class="stats-filter-control stats-user-select rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 min-w-[140px] hover:border-gray-300 transition-colors"
               @change="fetchStats"
             >
               <option value="">{{ t('llm.stats.allUsers') }}</option>
@@ -46,7 +46,7 @@
                 :key="opt.value"
                 type="button"
                 :class="[
-                  'px-4 py-1.5 text-xs font-semibold rounded-md transition-colors',
+                  'stats-granularity-btn px-4 py-1.5 text-xs font-semibold rounded-md transition-colors',
                   granularity === opt.value
                     ? 'bg-white text-primary-600 shadow-sm'
                     : 'text-gray-500 hover:text-gray-700'
@@ -74,7 +74,7 @@
                 v-model="selectedDate"
                 type="date"
                 :lang="locale"
-                class="rounded-lg border border-gray-200 px-3 py-2 text-sm w-40 focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
+                class="stats-filter-control rounded-lg border border-gray-200 px-3 py-2 text-sm w-40 focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
                 @change="fetchStats"
               />
             </template>
@@ -83,14 +83,14 @@
                 v-model="selectedMonth"
                 type="month"
                 :lang="locale"
-                class="rounded-lg border border-gray-200 px-3 py-2 text-sm w-40 focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
+                class="stats-filter-control rounded-lg border border-gray-200 px-3 py-2 text-sm w-40 focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
                 @change="fetchStats"
               />
             </template>
             <template v-else-if="granularity === 'year'">
               <select
                 v-model.number="selectedYear"
-                class="rounded-lg border border-gray-200 px-3 py-2 text-sm w-24 bg-white focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
+                class="stats-filter-control rounded-lg border border-gray-200 px-3 py-2 text-sm w-24 bg-white focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600 hover:border-gray-300 transition-colors"
                 @change="fetchStats"
               >
                 <option v-for="y in yearOptions" :key="y" :value="y">
@@ -104,7 +104,7 @@
           <BaseButton
             variant="outline"
             size="sm"
-            class="flex items-center gap-2 px-4 py-2 bg-gray-50 text-gray-600 hover:bg-gray-100 border border-gray-200 rounded-lg text-sm font-medium"
+            class="stats-refresh-btn flex items-center gap-2 px-4 py-2 bg-gray-50 text-gray-600 hover:bg-gray-100 border border-gray-200 rounded-lg text-sm font-medium"
             @click="fetchStats"
           >
             <svg
@@ -793,3 +793,24 @@ onMounted(() => {
   fetchStats()
 })
 </script>
+
+<style scoped>
+@media (max-width: 767px), (hover: none), (pointer: coarse) {
+  .stats-user-filter,
+  .stats-user-select {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .stats-filter-control,
+  .stats-granularity-btn,
+  :deep(.stats-refresh-btn) {
+    min-height: 44px;
+  }
+
+  .stats-granularity-btn {
+    min-width: 44px;
+  }
+}
+</style>

--- a/frontend/src/admin/pages/Management/Users.vue
+++ b/frontend/src/admin/pages/Management/Users.vue
@@ -39,10 +39,10 @@
 
         <div class="flex min-h-0 flex-1 flex-col px-5 py-4">
           <form
-            class="mb-4 flex flex-shrink-0 flex-wrap items-end gap-3"
+            class="mb-4 grid flex-shrink-0 grid-cols-2 gap-3 sm:flex sm:flex-wrap sm:items-end"
             @submit.prevent="applyExactFilters"
           >
-            <label class="min-w-0 flex-1 sm:max-w-xs">
+            <label class="min-w-0 sm:flex-1 sm:max-w-xs">
               <span class="mb-1 block text-sm font-medium text-ink-700">
                 {{ t('management.usernameFilter') }}
               </span>
@@ -50,11 +50,11 @@
                 v-model="usernameFilterInput"
                 data-testid="username-filter-input"
                 type="text"
-                class="form-input"
+                class="form-input user-filter-control"
                 :placeholder="t('management.usernameFilterPlaceholder')"
               />
             </label>
-            <label class="min-w-0 flex-1 sm:max-w-xs">
+            <label class="min-w-0 sm:flex-1 sm:max-w-xs">
               <span class="mb-1 block text-sm font-medium text-ink-700">
                 {{ t('management.emailFilter') }}
               </span>
@@ -62,11 +62,12 @@
                 v-model="emailFilterInput"
                 data-testid="email-filter-input"
                 type="email"
-                class="form-input"
+                class="form-input user-filter-control"
                 :placeholder="t('management.emailFilterPlaceholder')"
               />
             </label>
             <BaseButton
+              class="user-filter-action"
               data-testid="user-filter-submit"
               type="submit"
               :loading="loading"
@@ -74,6 +75,7 @@
               {{ t('common.search') }}
             </BaseButton>
             <BaseButton
+              class="user-filter-action"
               data-testid="user-filter-reset"
               variant="outline"
               :disabled="
@@ -718,5 +720,12 @@ onMounted(async () => {
 
 .form-input {
   @apply w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20;
+}
+
+@media (max-width: 767px), (hover: none), (pointer: coarse) {
+  .user-filter-control,
+  :deep(.user-filter-action) {
+    min-height: 44px;
+  }
 }
 </style>

--- a/frontend/src/components/lens/QaShareModal.vue
+++ b/frontend/src/components/lens/QaShareModal.vue
@@ -43,8 +43,9 @@
           </a>
           <button
             type="button"
-            class="shrink-0 rounded-md p-1.5 text-ink-400 transition-colors hover:bg-surface-sunken hover:text-primary-600"
+            class="qa-share-copy shrink-0 rounded-md p-1.5 text-ink-400 transition-colors hover:bg-surface-sunken hover:text-primary-600"
             :title="t('lens.share.copyLink')"
+            :aria-label="t('lens.share.copyLink')"
             @click="copy"
           >
             <Copy :size="15" :stroke-width="2" aria-hidden="true" />
@@ -56,10 +57,17 @@
 
     <template #footer>
       <div class="flex justify-end gap-2">
-        <BaseButton v-if="share" variant="danger" size="sm" @click="unshare">
+        <BaseButton
+          v-if="share"
+          class="qa-share-action"
+          variant="danger"
+          size="sm"
+          @click="unshare"
+        >
           {{ t('lens.qa.unshare') }}
         </BaseButton>
         <BaseButton
+          class="qa-share-action"
           variant="primary"
           size="sm"
           :loading="creating || saving"
@@ -204,3 +212,22 @@ async function unshare() {
   }
 }
 </script>
+
+<style scoped>
+@media (max-width: 767px), (hover: none), (pointer: coarse) {
+  .qa-share-copy,
+  :deep(.qa-share-action) {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .qa-share-copy {
+    display: flex;
+    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+  }
+}
+</style>

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -48,8 +48,9 @@
               </h3>
               <button
                 type="button"
-                class="flex-shrink-0 inline-flex items-center justify-center rounded-md p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 transition-colors"
-                aria-label="Close"
+                class="modal-close-btn inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1"
+                :aria-label="t('common.close')"
+                :title="t('common.close')"
                 @click="$emit('close')"
               >
                 <svg
@@ -108,6 +109,7 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import {
   acquireBodyScrollLock,
@@ -116,6 +118,8 @@ import {
   unregisterDialog,
   releaseBodyScrollLock
 } from './dialogScrollLock'
+
+const { t } = useI18n()
 
 const props = defineProps({
   show: {
@@ -250,3 +254,14 @@ onBeforeUnmount(() => {
   if (typeof window !== 'undefined') deactivateDialog()
 })
 </script>
+
+<style scoped>
+@media (max-width: 767px), (hover: none), (pointer: coarse) {
+  .modal-close-btn {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+</style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -216,8 +216,6 @@
       "copyFailed": "Copy failed.",
       "feedbackHelpful": "Helpful",
       "feedbackUnhelpful": "Not helpful",
-      "feedbackRecordedHelpful": "Recorded: Helpful",
-      "feedbackRecordedUnhelpful": "Recorded: Not helpful",
       "feedbackFailed": "Failed to save feedback, please try again.",
       "downloadFailed": "Download failed, please try again.",
       "preview": "Preview",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -216,8 +216,6 @@
       "copyFailed": "复制失败。",
       "feedbackHelpful": "有帮助",
       "feedbackUnhelpful": "没有帮助",
-      "feedbackRecordedHelpful": "已记录：有帮助",
-      "feedbackRecordedUnhelpful": "已记录：没有帮助",
       "feedbackFailed": "反馈保存失败，请重试。",
       "downloadFailed": "下载失败，请稍后重试。",
       "preview": "预览",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -173,7 +173,8 @@
                     <button
                       type="button"
                       class="session-action-btn session-action-confirm"
-                      :aria-label="t('common.confirm')"
+                      :aria-label="t('lens.chat.confirmDelete')"
+                      :title="t('lens.chat.confirmDelete')"
                       @click.stop="doDeleteSession(session)"
                     >
                       <svg
@@ -194,6 +195,7 @@
                       type="button"
                       class="session-action-btn session-action-cancel"
                       :aria-label="t('common.cancel')"
+                      :title="t('common.cancel')"
                       @click.stop="deletingSessionUuid = ''"
                     >
                       <svg
@@ -216,6 +218,7 @@
                       type="button"
                       class="session-rename-btn"
                       :aria-label="t('lens.chat.renameSession')"
+                      :title="t('lens.chat.renameSession')"
                       @click.stop="startRename(session)"
                     >
                       <svg
@@ -241,6 +244,7 @@
                       type="button"
                       class="session-delete-btn"
                       :aria-label="t('lens.chat.deleteSession')"
+                      :title="t('lens.chat.deleteSession')"
                       @click.stop="deletingSessionUuid = session.uuid"
                     >
                       <svg
@@ -678,6 +682,7 @@
                           type="button"
                           class="deliverable-action"
                           :title="t('lens.chat.preview')"
+                          :aria-label="t('lens.chat.preview')"
                           @click="openPreview(file)"
                         >
                           <Eye :size="18" />
@@ -686,6 +691,7 @@
                           type="button"
                           class="deliverable-action"
                           :title="t('lens.chat.download')"
+                          :aria-label="t('lens.chat.download')"
                           @click="downloadOutputFile(file)"
                         >
                           <Download :size="18" />
@@ -706,6 +712,8 @@
                   <button
                     type="button"
                     class="icon-btn"
+                    :title="t('common.copy')"
+                    :aria-label="t('common.copy')"
                     @click="copyMessage(message)"
                   >
                     <svg
@@ -763,6 +771,11 @@
                         ? t('lens.qa.sharedButton')
                         : t('lens.qa.shareButton')
                     "
+                    :aria-label="
+                      isMessageShared(message)
+                        ? t('lens.qa.sharedButton')
+                        : t('lens.qa.shareButton')
+                    "
                     @click="openShare(message)"
                   >
                     <svg
@@ -785,6 +798,8 @@
                   <button
                     type="button"
                     class="icon-btn"
+                    :title="t('lens.chat.retryAction')"
+                    :aria-label="t('lens.chat.retryAction')"
                     @click="retryLastQuestion"
                   >
                     <svg
@@ -806,18 +821,6 @@
                       />
                     </svg>
                   </button>
-                  <span
-                    v-if="message.feedback"
-                    class="message-feedback-status"
-                    :class="`is-${message.feedback}`"
-                  >
-                    <span class="message-feedback-dot" aria-hidden="true" />
-                    {{
-                      message.feedback === 'positive'
-                        ? t('lens.chat.feedbackRecordedHelpful')
-                        : t('lens.chat.feedbackRecordedUnhelpful')
-                    }}
-                  </span>
                 </div>
               </div>
             </div>
@@ -1192,9 +1195,10 @@
                     type="button"
                     class="composer-thumb-remove"
                     :aria-label="t('lens.chat.removeImage')"
+                    :title="t('lens.chat.removeImage')"
                     @click="removeAttachment(item)"
                   >
-                    ×
+                    <span aria-hidden="true">×</span>
                   </button>
                 </div>
               </div>
@@ -3342,24 +3346,6 @@ onBeforeUnmount(() => {
   color: #991b1b;
 }
 
-.message-feedback-status {
-  @apply ml-2 inline-flex h-7 items-center gap-2 rounded-full px-3 text-xs font-semibold;
-}
-
-.message-feedback-status.is-positive {
-  background: #ecfdf5;
-  color: #15803d;
-}
-
-.message-feedback-status.is-negative {
-  background: #fef2f2;
-  color: #b91c1c;
-}
-
-.message-feedback-dot {
-  @apply h-2 w-2 rounded-full bg-current;
-}
-
 .icon-btn-shared {
   background: rgba(34, 197, 94, 0.1);
   color: #15803d;
@@ -3851,8 +3837,50 @@ onBeforeUnmount(() => {
 }
 
 .composer-thumb-remove {
-  @apply absolute right-0.5 top-0.5 flex h-5 w-5 items-center justify-center
-    rounded-full bg-black/55 text-sm leading-none text-white;
+  @apply absolute right-0.5 top-0.5 flex h-5 w-5 items-center justify-center;
+}
+
+.composer-thumb-remove span {
+  @apply flex h-5 w-5 items-center justify-center rounded-full bg-black/55
+    text-sm leading-none text-white;
+}
+
+@media (max-width: 767px), (hover: none), (pointer: coarse) {
+  .sidebar-collapse-btn,
+  .composer-action-btn,
+  .session-delete-btn,
+  .session-action-btn,
+  .session-rename-btn,
+  .icon-btn,
+  .composer-attach-btn,
+  .composer-thumb-remove {
+    @apply h-11 w-11;
+  }
+
+  .deliverable-action,
+  .retry-hint-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .session-delete-btn,
+  .session-rename-btn {
+    @apply opacity-100;
+  }
+
+  .composer-thumb-remove {
+    top: 0;
+    right: 0;
+  }
+
+  .message-actions {
+    flex-wrap: wrap;
+  }
+}
+
+.session-delete-btn:focus-visible,
+.session-rename-btn:focus-visible {
+  @apply opacity-100;
 }
 
 @keyframes spin {


### PR DESCRIPTION
### **User description**
## Summary

- keep recent-session rename and delete actions discoverable on touch devices while preserving compact hover behavior on desktop
- increase mobile and coarse-pointer touch targets for chat actions, attachment controls, sharing dialogs, and modal close buttons
- add localized accessible names for copy, share, retry, image removal, and related icon-only actions
- improve mobile touch targets in LLM Stats and prevent long user names from overflowing filter controls
- prevent user-management filters from overlapping on narrow screens
- remove the redundant recorded-feedback status badge while preserving feedback state and aria-pressed
- retain the existing confirmation flow for session deletion

## Testing

- npm run lint
- npm run test:unit — 101 passed
- npm run build
- targeted Playwright mobile accessibility suite — 9 passed
- git diff --check
- manual ego-browser verification at 320px, 360px, 390px, 430px, 768px, and 1440px


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add 44px touch targets for chat actions, filters, and modals

- Add localized aria-labels and titles for icon-only buttons

- Remove redundant feedback status badge from assistant messages

- Add Playwright tests for mobile accessibility and Chinese localization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    A[Chat.vue] --> B[Touch targets & titles]
    C[BaseModal.vue] --> B
    D[QaShareModal.vue] --> B
    E[Stats.vue] --> F[Filter touch targets]
    G[Users.vue] --> F
  end
  subgraph Locales
    H[en.json, zh-CN.json] --> I[Remove feedback badge keys]
  end
  subgraph Tests
    J[chat-mobile-drawer.spec.js] --> K[Touch & localization tests]
    L[llm-stats-touch.spec.js] --> M[Stats touch tests]
    N[management-users-mobile.spec.js] --> O[Users filter layout tests]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Accessibility</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>Chat.vue</strong><dd><code>Add touch targets, titles, and remove feedback badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+62/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BaseModal.vue</strong><dd><code>Dynamic aria-label and touch target for close button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-1a6d18326079d5dc82054206b935e420f7242efde2793f49511587b75dce4cd5">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QaShareModal.vue</strong><dd><code>Touch targets and aria-label for share actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-6a0170acbff94a42351fbc02260c17196f047dca6d8ecb86dd67a822434d4677">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Stats.vue</strong><dd><code>Mobile touch targets for filter controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-962175c36e9677c6d5f28966316eb2959a75ce4918a6e21bf11773799288c462">+28/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Users.vue</strong><dd><code>Grid layout and touch targets for user filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-bd17c5feba4852cd6103733e18ec32304f0c2f48fcf10c9612260b209f19ed88">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>chat-mobile-drawer.spec.js</strong><dd><code>Touch and localization tests for chat actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-cb89d191cc946ddb676d704f3a7398dba03f09b1e45585cd92e06cefb093cdaa">+207/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>llm-stats-touch.spec.js</strong><dd><code>Touch target tests for LLM stats page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-d4a01d5bba2e203fd44a198aed3dbff5a4e1b5b411fc5c0e3745b7ec72000ab9">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>management-users-mobile.spec.js</strong><dd><code>Mobile filter layout tests for user management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-a10acd38ed58db408de94c235780e098d251a93dc1620b7b92ec9ecdd9a96772">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Remove recorded feedback status keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Remove recorded feedback status keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/175/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

