### PR TITLE
Restore mobile assistant switching

### DIFF
--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test'
 
-async function mockChat(page, messageDelays = {}, language = 'en') {
+async function mockChat(
+  page,
+  messageDelays = {},
+  language = 'en',
+  assistantList = null
+) {
   await page.addInitScript((selectedLanguage) => {
     localStorage.setItem('access_token', 'test-token')
     localStorage.setItem('userLanguage', selectedLanguage)
@@ -19,7 +24,7 @@ async function mockChat(page, messageDelays = {}, language = 'en') {
         features: ['workspace'],
         permissions: []
       },
-      '/api/lens/assistants/': [
+      '/api/lens/assistants/': assistantList || [
         {
           uuid: 'assistant-1',
           slug: 'drawer-test',
@@ -159,6 +164,43 @@ test('mobile session drawer opens, selects sessions, and closes', async ({
     .click({ position: { x: 380, y: 400 } })
   await expect(page.locator('.sidebar')).not.toHaveClass(/sidebar-open/)
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: -320 })
+})
+
+test('mobile header switches assistants without overflowing', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockChat(page, {}, 'en', [
+    {
+      uuid: 'assistant-1',
+      slug: 'drawer-test',
+      name: 'Drawer Test',
+      status: 'active'
+    },
+    {
+      uuid: 'assistant-2',
+      slug: 'mobile-switch',
+      name: 'Mobile Switch',
+      status: 'active'
+    }
+  ])
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  const switcher = page.getByRole('button', { name: 'Switch assistant' })
+  await expect(switcher).toBeVisible()
+  await expectMinimumTouchTarget(switcher)
+  await switcher.click()
+
+  const panel = page.locator('.assistant-switcher-panel')
+  await expect(panel).toBeVisible()
+  const panelBox = await panel.boundingBox()
+  expect(panelBox).not.toBeNull()
+  expect(panelBox.x).toBeGreaterThanOrEqual(0)
+  expect(panelBox.x + panelBox.width).toBeLessThanOrEqual(390)
+
+  await panel.getByRole('button', { name: /Mobile Switch/ }).click()
+  await expect(page).toHaveURL('/lens/assistants/mobile-switch/chat')
+  await expect(switcher).toContainText('Mobile Switch')
 })
 
 test('desktop sidebar still expands and collapses', async ({ page }) => {

--- a/frontend/src/components/lens/AssistantSwitcher.vue
+++ b/frontend/src/components/lens/AssistantSwitcher.vue
@@ -668,6 +668,26 @@ onUnmounted(() => {
   @apply mt-0.5 shrink-0 rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700;
 }
 
+@media (max-width: 1023px) {
+  .assistant-switcher-header-trigger {
+    min-height: 44px;
+  }
+
+  .assistant-switcher-header-name {
+    @apply text-sm;
+  }
+
+  .assistant-switcher-panel-down {
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + 3.5rem);
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    max-height: calc(100dvh - env(safe-area-inset-top) - 4.5rem);
+    overflow-y: auto;
+  }
+}
+
 .assistant-switcher-embedded {
   @apply w-full;
 }

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -300,7 +300,13 @@
           <PanelLeftOpen :size="20" :stroke-width="2.1" aria-hidden="true" />
         </button>
         <div class="mobile-topbar-title">
-          {{ mySharesOpen ? t('lens.qa.mineTitle') : assistantName }}
+          <span v-if="mySharesOpen" class="mobile-topbar-title-text">
+            {{ t('lens.qa.mineTitle') }}
+          </span>
+          <AssistantSwitcher v-else-if="switchable" mode="header" />
+          <span v-else class="mobile-topbar-title-text">
+            {{ assistantName }}
+          </span>
         </div>
         <button
           type="button"
@@ -3229,7 +3235,11 @@ onBeforeUnmount(() => {
 }
 
 .mobile-topbar-title {
-  @apply min-w-0 flex-1 truncate text-center text-sm font-semibold text-ink-900;
+  @apply flex min-w-0 flex-1 justify-center;
+}
+
+.mobile-topbar-title-text {
+  @apply min-w-0 truncate text-center text-sm font-semibold text-ink-900;
 }
 
 .chat-header {


### PR DESCRIPTION
### **User description**
## Summary

- show the assistant switcher on mobile when multiple assistants are available
- keep single-assistant, anonymous, and My Shares behavior unchanged
- enforce mobile touch target and dropdown viewport boundaries
- add mobile regression coverage for assistant switching

## Testing

- `npm run build`
- `npm run test:unit` (126 passed)
- ESLint on the changed frontend files
- `git diff --check origin/main...HEAD`
- ego-browser regression at 390x844 and 320x568

Closes #194


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restore assistant switcher on mobile topbar

- Enforce touch target and viewport boundaries

- Add E2E regression test for mobile switching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MobileTopbar["Mobile Topbar"] --> AssistantSwitcher["AssistantSwitcher Component"]
  AssistantSwitcher --> DropdownPanel["Dropdown Panel"]
  DropdownPanel --> AssistantSelection["Assistant Selection"]
  AssistantSelection --> URLChange["Navigate to URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AssistantSwitcher.vue</strong><dd><code>Mobile assistant switcher CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/lens/AssistantSwitcher.vue

<ul><li>Added mobile-specific CSS for trigger min-height (44px) and panel <br>positioning<br> <li> Ensures dropdown stays within viewport with safe-area-inset-top and <br>overflow-y</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/201/files#diff-8ebe891ec13cade36d347b93c2ec34d251724dabf21d3077cc7c0396baefc129">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Mobile topbar assistant switcher integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Replaced static assistant name with AssistantSwitcher component when <br>switchable<br> <li> Adjusted layout classes for proper centering in mobile topbar</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/201/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-mobile-drawer.spec.js</strong><dd><code>Mobile assistant switching E2E test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-mobile-drawer.spec.js

<ul><li>Added E2E test for mobile assistant switching with viewport <br>constraints<br> <li> Verifies button visibility, touch target, panel bounds, and navigation</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/201/files#diff-cb89d191cc946ddb676d704f3a7398dba03f09b1e45585cd92e06cefb093cdaa">+44/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

