### PR TITLE
Fix task statistics scope mismatch

### DIFF
--- a/frontend/src/admin/pages/TaskManagement/Stats.vue
+++ b/frontend/src/admin/pages/TaskManagement/Stats.vue
@@ -994,7 +994,10 @@ async function fetchStats() {
   }
   loading.value = true
   try {
-    const params = { granularity: granularity.value }
+    const params = {
+      granularity: granularity.value,
+      my_tasks: 'false'
+    }
     if (startDate.value) params.start_date = startDate.value
     if (endDate.value) params.end_date = endDate.value
     if (userScope.value) params.created_by = userScope.value

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -17,6 +17,19 @@ test('active chat run exposes a localized stop action', async () => {
   assert.equal(chinese.common.stop, '停止')
 })
 
+test('task statistics request all users unless a user is selected', async () => {
+  const stats = await source('admin/pages/TaskManagement/Stats.vue')
+  const fetchStart = stats.indexOf('async function fetchStats')
+  const fetchEnd = stats.indexOf(
+    'const res = await taskManagementApi.getStats(params)',
+    fetchStart
+  )
+  const requestSetup = stats.slice(fetchStart, fetchEnd)
+
+  assert.match(requestSetup, /my_tasks: 'false'/)
+  assert.match(requestSetup, /params\.created_by = userScope\.value/)
+})
+
 test('drawer leave transition completes when animations are suspended', async () => {
   const drawer = await source('components/ui/BaseDrawer.vue')
   const { runDrawerTransition } =


### PR DESCRIPTION
### **User description**
## Summary

- request task statistics across all users by default
- preserve the selected-user filter through created_by
- add regression coverage for statistics request parameters

## Verification

- frontend regression tests: 4 passed
- full frontend unit tests: 105 passed
- production frontend build passed
- manual browser verification confirmed matching list and statistics totals

Closes #180


___

### **PR Type**
Bug fix


___

### **Description**
- Fix all-user task statistics scope

- Add regression test for request parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Stats.vue] -->|Add my_tasks: 'false'| B[Correct API scope]
  C[Regression test] -->|Verify params| D[Ensure all-user scope]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Stats.vue</strong><dd><code>Add my_tasks parameter to stats API call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/pages/TaskManagement/Stats.vue

<ul><li>Added <code>my_tasks: 'false'</code> to the request parameters when fetching <br>statistics<br> <li> Ensures all-user scope when no specific user is selected</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/183/files#diff-1e0bba35c91b80da558a806a6dac2d0051cf243664e09b2581747b11046bed68">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>regressionFixes.test.js</strong><dd><code>Add regression test for stats scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/regressionFixes.test.js

<ul><li>Added regression test for task statistics request parameters<br> <li> Verifies <code>my_tasks: 'false'</code> is present when no user selected</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/183/files#diff-c6817d11aa2607c6dcdf8fef1d9bd8766a8fe8625f22ac8dbbf8d3181d0d1e06">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

