### PR TITLE
Fix retrying historical chat questions

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -810,7 +810,7 @@
                     class="icon-btn"
                     :title="t('lens.chat.retryAction')"
                     :aria-label="t('lens.chat.retryAction')"
-                    @click="retryLastQuestion"
+                    @click="retryLastQuestion(message)"
                   >
                     <svg
                       viewBox="0 0 24 24"
@@ -1380,6 +1380,7 @@ import {
   shouldReviewUnreadSession,
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
+import { precedingUserMessage } from '@/pages/lens/chatMessageContext'
 import { shouldShowRetryHint } from '@/pages/lens/chatRetryHint'
 import {
   activitiesForNode,
@@ -2907,24 +2908,17 @@ function questionForMessage(message) {
 }
 
 function userMessageForMessage(message) {
-  const list = messages.value
-  const idx = list.findIndex((item) => item.uuid === message.uuid)
-  for (let i = idx - 1; i >= 0; i -= 1) {
-    if (list[i].role === 'user') {
-      return list[i]
-    }
-  }
-  return null
+  return precedingUserMessage(messages.value, message)
 }
 
-function retryLastQuestion() {
-  const lastUserMessage = [...messages.value]
-    .reverse()
-    .find((message) => message.role === 'user')
-  if (!lastUserMessage) {
+function retryLastQuestion(message = null) {
+  const userMessage = message
+    ? userMessageForMessage(message)
+    : [...messages.value].reverse().find((item) => item.role === 'user')
+  if (!userMessage) {
     return
   }
-  question.value = lastUserMessage.content || ''
+  question.value = userMessage.content || ''
   nextTick(() => {
     composerRef.value?.focus()
   })

--- a/frontend/src/pages/lens/chatMessageContext.js
+++ b/frontend/src/pages/lens/chatMessageContext.js
@@ -1,0 +1,15 @@
+export function precedingUserMessage(messages, targetMessage) {
+  const targetIndex = messages.findIndex(
+    (message) => message.uuid === targetMessage?.uuid
+  )
+  if (targetIndex === -1) {
+    return null
+  }
+
+  for (let index = targetIndex - 1; index >= 0; index -= 1) {
+    if (messages[index].role === 'user') {
+      return messages[index]
+    }
+  }
+  return null
+}

--- a/frontend/tests/chatMessageContext.test.js
+++ b/frontend/tests/chatMessageContext.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import { precedingUserMessage } from '../src/pages/lens/chatMessageContext.js'
+
+test('passes the clicked assistant reply to the retry handler', async () => {
+  const chat = await readFile(
+    new URL('../src/pages/lens/Chat.vue', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(chat, /@click="retryLastQuestion\(message\)"/)
+})
+
+test('finds the user question for a historical assistant reply', () => {
+  const messages = [
+    { uuid: 'question-1', role: 'user', content: 'First question' },
+    { uuid: 'answer-1', role: 'assistant', content: 'First answer' },
+    { uuid: 'question-2', role: 'user', content: 'Second question' },
+    { uuid: 'answer-2', role: 'assistant', content: 'Second answer' }
+  ]
+
+  const question = precedingUserMessage(messages, messages[1])
+
+  assert.equal(question?.uuid, 'question-1')
+})
+
+test('returns null when the target reply is not in the message list', () => {
+  const messages = [
+    { uuid: 'question-1', role: 'user', content: 'First question' }
+  ]
+
+  const question = precedingUserMessage(messages, {
+    uuid: 'missing-answer',
+    role: 'assistant'
+  })
+
+  assert.equal(question, null)
+})


### PR DESCRIPTION
### **User description**
## Summary
- Restore the user question that precedes the specific historical assistant reply selected for retry
- Preserve latest-question retry behavior for terminal empty or failed responses
- Add focused regression coverage for historical reply lookup and missing targets

Closes #178

## Test plan
- [x] `npm run test:unit` (114 tests)
- [x] `npx eslint src/pages/lens/Chat.vue src/pages/lens/chatMessageContext.js tests/chatMessageContext.test.js`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Historical Q&A retry flow verified in ego-browser task space 61


___

### **PR Type**
Bug fix


___

### **Description**
- Restore the user question preceding the selected assistant reply for retry

- Extract lookup logic to reusable `precedingUserMessage` function

- Add regression tests for historical reply lookup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Retry button click"] --> B["precedingUserMessage(messages, target)"]
  B --> C{"Find user message before target?"}
  C -->|"Found"| D["Submit preceding question"]
  C -->|"Not found"| E["Return null, no retry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Pass target message to retry handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Changed retry button click handler to pass the current assistant <br>message<br> <li> Updated <code>retryLastQuestion</code> to accept optional message parameter<br> <li> Replaced inline lookup with <code>precedingUserMessage</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/191/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+9/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatMessageContext.js</strong><dd><code>Extract preceding user message lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatMessageContext.js

<ul><li>Added new utility function <code>precedingUserMessage</code><br> <li> Finds the nearest user message before a given target message in the <br>message list<br> <li> Returns null if target not found or no preceding user message</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/191/files#diff-11edd4449646f23149ea982a80a05db4fea162cadceaa1f56badb1b598012303">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatMessageContext.test.js</strong><dd><code>Add regression tests for message lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatMessageContext.test.js

<ul><li>Added test for button click handler passing message<br> <li> Added test for finding preceding user message correctly<br> <li> Added test for returning null when target not in list</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/191/files#diff-70603dfd5e3eda6bd4623f27510bde074141b99aa0ed4ddfd2f0b98e796e29cc">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

