### PR TITLE
Fix retry hint during active session restore

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1367,6 +1367,7 @@ import {
   shouldReviewUnreadSession,
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
+import { shouldShowRetryHint } from '@/pages/lens/chatRetryHint'
 import {
   activitiesForNode,
   applyRuntimeEvent,
@@ -1429,6 +1430,7 @@ const streamError = ref('')
 const failedRunError = ref(null)
 const queuePosition = ref(null)
 const currentRun = ref(null)
+const runStatusResolvingSessionUuid = ref('')
 const unreadSessions = ref(readUnreadSessions(window.localStorage))
 const loading = ref({ run: false })
 const streamController = ref(null)
@@ -1904,9 +1906,12 @@ const decoratedMessages = computed(() =>
 // retry-oriented hint (framed as a temporary hiccup, not a product fault)
 // instead of an empty bubble.
 const showRetryHint = computed(() => {
-  if (isRunActive.value) return false
-  const last = messages.value[messages.value.length - 1]
-  return !!last && last.role === 'assistant' && !(last.content || '').trim()
+  return shouldShowRetryHint({
+    isRunActive: isRunActive.value,
+    messages: messages.value,
+    runStatusResolving:
+      runStatusResolvingSessionUuid.value === selectedSessionUuid.value
+  })
 })
 
 // Map a backend run error code to a clear, blame-clarifying message: a
@@ -2110,6 +2115,7 @@ async function bootstrap() {
   // instead guarded inside submit() by binding to the session it started in.
   question.value = ''
   currentRun.value = null
+  runStatusResolvingSessionUuid.value = ''
   messages.value = []
   mySharesOpen.value = false
   resetStreamState()
@@ -2426,15 +2432,22 @@ async function selectSession(session, updateRoute = true) {
   const isCurrentLoad = () =>
     loadGeneration === sessionLoadGeneration &&
     selectedSessionUuid.value === session.uuid
+  const finishRunStatusResolution = () => {
+    if (isCurrentLoad()) {
+      runStatusResolvingSessionUuid.value = ''
+    }
+  }
   const sessionChanged = selectedSessionUuid.value !== session.uuid
   mySharesOpen.value = false
   clearAttachments()
   selectedSessionUuid.value = session.uuid
+  runStatusResolvingSessionUuid.value = session.uuid
   let loadedMessages
   try {
     loadedMessages = await listMessages(session.uuid)
   } catch (error) {
     if (!isCurrentLoad()) return
+    finishRunStatusResolution()
     if ([403, 404].includes(error?.response?.status)) {
       showError(t('lens.chat.sessionAccessDenied'))
       return
@@ -2460,7 +2473,11 @@ async function selectSession(session, updateRoute = true) {
   }
   await nextTick(scrollToBottom)
   if (!isCurrentLoad()) return
-  await maybeResumeActiveRun(session.uuid)
+  try {
+    await maybeResumeActiveRun(session.uuid, isCurrentLoad)
+  } finally {
+    finishRunStatusResolution()
+  }
   if (!isCurrentLoad()) return
   if (clearUnreadSession(window.localStorage, session.uuid)) {
     refreshUnreadSessions()
@@ -2470,7 +2487,7 @@ async function selectSession(session, updateRoute = true) {
 // If the session has a run still in progress (e.g. the user navigated away
 // mid-answer), re-attach the SSE stream so the live thinking panel and
 // streamed answer resume, then finalize like a normal run.
-async function maybeResumeActiveRun(sessionUuid) {
+async function maybeResumeActiveRun(sessionUuid, isCurrentLoad) {
   // the latest message carrying a run uuid (the user message of the most
   // recent turn) tells us whether that turn is still in progress
   const withRun = [...messages.value].reverse().find((m) => m.run)
@@ -2481,6 +2498,8 @@ async function maybeResumeActiveRun(sessionUuid) {
   } catch {
     return
   }
+  if (!isCurrentLoad()) return
+  runStatusResolvingSessionUuid.value = ''
   if (!['queued', 'running', 'streaming'].includes(run?.status)) {
     // A historically-failed turn keeps its retry hint with the right
     // (blame-clarifying) message after a reload, not just live.
@@ -2489,7 +2508,6 @@ async function maybeResumeActiveRun(sessionUuid) {
     }
     return
   }
-  if (selectedSessionUuid.value !== sessionUuid) return
   startCompletionTracking(run, sessionUuid)
   // hand the trailing in-progress assistant placeholder to the live row to
   // avoid showing it twice; the SSE sync replays its content and steps
@@ -2500,12 +2518,16 @@ async function maybeResumeActiveRun(sessionUuid) {
   currentRun.value = run
   try {
     await readSse(run.uuid)
-    currentRun.value = await getRun(run.uuid)
+    const restoredRun = await getRun(run.uuid)
+    if (!isCurrentLoad()) return
+    currentRun.value = restoredRun
   } catch {
     // stream aborted (e.g. the user switched sessions) — fall through
   }
-  if (selectedSessionUuid.value !== sessionUuid) return
-  messages.value = await listMessages(sessionUuid)
+  if (!isCurrentLoad()) return
+  const restoredMessages = await listMessages(sessionUuid)
+  if (!isCurrentLoad()) return
+  messages.value = restoredMessages
   resetStreamState()
 }
 

--- a/frontend/src/pages/lens/chatRetryHint.js
+++ b/frontend/src/pages/lens/chatRetryHint.js
@@ -1,0 +1,9 @@
+export function shouldShowRetryHint({
+  isRunActive,
+  messages,
+  runStatusResolving
+}) {
+  if (runStatusResolving || isRunActive) return false
+  const last = messages[messages.length - 1]
+  return !!last && last.role === 'assistant' && !(last.content || '').trim()
+}

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -9,7 +9,7 @@ test('reveals loaded chat before waiting for active run recovery', async () => {
   const source = await chatSource()
   const messagesLoaded = source.indexOf('messages.value = loadedMessages')
   const resumeActiveRun = source.indexOf(
-    'await maybeResumeActiveRun(session.uuid)',
+    'await maybeResumeActiveRun(session.uuid, isCurrentLoad)',
     messagesLoaded
   )
   const chatRevealed = source.indexOf('booted.value = true', messagesLoaded)
@@ -18,4 +18,17 @@ test('reveals loaded chat before waiting for active run recovery', async () => {
   assert.notEqual(resumeActiveRun, -1)
   assert.ok(chatRevealed > messagesLoaded)
   assert.ok(chatRevealed < resumeActiveRun)
+})
+
+test('guards restored run state with the current session load', async () => {
+  const source = await chatSource()
+
+  assert.match(
+    source,
+    /await maybeResumeActiveRun\(session\.uuid, isCurrentLoad\)/
+  )
+  assert.match(
+    source,
+    /async function maybeResumeActiveRun\(sessionUuid, isCurrentLoad\)/
+  )
 })

--- a/frontend/tests/chatRetryHint.test.js
+++ b/frontend/tests/chatRetryHint.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldShowRetryHint } from '../src/pages/lens/chatRetryHint.js'
+
+const emptyAnswerMessages = [
+  { role: 'user', content: 'What changed?' },
+  { role: 'assistant', content: '' }
+]
+
+test('hides retry guidance while an active run status is unresolved', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: true
+    }),
+    false
+  )
+
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: true,
+      messages: emptyAnswerMessages,
+      runStatusResolving: false
+    }),
+    false
+  )
+})
+
+test('shows retry guidance after a failed empty-answer run is resolved', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: true
+    }),
+    false
+  )
+
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: false
+    }),
+    true
+  )
+})
+
+test('shows retry guidance after a terminal empty-answer run is resolved', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: true
+    }),
+    false
+  )
+
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: false
+    }),
+    true
+  )
+})
+
+test('does not show retry guidance when the last message has answer text', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: [
+        { role: 'user', content: 'What changed?' },
+        { role: 'assistant', content: 'The run completed.' }
+      ],
+      runStatusResolving: false
+    }),
+    false
+  )
+})


### PR DESCRIPTION
### **User description**
## Summary
- suppress the empty-answer retry hint while the latest run status is unresolved
- guard restored run and message state against stale session switches
- preserve history-first rendering and failed or terminal empty-answer guidance

Closes #179

## Test plan
- [x] `npm run test:unit` (109 tests)
- [x] ESLint on affected frontend files
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser task space 51: active, failed, terminal-empty, and rapid session-switch flows


___

### **PR Type**
Bug fix


___

### **Description**
- Suppress retry hint while latest run status is unresolved

- Guard restored run and message state with session load generation

- Add unit tests for retry hint logic and session load guarding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  selectSession["selectSession()"] --> setResolving["set runStatusResolvingSessionUuid"]
  setResolving --> listMessages["listMessages()"]
  listMessages --> showChat["Show chat history (booted = true)"]
  showChat --> maybeResumeActiveRun["maybeResumeActiveRun(session.uuid, isCurrentLoad)"]
  maybeResumeActiveRun --> getRun["getRun()"]
  getRun --> checkLoad["isCurrentLoad()?"]
  checkLoad -- "yes" --> clearResolving["clear runStatusResolvingSessionUuid"]
  checkLoad -- "no" --> returnEarly["return early"]
  showChat -.-> computedRetryHint["computed showRetryHint"]
  computedRetryHint --> shouldShowRetryHint["shouldShowRetryHint()"]
  shouldShowRetryHint -- "runStatusResolving" --> hide["hide retry"]
  shouldShowRetryHint -- "isRunActive" --> hide
  shouldShowRetryHint -- "else" --> evaluate["check last message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Guard retry hint with run status resolution flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added <code>runStatusResolvingSessionUuid</code> ref to track pending run status <br>resolution<br> <li> Imported <code>shouldShowRetryHint</code> from new module and replaced inline logic <br>in <code>showRetryHint</code> computed<br> <li> Updated <code>selectSession</code> to set and clear the resolving flag, and pass <br><code>isCurrentLoad</code> to <code>maybeResumeActiveRun</code><br> <li> Modified <code>maybeResumeActiveRun</code> to accept <code>isCurrentLoad</code> and guard state <br>updates with it<br> <li> Cleared <code>runStatusResolvingSessionUuid</code> in <code>bootstrap</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/182/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+31/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.js</strong><dd><code>Extract retry hint logic to pure function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatRetryHint.js

<ul><li>New exported function <code>shouldShowRetryHint</code> that receives <code>isRunActive</code>, <br><code>messages</code>, <code>runStatusResolving</code><br> <li> Returns <code>false</code> if <code>runStatusResolving</code> or <code>isRunActive</code> is true<br> <li> Otherwise checks if the last message is an empty assistant message</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/182/files#diff-d52f24027c77c1e80e8d552fee09f04ce67f209ee900d56fcec7c0a71b5c23b6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add test for session load guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Updated existing test to expect <code>isCurrentLoad</code> parameter in <br><code>maybeResumeActiveRun</code> call<br> <li> Added new test <code>guards restored run state with the current session load</code> <br>verifying parameter presence</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/182/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.test.js</strong><dd><code>Unit tests for retry hint logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatRetryHint.test.js

<ul><li>New test file with unit tests for <code>shouldShowRetryHint</code><br> <li> Covers hiding retry while resolving, showing after resolution for <br>failed/terminal-empty, and hiding when answer text exists</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/182/files#diff-d1cdab0ee92331aa422aa4192dfc264de922675d700662ddcce4e40134bf4f33">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

