### PR TITLE
Keep retry hint hidden when run status is unavailable

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1380,7 +1380,10 @@ import {
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
 import { precedingUserMessage } from '@/pages/lens/chatMessageContext'
-import { shouldShowRetryHint } from '@/pages/lens/chatRetryHint'
+import {
+  resolveRunStatus,
+  shouldShowRetryHint
+} from '@/pages/lens/chatRetryHint'
 import {
   activitiesForNode,
   applyRuntimeEvent,
@@ -2487,11 +2490,7 @@ async function selectSession(session, updateRoute = true) {
   }
   await nextTick(scrollToBottom)
   if (!isCurrentLoad()) return
-  try {
-    await maybeResumeActiveRun(session.uuid, isCurrentLoad)
-  } finally {
-    finishRunStatusResolution()
-  }
+  await maybeResumeActiveRun(session.uuid, isCurrentLoad)
   if (!isCurrentLoad()) return
   if (clearUnreadSession(window.localStorage, session.uuid)) {
     refreshUnreadSessions()
@@ -2505,14 +2504,14 @@ async function maybeResumeActiveRun(sessionUuid, isCurrentLoad) {
   // the latest message carrying a run uuid (the user message of the most
   // recent turn) tells us whether that turn is still in progress
   const withRun = [...messages.value].reverse().find((m) => m.run)
-  if (!withRun) return
-  let run
-  try {
-    run = await getRun(withRun.run)
-  } catch {
+  if (!withRun) {
+    runStatusResolvingSessionUuid.value = ''
     return
   }
+  const resolution = await resolveRunStatus(getRun, withRun.run)
   if (!isCurrentLoad()) return
+  if (!resolution.resolved) return
+  const run = resolution.run
   runStatusResolvingSessionUuid.value = ''
   if (!['queued', 'running', 'streaming'].includes(run?.status)) {
     // A historically-failed turn keeps its retry hint with the right

--- a/frontend/src/pages/lens/chatRetryHint.js
+++ b/frontend/src/pages/lens/chatRetryHint.js
@@ -1,3 +1,11 @@
+export async function resolveRunStatus(getRun, runUuid) {
+  try {
+    return { resolved: true, run: await getRun(runUuid) }
+  } catch {
+    return { resolved: false, run: null }
+  }
+}
+
 export function shouldShowRetryHint({
   isRunActive,
   messages,

--- a/frontend/tests/chatRetryHint.test.js
+++ b/frontend/tests/chatRetryHint.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { shouldShowRetryHint } from '../src/pages/lens/chatRetryHint.js'
+import {
+  resolveRunStatus,
+  shouldShowRetryHint
+} from '../src/pages/lens/chatRetryHint.js'
 
 const emptyAnswerMessages = [
   { role: 'user', content: 'What changed?' },
@@ -80,4 +83,29 @@ test('does not show retry guidance when the last message has answer text', () =>
     }),
     false
   )
+})
+
+test('keeps retry guidance hidden when run status cannot be loaded', async () => {
+  const resolution = await resolveRunStatus(async () => {
+    throw new Error('temporary network failure')
+  }, 'run-uuid')
+
+  assert.deepEqual(resolution, { resolved: false, run: null })
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: emptyAnswerMessages,
+      runStatusResolving: !resolution.resolved
+    }),
+    false
+  )
+})
+
+test('returns the resolved run when its status loads', async () => {
+  const run = { uuid: 'run-uuid', status: 'running' }
+
+  assert.deepEqual(await resolveRunStatus(async () => run, run.uuid), {
+    resolved: true,
+    run
+  })
 })


### PR DESCRIPTION
### **User description**
## Summary
- keep the latest run status unresolved when its lookup fails so an empty placeholder cannot expose the retry hint
- clear the resolution guard only when no run is associated or the run status is successfully resolved
- cover both failed and successful run-status resolution with focused regression tests

Closes #179

## Test plan
- [x] npm run test:unit (118 tests)
- [x] ESLint on affected frontend files
- [x] npm run build
- [x] git diff --check
- [x] ego-browser task space 62: active-session restore and the unavailable run-status path remain free of the false retry hint


___

### **PR Type**
Bug fix


___

### **Description**
- Suppress retry hint while run status is unknown

- Introduce resolveRunStatus to handle failed status loading

- Update regression tests for resolved and unresolved statuses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Session select"] --> B["maybeResumeActiveRun"]
  B --> C{"Run exists?"}
  C -- No --> D["Clear resolving session"]
  C -- Yes --> E["resolveRunStatus"]
  E --> F{"Resolved?"}
  F -- No --> G["Return (no retry hint)"]
  F -- Yes --> H["Set run status, show progress or retry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Update session run status resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Modified maybeResumeActiveRun to use resolveRunStatus<br> <li> Defer clearing runStatusResolvingSessionUuid until status is resolved</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/192/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+10/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.js</strong><dd><code>Add resolveRunStatus helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatRetryHint.js

<ul><li>Added resolveRunStatus function that returns { resolved: false, run: <br>null } on failure<br> <li> Exported for use in Chat.vue</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/192/files#diff-d52f24027c77c1e80e8d552fee09f04ce67f209ee900d56fcec7c0a71b5c23b6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.test.js</strong><dd><code>Add tests for resolveRunStatus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatRetryHint.test.js

<ul><li>Added test for resolveRunStatus when API call fails<br> <li> Added test for resolveRunStatus when API call succeeds</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/192/files#diff-d1cdab0ee92331aa422aa4192dfc264de922675d700662ddcce4e40134bf4f33">+29/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

