### PR TITLE
Preserve verified tool results when route capabilities are empty

### DIFF
--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -6,6 +6,7 @@ PUBLIC_EVENT_TYPES = {
     "artifact.created",
     "capability.blocked",
     "execution.failed",
+    "verification.failed",
     "phase.changed",
     "plan.updated",
     "route.selected",
@@ -458,7 +459,11 @@ def _sanitize_payload(event_type, payload):
         if summary:
             output["summary"] = summary
         return output
-    if event_type in {"capability.blocked", "execution.failed"}:
+    if event_type in {
+        "capability.blocked",
+        "execution.failed",
+        "verification.failed",
+    }:
         return sanitize_termination_detail(payload)
     if event_type == "artifact.created":
         output = {

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -230,12 +230,30 @@ class AttachmentServiceTests(TestCase):
                     {
                         "agent_event": (
                             "tool.analyze_structured_output.start"
-                        )
+                        ),
+                        "operation": "count",
+                        "max_calls": 6,
                     },
                     {
                         "agent_event": (
                             "tool.analyze_structured_output.budget_exceeded"
-                        )
+                        ),
+                        "operation": "count",
+                        "max_calls": 6,
+                    },
+                    {
+                        "agent_event": (
+                            "tool.analyze_structured_output.start"
+                        ),
+                        "operation": "validate_records",
+                        "max_calls": 1,
+                    },
+                    {
+                        "agent_event": (
+                            "tool.analyze_structured_output.budget_exceeded"
+                        ),
+                        "operation": "validate_records",
+                        "max_calls": 1,
                     },
                     {
                         "agent_event": "tool.run_skill_transform.start"
@@ -257,6 +275,10 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(counts["artifact_call_limit_hits"], 1)
         self.assertEqual(counts["structured_analysis_calls"], 1)
         self.assertEqual(counts["structured_analysis_limit_hits"], 1)
+        self.assertEqual(counts["structured_analysis_max_calls"], 6)
+        self.assertEqual(counts["structured_validation_calls"], 1)
+        self.assertEqual(counts["structured_validation_limit_hits"], 1)
+        self.assertEqual(counts["structured_validation_max_calls"], 1)
         self.assertEqual(counts["transform_calls"], 1)
         self.assertEqual(counts["transform_call_limit_hits"], 1)
         self.assertEqual(counts["subagent_count"], 0)
@@ -268,6 +290,10 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(detail["artifact_call_limit_hits"], 1)
         self.assertEqual(detail["structured_analysis_calls"], 1)
         self.assertEqual(detail["structured_analysis_limit_hits"], 1)
+        self.assertEqual(detail["structured_analysis_max_calls"], 6)
+        self.assertEqual(detail["structured_validation_calls"], 1)
+        self.assertEqual(detail["structured_validation_limit_hits"], 1)
+        self.assertEqual(detail["structured_validation_max_calls"], 1)
         self.assertEqual(detail["transform_calls"], 1)
         self.assertEqual(detail["transform_call_limit_hits"], 1)
         self.assertEqual(detail["subagent_denied_count"], 1)

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -708,6 +708,24 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(event["payload"]["reason"], "execution_failed")
         self.assertEqual(event["payload"]["error_type"], "transient")
 
+    def test_verification_failure_event_is_distinct(self):
+        event = sanitize_runtime_event({
+            "event_type": "verification.failed",
+            "visibility": "user",
+            "payload": {
+                "reason": "evidence_unavailable",
+                "capability": "skill",
+                "error_type": "verification",
+            },
+        })
+
+        self.assertEqual(event["event_type"], "verification.failed")
+        self.assertEqual(
+            event["payload"]["reason"],
+            "evidence_unavailable",
+        )
+        self.assertEqual(event["payload"]["error_type"], "verification")
+
     def test_runtime_event_rejects_unknown_phase_and_status_values(self):
         phase_event = sanitize_runtime_event({
             "agent_event": "secret-token",

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -48,6 +48,10 @@ def _admin_run_step_counts(run):
         "artifact_call_limit_hits": 0,
         "structured_analysis_calls": 0,
         "structured_analysis_limit_hits": 0,
+        "structured_analysis_max_calls": None,
+        "structured_validation_calls": 0,
+        "structured_validation_limit_hits": 0,
+        "structured_validation_max_calls": None,
         "transform_calls": 0,
         "transform_call_limit_hits": 0,
         "llm_calls": 0,
@@ -73,11 +77,31 @@ def _admin_run_step_counts(run):
             ):
                 counts["artifact_call_limit_hits"] += 1
             elif agent_event == "tool.analyze_structured_output.start":
-                counts["structured_analysis_calls"] += 1
+                if event.get("operation") == "validate_records":
+                    prefix = "structured_validation"
+                else:
+                    prefix = "structured_analysis"
+                counts[f"{prefix}_calls"] += 1
+                try:
+                    max_calls = max(int(event.get("max_calls") or 0), 0)
+                except (TypeError, ValueError):
+                    max_calls = 0
+                if max_calls:
+                    counts[f"{prefix}_max_calls"] = max_calls
             elif agent_event == (
                 "tool.analyze_structured_output.budget_exceeded"
             ):
-                counts["structured_analysis_limit_hits"] += 1
+                if event.get("operation") == "validate_records":
+                    prefix = "structured_validation"
+                else:
+                    prefix = "structured_analysis"
+                counts[f"{prefix}_limit_hits"] += 1
+                try:
+                    max_calls = max(int(event.get("max_calls") or 0), 0)
+                except (TypeError, ValueError):
+                    max_calls = 0
+                if max_calls:
+                    counts[f"{prefix}_max_calls"] = max_calls
             elif agent_event == "tool.run_skill_transform.start":
                 counts["transform_calls"] += 1
             elif agent_event == (
@@ -222,6 +246,18 @@ def _admin_run_row(run):
         "structured_analysis_calls": counts["structured_analysis_calls"],
         "structured_analysis_limit_hits": counts[
             "structured_analysis_limit_hits"
+        ],
+        "structured_analysis_max_calls": counts[
+            "structured_analysis_max_calls"
+        ],
+        "structured_validation_calls": counts[
+            "structured_validation_calls"
+        ],
+        "structured_validation_limit_hits": counts[
+            "structured_validation_limit_hits"
+        ],
+        "structured_validation_max_calls": counts[
+            "structured_validation_max_calls"
         ],
         "transform_calls": counts["transform_calls"],
         "transform_call_limit_hits": counts[

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -68,6 +68,8 @@
     "artifactCallLimitHit": "call limit reached",
     "structuredAnalysisCalls": "Structured analysis",
     "structuredAnalysisCallsCount": "{n} structured analyses",
+    "structuredValidationCalls": "Completeness validation",
+    "structuredValidationCallsCount": "{n} completeness validations",
     "transformCalls": "Skill Transforms",
     "transformCallsCount": "{n} Transform calls",
     "callLimitHit": "call limit reached",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -68,6 +68,8 @@
     "artifactCallLimitHit": "已触发调用上限",
     "structuredAnalysisCalls": "结构化分析",
     "structuredAnalysisCallsCount": "{n} 次结构化分析",
+    "structuredValidationCalls": "完整性校验",
+    "structuredValidationCallsCount": "{n} 次完整性校验",
     "transformCalls": "Skill Transform",
     "transformCallsCount": "{n} 次 Transform 调用",
     "callLimitHit": "已触发调用上限",

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -540,8 +540,28 @@
                       </dt>
                       <dd class="overview-value tabular-nums">
                         {{ detail.structured_analysis_calls }}
+                        <template v-if="detail.structured_analysis_max_calls">
+                          / {{ detail.structured_analysis_max_calls }}
+                        </template>
                         <span
                           v-if="detail.structured_analysis_limit_hits"
+                          class="font-normal text-amber-600"
+                        >
+                          · {{ t('lensRuns.callLimitHit') }}
+                        </span>
+                      </dd>
+                    </div>
+                    <div v-if="detail.structured_validation_calls">
+                      <dt class="overview-label">
+                        {{ t('lensRuns.structuredValidationCalls') }}
+                      </dt>
+                      <dd class="overview-value tabular-nums">
+                        {{ detail.structured_validation_calls }}
+                        <template v-if="detail.structured_validation_max_calls">
+                          / {{ detail.structured_validation_max_calls }}
+                        </template>
+                        <span
+                          v-if="detail.structured_validation_limit_hits"
                           class="font-normal text-amber-600"
                         >
                           · {{ t('lensRuns.callLimitHit') }}
@@ -833,6 +853,16 @@
                       {{
                         t('lensRuns.structuredAnalysisCallsCount', {
                           n: detail.structured_analysis_calls
+                        })
+                      }}
+                    </span>
+                    <span
+                      v-if="detail.structured_validation_calls"
+                      class="token-summary-pill"
+                    >
+                      {{
+                        t('lensRuns.structuredValidationCallsCount', {
+                          n: detail.structured_validation_calls
                         })
                       }}
                     </span>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -264,6 +264,7 @@
         "activityCompleted": "Completed {count} activities",
         "blockedTitle": "Capability unavailable",
         "executionFailedTitle": "Capability execution failed",
+        "verificationFailedTitle": "Result verification incomplete",
         "artifactTitle": "Artifact ready",
         "outcomePartial": "Completed with limitations. Review the missing capability or unfinished items above.",
         "outcomeBlocked": "This request did not complete. Review the runtime details and retry.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -264,6 +264,7 @@
         "activityCompleted": "已完成 {count} 项活动",
         "blockedTitle": "所需能力当前不可用",
         "executionFailedTitle": "能力执行失败",
+        "verificationFailedTitle": "结果验证未完成",
         "artifactTitle": "交付文件已生成",
         "outcomePartial": "已返回部分结果，请查看上方缺失能力或未完成事项。",
         "outcomeBlocked": "当前请求未完成，请查看运行详情后重试。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -610,11 +610,25 @@
                 </div>
 
                 <div
+                  v-if="message._runtimeState?.verificationFailure"
+                  class="runtime-outcome-card"
+                  role="status"
+                >
+                  <div class="runtime-card-title">
+                    {{ t('lens.chat.runtime.verificationFailedTitle') }}
+                  </div>
+                  <div>
+                    {{ verificationFailureRecovery(message._runtimeState) }}
+                  </div>
+                </div>
+
+                <div
                   v-if="
                     message._runtimeState?.outcome === 'partial' ||
                     (message._runtimeState?.outcome === 'blocked' &&
                       !message._runtimeState?.capabilityBlock &&
-                      !message._runtimeState?.executionFailure)
+                      !message._runtimeState?.executionFailure &&
+                      !message._runtimeState?.verificationFailure)
                   "
                   class="runtime-outcome-card"
                   role="status"
@@ -1134,6 +1148,19 @@
                 </div>
 
                 <div
+                  v-if="runtimeState.verificationFailure"
+                  class="runtime-outcome-card"
+                  role="status"
+                >
+                  <div class="runtime-card-title">
+                    {{ t('lens.chat.runtime.verificationFailedTitle') }}
+                  </div>
+                  <div>
+                    {{ verificationFailureRecovery(runtimeState) }}
+                  </div>
+                </div>
+
+                <div
                   v-if="runtimeState.artifacts.length"
                   class="runtime-artifact-card"
                   role="status"
@@ -1154,7 +1181,8 @@
                     runtimeState.outcome === 'partial' ||
                     (runtimeState.outcome === 'blocked' &&
                       !runtimeState.capabilityBlock &&
-                      !runtimeState.executionFailure)
+                      !runtimeState.executionFailure &&
+                      !runtimeState.verificationFailure)
                   "
                   class="runtime-outcome-card"
                   role="status"
@@ -1898,6 +1926,10 @@ function capabilityRecovery(block) {
 
 function executionFailureRecovery(state) {
   return capabilityRecovery(state?.executionFailure)
+}
+
+function verificationFailureRecovery(state) {
+  return capabilityRecovery(state?.verificationFailure)
 }
 
 const decoratedMessages = computed(() =>

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -119,6 +119,7 @@ export function createRuntimeState() {
     activityAttempts: {},
     capabilityBlock: null,
     executionFailure: null,
+    verificationFailure: null,
     artifacts: [],
     outcome: null,
     terminationDetail: null
@@ -664,7 +665,11 @@ export function applyRuntimeEvent(state, event) {
       executionFailure:
         terminationDetail?.reason === 'execution_failed'
           ? { ...terminationDetail }
-          : current.executionFailure
+          : current.executionFailure,
+      verificationFailure:
+        terminationDetail?.reason === 'evidence_unavailable'
+          ? { ...terminationDetail }
+          : current.verificationFailure
     }
     if (event.type === 'done') {
       const status = event.outcome === 'completed' ? 'completed' : 'failed'
@@ -736,6 +741,9 @@ export function applyRuntimeEvent(state, event) {
   }
   if (event.event_type === 'execution.failed') {
     return { ...current, executionFailure: { ...payload } }
+  }
+  if (event.event_type === 'verification.failed') {
+    return { ...current, verificationFailure: { ...payload } }
   }
   if (event.event_type === 'artifact.created') {
     const artifact = {

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -172,6 +172,23 @@ test('keeps execution failures separate from capability availability', () => {
   assert.equal(state.executionFailure.error_type, 'transient')
 })
 
+test('keeps verification failures separate from tool execution failures', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'verification.failed',
+    visibility: 'user',
+    payload: {
+      reason: 'evidence_unavailable',
+      capability: 'skill',
+      error_type: 'verification'
+    }
+  })
+
+  assert.equal(state.executionFailure, null)
+  assert.equal(state.verificationFailure.reason, 'evidence_unavailable')
+  assert.equal(state.verificationFailure.error_type, 'verification')
+})
+
 test('restores the correct block card from terminal run details', () => {
   const capabilityState = applyRuntimeEvent(createRuntimeState(), {
     type: 'done',
@@ -189,11 +206,21 @@ test('restores the correct block card from terminal run details', () => {
       error_type: 'transient'
     }
   })
+  const verificationState = applyRuntimeEvent(createRuntimeState(), {
+    type: 'done',
+    outcome: 'blocked',
+    termination_detail: {
+      reason: 'evidence_unavailable',
+      error_type: 'verification'
+    }
+  })
 
   assert.equal(capabilityState.capabilityBlock.error_type, 'capability')
   assert.equal(capabilityState.executionFailure, null)
   assert.equal(executionState.capabilityBlock, null)
   assert.equal(executionState.executionFailure.error_type, 'transient')
+  assert.equal(verificationState.executionFailure, null)
+  assert.equal(verificationState.verificationFailure.error_type, 'verification')
 })
 
 test('ignores internal events and applies terminal outcome', () => {

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -312,6 +312,10 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
     """Apply bounded recovery without stopping the whole agent run."""
 
     CAPABILITY_CORRECTION_LIMIT = 4
+    TOOL_BUDGET_ERRORS = {
+        "STRUCTURED_ANALYSIS_CALL_LIMIT",
+        "STRUCTURED_VALIDATION_CALL_LIMIT",
+    }
 
     def __init__(
         self,
@@ -493,6 +497,11 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             payload = {"ok": False, "error": "MCP_TOOL_FAILED"}
         if payload.get("ok") is True:
             self._record_success(capability)
+            if payload.get("call_budget_exhausted") is True:
+                self.blocked_tools.add(tool_name)
+            return result
+        if str(payload.get("error") or "") in self.TOOL_BUDGET_ERRORS:
+            self.blocked_tools.add(tool_name)
             return result
         if capability is None:
             return result
@@ -1303,10 +1312,17 @@ class LensDeepAgentRuntime:
                 runtime_evidence=runtime_evidence,
             )
             if outcome == "blocked" and capability_middleware is not None:
-                emit_user_event(
-                    "execution.failed",
-                    termination_detail,
-                )
+                reason = termination_detail.get("reason")
+                if reason == "execution_failed":
+                    emit_user_event(
+                        "execution.failed",
+                        termination_detail,
+                    )
+                elif reason == "evidence_unavailable":
+                    emit_user_event(
+                        "verification.failed",
+                        termination_detail,
+                    )
                 answer = _unverified_execution_answer(
                     question,
                     termination_detail,
@@ -1621,7 +1637,56 @@ def _select_general_chat_route(
     except Exception:
         LOGGER.exception("General Chat route classification failed")
         return _parse_route_decision("")
-    return _parse_route_decision(getattr(response, "content", ""))
+    decision = _parse_route_decision(getattr(response, "content", ""))
+    return _normalize_route_evidence_capabilities(
+        decision,
+        available_tools,
+    )
+
+
+def _normalize_route_evidence_capabilities(decision, available_tools):
+    """Repair incomplete route evidence using available evidence families."""
+
+    normalized = dict(decision)
+    capability_order = (
+        "skill",
+        "mcp",
+        "workspace",
+        "artifact_delivery",
+    )
+    required = [
+        capability
+        for capability in normalized.get("required_capabilities") or []
+        if capability in capability_order
+    ]
+    evidence_requirement = normalized.get("evidence_requirement")
+    if evidence_requirement == "tool_result":
+        required = [
+            capability
+            for capability in required
+            if capability in {"skill", "mcp", "workspace"}
+        ]
+    if evidence_requirement == "tool_result" and not required:
+        available_capabilities = {
+            CapabilityBoundaryMiddleware._evidence_capability(
+                str(getattr(tool, "name", "") or "")
+            )
+            for tool in available_tools or []
+        }
+        required.extend(
+            capability
+            for capability in capability_order
+            if capability in {"skill", "mcp", "workspace"}
+            and capability in available_capabilities
+            and capability not in required
+        )
+    if (
+        evidence_requirement == "artifact"
+        and "artifact_delivery" not in required
+    ):
+        required.append("artifact_delivery")
+    normalized["required_capabilities"] = required
+    return normalized
 
 
 def _capability_termination_detail(capability, tool=""):
@@ -1768,6 +1833,18 @@ def _finalize_runtime_outcome(
             "partial" if useful_evidence else "blocked",
             termination_detail,
         )
+
+    delivered_artifact_wrapup = (
+        truncated
+        and stop_reason in {"token_budget_wrapup", "token_capped"}
+        and "artifact_delivery" in successful
+        and (
+            evidence_requirement == "artifact"
+            or bool(relevant_successes)
+        )
+    )
+    if delivered_artifact_wrapup:
+        return "completed", {}
 
     record_validation = (runtime_evidence or {}).get(
         "record_validation"

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -1036,6 +1036,15 @@ def build_general_chat_tools(
     )
     structured_analysis_calls = {"count": 0}
     structured_validation_calls = {"count": 0}
+    structured_limit_results = {
+        "analysis": None,
+        "validation": None,
+    }
+    structured_budget_instruction = (
+        "The structured analysis budget is exhausted. Do not call this "
+        "tool again. Use existing bounded results and finish the final "
+        "answer."
+    )
     saved_output_inspection_max_calls = min(
         _positive_int(
             tool_policy.get("saved_output_inspection_max_calls"),
@@ -1089,6 +1098,10 @@ def build_general_chat_tools(
         invocation_id = uuid.uuid4().hex
         normalized_operation = str(operation or "").strip().lower()
         is_validation = normalized_operation == "validate_records"
+        limit_key = "validation" if is_validation else "analysis"
+        prior_limit_result = structured_limit_results[limit_key]
+        if prior_limit_result is not None:
+            return _json(prior_limit_result)
         call_counter = (
             structured_validation_calls
             if is_validation
@@ -1119,15 +1132,16 @@ def build_general_chat_tools(
                 "tool.analyze_structured_output.budget_exceeded",
                 detail,
             )
-            return _json(
-                {
-                    "ok": False,
-                    "error": limit_error,
-                    "invocation_id": invocation_id,
-                    "call_count": call_count,
-                    "max_calls": max_calls,
-                }
-            )
+            limit_result = {
+                "ok": False,
+                "error": limit_error,
+                "invocation_id": invocation_id,
+                "call_count": call_count,
+                "max_calls": max_calls,
+                "instruction": structured_budget_instruction,
+            }
+            structured_limit_results[limit_key] = limit_result
+            return _json(limit_result)
 
         request_detail = {
             "invocation_id": invocation_id,
@@ -1227,6 +1241,7 @@ def build_general_chat_tools(
             structured_analysis_output_limit,
         )
         result_count = len(result) if isinstance(result, (dict, list)) else 1
+        call_budget_exhausted = call_count >= max_calls
         input_sha256 = hashlib.sha256(raw).hexdigest()
         detail = {
             "invocation_id": invocation_id,
@@ -1242,6 +1257,7 @@ def build_general_chat_tools(
             "output_ref": output["output_ref"],
             "call_count": call_count,
             "max_calls": max_calls,
+            "call_budget_exhausted": call_budget_exhausted,
             "summary": (
                 f"{normalized_operation} · {result_count} result"
                 f"{'s' if result_count != 1 else ''} · {duration_ms}ms"
@@ -1258,7 +1274,13 @@ def build_general_chat_tools(
                 "input_sha256": input_sha256,
                 "duration_ms": duration_ms,
                 "result_count": result_count,
+                "call_budget_exhausted": call_budget_exhausted,
                 **output,
+                **(
+                    {"instruction": structured_budget_instruction}
+                    if call_budget_exhausted
+                    else {}
+                ),
             }
         )
 

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -339,6 +339,72 @@ def test_route_selection_matches_intent_against_skill_and_tool_capabilities():
     assert "creating an order" in prompt
 
 
+def test_route_selection_recovers_missing_tool_evidence_capabilities():
+    class Model:
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"action","complexity":"complex",'
+                    '"route":"plan_execute",'
+                    '"required_capabilities":[],'
+                    '"evidence_requirement":"tool_result"}'
+                )
+            )
+
+    decision = agent_runtime._select_general_chat_route(
+        Model(),
+        "查询订单并生成流程图",
+        context_skill_contents=["This Skill can query Income orders."],
+        available_tools=[
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            ),
+            SimpleNamespace(
+                name="save_deliverable",
+                description="Deliver a generated file.",
+            ),
+        ],
+    )
+
+    assert decision["evidence_requirement"] == "tool_result"
+    assert decision["required_capabilities"] == ["skill"]
+
+
+def test_route_selection_requires_delivery_for_artifact_evidence():
+    class Model:
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"action","complexity":"complex",'
+                    '"route":"plan_execute",'
+                    '"required_capabilities":["skill"],'
+                    '"evidence_requirement":"artifact"}'
+                )
+            )
+
+    decision = agent_runtime._select_general_chat_route(
+        Model(),
+        "生成并交付流程图",
+        context_skill_contents=["This Skill generates flowcharts."],
+        available_tools=[
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            ),
+            SimpleNamespace(
+                name="save_deliverable",
+                description="Deliver a generated file.",
+            ),
+        ],
+    )
+
+    assert decision["required_capabilities"] == [
+        "skill",
+        "artifact_delivery",
+    ]
+
+
 def test_route_selection_uses_history_to_resolve_an_action_follow_up():
     class Model:
         def __init__(self):
@@ -579,6 +645,153 @@ def test_unmatched_capability_returns_before_any_tool_call(monkeypatch):
         "capability_unavailable"
     )
     assert tool_calls["count"] == 0
+
+
+def test_successful_skill_evidence_preserves_the_final_answer(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 1}
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"action","complexity":"complex",'
+                    '"route":"plan_execute",'
+                    '"required_capabilities":[],'
+                    '"evidence_requirement":"tool_result"}'
+                )
+            )
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=["This Skill can query Income orders."],
+        mcp_configs=[],
+        skill_paths=["skills/income"],
+        mcp_config_path=tmp_path / "mcp.json",
+    )
+    config = SimpleNamespace(
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+        summary_trigger_tokens=0,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_apply_offload_thresholds",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_build_summarization_middleware",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def middleware(
+        _command,
+        _summarizer,
+        _emit_event,
+        capability_middleware=None,
+        **_kwargs,
+    ):
+        captured["boundary"] = capability_middleware
+        return [capability_middleware]
+
+    monkeypatch.setattr(agent_runtime, "_agent_middleware", middleware)
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        lambda **_kwargs: object(),
+    )
+
+    def run_agent(*_args, **_kwargs):
+        captured["boundary"].success_count = 2
+        captured["boundary"].successful_capabilities = {
+            "artifact_delivery",
+            "skill",
+        }
+        return "已生成并交付订单流程图。", True, "token_budget_wrapup"
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_agent_with_turn_limit",
+        run_agent,
+    )
+
+    result = agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000002",
+            "task": "general_chat",
+            "question": "查询订单并生成流程图",
+            "agent_model_ref": "model-ref",
+        }
+    )
+
+    assert captured["boundary"].required_capabilities == {"skill"}
+    assert result["answer"] == "已生成并交付订单流程图。"
+    assert result["outcome"] == "completed"
+    assert result["termination_detail"] == {}
+
+
+def test_delivered_artifact_completes_after_token_budget_wrapup():
+    middleware = SimpleNamespace(
+        successful_capabilities={"skill", "artifact_delivery"},
+        failed_capabilities=set(),
+        recovered_capabilities=set(),
+        exhaustion_details=[],
+        termination_detail={},
+    )
+
+    outcome, termination_detail = _finalize_runtime_outcome(
+        capability_middleware=middleware,
+        evidence_requirement="tool_result",
+        required_capabilities=["skill"],
+        truncated=True,
+        stop_reason="token_budget_wrapup",
+    )
+
+    assert outcome == "completed"
+    assert termination_detail == {}
 
 
 def test_legacy_runtime_modes_skip_general_chat_execution_gates(
@@ -1214,6 +1427,83 @@ def test_capability_boundary_allows_one_transient_retry():
     middleware.wrap_tool_call(request, fail)
     assert middleware.blocked_tools == {"mcp__orders"}
     assert middleware.termination_detail["capability"] == "mcp"
+
+
+def test_structured_analysis_limit_blocks_only_the_exhausted_tool():
+    middleware = agent_runtime.CapabilityBoundaryMiddleware()
+    request = SimpleNamespace(
+        tool=SimpleNamespace(name="analyze_structured_output"),
+        tool_call={
+            "name": "analyze_structured_output",
+            "id": "call-1",
+        },
+    )
+
+    result = middleware.wrap_tool_call(
+        request,
+        lambda _request: ToolMessage(
+            content=json.dumps(
+                {
+                    "ok": False,
+                    "error": "STRUCTURED_ANALYSIS_CALL_LIMIT",
+                    "instruction": (
+                        "Use existing bounded results and finish the answer."
+                    ),
+                }
+            ),
+            name="analyze_structured_output",
+            tool_call_id="call-1",
+            status="error",
+        ),
+    )
+
+    assert json.loads(result.content)["error"] == (
+        "STRUCTURED_ANALYSIS_CALL_LIMIT"
+    )
+    assert middleware.blocked_tools == {"analyze_structured_output"}
+    assert middleware.termination_detail == {}
+    assert middleware.failed_capabilities == set()
+
+    denied = middleware.wrap_tool_call(
+        request,
+        lambda _request: (_ for _ in ()).throw(
+            AssertionError("The blocked tool must not execute again")
+        ),
+    )
+
+    assert json.loads(denied.content)["error"] == "CAPABILITY_BLOCKED"
+
+
+def test_last_structured_analysis_call_prevents_an_over_limit_attempt():
+    middleware = agent_runtime.CapabilityBoundaryMiddleware()
+    request = SimpleNamespace(
+        tool=SimpleNamespace(name="analyze_structured_output"),
+        tool_call={
+            "name": "analyze_structured_output",
+            "id": "call-1",
+        },
+    )
+
+    result = middleware.wrap_tool_call(
+        request,
+        lambda _request: ToolMessage(
+            content=json.dumps(
+                {
+                    "ok": True,
+                    "call_budget_exhausted": True,
+                    "instruction": (
+                        "Use existing bounded results and finish the answer."
+                    ),
+                }
+            ),
+            name="analyze_structured_output",
+            tool_call_id="call-1",
+        ),
+    )
+
+    assert json.loads(result.content)["ok"] is True
+    assert middleware.blocked_tools == {"analyze_structured_output"}
+    assert middleware.termination_detail == {}
 
 
 def test_request_failures_are_isolated_by_normalized_arguments():

--- a/lensnode/tests/test_structured_output.py
+++ b/lensnode/tests/test_structured_output.py
@@ -417,12 +417,21 @@ def test_analyze_structured_output_enforces_call_budget(tmp_path):
 
     first = json.loads(tool.invoke({"ref": ref, "operation": "count"}))
     second = json.loads(tool.invoke({"ref": ref, "operation": "count"}))
+    third = json.loads(tool.invoke({"ref": ref, "operation": "count"}))
 
     assert first["ok"] is True
+    assert first["call_budget_exhausted"] is True
+    assert "finish the final answer" in first["instruction"]
     assert second["error"] == "STRUCTURED_ANALYSIS_CALL_LIMIT"
     assert second["call_count"] == 2
     assert second["max_calls"] == 1
-    assert events[-1][0] == "tool.analyze_structured_output.budget_exceeded"
+    assert "finish the final answer" in second["instruction"]
+    assert third == second
+    assert [
+        name
+        for name, _detail in events
+        if name == "tool.analyze_structured_output.budget_exceeded"
+    ] == ["tool.analyze_structured_output.budget_exceeded"]
 
 
 def test_record_validation_has_reserved_budget_and_understands_wrapper(


### PR DESCRIPTION
### **User description**
## Summary
- Recover missing General Chat evidence capability contracts from the bound tool inventory.
- Preserve verified artifact answers during token-budget wrap-up and stop exhausted structured-analysis tools from being called again.
- Distinguish verification failures from execution failures and expose analysis and validation budgets in the UI.

Closes #181

## Test plan
- [x] LensNode regression tests: 105 passed
- [x] Django backend regression tests: 87 passed in `sourcelens-api-dev`
- [x] Frontend unit tests: 126 passed
- [x] ESLint passed for affected frontend files
- [x] Frontend production build passed
- [x] `ego-browser` task space 64 verified the completed 5/5 General Chat flow, preserved final answer, and separated admin analysis/validation counts


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Recover missing capability contracts from bound tools

- Preserve verified artifact answers during token-budget wrap-up

- Distinguish verification failures from execution failures

- Expose analysis and validation budgets in UI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Route Classification"] --> B["Normalize Capabilities"]
  B --> C["Execute Tools"]
  C --> D["Token Budget Wrap-up"]
  D --> E["Evidence Check"]
  E --> F["Completed"]
  E --> G["Verification Failed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>runtime_events.py</strong><dd><code>Add verification.failed event type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-c9a17a59ab1b816ecb943fc96701791319bddd6e65c78a3dfe42616fbd6e33b5">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin_runs.py</strong><dd><code>Add structured validation counts to admin API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_tools.py</strong><dd><code>Handle tool budget exhaustion and prevent repeated calls</code>&nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+31/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RunObservation.vue</strong><dd><code>Show structured validation counts in admin UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Show verification failure card in chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+34/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.js</strong><dd><code>Add verification failure runtime state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_attachments.py</strong><dd><code>Add structured validation count tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+28/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add verification failure event test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Add tests for route capability recovery and evidence preservation</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+290/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_structured_output.py</strong><dd><code>Update structured analysis budget test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-a7388aabe8f10f3f9aed6311d3240a3fb6eb398fa8fe283421b15f3f3bdc2ea1">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.test.js</strong><dd><code>Add verification failure runtime event tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Normalize route capabilities and preserve verified results</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+82/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English admin locale for structured validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese admin locale for structured validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English locale for verification failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese locale for verification failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/193/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

