### PR TITLE
Make Run history retry-aware

### DIFF
--- a/backend/lens/migrations/0031_run_retry_of_run.py
+++ b/backend/lens/migrations/0031_run_retry_of_run.py
@@ -1,0 +1,22 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0030_alter_token_budget_profile_choices"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="run",
+            name="retry_of_run",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="retry_runs",
+                to="lens.run",
+            ),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -706,6 +706,13 @@ class Run(models.Model):
         on_delete=models.SET_NULL,
         related_name="response_runs",
     )
+    retry_of_run = models.ForeignKey(
+        "self",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="retry_runs",
+    )
     lensnode = models.ForeignKey(
         LensNode,
         null=True,

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -57,7 +57,7 @@ from .runtime_events import (
     sanitize_loaded_skills,
     sanitize_termination_detail,
 )
-from .services import create_execution_run
+from .services import create_execution_run, validate_retry_run
 from .skill_generation import (
     get_workspace_guide_payload,
     sync_workspace_guide_skill,
@@ -2048,6 +2048,10 @@ class RunSerializer(serializers.ModelSerializer):
     steps = RunStepSerializer(many=True, read_only=True)
     execution = RunExecutionSerializer(read_only=True)
     lensnode = serializers.UUIDField(source="lensnode.uuid", read_only=True)
+    retry_of_run_uuid = serializers.UUIDField(
+        source="retry_of_run.uuid",
+        read_only=True,
+    )
     termination_detail = serializers.SerializerMethodField()
 
     def get_termination_detail(self, obj):
@@ -2062,6 +2066,7 @@ class RunSerializer(serializers.ModelSerializer):
             "status",
             "input_message",
             "output_message",
+            "retry_of_run_uuid",
             "lensnode",
             "metering_ref",
             "error",
@@ -2168,7 +2173,12 @@ class RunCreateSerializer(serializers.Serializer):
         allow_blank=True,
         default="",
     )
-    idempotency_key = serializers.CharField(required=False, allow_blank=True)
+    idempotency_key = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=128,
+    )
+    retry_of_run_uuid = serializers.UUIDField(required=False, allow_null=True)
     enqueue = serializers.BooleanField(required=False, default=True)
     run_inline = serializers.BooleanField(required=False, default=False)
     attachment_uuids = serializers.ListField(
@@ -2190,6 +2200,16 @@ class RunCreateSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 f"At most {ATTACHMENT_MAX_PER_MESSAGE} images per message."
             )
+        retry_uuid = attrs.get("retry_of_run_uuid")
+        if retry_uuid is not None:
+            try:
+                retry_of_run = Run.objects.get(uuid=retry_uuid)
+                validate_retry_run(self.context["session"], retry_of_run)
+            except (Run.DoesNotExist, ValueError):
+                raise serializers.ValidationError(
+                    {"retry_of_run_uuid": "Invalid Retry Run."}
+                )
+            attrs["retry_of_run"] = retry_of_run
         return attrs
 
     def create(self, validated_data):
@@ -2201,6 +2221,7 @@ class RunCreateSerializer(serializers.Serializer):
                 session=session,
                 question=validated_data.get("question", ""),
                 idempotency_key=validated_data.get("idempotency_key", ""),
+                retry_of_run=validated_data.get("retry_of_run"),
                 enqueue=(
                     validated_data.get("enqueue", True) and not run_inline
                 ),

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -274,6 +274,7 @@ def create_execution_run(
     session,
     question,
     idempotency_key="",
+    retry_of_run=None,
     enqueue=True,
     attachment_uuids=None,
     user=None,
@@ -296,6 +297,8 @@ def create_execution_run(
         if existing:
             return existing
 
+    validate_retry_run(session, retry_of_run)
+
     input_message = Message.objects.create(
         session=session,
         role=Message.Role.USER,
@@ -313,6 +316,7 @@ def create_execution_run(
         status=Run.Status.QUEUED,
         input_message=input_message,
         output_message=output_message,
+        retry_of_run=retry_of_run,
         lensnode=session.assistant.lensnode,
         idempotency_key=idempotency_key,
     )
@@ -325,6 +329,28 @@ def create_execution_run(
         transaction.on_commit(lambda: _enqueue_answer_run(run.uuid))
 
     return run
+
+
+def validate_retry_run(session, retry_of_run):
+    """Reject Retry links outside the Session or with an existing cycle."""
+
+    if retry_of_run is None:
+        return
+    seen = set()
+    current = retry_of_run
+    while current is not None:
+        if current.session_id != session.pk:
+            raise ValueError("Retry Run must belong to the same Session.")
+        if current.pk in seen:
+            raise ValueError("Retry Run chain contains a cycle.")
+        seen.add(current.pk)
+        if current.retry_of_run_id is None:
+            return
+        current = Run.objects.only(
+            "pk",
+            "session_id",
+            "retry_of_run_id",
+        ).get(pk=current.retry_of_run_id)
 
 
 def _enqueue_answer_run(run_uuid):
@@ -663,44 +689,158 @@ AGENT_TURNS_BY_ROUNDS = {
 
 
 def build_run_history(run):
-    """Return prior conversation turns for a run as role/content dicts.
+    """Return trusted prior Run turns in chronological order."""
 
-    Includes only completed user and assistant messages before the
-    current turn, newest-first up to the caps, then returned in
-    chronological order. A Message stores only final content (never tool
-    traces), so the carried history stays compact and the agent context
-    cannot blow up from a long session. Capability-unavailable fallback
-    answers are omitted because their boundary decision applies only to
-    that request; the user message remains available for follow-up context.
-    """
-
-    blocked_runs = Run.objects.filter(
-        session=run.session,
-        termination_detail__reason="capability_unavailable",
-        output_message_id__isnull=False,
-    )
-    messages = Message.objects.filter(
-        session=run.session,
-        sequence__lt=run.input_message.sequence,
-        role__in=[Message.Role.USER, Message.Role.ASSISTANT],
-    ).exclude(
-        pk__in=blocked_runs.values("output_message_id")
-    ).order_by("-sequence")
-    history = []
-    total_chars = 0
-    for message in messages:
-        content = (message.content or "").strip()
-        if not content:
-            continue
-        content = content[:HISTORY_MAX_MESSAGE_CHARS]
-        if total_chars + len(content) > HISTORY_MAX_TOTAL_CHARS:
-            break
-        history.append({"role": message.role, "content": content})
-        total_chars += len(content)
-        if len(history) >= HISTORY_MAX_PAIRS * 2:
-            break
-    history.reverse()
+    history, _ = _build_run_history_data(run)
     return history
+
+
+def build_run_history_metadata(run):
+    """Return non-sensitive counts describing Run history filtering."""
+
+    _, metadata = _build_run_history_data(run)
+    return metadata
+
+
+def _build_run_history_data(run):
+    """Build trusted history and the corresponding filter counts."""
+
+    all_prior_runs = list(
+        Run.objects.filter(
+            session=run.session,
+            input_message__sequence__lt=run.input_message.sequence,
+        )
+        .select_related(
+            "input_message",
+            "output_message",
+        )
+        .order_by("input_message__sequence")
+    )
+    runs_by_id = {item.pk: item for item in all_prior_runs}
+    cutoff_sequence = run.input_message.sequence
+    superseded_current_attempts = 0
+    if run.retry_of_run_id:
+        root, superseded_current_attempts = _retry_chain_root(
+            run,
+            runs_by_id,
+        )
+        cutoff_sequence = root.input_message.sequence
+    prior_runs = [
+        item
+        for item in all_prior_runs
+        if item.input_message.sequence < cutoff_sequence
+    ]
+    latest_attempts = _latest_retry_attempts(prior_runs)
+    limited_pairs = []
+    total_chars = 0
+    for prior in reversed(latest_attempts):
+        entries = _trusted_history_entries(prior)
+        pair_chars = sum(len(item["content"]) for item in entries)
+        if total_chars + pair_chars > HISTORY_MAX_TOTAL_CHARS:
+            break
+        if entries:
+            limited_pairs.append(entries)
+            total_chars += pair_chars
+        if len(limited_pairs) >= HISTORY_MAX_PAIRS:
+            break
+    history = [
+        item
+        for pair in reversed(limited_pairs)
+        for item in pair
+    ]
+    metadata = {
+        "history_runs_before_filtering": len(all_prior_runs),
+        "history_runs_after_filtering": len(latest_attempts),
+        "superseded_retry_attempts_removed": (
+            superseded_current_attempts
+            + len(prior_runs)
+            - len(latest_attempts)
+        ),
+        "non_completed_assistant_outputs_excluded": sum(
+            bool(
+                prior.output_message_id
+                and (prior.output_message.content or "").strip()
+            )
+            and not _assistant_output_is_trusted(prior)
+            for prior in latest_attempts
+        ),
+    }
+    return history, metadata
+
+
+def _retry_chain_root(run, runs_by_id):
+    """Return the first Run in a valid Retry chain."""
+
+    seen = set()
+    current = run
+    attempts = 0
+    while current.retry_of_run_id and current.pk not in seen:
+        seen.add(current.pk)
+        parent = runs_by_id.get(current.retry_of_run_id)
+        if parent is None:
+            break
+        current = parent
+        attempts += 1
+    return current, attempts
+
+
+def _latest_retry_attempts(prior_runs):
+    """Collapse each Retry chain to its latest prior attempt."""
+
+    runs_by_id = {item.pk: item for item in prior_runs}
+    latest_by_root = {}
+    for prior in prior_runs:
+        root_id = prior.pk
+        current = prior
+        seen = set()
+        while (
+            current.retry_of_run_id in runs_by_id
+            and current.pk not in seen
+        ):
+            seen.add(current.pk)
+            current = runs_by_id[current.retry_of_run_id]
+            root_id = current.pk
+        latest_by_root[root_id] = prior
+    return sorted(
+        latest_by_root.values(),
+        key=lambda item: item.input_message.sequence,
+    )
+
+
+def _trusted_history_entries(run):
+    """Build one bounded Run turn, excluding untrusted assistant output."""
+
+    entries = []
+    question = (run.input_message.content or "").strip()
+    if question:
+        entries.append(
+            {
+                "role": Message.Role.USER,
+                "content": question[:HISTORY_MAX_MESSAGE_CHARS],
+            }
+        )
+    if (
+        _assistant_output_is_trusted(run)
+        and run.output_message_id
+    ):
+        answer = (run.output_message.content or "").strip()
+        if answer:
+            entries.append(
+                {
+                    "role": Message.Role.ASSISTANT,
+                    "content": answer[:HISTORY_MAX_MESSAGE_CHARS],
+                }
+            )
+    return entries
+
+
+def _assistant_output_is_trusted(run):
+    """Return whether a Run's assistant output is safe as history."""
+
+    return (
+        run.status == Run.Status.DONE
+        and run.outcome in {"", Run.Outcome.COMPLETED}
+    )
 
 
 def _recent_history_context(run):

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -2504,6 +2504,147 @@ class LensApiTests(TestCase):
         self.assertIn('"type": "sync"', body)
         self.assertIn('"type": "done"', body)
 
+    def test_explicit_retry_is_linked_and_idempotent(self):
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        original = create_execution_run(
+            session=session,
+            question="Retry this question",
+            idempotency_key="original-submission",
+            enqueue=False,
+        )
+        payload = {
+            "question": "Retry this question",
+            "idempotency_key": "retry-submission",
+            "retry_of_run_uuid": str(original.uuid),
+            "enqueue": False,
+        }
+
+        first_response = self.client.post(
+            f"/api/lens/sessions/{session.uuid}/runs/",
+            payload,
+            format="json",
+        )
+        replay_response = self.client.post(
+            f"/api/lens/sessions/{session.uuid}/runs/",
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(first_response.status_code, 201)
+        self.assertEqual(replay_response.status_code, 201)
+        self.assertEqual(
+            replay_response.data["uuid"],
+            first_response.data["uuid"],
+        )
+        self.assertEqual(
+            first_response.data["retry_of_run_uuid"],
+            str(original.uuid),
+        )
+        self.assertEqual(session.message_set.count(), 4)
+
+    def test_retry_rejects_run_from_another_session(self):
+        source_session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        target_session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        original = create_execution_run(
+            session=source_session,
+            question="Source question",
+            enqueue=False,
+        )
+
+        response = self.client.post(
+            f"/api/lens/sessions/{target_session.uuid}/runs/",
+            {
+                "question": "Source question",
+                "idempotency_key": "cross-session-retry",
+                "retry_of_run_uuid": str(original.uuid),
+                "enqueue": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(target_session.run_set.count(), 0)
+        self.assertEqual(target_session.message_set.count(), 0)
+
+    def test_retry_rejects_inaccessible_run_without_leaking_it(self):
+        other_user = User.objects.create_user(
+            username="retry-owner",
+            email="retry-owner@example.com",
+            password="pass12345",
+        )
+        private_session = Session.objects.create(
+            assistant=self.assistant,
+            user=other_user,
+        )
+        private_run = create_execution_run(
+            session=private_session,
+            question="Private question",
+            enqueue=False,
+        )
+        target_session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+
+        response = self.client.post(
+            f"/api/lens/sessions/{target_session.uuid}/runs/",
+            {
+                "question": "Private question",
+                "idempotency_key": "inaccessible-retry",
+                "retry_of_run_uuid": str(private_run.uuid),
+                "enqueue": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["retry_of_run_uuid"][0],
+            "Invalid Retry Run.",
+        )
+        self.assertEqual(target_session.run_set.count(), 0)
+
+    def test_retry_rejects_an_existing_cycle(self):
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        first = create_execution_run(
+            session=session,
+            question="First attempt",
+            enqueue=False,
+        )
+        second = create_execution_run(
+            session=session,
+            question="Second attempt",
+            retry_of_run=first,
+            enqueue=False,
+        )
+        Run.objects.filter(pk=first.pk).update(retry_of_run=second)
+
+        response = self.client.post(
+            f"/api/lens/sessions/{session.uuid}/runs/",
+            {
+                "question": "Third attempt",
+                "idempotency_key": "cyclic-retry",
+                "retry_of_run_uuid": str(second.uuid),
+                "enqueue": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(session.run_set.count(), 2)
+
     def test_run_created_at_is_read_only(self):
         session_response = self.client.post(
             "/api/lens/sessions/",

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -202,6 +202,9 @@ class LensServiceTests(TransactionTestCase):
         )
         run1.output_message.content = "a1"
         run1.output_message.save(update_fields=["content"])
+        run1.status = Run.Status.DONE
+        run1.outcome = Run.Outcome.COMPLETED
+        run1.save(update_fields=["status", "outcome"])
         # second turn left unanswered -> its empty answer must be skipped
         create_execution_run(
             session=self.session, question="q2", enqueue=False
@@ -259,13 +262,20 @@ class LensServiceTests(TransactionTestCase):
         )
         answered.output_message.content = "Order states explained"
         answered.output_message.save(update_fields=["content"])
+        answered.status = Run.Status.DONE
+        answered.outcome = Run.Outcome.COMPLETED
+        answered.save(update_fields=["status", "outcome"])
         blocked = create_execution_run(
             session=self.session,
             question="Create an order",
             enqueue=False,
         )
+        blocked.status = Run.Status.DONE
+        blocked.outcome = Run.Outcome.BLOCKED
         blocked.termination_detail = {"reason": "capability_unavailable"}
-        blocked.save(update_fields=["termination_detail"])
+        blocked.save(
+            update_fields=["status", "outcome", "termination_detail"]
+        )
         blocked.output_message.delete()
         current = create_execution_run(
             session=self.session,
@@ -282,6 +292,228 @@ class LensServiceTests(TransactionTestCase):
                 {"role": "assistant", "content": "Order states explained"},
                 {"role": "user", "content": "Create an order"},
             ],
+        )
+
+    def test_build_run_history_excludes_untrusted_assistant_outputs(self):
+        cases = [
+            (Run.Status.DONE, Run.Outcome.BLOCKED),
+            (Run.Status.FAILED, Run.Outcome.BLOCKED),
+            (Run.Status.CANCELLED, Run.Outcome.PARTIAL),
+        ]
+        expected = []
+        for index, (status, outcome) in enumerate(cases, start=1):
+            prior = create_execution_run(
+                session=self.session,
+                question=f"question {index}",
+                enqueue=False,
+            )
+            prior.output_message.content = f"partial answer {index}"
+            prior.output_message.save(update_fields=["content"])
+            prior.status = status
+            prior.outcome = outcome
+            prior.save(update_fields=["status", "outcome"])
+            expected.append(
+                {"role": "user", "content": f"question {index}"}
+            )
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(history, expected)
+
+    def test_build_run_history_collapses_retry_chain_to_latest_attempt(self):
+        first = create_execution_run(
+            session=self.session,
+            question="same question",
+            enqueue=False,
+        )
+        first.status = Run.Status.DONE
+        first.outcome = Run.Outcome.BLOCKED
+        first.save(update_fields=["status", "outcome"])
+        second = create_execution_run(
+            session=self.session,
+            question="same question",
+            retry_of_run=first,
+            enqueue=False,
+        )
+        second.status = Run.Status.FAILED
+        second.outcome = Run.Outcome.BLOCKED
+        second.save(update_fields=["status", "outcome"])
+        third = create_execution_run(
+            session=self.session,
+            question="same question",
+            retry_of_run=second,
+            enqueue=False,
+        )
+        third.output_message.content = "fresh completed answer"
+        third.output_message.save(update_fields=["content"])
+        third.status = Run.Status.DONE
+        third.outcome = Run.Outcome.COMPLETED
+        third.save(update_fields=["status", "outcome"])
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(
+            history,
+            [
+                {"role": "user", "content": "same question"},
+                {"role": "assistant", "content": "fresh completed answer"},
+            ],
+        )
+
+    def test_retry_history_stops_before_the_original_run(self):
+        context = create_execution_run(
+            session=self.session,
+            question="context question",
+            enqueue=False,
+        )
+        context.output_message.content = "context answer"
+        context.output_message.save(update_fields=["content"])
+        context.status = Run.Status.DONE
+        context.outcome = Run.Outcome.COMPLETED
+        context.save(update_fields=["status", "outcome"])
+        original = create_execution_run(
+            session=self.session,
+            question="regenerate this",
+            enqueue=False,
+        )
+        original.output_message.content = "original answer"
+        original.output_message.save(update_fields=["content"])
+        original.status = Run.Status.DONE
+        original.outcome = Run.Outcome.COMPLETED
+        original.save(update_fields=["status", "outcome"])
+        later = create_execution_run(
+            session=self.session,
+            question="later question",
+            enqueue=False,
+        )
+        later.output_message.content = "later answer"
+        later.output_message.save(update_fields=["content"])
+        later.status = Run.Status.DONE
+        later.outcome = Run.Outcome.COMPLETED
+        later.save(update_fields=["status", "outcome"])
+        retry = create_execution_run(
+            session=self.session,
+            question="regenerate this",
+            retry_of_run=original,
+            enqueue=False,
+        )
+
+        history = build_run_history(retry)
+
+        self.assertEqual(
+            history,
+            [
+                {"role": "user", "content": "context question"},
+                {"role": "assistant", "content": "context answer"},
+            ],
+        )
+
+    def test_retry_history_resolves_a_long_chain_in_one_query(self):
+        original = create_execution_run(
+            session=self.session,
+            question="original",
+            enqueue=False,
+        )
+        previous = original
+        for index in range(5):
+            previous = create_execution_run(
+                session=self.session,
+                question=f"retry {index}",
+                retry_of_run=previous,
+                enqueue=False,
+            )
+        current = create_execution_run(
+            session=self.session,
+            question="latest retry",
+            retry_of_run=previous,
+            enqueue=False,
+        )
+
+        with self.assertNumQueries(1):
+            history = build_run_history(current)
+
+        self.assertEqual(history, [])
+
+    def test_build_run_history_preserves_manual_identical_turns(self):
+        for answer in ("first answer", "second answer"):
+            prior = create_execution_run(
+                session=self.session,
+                question="same text",
+                enqueue=False,
+            )
+            prior.output_message.content = answer
+            prior.output_message.save(update_fields=["content"])
+            prior.status = Run.Status.DONE
+            prior.outcome = Run.Outcome.COMPLETED
+            prior.save(update_fields=["status", "outcome"])
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(
+            history,
+            [
+                {"role": "user", "content": "same text"},
+                {"role": "assistant", "content": "first answer"},
+                {"role": "user", "content": "same text"},
+                {"role": "assistant", "content": "second answer"},
+            ],
+        )
+
+    def test_history_limits_apply_after_untrusted_outputs_are_filtered(self):
+        completed = create_execution_run(
+            session=self.session,
+            question="trusted question",
+            enqueue=False,
+        )
+        completed.output_message.content = "trusted answer"
+        completed.output_message.save(update_fields=["content"])
+        completed.status = Run.Status.DONE
+        completed.outcome = Run.Outcome.COMPLETED
+        completed.save(update_fields=["status", "outcome"])
+        for index in range(4):
+            blocked = create_execution_run(
+                session=self.session,
+                question=f"blocked question {index}",
+                enqueue=False,
+            )
+            blocked.output_message.content = "x" * 8000
+            blocked.output_message.save(update_fields=["content"])
+            blocked.status = Run.Status.DONE
+            blocked.outcome = Run.Outcome.BLOCKED
+            blocked.save(update_fields=["status", "outcome"])
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        self.assertEqual(
+            history[0:2],
+            [
+                {"role": "user", "content": "trusted question"},
+                {"role": "assistant", "content": "trusted answer"},
+            ],
+        )
+        self.assertEqual(
+            [item["content"] for item in history[2:]],
+            [f"blocked question {index}" for index in range(4)],
         )
 
     def test_rewrite_query_passthrough_without_preprocess_model(self):
@@ -334,6 +566,25 @@ class LensServiceTests(TransactionTestCase):
 
         self.assertEqual(first.uuid, second.uuid)
         self.assertEqual(self.session.message_set.count(), 2)
+
+    def test_create_execution_run_persists_retry_relationship(self):
+        first = create_execution_run(
+            session=self.session,
+            question="How does SSE work?",
+            idempotency_key="first-run",
+            enqueue=False,
+        )
+
+        retry = create_execution_run(
+            session=self.session,
+            question="How does SSE work?",
+            idempotency_key="retry-run",
+            retry_of_run=first,
+            enqueue=False,
+        )
+
+        self.assertEqual(retry.retry_of_run, first)
+        self.assertEqual(self.session.message_set.count(), 4)
 
     def test_execute_answer_run_creates_execution_snapshot(self):
         self.assistant.agent_rounds = "max"

--- a/backend/lens/tests/test_trace_export.py
+++ b/backend/lens/tests/test_trace_export.py
@@ -193,6 +193,33 @@ class LangfuseTraceExportTests(TestCase):
         )
         self.assertNotIn("comment", json.dumps(batch_without_summaries))
 
+    def test_trace_metadata_reports_retry_filtering_without_content(self):
+        retry = create_execution_run(
+            session=self.run.session,
+            question="Do not export retried content",
+            idempotency_key="retry-trace",
+            retry_of_run=self.run,
+            enqueue=False,
+        )
+        retry.status = Run.Status.DONE
+        retry.outcome = Run.Outcome.COMPLETED
+        retry.save(update_fields=["status", "outcome"])
+
+        batch = build_ingestion_batch(
+            retry,
+            root_observation_id_for_run(retry.uuid),
+        )
+
+        metadata = batch[0]["body"]["metadata"]
+        self.assertEqual(metadata["retryOfRunUuid"], str(self.run.uuid))
+        self.assertTrue(metadata["explicitRetry"])
+        self.assertEqual(metadata["historyRunsBeforeFiltering"], 1)
+        self.assertEqual(metadata["historyRunsAfterFiltering"], 0)
+        self.assertEqual(metadata["supersededRetryAttemptsRemoved"], 1)
+        self.assertEqual(metadata["nonCompletedAssistantOutputsExcluded"], 0)
+        serialized = json.dumps(metadata)
+        self.assertNotIn("Do not export", serialized)
+
     @patch("lens.trace_export.request.urlopen")
     def test_export_skips_network_without_observation_events(
         self,

--- a/backend/lens/trace_export.py
+++ b/backend/lens/trace_export.py
@@ -41,6 +41,8 @@ def build_ingestion_batch(
 ):
     """Build one privacy-bounded Langfuse ingestion batch for a run."""
 
+    from .services import build_run_history_metadata
+
     trace_id = trace_id_for_run(run.uuid)
     started_at = _timestamp(run.started_at or run.created_at)
     finished_at = _timestamp(
@@ -50,7 +52,28 @@ def build_ingestion_batch(
         "runUuid": str(run.uuid),
         "status": run.status,
         "outcome": run.outcome,
+        "retryOfRunUuid": (
+            str(run.retry_of_run.uuid) if run.retry_of_run_id else None
+        ),
+        "explicitRetry": bool(run.retry_of_run_id),
     }
+    history_metadata = build_run_history_metadata(run)
+    run_metadata.update(
+        {
+            "historyRunsBeforeFiltering": history_metadata[
+                "history_runs_before_filtering"
+            ],
+            "historyRunsAfterFiltering": history_metadata[
+                "history_runs_after_filtering"
+            ],
+            "supersededRetryAttemptsRemoved": history_metadata[
+                "superseded_retry_attempts_removed"
+            ],
+            "nonCompletedAssistantOutputsExcluded": history_metadata[
+                "non_completed_assistant_outputs_excluded"
+            ],
+        }
+    )
     root_metadata = dict(run_metadata)
     if include_summaries:
         root_metadata["comment"] = ROOT_OBSERVATION_SUMMARY

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1413,7 +1413,11 @@ import {
   shouldReviewUnreadSession,
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
-import { precedingUserMessage } from '@/pages/lens/chatMessageContext'
+import {
+  precedingUserMessage,
+  retryRunUuid
+} from '@/pages/lens/chatMessageContext'
+import { prepareRunSubmission } from '@/pages/lens/chatSubmission'
 import {
   resolveRunStatus,
   shouldShowRetryHint
@@ -1481,6 +1485,8 @@ const streamError = ref('')
 const failedRunError = ref(null)
 const queuePosition = ref(null)
 const currentRun = ref(null)
+const pendingRunSubmission = ref(null)
+const retryDraft = ref(null)
 const runStatusResolvingSessionUuid = ref('')
 const unreadSessions = ref(readUnreadSessions(window.localStorage))
 const loading = ref({ run: false })
@@ -2528,6 +2534,7 @@ async function selectSession(session, updateRoute = true) {
   booted.value = true
   if (sessionChanged) {
     question.value = ''
+    retryDraft.value = null
     if (composerRef.value) composerRef.value.style.height = 'auto'
   }
   currentRun.value = null
@@ -2705,6 +2712,15 @@ async function submit() {
     (item) => item.status === 'done'
   )
   const attachmentUuids = pendingImages.map((item) => item.uuid)
+  const retryDraftAtSubmit = retryDraft.value
+  const preparedSubmission = prepareRunSubmission({
+    sessionUuid: sessionAtSubmit,
+    question: optimisticText,
+    attachmentUuids,
+    retryDraft: retryDraftAtSubmit,
+    pendingSubmission: pendingRunSubmission.value
+  })
+  pendingRunSubmission.value = preparedSubmission.submission
   attachments.value = []
   // Revoke the optimistic object URLs on every exit path, unless they are
   // restored to the composer for a retry (set below on real failures).
@@ -2741,13 +2757,16 @@ async function submit() {
       updateSession(sessionAtSubmit, { title: autoTitle }).catch(() => {})
     }
   }
+  currentRun.value = null
   try {
-    const run = await createRun(sessionAtSubmit, {
-      question: optimisticText,
-      run_inline: false,
-      enqueue: true,
-      attachment_uuids: attachmentUuids
-    })
+    const run = await createRun(sessionAtSubmit, preparedSubmission.payload)
+    if (
+      pendingRunSubmission.value?.idempotencyKey ===
+      preparedSubmission.submission.idempotencyKey
+    ) {
+      pendingRunSubmission.value = null
+    }
+    retryDraft.value = null
     startCompletionTracking(run, sessionAtSubmit)
     // switched away between createRun and here — don't bind this run's live
     // state onto the now-current assistant
@@ -2757,6 +2776,13 @@ async function submit() {
     // switched away while streaming — leave the new assistant untouched
     if (selectedSessionUuid.value !== sessionAtSubmit) return
     await finishSubmittedRun(run.uuid, sessionAtSubmit)
+    if (
+      pendingRunSubmission.value?.idempotencyKey ===
+      preparedSubmission.submission.idempotencyKey
+    ) {
+      pendingRunSubmission.value = null
+    }
+    retryDraft.value = null
   } catch (err) {
     // a deliberate stream abort (switch/navigate) or a switch away is not a
     // submit failure — bail silently without touching the current state
@@ -2773,6 +2799,13 @@ async function submit() {
         if (selectedSessionUuid.value !== sessionAtSubmit) return
         currentRun.value = run
         await finishSubmittedRun(runUuid, sessionAtSubmit)
+        if (
+          pendingRunSubmission.value?.idempotencyKey ===
+          preparedSubmission.submission.idempotencyKey
+        ) {
+          pendingRunSubmission.value = null
+        }
+        retryDraft.value = null
         return
       } catch {
         // Fall through to the true submit-failure recovery path.
@@ -2780,6 +2813,7 @@ async function submit() {
     }
     messages.value = messages.value.filter((m) => m.uuid !== '__optimistic__')
     question.value = optimisticText
+    retryDraft.value = retryDraftAtSubmit
     // Restore the uploaded (still-unbound) images so the user can retry;
     // keep their object URLs alive for the composer thumbnails.
     if (pendingImages.length) {
@@ -2968,6 +3002,8 @@ function retryLastQuestion(message = null) {
     return
   }
   question.value = userMessage.content || ''
+  const runUuid = retryRunUuid(messages.value, message)
+  retryDraft.value = runUuid ? { question: question.value, runUuid } : null
   nextTick(() => {
     composerRef.value?.focus()
   })

--- a/frontend/src/pages/lens/chatMessageContext.js
+++ b/frontend/src/pages/lens/chatMessageContext.js
@@ -13,3 +13,10 @@ export function precedingUserMessage(messages, targetMessage) {
   }
   return null
 }
+
+export function retryRunUuid(messages, targetMessage = null) {
+  const userMessage = targetMessage
+    ? precedingUserMessage(messages, targetMessage)
+    : [...messages].reverse().find((message) => message.role === 'user')
+  return targetMessage?.run || userMessage?.run || ''
+}

--- a/frontend/src/pages/lens/chatSubmission.js
+++ b/frontend/src/pages/lens/chatSubmission.js
@@ -1,0 +1,49 @@
+function sameAttachmentUuids(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  )
+}
+
+function isSameSubmission(pending, candidate) {
+  return Boolean(
+    pending &&
+      pending.sessionUuid === candidate.sessionUuid &&
+      pending.question === candidate.question &&
+      pending.retryOfRunUuid === candidate.retryOfRunUuid &&
+      sameAttachmentUuids(pending.attachmentUuids, candidate.attachmentUuids)
+  )
+}
+
+export function prepareRunSubmission({
+  sessionUuid,
+  question,
+  attachmentUuids = [],
+  retryDraft = null,
+  pendingSubmission = null,
+  randomUUID = () => globalThis.crypto.randomUUID()
+}) {
+  const retryOfRunUuid =
+    retryDraft?.question === question ? retryDraft.runUuid || '' : ''
+  const candidate = {
+    sessionUuid,
+    question,
+    attachmentUuids: [...attachmentUuids],
+    retryOfRunUuid
+  }
+  const idempotencyKey = isSameSubmission(pendingSubmission, candidate)
+    ? pendingSubmission.idempotencyKey
+    : randomUUID()
+  const submission = { ...candidate, idempotencyKey }
+  const payload = {
+    question,
+    run_inline: false,
+    enqueue: true,
+    attachment_uuids: [...attachmentUuids],
+    idempotency_key: idempotencyKey
+  }
+  if (retryOfRunUuid) {
+    payload.retry_of_run_uuid = retryOfRunUuid
+  }
+  return { payload, submission }
+}

--- a/frontend/tests/chatMessageContext.test.js
+++ b/frontend/tests/chatMessageContext.test.js
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
-import { precedingUserMessage } from '../src/pages/lens/chatMessageContext.js'
+import {
+  precedingUserMessage,
+  retryRunUuid
+} from '../src/pages/lens/chatMessageContext.js'
 
 test('passes the clicked assistant reply to the retry handler', async () => {
   const chat = await readFile(
@@ -37,4 +40,25 @@ test('returns null when the target reply is not in the message list', () => {
   })
 
   assert.equal(question, null)
+})
+
+test('finds the Run for a historical assistant reply', () => {
+  const messages = [
+    { uuid: 'question-1', role: 'user', content: 'First', run: 'run-1' },
+    { uuid: 'answer-1', role: 'assistant', content: 'Answer', run: 'run-1' },
+    { uuid: 'question-2', role: 'user', content: 'Second', run: 'run-2' },
+    { uuid: 'answer-2', role: 'assistant', content: 'Answer', run: 'run-2' }
+  ]
+
+  assert.equal(retryRunUuid(messages, messages[1]), 'run-1')
+})
+
+test('uses the latest user Run for an empty-answer Retry hint', () => {
+  const messages = [
+    { uuid: 'question-1', role: 'user', content: 'First', run: 'run-1' },
+    { uuid: 'answer-1', role: 'assistant', content: 'Answer', run: 'run-1' },
+    { uuid: 'question-2', role: 'user', content: 'Second', run: 'run-2' }
+  ]
+
+  assert.equal(retryRunUuid(messages), 'run-2')
 })

--- a/frontend/tests/chatSubmission.test.js
+++ b/frontend/tests/chatSubmission.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { prepareRunSubmission } from '../src/pages/lens/chatSubmission.js'
+
+test('reuses the idempotency key for the same unknown-result replay', () => {
+  const first = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    attachmentUuids: ['attachment-1'],
+    randomUUID: () => 'submission-1'
+  })
+
+  const replay = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    attachmentUuids: ['attachment-1'],
+    pendingSubmission: first.submission,
+    randomUUID: () => 'must-not-be-used'
+  })
+
+  assert.equal(replay.payload.idempotency_key, 'submission-1')
+  assert.deepEqual(replay.submission, first.submission)
+})
+
+test('explicit Retry creates a new key and carries the source Run', () => {
+  const prepared = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    retryDraft: {
+      question: 'Check status',
+      runUuid: 'run-1'
+    },
+    randomUUID: () => 'retry-submission'
+  })
+
+  assert.equal(prepared.payload.idempotency_key, 'retry-submission')
+  assert.equal(prepared.payload.retry_of_run_uuid, 'run-1')
+})
+
+test('manual identical submission remains a distinct ordinary turn', () => {
+  const first = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    randomUUID: () => 'submission-1'
+  })
+  const second = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    randomUUID: () => 'submission-2'
+  })
+
+  const firstKey = first.payload.idempotency_key
+  const secondKey = second.payload.idempotency_key
+  assert.notEqual(firstKey, secondKey)
+  assert.equal('retry_of_run_uuid' in second.payload, false)
+})
+
+test('editing a Retry draft turns it into an ordinary new turn', () => {
+  const prepared = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check a different status',
+    retryDraft: {
+      question: 'Check status',
+      runUuid: 'run-1'
+    },
+    randomUUID: () => 'submission-2'
+  })
+
+  assert.equal('retry_of_run_uuid' in prepared.payload, false)
+})

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -74,6 +74,60 @@ def test_build_initial_messages_without_history():
     ]
 
 
+def test_build_initial_messages_contains_current_retry_question_once():
+    history = [
+        {"role": "user", "content": "context question"},
+        {"role": "assistant", "content": "context answer"},
+    ]
+
+    messages = _build_initial_messages(history, "retried question")
+
+    assert messages.count(
+        {"role": "user", "content": "retried question"}
+    ) == 1
+
+
+def test_build_initial_messages_preserves_intentional_identical_turns():
+    history = [
+        {"role": "user", "content": "query again"},
+        {"role": "assistant", "content": "old fresh result"},
+    ]
+
+    messages = _build_initial_messages(history, "query again")
+
+    assert messages.count(
+        {"role": "user", "content": "query again"}
+    ) == 2
+
+
+def test_historical_assistant_content_is_not_current_tool_evidence():
+    messages = _build_initial_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "The previous tool call succeeded.",
+            }
+        ],
+        "Run the operation again",
+    )
+    middleware = agent_runtime.CapabilityBoundaryMiddleware(
+        required_capabilities=["skill"]
+    )
+
+    outcome, termination_detail = _finalize_runtime_outcome(
+        capability_middleware=middleware,
+        evidence_requirement="tool_result",
+        required_capabilities=["skill"],
+        truncated=False,
+        stop_reason=None,
+    )
+
+    assert messages[0]["role"] == "assistant"
+    assert middleware.successful_capabilities == set()
+    assert outcome == "blocked"
+    assert termination_detail["reason"] == "evidence_unavailable"
+
+
 def test_model_event_records_cache_reasoning_and_latency():
     events = []
     message = _Msg(


### PR DESCRIPTION
### **User description**
## Summary
- Persist explicit Retry relationships and build conversation history from Run outcomes
- Make first-party submissions idempotent while preserving intentional identical turns
- Exclude untrusted historical outputs and add privacy-safe Retry filtering metadata

Closes #207

## Test plan
- [x] Backend Retry, history, API, and trace regression tests (12 passed)
- [x] LensNode history tests (91 passed)
- [x] Frontend unit tests (144 passed)
- [x] ESLint for affected frontend files
- [x] Frontend production build
- [x] Django migration consistency check
- [x] ego-browser task space 80: unknown-result replay, failed and completed Retry, historical-answer Retry, manual identical submission, and normal follow-up


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add retry relationship and idempotency key

- Filter untrusted assistant outputs from history

- Collapse retry chains to avoid duplicate prompts

- Add privacy-safe trace metadata for diagnostics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Frontend --> prepareRunSubmission
  prepareRunSubmission -- "idempotency key, retry draft" --> createRun
  createRun --> validateRetry
  validateRetry --> createExecutionRun
  createExecutionRun --> buildRunHistory
  buildRunHistory -- "filter/collapse" --> modelHistory
  createExecutionRun --> traceExport
  traceExport -- "metadata" --> Langfuse
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0031_run_retry_of_run.py</strong><dd><code>Add migration for retry_of_run field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-9ee0f4449f5d838164f95c5926248067ac25af2c329f5af605aacd309d253838">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>models.py</strong><dd><code>Add retry_of_run ForeignKey to Run model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add retry_of_run_uuid field and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+23/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Rewrite history building with retry and outcome filtering</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+173/-33</a></td>

</tr>

<tr>
  <td><strong>trace_export.py</strong><dd><code>Add retry/filtering metadata to trace ingestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-47c20fde108f933649e859af7ff70f23853361417c2da2eeb98ff73e4dc21155">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Integrate idempotency key and retry draft in submit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+43/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatMessageContext.js</strong><dd><code>Add retryRunUuid helper to find run for message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-11edd4449646f23149ea982a80a05db4fea162cadceaa1f56badb1b598012303">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatSubmission.js</strong><dd><code>New module for idempotency and retry submission logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-e73e7f06403bf2928592a1a33440d3294cbc8dae81ffe7e2c23e12ba28a437e5">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for retry API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+141/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add tests for history filtering and retry chains</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+252/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_trace_export.py</strong><dd><code>Add test for retry metadata in trace export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-109e56b23dd3e81900b90e8a9851bcb1b4f6a130223cccaca9a9fb671eeafb96">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Add tests for lensnode history deduplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatMessageContext.test.js</strong><dd><code>Add tests for retryRunUuid function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-70603dfd5e3eda6bd4623f27510bde074141b99aa0ed4ddfd2f0b98e796e29cc">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatSubmission.test.js</strong><dd><code>Add tests for submission idempotency and retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/212/files#diff-89187ab7c8cbc45d8e6f2fb7c61019968ae9453513344aa6d38ab844f0fc0d96">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

