### PR TITLE
Fix admin sidebar scrolling and user identity display

### DIFF
--- a/frontend/e2e/admin-layout-scroll.spec.js
+++ b/frontend/e2e/admin-layout-scroll.spec.js
@@ -81,3 +81,197 @@ for (const viewport of VIEWPORTS) {
     expect(layout.mainOverflowY).toBe('auto')
   })
 }
+
+test('admin sidebar reveals a deep direct link with minimal scrolling', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1280, height: 600 })
+  await mockAdminApis(page)
+  await page.goto('/management/notifier/settings')
+
+  const navigation = page.locator('#admin-sidebar nav')
+  const activeItem = navigation.locator('.admin-nav-item-active')
+  await expect(activeItem).toHaveAttribute(
+    'href',
+    '/management/notifier/settings'
+  )
+
+  const position = await navigation.evaluate((element) => {
+    const active = element.querySelector('.admin-nav-item-active')
+    const containerRect = element.getBoundingClientRect()
+    const activeRect = active.getBoundingClientRect()
+    return {
+      activeBottom: activeRect.bottom,
+      activeTop: activeRect.top,
+      containerBottom: containerRect.bottom,
+      containerTop: containerRect.top,
+      scrollTop: element.scrollTop
+    }
+  })
+
+  expect(position.scrollTop).toBeGreaterThan(0)
+  expect(position.activeTop).toBeGreaterThanOrEqual(position.containerTop)
+  expect(position.activeBottom).toBeLessThanOrEqual(position.containerBottom)
+})
+
+test('admin sidebar hides only its scrollbar and keeps native scrolling', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1280, height: 600 })
+  await mockAdminApis(page)
+  await page.goto('/management/users')
+
+  const navigation = page.locator('#admin-sidebar nav')
+  await expect(navigation).toBeVisible()
+  const styles = await navigation.evaluate((nav) => {
+    const main = document.querySelector('.layout-admin main')
+    const navStyle = getComputedStyle(nav)
+    const navScrollbarStyle = getComputedStyle(nav, '::-webkit-scrollbar')
+    const mainStyle = getComputedStyle(main)
+    return {
+      mainOverflowY: mainStyle.overflowY,
+      mainScrollbarWidth: mainStyle.scrollbarWidth,
+      navOverflowY: navStyle.overflowY,
+      navScrollbarDisplay: navScrollbarStyle.display,
+      navScrollbarWidth: navStyle.scrollbarWidth,
+      navWebkitScrollbarWidth: navScrollbarStyle.width
+    }
+  })
+
+  expect(styles.navOverflowY).toBe('auto')
+  expect(styles.navScrollbarWidth).toBe('none')
+  expect(
+    styles.navScrollbarDisplay === 'none' ||
+      styles.navWebkitScrollbarWidth === '0px'
+  ).toBe(true)
+  expect(styles.mainOverflowY).toBe('auto')
+  expect(styles.mainScrollbarWidth).not.toBe('none')
+
+  await navigation.focus()
+  await expect(navigation).toBeFocused()
+  await page.keyboard.press('PageDown')
+  await expect
+    .poll(() => navigation.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0)
+
+  const afterPageDown = await navigation.evaluate(
+    (element) => element.scrollTop
+  )
+  await page.keyboard.press('ArrowDown')
+  await expect
+    .poll(() => navigation.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(afterPageDown)
+
+  const afterArrowDown = await navigation.evaluate(
+    (element) => element.scrollTop
+  )
+  await page.keyboard.press('ArrowUp')
+  await expect
+    .poll(() => navigation.evaluate((element) => element.scrollTop))
+    .toBeLessThan(afterArrowDown)
+
+  const afterArrowUp = await navigation.evaluate((element) => element.scrollTop)
+  await page.keyboard.press('PageUp')
+  await expect
+    .poll(() => navigation.evaluate((element) => element.scrollTop))
+    .toBeLessThan(afterArrowUp)
+
+  await navigation.evaluate((element) => {
+    element.scrollTop = 0
+  })
+  await navigation.hover()
+  await page.mouse.wheel(0, 240)
+  await expect
+    .poll(() => navigation.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0)
+})
+
+test('admin sidebar preserves position across navigation and group toggles', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1280, height: 600 })
+  await mockAdminApis(page)
+  await page.goto('/management/notifier/stats')
+
+  const navigation = page.locator('#admin-sidebar nav')
+  await navigation.evaluate((element) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight
+    element.dispatchEvent(new Event('scroll'))
+  })
+  const beforeNavigation = await navigation.evaluate(
+    (element) => element.scrollTop
+  )
+
+  await navigation.locator('a[href="/management/notifier/records"]').click()
+  await expect(page).toHaveURL(/\/management\/notifier\/records$/)
+  await expect(
+    navigation.locator('a[href="/management/notifier/records"]')
+  ).toHaveClass(/admin-nav-item-active/)
+  const afterNavigation = await navigation.evaluate(
+    (element) => element.scrollTop
+  )
+
+  expect(afterNavigation).toBe(beforeNavigation)
+
+  const notificationToggle = navigation.getByRole('button', {
+    name: 'Notifications',
+    exact: true
+  })
+  await notificationToggle.click()
+  const afterCollapse = await navigation.evaluate(
+    (element) => element.scrollTop
+  )
+  expect(afterCollapse).toBeGreaterThan(0)
+
+  await notificationToggle.click()
+  await expect(
+    navigation.locator('a[href="/management/notifier/records"]')
+  ).toBeVisible()
+  await page.waitForTimeout(250)
+
+  const activePosition = await navigation.evaluate((element) => {
+    const active = element.querySelector('.admin-nav-item-active')
+    const containerRect = element.getBoundingClientRect()
+    const activeRect = active.getBoundingClientRect()
+    return {
+      activeBottom: activeRect.bottom,
+      activeTop: activeRect.top,
+      containerBottom: containerRect.bottom,
+      containerTop: containerRect.top
+    }
+  })
+  expect(activePosition.activeTop).toBeGreaterThanOrEqual(
+    activePosition.containerTop - 1
+  )
+  expect(activePosition.activeBottom).toBeLessThanOrEqual(
+    activePosition.containerBottom + 1
+  )
+})
+
+test('admin user menu exposes a full-width settings hit area', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1512, height: 945 })
+  await mockAdminApis(page)
+  await page.goto('/management/users')
+
+  const header = page.locator('header')
+  await header.getByRole('button', { name: /admin/i }).click()
+
+  const settingsBox = await header
+    .getByRole('button', { name: 'Settings', exact: true })
+    .boundingBox()
+  const logoutBox = await header
+    .getByRole('button', { name: 'Logout', exact: true })
+    .boundingBox()
+
+  expect(settingsBox).not.toBeNull()
+  expect(logoutBox).not.toBeNull()
+  expect(settingsBox.width).toBeGreaterThanOrEqual(logoutBox.width * 0.98)
+  expect(Math.abs(settingsBox.x - logoutBox.x)).toBeLessThanOrEqual(3)
+  expect(
+    Math.abs(
+      settingsBox.x + settingsBox.width - (logoutBox.x + logoutBox.width)
+    )
+  ).toBeLessThanOrEqual(3)
+})

--- a/frontend/e2e/management-users-mobile.spec.js
+++ b/frontend/e2e/management-users-mobile.spec.js
@@ -20,14 +20,33 @@ async function mockManagement(page) {
       }
     } else if (pathname === '/api/v1/management/users/') {
       data = {
-        count: 1,
+        count: 3,
         results: [
           {
             id: 1,
             username: 'admin',
-            email: 'admin@example.com',
+            display_name: 'admin',
+            email: 'admin',
             is_active: true,
             is_staff: true,
+            groups: []
+          },
+          {
+            id: 2,
+            username: 'operator',
+            display_name: 'Operations Owner',
+            email: 'operator@example.com',
+            is_active: true,
+            is_staff: true,
+            groups: []
+          },
+          {
+            id: 3,
+            username: `long-${'username-'.repeat(30)}end`,
+            display_name: '',
+            email: 'long-user@example.com',
+            is_active: true,
+            is_staff: false,
             groups: []
           }
         ]
@@ -73,4 +92,39 @@ test('user filters keep distinct rows and usable widths on mobile', async ({
   expect(usernameBox.y).toBe(emailBox.y)
   expect(searchBox.y).toBe(resetBox.y)
   expect(searchBox.y).toBeGreaterThan(usernameBox.y + usernameBox.height)
+})
+
+test('user identities stay distinct and row actions remain reachable', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1512, height: 945 })
+  await mockManagement(page)
+  await page.goto('/management/users')
+
+  const identities = page.getByTestId('user-identity')
+  await expect(identities).toHaveCount(3)
+  await expect(identities.nth(0).getByTestId('secondary-identity')).toHaveCount(
+    0
+  )
+  await expect(identities.nth(1).getByTestId('secondary-identity')).toHaveText(
+    'Operations Owner'
+  )
+  await expect(page.getByTestId('user-email').nth(0)).toHaveText('—')
+  await expect(page.getByTestId('user-email').nth(1)).toHaveText(
+    'operator@example.com'
+  )
+
+  const longUsername = `long-${'username-'.repeat(30)}end`
+  await expect(
+    identities.nth(2).getByTestId('user-detail-trigger')
+  ).toHaveAttribute('title', longUsername)
+
+  const table = page.getByTestId('user-table-scroll')
+  const actions = page.getByTestId('user-actions').first()
+  const scrollWidth = await table.evaluate((element) => element.scrollWidth)
+  const actionsBox = await actions.boundingBox()
+
+  expect(scrollWidth).toBeLessThan(1300)
+  expect(actionsBox).not.toBeNull()
+  expect(actionsBox.x + actionsBox.width).toBeLessThanOrEqual(1512)
 })

--- a/frontend/src/admin/layout/AdminHeader.vue
+++ b/frontend/src/admin/layout/AdminHeader.vue
@@ -109,10 +109,10 @@
                     {{ displayName }}
                   </div>
                 </div>
-                <div class="px-4 py-2">
+                <div class="contents">
                   <button
                     type="button"
-                    class="flex min-h-11 items-center gap-2 rounded-md px-2 py-1.5 text-sm text-ink-700 transition-colors hover:bg-line-soft hover:text-ink-900"
+                    class="my-2 flex min-h-11 w-full items-center gap-2 px-4 py-1.5 text-left text-sm text-ink-700 transition-colors hover:bg-line-soft hover:text-ink-900"
                     @click="openSettings"
                   >
                     <svg

--- a/frontend/src/admin/layout/AdminSidebar.vue
+++ b/frontend/src/admin/layout/AdminSidebar.vue
@@ -17,7 +17,7 @@
   <aside
     id="admin-sidebar"
     :class="[
-      'layout-admin-sidebar flex h-full w-64 flex-shrink-0 flex-col border-r border-ink-800 bg-ink-900 transition-transform duration-300 ease-in-out',
+      'layout-admin-sidebar flex h-full w-64 flex-shrink-0 flex-col border-r border-ink-700 bg-ink-900 transition-transform duration-300 ease-in-out',
       isMobile ? 'fixed inset-y-0 left-0 z-50' : 'static',
       isMobile && !showMobileMenu ? '-translate-x-full' : 'translate-x-0'
     ]"
@@ -59,7 +59,14 @@
       </button>
     </div>
 
-    <nav class="flex flex-1 flex-col space-y-1 overflow-y-auto px-3 py-4">
+    <nav
+      ref="navigation"
+      :aria-label="t('management.adminConsole')"
+      class="admin-sidebar-navigation flex flex-1 flex-col space-y-1 overflow-y-auto px-3 py-4"
+      tabindex="0"
+      @keydown="handleNavigationKeydown"
+      @scroll.passive="saveScrollPosition"
+    >
       <div class="flex-1 space-y-1">
         <div
           v-if="userStore.userHasFeature('admin_console')"
@@ -99,6 +106,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -281,6 +289,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -505,6 +514,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -603,6 +613,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -759,6 +770,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -891,6 +903,7 @@
             </svg>
           </button>
           <Transition
+            @after-enter="keepActiveItemVisible"
             enter-active-class="transition-all duration-200 ease-out"
             enter-from-class="opacity-0 max-h-0"
             enter-to-class="opacity-100 max-h-96"
@@ -1046,11 +1059,12 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import BrandLogo from '@/components/layout/BrandLogo.vue'
 import { useIsMobile } from '@/composables/useIsMobile'
+import { useUiStore } from '@/store/ui'
 import { useUserStore } from '@/store/user'
 
 defineProps({
@@ -1065,8 +1079,10 @@ defineEmits(['close'])
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
+const uiStore = useUiStore()
 const userStore = useUserStore()
 
+const navigation = ref(null)
 const userManagementMenuOpen = ref(true)
 const lensMenuOpen = ref(true)
 const dataManagementMenuOpen = ref(true)
@@ -1075,6 +1091,45 @@ const taskManagementMenuOpen = ref(true)
 const notificationManagementMenuOpen = ref(true)
 
 const { isMobile } = useIsMobile()
+
+const saveScrollPosition = () => {
+  if (!navigation.value) return
+  uiStore.adminSidebarScrollTop = navigation.value.scrollTop
+}
+
+const handleNavigationKeydown = (event) => {
+  const container = navigation.value
+  if (!container || event.target !== container) return
+
+  const scrollAmounts = {
+    ArrowDown: 40,
+    ArrowUp: -40,
+    PageDown: container.clientHeight,
+    PageUp: -container.clientHeight
+  }
+  const top = scrollAmounts[event.key]
+  if (top === undefined) return
+
+  event.preventDefault()
+  container.scrollBy({ top })
+}
+
+const keepActiveItemVisible = () => {
+  const container = navigation.value
+  const activeItem = container?.querySelector('.admin-nav-item-active')
+  if (!container || !activeItem) return
+
+  const containerRect = container.getBoundingClientRect()
+  const activeRect = activeItem.getBoundingClientRect()
+
+  if (activeRect.top < containerRect.top) {
+    container.scrollTop -= containerRect.top - activeRect.top
+  } else if (activeRect.bottom > containerRect.bottom) {
+    container.scrollTop += activeRect.bottom - containerRect.bottom
+  }
+
+  uiStore.adminSidebarScrollTop = container.scrollTop
+}
 
 const isActive = (path) => {
   return route.path === path || route.path.startsWith(path + '/')
@@ -1106,7 +1161,7 @@ const toggleNotificationManagementMenu = () => {
 
 watch(
   () => route.path,
-  (newPath) => {
+  async (newPath) => {
     if (
       newPath.startsWith('/management/users') ||
       newPath.startsWith('/management/groups')
@@ -1123,9 +1178,20 @@ watch(
       taskManagementMenuOpen.value = true
     if (newPath.startsWith('/management/notifier'))
       notificationManagementMenuOpen.value = true
+
+    if (navigation.value) {
+      await nextTick()
+      keepActiveItemVisible()
+    }
   },
   { immediate: true }
 )
+
+onMounted(async () => {
+  await nextTick()
+  navigation.value.scrollTop = uiStore.adminSidebarScrollTop
+  keepActiveItemVisible()
+})
 
 const preloadCache = new Set()
 const preloadRoute = (path) => {
@@ -1147,6 +1213,16 @@ const preloadRoute = (path) => {
 </script>
 
 <style scoped>
+.admin-sidebar-navigation {
+  scrollbar-width: none;
+}
+
+.admin-sidebar-navigation::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 .admin-nav-item {
   @apply flex min-h-11 items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-ink-300 transition-colors hover:bg-white/10 hover:text-white;
 }

--- a/frontend/src/admin/pages/Management/Users.vue
+++ b/frontend/src/admin/pages/Management/Users.vue
@@ -119,8 +119,22 @@
           <div
             v-else
             class="relative min-h-0 flex-1 overflow-auto rounded-lg border border-line bg-surface"
+            data-testid="user-table-scroll"
           >
-            <table class="min-w-full divide-y divide-line">
+            <table
+              class="w-full min-w-[73rem] table-fixed divide-y divide-line"
+            >
+              <colgroup>
+                <col class="w-12" />
+                <col class="w-16" />
+                <col class="w-48" />
+                <col class="w-56" />
+                <col class="w-48" />
+                <col class="w-24" />
+                <col class="w-28" />
+                <col class="w-44" />
+                <col class="w-16" />
+              </colgroup>
               <thead class="sticky top-0 z-10 bg-surface-sunken">
                 <tr>
                   <th class="table-head w-12">
@@ -140,14 +154,18 @@
                   <th class="table-head">{{ t('dashboard.isStaff') }}</th>
                   <th class="table-head">{{ t('management.isActive') }}</th>
                   <th class="table-head">{{ t('management.dateJoined') }}</th>
-                  <th class="table-head">{{ t('common.actions') }}</th>
+                  <th
+                    class="table-head sticky right-0 z-20 bg-surface-sunken text-right"
+                  >
+                    {{ t('common.actions') }}
+                  </th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-line bg-surface">
                 <tr
                   v-for="user in users"
                   :key="user.id"
-                  class="cursor-pointer transition-colors hover:bg-line-soft focus-visible:bg-line-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-500"
+                  class="group cursor-pointer transition-colors hover:bg-line-soft focus-visible:bg-line-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-500"
                   data-testid="user-detail-row"
                   tabindex="0"
                   @click="openDetail(user)"
@@ -168,23 +186,37 @@
                   <td class="table-cell font-mono text-ink-500">
                     {{ user.id }}
                   </td>
-                  <td class="table-cell">
+                  <td class="table-cell min-w-0" data-testid="user-identity">
                     <button
-                      class="font-medium text-brand-700 hover:underline"
+                      class="block w-full truncate text-left font-medium text-brand-700 hover:underline"
                       data-testid="user-detail-trigger"
+                      :title="user.username"
                       @click.stop="openDetail(user)"
                     >
                       {{ user.username }}
                     </button>
-                    <div class="text-xs text-ink-400">
-                      {{ user.display_name || '—' }}
+                    <div
+                      v-if="secondaryDisplayName(user)"
+                      class="truncate text-xs text-ink-400"
+                      data-testid="secondary-identity"
+                      :title="secondaryDisplayName(user)"
+                    >
+                      {{ secondaryDisplayName(user) }}
                     </div>
                   </td>
-                  <td class="table-cell text-ink-600">
-                    {{ user.email || '—' }}
+                  <td class="table-cell min-w-0 text-ink-600">
+                    <div
+                      class="truncate"
+                      data-testid="user-email"
+                      :title="secondaryIdentity(user.email, user.username)"
+                    >
+                      {{ secondaryIdentity(user.email, user.username) || '—' }}
+                    </div>
                   </td>
-                  <td class="table-cell text-ink-600">
-                    {{ joinNames(user.groups) }}
+                  <td class="table-cell min-w-0 text-ink-600">
+                    <div class="truncate" :title="joinNames(user.groups)">
+                      {{ joinNames(user.groups) }}
+                    </div>
                   </td>
                   <td class="table-cell">
                     <span
@@ -205,7 +237,11 @@
                   <td class="table-cell text-ink-500">
                     {{ formatDate(user.date_joined) }}
                   </td>
-                  <td class="table-cell text-right" @click.stop>
+                  <td
+                    class="table-cell sticky right-0 z-10 bg-surface text-right group-hover:bg-line-soft group-focus-visible:bg-line-soft"
+                    data-testid="user-actions"
+                    @click.stop
+                  >
                     <RowActionMenu
                       :actions="rowActions(user)"
                       @select="handleRowAction($event, user)"
@@ -443,6 +479,16 @@ function joinNames(items) {
   return Array.isArray(items) && items.length
     ? items.map((item) => item.name).join(', ')
     : '—'
+}
+
+function secondaryDisplayName(user) {
+  return secondaryIdentity(user?.display_name, user?.username)
+}
+
+function secondaryIdentity(value, username) {
+  const identity = (value || '').trim()
+  const primary = (username || '').trim()
+  return identity && identity !== primary ? identity : ''
 }
 
 function formatDate(value) {

--- a/frontend/src/store/ui.js
+++ b/frontend/src/store/ui.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useUiStore = defineStore('ui', () => {
+  const adminSidebarScrollTop = ref(0)
   const settingsOpen = ref(false)
   const settingsTab = ref('profile')
 
@@ -15,6 +16,7 @@ export const useUiStore = defineStore('ui', () => {
   }
 
   return {
+    adminSidebarScrollTop,
     settingsOpen,
     settingsTab,
     openSettings,


### PR DESCRIPTION
### **User description**
## Summary

- persist admin sidebar scroll position across route changes and group toggle transitions
- auto-scroll to the active navigation item after expandable-group animations and direct deep-link navigation
- hide the sidebar scrollbar while keeping native keyboard (PageUp/Down, arrows) and wheel scrolling functional
- restore the saved scroll position on first mount
- show the secondary user identity line only when display_name differs from username
- display "—" for blank email fields and truncate long group names with title attributes
- assign fixed column widths via table-fixed + colgroup and pin the actions column with sticky positioning
- widen the Settings and Logout click targets to full menu-item width in the admin user dropdown

## Testing

- 5 new Playwright E2E tests covering scroll persistence (nav, collapse, deep-link), identity distinction, and actions reachability
- viewports: 1280×600 (constrained sidebar) and 1512×945 (full desktop)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Persist admin sidebar scroll position across navigation and group toggles

- Hide sidebar scrollbar while keeping native keyboard and wheel scrolling

- Auto-scroll to active navigation item after group expand animations

- Show secondary user identity only when display_name differs from username

- Display "—" for blank email and truncate long group names in user table

- Assign fixed column widths and sticky actions column for reliable layout

- Widen Settings and Logout click targets to full menu-item width in user dropdown

- Add 5 new Playwright E2E tests for scroll behavior, identity, and actions


___

### Diagram Walkthrough


```mermaid
flowchart LR
    AdminSidebar["AdminSidebar.vue"] -->|Scroll persistence, hide scrollbar, keyboard nav| SidebarUX["Sidebar UX"]
    Users["Users.vue"] -->|Fixed columns, sticky actions, identity display| UserTable["User Table"]
    AdminHeader["AdminHeader.vue"] -->|Full-width menu items| UserMenu["User Menu"]
    SidebarUX -->|Stored in| uiStore["ui store"]
    UserTable -->|Tested by| E2E["E2E tests"]
    UserMenu -->|Tested by| E2E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdminSidebar.vue</strong><dd><code>Sidebar scroll persistence, keyboard nav, and scrollbar hiding</code></dd></summary>
<hr>

frontend/src/admin/layout/AdminSidebar.vue

<ul><li>Added scroll persistence saving to ui store and restoring on mount<br> <li> Hid scrollbar via CSS (scrollbar-width: none, ::-webkit-scrollbar <br>display: none)<br> <li> Implemented keyboard navigation (ArrowUp/Down, PageUp/PageDown) with <br>@keydown handler<br> <li> Added @after-enter on group transitions to keep active item visible<br> <li> Added aria-label, tabindex, and passive scroll event listener<br> <li> Changed border color from ink-800 to ink-700</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-68245495c461d476760afe3a8f4ca43037fde7fb7ad1a6e64bdc24b2c67dc8e1">+80/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AdminHeader.vue</strong><dd><code>Full-width Settings and Logout click targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/layout/AdminHeader.vue

<ul><li>Changed Settings and Logout buttons to full-width in user dropdown<br> <li> Wrapped buttons in a div with class "contents" to align with <br>full-width layout<br> <li> Updated button classes to include w-full, increased padding, and <br>text-left alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-72b027d627396e485c9cc13fc1b63078364fa57d249b1af9b940fef26d8e5334">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Users.vue</strong><dd><code>Fixed column widths, sticky actions, and identity display improvements</code></dd></summary>
<hr>

frontend/src/admin/pages/Management/Users.vue

<ul><li>Added colgroup with fixed column widths and table-fixed class<br> <li> Made actions column sticky with right-0 and z-index<br> <li> Added secondary identity display only when display_name differs from <br>username<br> <li> Truncated long text with title attributes for username, email, and <br>groups<br> <li> Displayed "—" for blank email and removed duplicate display_name row<br> <li> Added data-testid attributes for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-bd17c5feba4852cd6103733e18ec32304f0c2f48fcf10c9612260b209f19ed88">+58/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ui.js</strong><dd><code>Add scroll position state to ui store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/store/ui.js

<ul><li>Added reactive adminSidebarScrollTop variable to persist sidebar <br>scroll position</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-2b1e00d550e83d55acf19427728fa2c6ad81d9feceb6b1b79f4bcbb608944243">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-layout-scroll.spec.js</strong><dd><code>E2E tests for sidebar scroll behavior and user menu width</code></dd></summary>
<hr>

frontend/e2e/admin-layout-scroll.spec.js

<ul><li>Added test for deep direct link revealing active item with minimal <br>scrolling<br> <li> Added test for hidden scrollbar while keeping native scrolling <br>(keyboard and wheel)<br> <li> Added test for scroll position preservation across navigation and <br>group toggles<br> <li> Added test for full-width settings and logout hit areas in user menu</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-bc4911ecdac0091add9f00c0679059486a8bc50cbccf18c97d76a0489db5578a">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>management-users-mobile.spec.js</strong><dd><code>E2E tests for user identity display and table layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/management-users-mobile.spec.js

<ul><li>Extended mock user data to include multiple users with different <br>display_name states<br> <li> Added test for user identity distinction (secondary display only when <br>different)<br> <li> Added test for email display with "—" for blank, long username <br>truncation with title<br> <li> Added test for row actions reachability within fixed column layout</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/227/files#diff-a10acd38ed58db408de94c235780e098d251a93dc1620b7b92ec9ecdd9a96772">+56/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



Closes #220
