### PR TITLE
Fix stuck drawer transitions and stop action labels

### DIFF
--- a/frontend/src/components/ui/BaseDrawer.vue
+++ b/frontend/src/components/ui/BaseDrawer.vue
@@ -1,13 +1,6 @@
 <template>
   <Teleport to="body">
-    <Transition
-      enter-active-class="transition-opacity duration-200 ease-out"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-150 ease-in"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
+    <Transition :css="false" @enter="enterDrawer" @leave="leaveDrawer">
       <div
         v-if="show"
         ref="dialogRef"
@@ -17,73 +10,65 @@
         :aria-label="title"
       >
         <div class="fixed inset-0 bg-black/40" @click="handleBackdropClick" />
-        <Transition
-          enter-active-class="transition-transform duration-300 ease-out"
-          enter-from-class="translate-x-full"
-          enter-to-class="translate-x-0"
-          leave-active-class="transition-transform duration-200 ease-in"
-          leave-from-class="translate-x-0"
-          leave-to-class="translate-x-full"
+        <div
+          v-if="show"
+          data-drawer-panel
+          tabindex="-1"
+          class="relative z-10 flex h-full w-full flex-col bg-surface shadow-xl"
+          :class="widthClass"
+          @click.stop
         >
           <div
-            v-if="show"
-            tabindex="-1"
-            class="relative z-10 flex h-full w-full flex-col bg-surface shadow-xl"
-            :class="widthClass"
-            @click.stop
+            class="flex flex-shrink-0 items-center justify-between border-b border-line px-6 py-4"
           >
-            <div
-              class="flex flex-shrink-0 items-center justify-between border-b border-line px-6 py-4"
-            >
-              <div class="min-w-0 flex-1">
-                <h2 class="truncate text-base font-semibold text-ink-900">
-                  {{ title }}
-                </h2>
-                <p v-if="subtitle" class="mt-0.5 truncate text-sm text-ink-500">
-                  {{ subtitle }}
-                </p>
-              </div>
-              <div
-                v-if="$slots.actions"
-                class="flex flex-shrink-0 items-center gap-2"
-              >
-                <slot name="actions" />
-              </div>
-              <button
-                type="button"
-                class="ml-3 flex-shrink-0 rounded-md p-1.5 text-ink-400 transition-colors hover:bg-surface-sunken hover:text-ink-600 focus:outline-none"
-                :aria-label="t('common.close')"
-                @click="requestClose"
-              >
-                <svg
-                  class="h-5 w-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div v-if="$slots.tabs" class="flex-shrink-0 bg-surface">
-              <slot name="tabs" />
-            </div>
-            <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-              <slot />
+            <div class="min-w-0 flex-1">
+              <h2 class="truncate text-base font-semibold text-ink-900">
+                {{ title }}
+              </h2>
+              <p v-if="subtitle" class="mt-0.5 truncate text-sm text-ink-500">
+                {{ subtitle }}
+              </p>
             </div>
             <div
-              v-if="$slots.footer"
-              class="flex-shrink-0 border-t border-line bg-surface-sunken px-6 py-4"
+              v-if="$slots.actions"
+              class="flex flex-shrink-0 items-center gap-2"
             >
-              <slot name="footer" />
+              <slot name="actions" />
             </div>
+            <button
+              type="button"
+              class="ml-3 flex-shrink-0 rounded-md p-1.5 text-ink-400 transition-colors hover:bg-surface-sunken hover:text-ink-600 focus:outline-none"
+              :aria-label="t('common.close')"
+              @click="requestClose"
+            >
+              <svg
+                class="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
           </div>
-        </Transition>
+          <div v-if="$slots.tabs" class="flex-shrink-0 bg-surface">
+            <slot name="tabs" />
+          </div>
+          <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+            <slot />
+          </div>
+          <div
+            v-if="$slots.footer"
+            class="flex-shrink-0 border-t border-line bg-surface-sunken px-6 py-4"
+          >
+            <slot name="footer" />
+          </div>
+        </div>
       </div>
     </Transition>
   </Teleport>
@@ -100,6 +85,7 @@ import {
   unregisterDialog,
   releaseBodyScrollLock
 } from './dialogScrollLock'
+import { runDrawerTransition } from './drawerTransition'
 
 const { t } = useI18n()
 
@@ -170,6 +156,14 @@ function handleKeydown(event) {
 
 function requestClose() {
   emit('close')
+}
+
+function enterDrawer(element, done) {
+  runDrawerTransition(element, 'enter', 300, done)
+}
+
+function leaveDrawer(element, done) {
+  runDrawerTransition(element, 'leave', 200, done)
 }
 
 function getFocusableElements() {

--- a/frontend/src/components/ui/drawerTransition.js
+++ b/frontend/src/components/ui/drawerTransition.js
@@ -1,0 +1,53 @@
+const TRANSITION_FALLBACK_DELAY = 100
+
+const KEYFRAMES = {
+  enter: {
+    backdrop: [{ opacity: 0 }, { opacity: 1 }],
+    panel: [{ transform: 'translateX(100%)' }, { transform: 'translateX(0)' }]
+  },
+  leave: {
+    backdrop: [{ opacity: 1 }, { opacity: 0 }],
+    panel: [{ transform: 'translateX(0)' }, { transform: 'translateX(100%)' }]
+  }
+}
+
+export function runDrawerTransition(element, direction, duration, done) {
+  if (element.ownerDocument?.hidden) {
+    done()
+    return
+  }
+
+  const panel = element.querySelector('[data-drawer-panel]')
+  if (typeof element.animate !== 'function' || !panel) {
+    done()
+    return
+  }
+
+  const easing =
+    direction === 'enter'
+      ? 'cubic-bezier(0, 0, 0.2, 1)'
+      : 'cubic-bezier(0.4, 0, 1, 1)'
+  const options = { duration, easing, fill: 'both' }
+  const frames = KEYFRAMES[direction]
+  const animations = [
+    element.animate(frames.backdrop, options),
+    panel.animate(frames.panel, options)
+  ]
+  let completed = false
+
+  const complete = () => {
+    if (completed) return
+    completed = true
+    clearTimeout(fallbackTimer)
+    animations.forEach((animation) => animation.cancel())
+    done()
+  }
+  const fallbackTimer = setTimeout(
+    complete,
+    duration + TRANSITION_FALLBACK_DELAY
+  )
+
+  Promise.allSettled(animations.map((animation) => animation.finished)).then(
+    complete
+  )
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -16,6 +16,7 @@
     "previous": "Previous",
     "pageInfo": "Page {current} of {total}",
     "submit": "Submit",
+    "stop": "Stop",
     "submitting": "Submitting…",
     "search": "Search",
     "filter": "Filter",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -16,6 +16,7 @@
     "previous": "上一页",
     "pageInfo": "第 {current} 页，共 {total} 页",
     "submit": "提交",
+    "stop": "停止",
     "submitting": "提交中…",
     "search": "搜索",
     "filter": "筛选",

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const source = (path) =>
+  readFile(new URL(`../src/${path}`, import.meta.url), 'utf8')
+
+test('active chat run exposes a localized stop action', async () => {
+  const [chat, english, chinese] = await Promise.all([
+    source('pages/lens/Chat.vue'),
+    source('locales/en.json').then(JSON.parse),
+    source('locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  assert.match(chat, /isRunActive \? t\('common\.stop'\)/)
+  assert.equal(english.common.stop, 'Stop')
+  assert.equal(chinese.common.stop, '停止')
+})
+
+test('drawer leave transition completes when animations are suspended', async () => {
+  const drawer = await source('components/ui/BaseDrawer.vue')
+  const { runDrawerTransition } =
+    await import('../src/components/ui/drawerTransition.js')
+
+  let cancelledAnimations = 0
+  const suspendedAnimation = () => ({
+    cancel() {
+      cancelledAnimations += 1
+    },
+    finished: new Promise(() => {})
+  })
+  const panel = { animate: suspendedAnimation }
+  const element = {
+    animate: suspendedAnimation,
+    querySelector() {
+      return panel
+    }
+  }
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('drawer transition did not complete')),
+      500
+    )
+
+    runDrawerTransition(element, 'leave', 10, () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+  })
+
+  assert.match(drawer, /<Transition\s+:css="false"/)
+  assert.equal(cancelledAnimations, 2)
+})
+
+test('drawer skips visual transitions in a hidden document', async () => {
+  const { runDrawerTransition } =
+    await import('../src/components/ui/drawerTransition.js')
+  let animationCount = 0
+  let completed = false
+  const panel = {
+    animate() {
+      animationCount += 1
+    }
+  }
+  const element = {
+    ownerDocument: { hidden: true },
+    animate() {
+      animationCount += 1
+    },
+    querySelector() {
+      return panel
+    }
+  }
+
+  runDrawerTransition(element, 'enter', 300, () => {
+    completed = true
+  })
+
+  assert.equal(completed, true)
+  assert.equal(animationCount, 0)
+})


### PR DESCRIPTION
### **User description**
## Summary
- replace CSS-dependent drawer transitions with bounded Web Animations that complete when frames are suspended
- skip visual transitions for hidden documents to keep background automation responsive
- localize active-run stop labels in English and Chinese
- add regression coverage for suspended animations, hidden documents, and stop labels

Closes #176

## Test plan
- [x] `npm run test:unit` (104 passed)
- [x] repository-wide read-only ESLint
- [x] `npm run build`
- [x] ego-browser task space 44: managed workspace save removes the drawer and clears loading state
- [x] ego-browser task space 44: active run exposes `aria-label="停止"`


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Replace CSS transitions with Web Animations

- Add localized stop action labels in English and Chinese

- Add regression tests for suspended animations and hidden documents


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph user["User Action"]
    open["Open/Close Drawer"]
  end
  subgraph base["BaseDrawer.vue"]
    transition["<Transition :css='false'>"]
    hooks["@enter / @leave"]
  end
  subgraph anim["drawerTransition.js"]
    run["runDrawerTransition"]
    fallback["Fallback timer + Promise.allSettled"]
  end
  subgraph locale["Locales"]
    en["en.json: stop: Stop"]
    zh["zh-CN.json: stop: 停止"]
  end
  subgraph tests["regressionFixes.test.js"]
    suspend["Test: suspended animations"]
    hidden["Test: hidden document"]
    label["Test: localized stop labels"]
  end
  open --> transition
  transition --> hooks
  hooks --> run
  run --> fallback
  run --> locale
  tests --> run
  tests --> locale
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseDrawer.vue</strong><dd><code>Switch to programmatic Web Animations for drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/BaseDrawer.vue

<ul><li>Replaced CSS <code>Transition</code> classes with <code>:css="false"</code> and <code>@enter</code>/<code>@leave</code> <br>hooks<br> <li> Moved panel <code><div></code> outside inner <code>Transition</code> to fix nesting<br> <li> Added <code>enterDrawer</code> and <code>leaveDrawer</code> handler functions<br> <li> Integrated <code>runDrawerTransition</code> from new helper module</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/177/files#diff-9179f20c96236a212c5eb8b5f85b8f2690570886366191e6365fc58666c4c7b4">+61/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>drawerTransition.js</strong><dd><code>Add Web Animations helper for drawer transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/drawerTransition.js

<ul><li>New module exporting <code>runDrawerTransition</code> function<br> <li> Defines keyframes for backdrop and panel enter/leave<br> <li> Uses Web Animations API with fallback timer<br> <li> Skips animation when document is hidden<br> <li> Cancels animations on completion</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/177/files#diff-c43bd2edde15eadcee15bb3a1897251a881b917eaec114343b1a5057ff4b2d13">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>regressionFixes.test.js</strong><dd><code>Add regression tests for drawer and stop labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/regressionFixes.test.js

<ul><li>New test file for regression fixes<br> <li> Tests that drawer transition completes when animations are suspended<br> <li> Tests that drawer skips visual transitions in hidden document<br> <li> Tests that active chat run exposes localized stop action<br> <li> Verifies English and Chinese stop translations</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/177/files#diff-c6817d11aa2607c6dcdf8fef1d9bd8766a8fe8625f22ac8dbbf8d3181d0d1e06">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English stop translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/en.json

- Added `"stop": "Stop"` to the `common` section


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/177/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese stop translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/zh-CN.json

- Added `"stop": "停止"` to the `common` section


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/177/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

