### PR TITLE
Support policy-controlled hidden file retrieval

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -121,6 +121,30 @@ def validate_retrieval_scope(value):
             "retrieval_scope.max_depth must be a positive integer"
         )
 
+    include_hidden = value.get("include_hidden")
+    if "include_hidden" in value and not isinstance(include_hidden, bool):
+        raise serializers.ValidationError(
+            "retrieval_scope.include_hidden must be a boolean"
+        )
+
+    return value
+
+
+def validate_retrieval_policy(value):
+    """Validate Assistant-level retrieval policy options."""
+
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise serializers.ValidationError(
+            "settings.retrieval_policy must be an object or null"
+        )
+    include_hidden = value.get("include_hidden")
+    if "include_hidden" in value and not isinstance(include_hidden, bool):
+        raise serializers.ValidationError(
+            "settings.retrieval_policy.include_hidden must be "
+            "a boolean"
+        )
     return value
 
 
@@ -519,6 +543,12 @@ class AssistantSerializer(serializers.ModelSerializer):
                 )
         else:
             validate_selected_dirs(selected_dirs, lensnode)
+        settings = attrs.get(
+            "settings",
+            getattr(self.instance, "settings", {}),
+        )
+        if isinstance(settings, dict) and "retrieval_policy" in settings:
+            validate_retrieval_policy(settings.get("retrieval_policy"))
         return attrs
 
     def _sync_bindings(self, assistant, validated_data):

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -14,9 +14,15 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import close_old_connections, connection
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import (
+    SimpleTestCase,
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+)
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import AccessToken
 
@@ -48,7 +54,11 @@ from lens.models import (
     SharedQA,
     Skill,
 )
-from lens.serializers import AssistantSerializer
+from lens.serializers import (
+    AssistantSerializer,
+    validate_retrieval_policy,
+    validate_retrieval_scope,
+)
 from lens.services import (
     LensNodeDispatchError,
     build_loaded_skills,
@@ -175,6 +185,35 @@ def skill_zip_upload_with_file(name, file_size):
         buffer.read(),
         content_type="application/zip",
     )
+
+
+class RetrievalPolicyValidationTests(SimpleTestCase):
+    def test_hidden_file_retrieval_options_accept_booleans(self):
+        self.assertEqual(
+            validate_retrieval_scope({"include_hidden": True}),
+            {"include_hidden": True},
+        )
+        self.assertEqual(
+            validate_retrieval_policy({"include_hidden": False}),
+            {"include_hidden": False},
+        )
+
+    def test_hidden_file_retrieval_options_reject_non_booleans(self):
+        for value in ("true", None, 1):
+            with self.subTest(scope_value=value):
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "retrieval_scope.include_hidden must be a boolean",
+                ):
+                    validate_retrieval_scope({"include_hidden": value})
+
+            with self.subTest(policy_value=value):
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "settings.retrieval_policy.include_hidden must be "
+                    "a boolean",
+                ):
+                    validate_retrieval_policy({"include_hidden": value})
 
 
 @override_settings(CACHES=TEST_CACHES, CHANNEL_LAYERS=TEST_CHANNEL_LAYERS)
@@ -321,6 +360,34 @@ class LensApiTests(TestCase):
             response.data["description"],
             "Updated assistant description.",
         )
+
+    def test_assistant_serializer_rejects_non_boolean_hidden_options(self):
+        scope_serializer = AssistantSerializer(
+            self.assistant,
+            data={
+                "selected_dirs": [
+                    {
+                        "path": "/workspace/repo",
+                        "retrieval_scope": {"include_hidden": "true"},
+                    }
+                ]
+            },
+            partial=True,
+        )
+        policy_serializer = AssistantSerializer(
+            self.assistant,
+            data={
+                "settings": {
+                    "retrieval_policy": {"include_hidden": "false"},
+                }
+            },
+            partial=True,
+        )
+
+        self.assertFalse(scope_serializer.is_valid())
+        self.assertFalse(policy_serializer.is_valid())
+        self.assertIn("include_hidden", str(scope_serializer.errors))
+        self.assertIn("include_hidden", str(policy_serializer.errors))
 
     def test_assistant_archive_moves_it_to_archived_list(self):
         response = self.client.post(

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -22,11 +22,12 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from .tls import create_config_ssl_context
 from .workspace import (
-    DEFAULT_EXCLUDED_DIRS,
-    DEFAULT_EXCLUDED_EXTENSIONS,
     glob_files,
+    is_path_allowed,
+    is_path_excluded,
     read_workspace_window,
     search_workspace as search_workspace_files,
+    target_scope,
 )
 
 
@@ -201,11 +202,19 @@ def build_agent_tools(command, resources=None, config=None, emit_event=None):
                 ),
             },
         )
-        resolved = _resolve_allowed_path(path, target_dirs)
+        resolved = _resolve_allowed_path(path, target_dirs, retrieval_policy)
         if resolved is None:
-            directory = _resolve_allowed_directory(path, target_dirs)
+            directory = _resolve_allowed_directory(
+                path,
+                target_dirs,
+                retrieval_policy,
+            )
             if directory is not None:
-                candidates = _list_directory_files(directory)
+                candidates = _list_directory_files(
+                    directory,
+                    target_dirs,
+                    retrieval_policy,
+                )
                 emit(
                     "tool.read_workspace_file.directory",
                     {
@@ -3135,7 +3144,7 @@ def _safe_resource_name(value):
     return "".join(output).strip("-_")
 
 
-def _resolve_allowed_path(path, target_dirs):
+def _resolve_allowed_path(path, target_dirs, policy=None):
     """Resolve a file path and ensure it is under selected dirs."""
 
     candidate = Path(path).resolve()
@@ -3145,12 +3154,13 @@ def _resolve_allowed_path(path, target_dirs):
             candidate.relative_to(root)
         except ValueError:
             continue
-        if candidate.is_file():
+        scope = target_scope(item)
+        if is_path_allowed(root, candidate, scope, policy or {}):
             return candidate
     return None
 
 
-def _resolve_allowed_directory(path, target_dirs):
+def _resolve_allowed_directory(path, target_dirs, policy=None):
     """Resolve a directory path and ensure it is under selected dirs."""
 
     candidate = Path(path).resolve()
@@ -3160,7 +3170,13 @@ def _resolve_allowed_directory(path, target_dirs):
             candidate.relative_to(root)
         except ValueError:
             continue
-        if candidate.is_dir():
+        scope = target_scope(item)
+        if candidate.is_dir() and not is_path_excluded(
+            root,
+            candidate,
+            scope,
+            policy or {},
+        ):
             return candidate
     return None
 
@@ -3273,23 +3289,41 @@ def _name_tokens(name):
     return tokens
 
 
-def _list_directory_files(directory, limit=50):
+def _list_directory_files(directory, target_dirs, policy=None, limit=50):
     """Return a bounded, recursive list of candidate files in a directory."""
 
+    context = None
+    for item in target_dirs:
+        root = Path(item.get("path", "")).resolve()
+        try:
+            directory.relative_to(root)
+        except ValueError:
+            continue
+        context = (root, target_scope(item))
+        break
+    if context is None:
+        return []
+
+    root, scope = context
+    policy = policy or {}
     files = []
     for current, subdirs, filenames in os.walk(directory):
+        current_path = Path(current)
         subdirs[:] = sorted(
             name
             for name in subdirs
-            if not name.startswith(".") and name not in DEFAULT_EXCLUDED_DIRS
+            if not is_path_excluded(
+                root,
+                current_path / name,
+                scope,
+                policy,
+            )
         )
         for name in sorted(filenames):
             if len(files) >= limit:
                 return files
-            if name.startswith("."):
-                continue
-            path = Path(current) / name
-            if path.suffix in DEFAULT_EXCLUDED_EXTENSIONS:
+            path = current_path / name
+            if not is_path_allowed(root, path, scope, policy):
                 continue
             files.append(str(path))
     return files

--- a/lensnode/lensnode/workspace.py
+++ b/lensnode/lensnode/workspace.py
@@ -107,7 +107,7 @@ def search_workspace(
     for item in target_dirs:
         root = Path(item.get("path", ""))
         if root.exists() and root.is_dir():
-            dirs.append((root, _target_scope(item)))
+            dirs.append((root, target_scope(item)))
 
     if output_mode == "files":
         files = []
@@ -199,12 +199,12 @@ def glob_files(target_dirs, pattern, max_results=None, policy=None):
         root = Path(item.get("path", ""))
         if not root.exists() or not root.is_dir():
             continue
-        scope = _target_scope(item)
+        scope = target_scope(item)
         try:
             for path in root.glob(pattern):
                 if len(found) >= GLOB_SCAN_LIMIT:
                     break
-                if _is_allowed(root, path, scope, policy):
+                if is_path_allowed(root, path, scope, policy):
                     found.append(path)
         except (ValueError, NotImplementedError):
             continue
@@ -269,7 +269,7 @@ def read_text_samples(target_dirs, max_files=16, max_chars=30000, policy=None):
         root = Path(item.get("path", ""))
         if not root.exists() or not root.is_dir():
             continue
-        scope = _target_scope(item)
+        scope = target_scope(item)
         for path in _iter_allowed_paths(root, scope, policy):
             if len(samples) >= max_files or remaining_chars <= 0:
                 return samples
@@ -307,7 +307,7 @@ def summarize_snippets(samples):
     return json.dumps({"snippets": snippets}, ensure_ascii=False)
 
 
-def _is_allowed(root, path, scope, policy):
+def is_path_allowed(root, path, scope, policy):
     """Return whether a path is useful as a workspace sample.
 
     File size is intentionally not a criterion: large files are read in
@@ -315,9 +315,13 @@ def _is_allowed(root, path, scope, policy):
     file from retrieval.
     """
 
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
     if not path.is_file():
         return False
-    if _is_excluded_path(root, path, scope, policy):
+    if is_path_excluded(root, path, scope, policy):
         return False
     exclude_extensions = _option(
         scope,
@@ -381,6 +385,8 @@ def _rg_glob_args(scope, policy, glob):
     """
 
     args = []
+    if _include_hidden(scope, policy):
+        args.append("--hidden")
     for pattern in scope.get("include_paths") or []:
         if pattern == "**/*":
             continue
@@ -643,7 +649,7 @@ def _iter_scope_files(root, scope, policy, limit=DEFAULT_FILE_LIST_LIMIT):
         for path in root.glob(pattern):
             if len(found) >= limit:
                 return sorted(set(found))[:limit]
-            if _is_allowed(root, path, scope, policy):
+            if is_path_allowed(root, path, scope, policy):
                 found.append(path)
     return sorted(set(found))[:limit]
 
@@ -656,7 +662,7 @@ def _iter_allowed_paths(root, scope, policy):
         paths.extend(
             path
             for path in root.glob(pattern)
-            if _is_allowed(root, path, scope, policy)
+            if is_path_allowed(root, path, scope, policy)
         )
     return sorted(set(paths))
 
@@ -671,13 +677,19 @@ def _option(scope, policy, key, default):
     return default
 
 
-def _target_scope(item):
+def target_scope(item):
     """Return retrieval options plus the trusted runtime material role."""
 
     scope = dict(item.get("retrieval_scope") or {})
     if item.get("material_role") == "subject":
         scope["material_role"] = "subject"
     return scope
+
+
+def _include_hidden(scope, policy):
+    """Return whether hidden descendants are explicitly enabled."""
+
+    return _option(scope, policy, "include_hidden", False) is True
 
 
 def _bounded_results(max_results, policy):
@@ -706,31 +718,36 @@ def _bounded_limit(limit, policy):
     return min(value, MAX_READ_LIMIT)
 
 
-def _is_excluded_path(root, path, scope, policy):
+def is_path_excluded(root, path, scope, policy):
     """Return whether a path is excluded by configured rules."""
 
-    relative_parts = path.parts if root is None else path.relative_to(root).parts
-    hidden_parts = (
-        relative_parts
-        if _is_subject_runtime_root(root, scope)
-        else path.parts
-    )
+    try:
+        relative = path if root is None else path.relative_to(root)
+    except ValueError:
+        return True
+    if _include_hidden(scope, policy):
+        hidden_parts = ()
+    elif _is_subject_runtime_root(root, scope):
+        hidden_parts = relative.parts
+    else:
+        hidden_parts = path.parts
     if any(part.startswith(".") for part in hidden_parts):
         return True
-    parts = set(relative_parts)
+    parts = set(relative.parts)
     exclude_dirs = set(
         _option(scope, policy, "exclude_dirs", DEFAULT_EXCLUDED_DIRS)
     )
-    if parts.intersection(exclude_dirs):
+    if parts.intersection(exclude_dirs) or (
+        root is not None and root.name in exclude_dirs
+    ):
         return True
     max_depth = _option(scope, policy, "max_depth", None)
     if root is not None and max_depth is not None:
-        if len(path.relative_to(root).parts) > int(max_depth):
+        if len(relative.parts) > int(max_depth):
             return True
     exclude_paths = _option(scope, policy, "exclude_paths", [])
     if root is None:
         return False
-    relative = path.relative_to(root)
     return any(relative.match(pattern) for pattern in exclude_paths)
 
 

--- a/lensnode/tests/test_workspace.py
+++ b/lensnode/tests/test_workspace.py
@@ -1,5 +1,6 @@
 import json
 
+from lensnode import workspace as workspace_module
 from lensnode.agent_tools import build_agent_tools
 from lensnode.workspace import (
     glob_files,
@@ -235,6 +236,306 @@ def test_search_without_match_lists_nested_files(tmp_path):
     assert result["matches"] == []
     assert any(path.endswith("a.txt") for path in result["files"])
     assert "note" in result
+
+
+def test_hidden_descendants_are_excluded_by_default_across_discovery_modes(
+    tmp_path,
+):
+    root = tmp_path / "ws"
+    hidden = root / ".claude"
+    hidden.mkdir(parents=True)
+    hidden_file = hidden / "instructions.md"
+    hidden_file.write_text("hidden policy marker\n", encoding="utf-8")
+
+    content = search_workspace([{"path": str(root)}], "policy marker")
+    files = search_workspace(
+        [{"path": str(root)}],
+        "policy marker",
+        output_mode="files",
+    )
+    counts = search_workspace(
+        [{"path": str(root)}],
+        "policy marker",
+        output_mode="count",
+    )
+    fallback = search_workspace([{"path": str(root)}], "zzzznomatchquery")
+
+    assert content["matches"] == []
+    assert files["files"] == []
+    assert counts["counts"] == []
+    assert str(hidden_file) not in fallback["files"]
+    assert str(hidden_file) not in glob_files([{"path": str(root)}], "**/*")
+
+
+def test_scope_include_hidden_applies_to_all_discovery_modes(tmp_path):
+    root = tmp_path / "ws"
+    hidden = root / ".codex"
+    hidden.mkdir(parents=True)
+    hidden_file = hidden / "instructions.md"
+    hidden_file.write_text("hidden policy marker\n", encoding="utf-8")
+    target_dirs = [
+        {
+            "path": str(root),
+            "retrieval_scope": {"include_hidden": True},
+        }
+    ]
+
+    content = search_workspace(target_dirs, "policy marker")
+    files = search_workspace(
+        target_dirs,
+        "policy marker",
+        output_mode="files",
+    )
+    counts = search_workspace(
+        target_dirs,
+        "policy marker",
+        output_mode="count",
+    )
+    fallback = search_workspace(target_dirs, "zzzznomatchquery")
+
+    assert content["matches"][0]["path"] == str(hidden_file)
+    assert files["files"] == [str(hidden_file)]
+    assert counts["counts"] == [{"path": str(hidden_file), "count": 1}]
+    assert str(hidden_file) in fallback["files"]
+    assert str(hidden_file) in glob_files(target_dirs, "**/*")
+
+
+def test_directory_scope_overrides_assistant_hidden_policy(tmp_path):
+    root = tmp_path / "ws"
+    hidden = root / ".claude"
+    hidden.mkdir(parents=True)
+    hidden_file = hidden / "settings.json"
+    hidden_file.write_text("policy marker\n", encoding="utf-8")
+
+    disabled = search_workspace(
+        [
+            {
+                "path": str(root),
+                "retrieval_scope": {"include_hidden": False},
+            }
+        ],
+        "policy marker",
+        policy={"include_hidden": True},
+    )
+    enabled = search_workspace(
+        [
+            {
+                "path": str(root),
+                "retrieval_scope": {"include_hidden": True},
+            }
+        ],
+        "policy marker",
+        policy={"include_hidden": False},
+    )
+
+    assert disabled["matches"] == []
+    assert enabled["matches"][0]["path"] == str(hidden_file)
+
+
+def test_explicit_hidden_root_is_evaluated_relative_to_itself(tmp_path):
+    root = tmp_path / ".managed" / ".claude"
+    root.mkdir(parents=True)
+    target = root / "instructions.md"
+    target.write_text("policy marker\n", encoding="utf-8")
+
+    result = search_workspace(
+        [
+            {
+                "path": str(root),
+                "retrieval_scope": {"include_hidden": True},
+            }
+        ],
+        "policy marker",
+    )
+
+    assert result["matches"][0]["path"] == str(target)
+
+
+def test_subject_runtime_root_remains_readable_through_agent_tools(tmp_path):
+    root = (
+        tmp_path
+        / ".sourcelens"
+        / "runtime"
+        / "runs"
+        / "run-123"
+        / "subject-documents"
+    )
+    root.mkdir(parents=True)
+    target = root / "content.md"
+    target.write_text("subject marker\n", encoding="utf-8")
+    tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {
+                "target_dirs": [
+                    {
+                        "path": str(root),
+                        "material_role": "subject",
+                    }
+                ],
+                "settings": {},
+            }
+        )
+    }
+
+    result = json.loads(
+        tools["read_workspace_file"].invoke({"path": str(target)})
+    )
+
+    assert "subject marker" in result["content"]
+
+
+def test_ripgrep_modes_add_hidden_flag_only_when_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "ws"
+    root.mkdir()
+    commands = []
+
+    def record_command(command):
+        commands.append(command)
+        return ""
+
+    monkeypatch.setattr(workspace_module, "_run_rg", record_command)
+    enabled = [
+        {
+            "path": str(root),
+            "retrieval_scope": {"include_hidden": True},
+        }
+    ]
+    disabled = [{"path": str(root)}]
+
+    for output_mode in ("content", "files", "count"):
+        search_workspace(enabled, "marker", output_mode=output_mode)
+
+    assert len(commands) == 3
+    assert all("--hidden" in command for command in commands)
+
+    commands.clear()
+    for output_mode in ("content", "files", "count"):
+        search_workspace(disabled, "marker", output_mode=output_mode)
+
+    assert len(commands) == 3
+    assert all("--hidden" not in command for command in commands)
+
+
+def test_include_hidden_keeps_exclusions_and_symlink_containment(tmp_path):
+    root = tmp_path / "ws"
+    hidden = root / ".codex"
+    excluded = root / ".git"
+    hidden.mkdir(parents=True)
+    excluded.mkdir()
+    allowed_file = hidden / "instructions.md"
+    excluded_file = excluded / "config"
+    outside_file = tmp_path / "outside.txt"
+    allowed_file.write_text("policy marker\n", encoding="utf-8")
+    excluded_file.write_text("policy marker\n", encoding="utf-8")
+    outside_file.write_text("policy marker\n", encoding="utf-8")
+    (hidden / "outside-link.txt").symlink_to(outside_file)
+    target_dirs = [
+        {
+            "path": str(root),
+            "retrieval_scope": {
+                "include_hidden": True,
+                "exclude_dirs": [".git"],
+            },
+        }
+    ]
+
+    result = search_workspace(target_dirs, "policy marker")
+    found = glob_files(target_dirs, "**/*")
+
+    assert [item["path"] for item in result["matches"]] == [str(allowed_file)]
+    assert str(allowed_file) in found
+    assert str(excluded_file) not in found
+    assert str(hidden / "outside-link.txt") not in found
+
+
+def test_python_search_fallback_honors_include_hidden(tmp_path, monkeypatch):
+    root = tmp_path / "ws"
+    hidden = root / ".claude"
+    hidden.mkdir(parents=True)
+    target = hidden / "instructions.md"
+    target.write_text("policy marker\n", encoding="utf-8")
+    monkeypatch.setattr(workspace_module, "_run_rg", lambda _cmd: None)
+
+    result = search_workspace(
+        [
+            {
+                "path": str(root),
+                "retrieval_scope": {"include_hidden": True},
+            }
+        ],
+        "policy marker",
+    )
+
+    assert result["matches"][0]["path"] == str(target)
+
+
+def test_hidden_policy_controls_direct_reads_and_directory_fallback(tmp_path):
+    root = tmp_path / "ws"
+    hidden = root / ".claude"
+    excluded = root / ".git"
+    hidden.mkdir(parents=True)
+    excluded.mkdir()
+    hidden_file = hidden / "instructions.md"
+    excluded_file = excluded / "config"
+    outside_file = tmp_path / "outside.txt"
+    hidden_file.write_text("policy marker\n", encoding="utf-8")
+    excluded_file.write_text("excluded marker\n", encoding="utf-8")
+    outside_file.write_text("outside marker\n", encoding="utf-8")
+    link = hidden / "outside-link.txt"
+    link.symlink_to(outside_file)
+
+    default_tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {"target_dirs": [{"path": str(root)}], "settings": {}}
+        )
+    }
+    enabled_tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {
+                "target_dirs": [
+                    {
+                        "path": str(root),
+                        "retrieval_scope": {
+                            "include_hidden": True,
+                            "exclude_dirs": [".git"],
+                        },
+                    }
+                ],
+                "settings": {},
+            }
+        )
+    }
+
+    default_read = json.loads(
+        default_tools["read_workspace_file"].invoke({"path": str(hidden_file)})
+    )
+    enabled_read = json.loads(
+        enabled_tools["read_workspace_file"].invoke({"path": str(hidden_file)})
+    )
+    directory = json.loads(
+        enabled_tools["read_workspace_file"].invoke({"path": str(root)})
+    )
+    excluded_read = json.loads(
+        enabled_tools["read_workspace_file"].invoke(
+            {"path": str(excluded_file)}
+        )
+    )
+    escaped_read = json.loads(
+        enabled_tools["read_workspace_file"].invoke({"path": str(link)})
+    )
+
+    assert default_read["error"] == "PATH_NOT_ALLOWED"
+    assert "policy marker" in enabled_read["content"]
+    assert str(hidden_file) in directory["candidate_files"]
+    assert str(excluded_file) not in directory["candidate_files"]
+    assert excluded_read["error"] == "PATH_NOT_ALLOWED"
+    assert escaped_read["error"] == "PATH_NOT_ALLOWED"
 
 
 def test_tools_search_and_read_large_file_through_wrapper(tmp_path):


### PR DESCRIPTION
### **User description**
## Summary

- Add strict `include_hidden` validation for per-directory retrieval scopes and Assistant retrieval policies.
- Apply the effective hidden-file policy consistently to ripgrep, Python fallback/glob discovery, direct reads, and directory listings.
- Preserve explicit exclusions and resolved-path containment while covering default, hidden-root, override, and symlink behavior.

Closes #217

## Test plan

- [x] LensNode test suite (310 passed)
- [x] Backend focused tests (46 passed)
- [x] Django system check


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add policy-controlled include_hidden option for workspace retrieval

- Validate boolean include_hidden in per-directory scope and assistant policy

- Apply consistent hidden-file policy across ripgrep, Python glob, and agent tools

- Preserve exclusions, containment, and symlink safety with include_hidden enabled

- Add comprehensive tests for default, override, hidden root, and subject runtime


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Policy/Scope include_hidden"] --> B["is_path_allowed, is_path_excluded"]
  B --> C["search_workspace, glob_files, read_text_samples"]
  B --> D["agent_tools: resolve, list_directory, read"]
  A --> E["ripgrep: --hidden flag"]
  C --> F["Consistent hidden-file inclusion"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Validate include_hidden in retrieval scope and policy</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/serializers.py

<ul><li>Added <code>validate_retrieval_policy</code> function for assistant-level policy <br>validation<br> <li> Extended <code>validate_retrieval_scope</code> to accept and validate <br><code>include_hidden</code> boolean<br> <li> Integrated policy validation into AssistantSerializer.validate</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/219/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_tools.py</strong><dd><code>Apply hidden policy to direct reads and directory listings</code></dd></summary>
<hr>

lensnode/lensnode/agent_tools.py

<ul><li>Updated <code>_resolve_allowed_path</code> and <code>_resolve_allowed_directory</code> to use <br><code>is_path_allowed</code>/<code>is_path_excluded</code> with policy<br> <li> Refactored <code>_list_directory_files</code> to apply hidden policy and exclusions<br> <li> Imported <code>target_scope</code>, <code>is_path_allowed</code>, <code>is_path_excluded</code> from <br>workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/219/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+49/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace.py</strong><dd><code>Centralize hidden-file policy in workspace module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/workspace.py

<ul><li>Exposed <code>is_path_allowed</code>, <code>is_path_excluded</code>, <code>target_scope</code> as public <br>functions<br> <li> Added <code>_include_hidden</code> helper to decide hidden-file inclusion<br> <li> Updated <code>search_workspace</code>, <code>glob_files</code>, <code>read_text_samples</code>, <code>_iter_xxx</code> to <br>use new functions<br> <li> Added <code>--hidden</code> to ripgrep args when <code>include_hidden</code> is true<br> <li> Modified <code>is_path_excluded</code> to skip hidden detection when enabled, and <br>handle root name exclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/219/files#diff-d710eb194a4daf8bf6178ae498494331d37629a86d7629780a486e5fcd8d5b20">+37/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add tests for include_hidden validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_api.py

<ul><li>Added <code>RetrievalPolicyValidationTests</code> for boolean acceptance and <br>rejection<br> <li> Added test for serializer rejecting non-boolean hidden options<br> <li> Imported new validation functions and SimpleTestCase</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/219/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+69/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_workspace.py</strong><dd><code>Add comprehensive tests for hidden file policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_workspace.py

<ul><li>Added tests for default hidden exclusion across discovery modes<br> <li> Tested scope-level include_hidden enabling all modes<br> <li> Tested scope override of assistant policy<br> <li> Tested hidden root with relative evaluation<br> <li> Tested subject runtime root readability<br> <li> Tested ripgrep flag addition only when enabled<br> <li> Tested exclusion and symlink containment with include_hidden<br> <li> Tested Python fallback and agent tool integration</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/219/files#diff-024a4c4c32ac005dc254516b204d735def18a042cf823c5fc1d0b4d45dc9295e">+301/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

