### PR TITLE
Overhaul run diagnostics: timeline, progress, i18n, and lifecycle fixes

### DIFF
--- a/backend/lens/migrations/0035_rundiagnostic_language.py
+++ b/backend/lens/migrations/0035_rundiagnostic_language.py
@@ -1,0 +1,27 @@
+"""Add the request-time UI language to RunDiagnostic."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "lens",
+            "0034_runexecution_runtime_snapshot_rundiagnosticevidence_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="rundiagnostic",
+            name="language",
+            field=models.CharField(
+                default="en",
+                help_text=(
+                    "UI language active when the diagnosis was requested."
+                ),
+                max_length=16,
+            ),
+        ),
+    ]

--- a/backend/lens/migrations/0036_rundiagnostic_progress.py
+++ b/backend/lens/migrations/0036_rundiagnostic_progress.py
@@ -1,0 +1,22 @@
+"""Add execution progress tracking to RunDiagnostic."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("lens", "0035_rundiagnostic_language"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="rundiagnostic",
+            name="progress",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Execution stage and detail while the diagnosis is pending.",
+            ),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -934,6 +934,16 @@ class RunDiagnostic(TimestampedUUIDModel):
         on_delete=models.SET_NULL,
         related_name="requested_run_diagnostics",
     )
+    language = models.CharField(
+        max_length=16,
+        default="en",
+        help_text="UI language active when the diagnosis was requested.",
+    )
+    progress = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Execution stage and detail while the diagnosis is pending.",
+    )
     status = models.CharField(
         max_length=16,
         choices=Status.choices,

--- a/backend/lens/run_diagnostics.py
+++ b/backend/lens/run_diagnostics.py
@@ -6,9 +6,10 @@ import logging
 import re
 import uuid
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.utils import timezone
+from django.utils import timezone, translation
 
 from .llm import run_completion
 from .models import (
@@ -28,14 +29,41 @@ TERMINAL_RUN_STATUSES = {
     Run.Status.FAILED,
     Run.Status.CANCELLED,
 }
-DIAGNOSTIC_PROMPT_VERSION = "run-diagnosis-v1"
+DIAGNOSTIC_PROMPT_VERSION = "run-diagnosis-v3"
+STALE_EXECUTION_SECONDS = 600
 MAX_QUESTION_CHARS = 2000
 MAX_SUMMARY_CHARS = 4000
 MAX_ANSWER_CHARS = 8000
-MAX_FINDINGS = 20
+MAX_EVENTS = 30
 MAX_LIST_ITEMS = 20
-VALID_SEVERITIES = {"low", "medium", "high", "critical"}
-VALID_FINDING_KINDS = {"fact", "hypothesis"}
+SEVERITY_SYNONYMS = {
+    "low": "low",
+    "info": "low",
+    "informational": "low",
+    "ok": "low",
+    "okay": "low",
+    "success": "low",
+    "none": "low",
+    "normal": "low",
+    "medium": "medium",
+    "moderate": "medium",
+    "warning": "medium",
+    "high": "high",
+    "critical": "critical",
+    "severe": "critical",
+}
+EVENT_STATUS_SYNONYMS = {
+    "ok": "ok",
+    "success": "ok",
+    "successful": "ok",
+    "done": "ok",
+    "failed": "failed",
+    "error": "failed",
+    "failure": "failed",
+    "recovered": "recovered",
+    "retried": "recovered",
+    "unknown": "unknown",
+}
 SAFE_EVENT_FIELDS = {
     "agent_event",
     "status",
@@ -59,6 +87,11 @@ SAFE_OBSERVATION_FIELDS = {
     "ended_at",
 }
 SAFE_CODE_PATTERN = re.compile(r"[A-Za-z0-9_.:-]{1,96}")
+SENSITIVE_ERROR_RE = re.compile(
+    r"(api[_-]?key|apikey|secret|password|passwd|bearer|authorization|"
+    r"private[_-]?key|access[_-]?key|access[_-]?token|refresh[_-]?token|"
+    r"id_token|credential)\b|token[=:]"
+)
 SAFE_MIME_PATTERN = re.compile(
     r"[A-Za-z0-9][A-Za-z0-9.+-]*/[A-Za-z0-9][A-Za-z0-9.+-]*"
 )
@@ -108,9 +141,15 @@ def create_run_diagnostic(run, requested_by, idempotency_key="initial-v1"):
         defaults={
             "evidence": evidence,
             "requested_by": requested_by,
+            "language": translation.get_language()
+            or settings.LANGUAGE_CODE,
             "model_ref": model_ref,
             "model_config_hash": model_config_hash,
             "prompt_version": DIAGNOSTIC_PROMPT_VERSION,
+            "progress": {
+                "stage": "queued",
+                "updated_at": timezone.now().isoformat(),
+            },
         },
     )
     should_enqueue = created
@@ -119,14 +158,35 @@ def create_run_diagnostic(run, requested_by, idempotency_key="initial-v1"):
         diagnostic.error_code = ""
         diagnostic.started_at = None
         diagnostic.finished_at = None
+        diagnostic.progress = {
+            "stage": "queued",
+            "updated_at": timezone.now().isoformat(),
+        }
         diagnostic.save(
             update_fields=[
                 "status",
                 "error_code",
                 "started_at",
                 "finished_at",
+                "progress",
                 "updated_at",
             ]
+        )
+        should_enqueue = True
+    elif (
+        not created
+        and diagnostic.status == RunDiagnostic.Status.RUNNING
+        and _is_stale_started(diagnostic)
+    ):
+        # The worker died mid-run; reset so the user can re-trigger.
+        diagnostic.status = RunDiagnostic.Status.QUEUED
+        diagnostic.started_at = None
+        diagnostic.progress = {
+            "stage": "queued",
+            "updated_at": timezone.now().isoformat(),
+        }
+        diagnostic.save(
+            update_fields=["status", "started_at", "progress", "updated_at"]
         )
         should_enqueue = True
     if should_enqueue:
@@ -178,6 +238,17 @@ def create_diagnostic_turn(diagnostic, requested_by, question):
         transaction.on_commit(
             lambda turn_uuid=turn.uuid: enqueue_diagnostic_turn(turn_uuid)
         )
+    elif (
+        turn.status == RunDiagnosticTurn.Status.RUNNING
+        and _is_stale_started(turn)
+    ):
+        # The worker died while answering; reset so the user can re-ask.
+        turn.status = RunDiagnosticTurn.Status.QUEUED
+        turn.started_at = None
+        turn.save(update_fields=["status", "started_at", "updated_at"])
+        transaction.on_commit(
+            lambda turn_uuid=turn.uuid: enqueue_diagnostic_turn(turn_uuid)
+        )
     return turn, created
 
 
@@ -195,13 +266,29 @@ def execute_diagnostic(diagnostic_uuid):
     diagnostic = _mark_diagnostic_running(diagnostic_uuid)
     if diagnostic is None:
         return False
-    findings = _deterministic_findings(diagnostic.run, diagnostic.evidence)
+    _set_diagnostic_progress(diagnostic, "deterministic_checks")
+    findings = _deterministic_findings(
+        diagnostic.run,
+        diagnostic.evidence,
+        diagnostic.language,
+    )
     diagnostic.deterministic_findings = findings
     diagnostic.save(update_fields=["deterministic_findings", "updated_at"])
+    _set_diagnostic_progress(
+        diagnostic,
+        "model_analysis",
+        detail={
+            "model": (
+                str(diagnostic.model_ref) if diagnostic.model_ref else ""
+            ),
+            "deterministic_findings_count": len(findings),
+        },
+    )
+    completion = None
     try:
         completion = run_completion(
             model_ref=diagnostic.model_ref,
-            system=_diagnostic_system_prompt(),
+            system=_diagnostic_system_prompt(diagnostic.language),
             user=json.dumps(
                 {
                     "evidence_snapshot": diagnostic.evidence.payload,
@@ -214,11 +301,18 @@ def execute_diagnostic(diagnostic_uuid):
             node_name="run_diagnostics",
             user_id=diagnostic.requested_by_id,
         )
+        _set_diagnostic_progress(diagnostic, "validating")
         result = validate_diagnostic_result(
             _parse_json_object(completion.content),
             diagnostic.evidence,
         )
     except DiagnosticResultError as exc:
+        _log_rejected_output(
+            exc.code,
+            "run diagnosis",
+            {"diagnostic_uuid": diagnostic.uuid},
+            getattr(completion, "content", None) if completion else None,
+        )
         _fail_diagnostic(diagnostic, exc.code)
         return False
     except Exception:
@@ -235,6 +329,10 @@ def execute_diagnostic(diagnostic_uuid):
     diagnostic.usage = completion.usage or {}
     diagnostic.error_code = ""
     diagnostic.finished_at = now
+    diagnostic.progress = {
+        "stage": "completed",
+        "updated_at": now.isoformat(),
+    }
     diagnostic.save(
         update_fields=[
             "status",
@@ -242,6 +340,7 @@ def execute_diagnostic(diagnostic_uuid):
             "usage",
             "error_code",
             "finished_at",
+            "progress",
             "updated_at",
         ]
     )
@@ -255,10 +354,11 @@ def execute_diagnostic_follow_up(turn_uuid):
     if turn is None:
         return False
     diagnostic = turn.diagnostic
+    completion = None
     try:
         completion = run_completion(
             model_ref=diagnostic.model_ref,
-            system=_follow_up_system_prompt(),
+            system=_follow_up_system_prompt(diagnostic.language),
             user=json.dumps(
                 {
                     "diagnosis": diagnostic.result,
@@ -277,6 +377,12 @@ def execute_diagnostic_follow_up(turn_uuid):
             diagnostic.evidence,
         )
     except DiagnosticResultError as exc:
+        _log_rejected_output(
+            exc.code,
+            "run diagnosis follow-up",
+            {"turn_uuid": turn.uuid},
+            getattr(completion, "content", None) if completion else None,
+        )
         _fail_turn(turn, exc.code)
         return False
     except Exception:
@@ -313,16 +419,12 @@ def validate_diagnostic_result(result, evidence):
     if not isinstance(result, dict):
         raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
     summary = _bounded_text(result.get("summary"), MAX_SUMMARY_CHARS)
-    severity = result.get("severity")
-    if severity not in VALID_SEVERITIES:
+    severity = _normalize_severity(result.get("severity"))
+    if severity is None:
         raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
     confidence = _confidence(result.get("confidence"))
-    findings = result.get("findings")
-    if not isinstance(findings, list) or len(findings) > MAX_FINDINGS:
-        raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
-    normalized_findings = [
-        _validate_finding(item, evidence) for item in findings
-    ]
+    events = _validate_events(result.get("events"), evidence)
+    root_cause = _validate_root_cause(result.get("root_cause"), evidence)
     cause_categories = _short_string_list(
         result.get("cause_categories"),
         MAX_LIST_ITEMS,
@@ -336,7 +438,8 @@ def validate_diagnostic_result(result, evidence):
         "summary": summary,
         "severity": severity,
         "confidence": confidence,
-        "findings": normalized_findings,
+        "events": events,
+        "root_cause": root_cause,
         "cause_categories": cause_categories,
         "recommendations": recommendations,
         "unknowns": unknowns,
@@ -357,6 +460,8 @@ def serialize_diagnostic(diagnostic):
         ),
         "deterministic_findings": diagnostic.deterministic_findings,
         "prompt_version": diagnostic.prompt_version,
+        "language": diagnostic.language,
+        "progress": diagnostic.progress or {},
         "result": diagnostic.result,
         "usage": diagnostic.usage,
         "error_code": diagnostic.error_code,
@@ -555,7 +660,7 @@ def _step_evidence(step):
                 safe_event["observation"] = safe_observation
         if safe_event:
             events.append(safe_event)
-    return {
+    evidence = {
         "step_uuid": str(step.uuid),
         "step_type": step.step_type,
         "status": step.status,
@@ -563,6 +668,10 @@ def _step_evidence(step):
         "events": events[:100],
         "updated_at": step.updated_at.isoformat(),
     }
+    error = detail.get("error")
+    if isinstance(error, str) and error.strip():
+        evidence["error"] = _safe_run_error_code(error)
+    return evidence
 
 
 def _usage_evidence(run):
@@ -597,7 +706,10 @@ def _diagnostic_model_snapshot(run):
         .values_list("value", flat=True)
         .first()
     )
-    runtime_snapshot = getattr(run.execution, "runtime_snapshot", {}) or {}
+    runtime_snapshot = (
+        getattr(getattr(run, "execution", None), "runtime_snapshot", None)
+        or {}
+    )
     model_refs = runtime_snapshot.get("model_refs") or {}
     raw_model_ref = configured or model_refs.get("agent")
     try:
@@ -612,14 +724,23 @@ def _diagnostic_model_snapshot(run):
     return model_ref, config_hash
 
 
-def _deterministic_findings(run, evidence):
+def _deterministic_findings(run, evidence, language="en"):
+    zh = language == "zh-hans"
     findings = [
         {
             "kind": "fact",
-            "title": "Terminal Run state",
+            "title": "终端运行状态" if zh else "Terminal Run state",
             "statement": (
-                f"The Run finished with executor status {run.status}"
-                f" and business outcome {run.outcome or 'unknown'}."
+                "运行以执行器状态 {status} 结束，"
+                "业务结果为 {outcome}。"
+                if zh
+                else (
+                    "The Run finished with executor status {status}"
+                    " and business outcome {outcome}."
+                )
+            ).format(
+                status=run.status,
+                outcome=run.outcome or ("未知" if zh else "unknown"),
             ),
             "confidence": 1.0,
             "evidence_refs": ["E-RUN"],
@@ -630,12 +751,36 @@ def _deterministic_findings(run, evidence):
         findings.append(
             {
                 "kind": "unknown",
-                "title": "Missing evidence",
+                "title": "缺失证据" if zh else "Missing evidence",
                 "statement": ", ".join(str(item) for item in missing),
                 "evidence_refs": [],
             }
         )
     return findings
+
+
+def _is_stale_started(instance):
+    """Return True when a pending run started too long ago to be alive."""
+
+    started_at = getattr(instance, "started_at", None)
+    if started_at is None:
+        return True
+    return (
+        timezone.now() - started_at
+    ).total_seconds() > STALE_EXECUTION_SECONDS
+
+
+def _set_diagnostic_progress(diagnostic, stage, detail=None):
+    """Persist the current execution stage for the pending state UI."""
+
+    progress = {
+        "stage": stage,
+        "updated_at": timezone.now().isoformat(),
+    }
+    if detail:
+        progress.update(detail)
+    diagnostic.progress = progress
+    diagnostic.save(update_fields=["progress", "updated_at"])
 
 
 @transaction.atomic
@@ -689,11 +834,16 @@ def _fail_diagnostic(diagnostic, error_code):
     diagnostic.status = RunDiagnostic.Status.FAILED
     diagnostic.error_code = error_code
     diagnostic.finished_at = timezone.now()
+    diagnostic.progress = {
+        "stage": "failed",
+        "updated_at": diagnostic.finished_at.isoformat(),
+    }
     diagnostic.save(
         update_fields=[
             "status",
             "error_code",
             "finished_at",
+            "progress",
             "updated_at",
         ]
     )
@@ -714,55 +864,140 @@ def _fail_turn(turn, error_code):
 
 
 def _parse_json_object(content):
+    """Parse one JSON object, tolerating a markdown code fence wrapper."""
+
     raw = str(content or "").strip()
-    if raw.startswith("```"):
-        raw = raw.removeprefix("```json").removeprefix("```")
-        raw = raw.removesuffix("```").strip()
-    try:
-        result = json.loads(raw)
-    except (TypeError, json.JSONDecodeError) as exc:
-        raise DiagnosticResultError("MODEL_RESPONSE_INVALID") from exc
-    if not isinstance(result, dict):
-        raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
-    return result
+    candidates = [raw]
+    fence = _FENCE_RE.search(raw)
+    if fence:
+        candidates.insert(0, fence.group(1).strip())
+    for candidate in candidates:
+        try:
+            result = json.loads(candidate)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(result, dict):
+            return result
+    raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
 
 
-def _diagnostic_system_prompt():
+_FENCE_RE = re.compile(r"```[A-Za-z0-9_+-]*\s*\n(.*?)```", re.DOTALL)
+
+
+def _log_rejected_output(error_code, flow, ids, content):
+    """Log the rejected model output so the failure is diagnosable."""
+
+    logger.warning(
+        "%s rejected model output: code=%s ids=%s raw_output=%r",
+        flow,
+        error_code,
+        ids,
+        str(content or "")[:8000],
+    )
+
+
+def _diagnostic_system_prompt(language="en"):
     return (
         "You are a read-only Run Diagnostics Assistant. Analyze only the "
         "provided immutable evidence snapshot. Do not request tools, perform "
-        "actions, reveal hidden reasoning, or infer facts without labeling "
-        "them as hypotheses. Return strict JSON with summary, severity, "
-        "confidence, findings, cause_categories, recommendations, and "
-        "unknowns. Every fact, hypothesis, and recommendation must cite only "
-        "Evidence IDs present in the snapshot."
+        "actions, reveal hidden reasoning, or speculate without labeling it "
+        "as a hypothesis. Return strict JSON with exactly: summary (string), "
+        "severity (one of low|medium|high|critical), confidence (number 0-1), "
+        "events (array of {title, description, status, evidence_refs} in "
+        "chronological order, status one of ok|failed|recovered|unknown), "
+        "root_cause ({title, description, evidence_refs} or null when the "
+        "Run completed without a failure), cause_categories (array of short "
+        "strings), recommendations (array of {title, action, evidence_refs}), "
+        "and unknowns (array of {statement, evidence_refs}). Every event, "
+        "root cause, and recommendation must cite only Evidence IDs present "
+        "in the snapshot."
+        " Be concise and focus on what matters: summary is 1-3 sentences "
+        "stating the outcome and any failure or recovery; events are only "
+        "meaningful milestones (start, major steps, failures, recoveries, "
+        "completion) with 1-2 short sentences each; omit routine details "
+        "such as timestamps, token counts, budgets, and timeouts unless they "
+        "directly explain the outcome; root_cause names the concrete failure "
+        "point and why it failed; recommendations are specific and "
+        "actionable; unknowns list only genuinely missing information."
+        + _language_instruction(language)
     )
 
 
-def _follow_up_system_prompt():
+def _follow_up_system_prompt(language="en"):
     return (
-        "Answer only about the single target Run using its bound diagnosis and "
-        "immutable evidence. Do not use tools, search for other Runs, perform "
-        "actions, or reveal hidden reasoning. Return strict JSON with answer "
-        "and evidence_refs. Cite only Evidence IDs present in the snapshot."
+        "Answer only about the single target Run using its bound diagnosis"
+        " and immutable evidence. Do not use tools, search for other Runs,"
+        " perform actions, or reveal hidden reasoning. Return strict JSON"
+        "actions, or reveal hidden reasoning. Return strict JSON with exactly "
+        "answer (string) and evidence_refs (array of Evidence IDs present in "
+        "the snapshot)."
+        + _language_instruction(language)
     )
 
 
-def _validate_finding(item, evidence):
-    if (
-        not isinstance(item, dict)
-        or item.get("kind") not in VALID_FINDING_KINDS
-    ):
+def _language_instruction(language):
+    """Return a prompt suffix pinning the output language to the UI."""
+
+    names = {
+        "zh-hans": "Simplified Chinese",
+        "zh": "Simplified Chinese",
+        "en": "English",
+    }
+    name = names.get((language or "en").lower(), "English")
+    return (
+        f" Respond in {name}: all summary, event titles and descriptions, "
+        "cause categories, recommendation titles and actions, unknowns, and "
+        "answers must be written in that language."
+    )
+
+
+def _validate_events(items, evidence):
+    """Validate the chronological event timeline of the Run."""
+
+    if not isinstance(items, list) or len(items) > MAX_EVENTS:
+        raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
+    normalized = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
+        status = _normalize_event_status(item.get("status"))
+        if status is None:
+            raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
+        normalized.append(
+            {
+                "title": _bounded_text(item.get("title"), 240),
+                "description": _bounded_text(item.get("description"), 2000),
+                "status": status,
+                "evidence_refs": _evidence_refs(
+                    item.get("evidence_refs", []),
+                    evidence,
+                ),
+            }
+        )
+    return normalized
+
+
+def _normalize_event_status(value):
+    """Map case variants and synonyms onto the event-status enum."""
+
+    if not isinstance(value, str):
+        return None
+    return EVENT_STATUS_SYNONYMS.get(value.strip().lower())
+
+
+def _validate_root_cause(value, evidence):
+    """Validate the failure root cause, or None when nothing failed."""
+
+    if value is None:
+        return None
+    if not isinstance(value, dict):
         raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
     return {
-        "kind": item["kind"],
-        "title": _bounded_text(item.get("title"), 240),
-        "statement": _bounded_text(item.get("statement"), 2000),
-        "confidence": _confidence(item.get("confidence")),
+        "title": _bounded_text(value.get("title"), 240),
+        "description": _bounded_text(value.get("description"), 2000),
         "evidence_refs": _evidence_refs(
-            item.get("evidence_refs"),
+            value.get("evidence_refs", []),
             evidence,
-            required=True,
         ),
     }
 
@@ -777,7 +1012,10 @@ def _validate_recommendations(items, evidence):
         normalized.append(
             {
                 "title": _bounded_text(item.get("title"), 240),
-                "action": _bounded_text(item.get("action"), 2000),
+                "action": _bounded_text(
+                    item.get("action") or item.get("statement"),
+                    2000,
+                ),
                 "evidence_refs": _evidence_refs(
                     item.get("evidence_refs"),
                     evidence,
@@ -842,6 +1080,14 @@ def _bounded_text(value, maximum):
     return value
 
 
+def _normalize_severity(value):
+    """Map case variants and common synonyms onto the severity enum."""
+
+    if not isinstance(value, str):
+        return None
+    return SEVERITY_SYNONYMS.get(value.strip().lower())
+
+
 def _confidence(value):
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise DiagnosticResultError("MODEL_RESPONSE_INVALID")
@@ -890,12 +1136,21 @@ def _model_config_hash(model_ref):
 
 
 def _safe_run_error_code(value):
-    value = str(value or "")
+    """Sanitize one error message: mask credentials, keep operational text."""
+
+    value = str(value or "").strip()
     if not value:
         return ""
-    if SAFE_CODE_PATTERN.fullmatch(value):
-        return value
-    return "UNCLASSIFIED_RUN_ERROR"
+    if len(value) > 200:
+        return "UNCLASSIFIED_RUN_ERROR"
+    if any(ch in value for ch in "\r\n\t") or any(
+        ord(ch) < 32 for ch in value
+    ):
+        return "UNCLASSIFIED_RUN_ERROR"
+    lowered = value.lower()
+    if SENSITIVE_ERROR_RE.search(lowered):
+        return "UNCLASSIFIED_RUN_ERROR"
+    return value
 
 
 def _safe_event_value(key, value):

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -171,15 +171,36 @@ def fail_active_runs_for_lensnode(lensnode_uuid):
     """
 
     now = timezone.now()
-    Run.objects.filter(
-        lensnode__uuid=lensnode_uuid,
-        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
-    ).update(
+    run_ids = list(
+        Run.objects.filter(
+            lensnode__uuid=lensnode_uuid,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        ).values_list("id", flat=True)
+    )
+    if not run_ids:
+        return 0
+    Run.objects.filter(id__in=run_ids).update(
         status=Run.Status.FAILED,
         error="LENSNODE_DISCONNECTED",
         finished_at=now,
         updated_at=now,
     )
+    fail_running_steps_for_runs(run_ids)
+    return len(run_ids)
+
+
+def fail_running_steps_for_runs(run_ids):
+    """Finalize in-flight steps for runs failed outside the step context.
+
+    Out-of-band failure paths (lensnode disconnect, orphan reconcile, idle
+    sweep) update the Run row directly, so their RUNNING RunStep rows would
+    otherwise stay RUNNING forever and disagree with the terminal Run state.
+    """
+
+    return RunStep.objects.filter(
+        run_id__in=run_ids,
+        status=RunStep.Status.RUNNING,
+    ).update(status=RunStep.Status.FAILED, updated_at=timezone.now())
 
 
 RECONCILE_GRACE_SECONDS = 60

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -881,6 +881,15 @@ def confirm_reconcile_orphan(run_uuid):
         updated_at=now,
     )
     if updated:
+        from .services import fail_running_steps_for_runs
+
+        run_id = (
+            Run.objects.filter(uuid=run_uuid)
+            .values_list("id", flat=True)
+            .first()
+        )
+        if run_id:
+            fail_running_steps_for_runs([run_id])
         logger.warning(
             "Run %s still non-terminal after the reconcile confirm grace "
             "window; marking it failed (LENSNODE_RECONNECT_ORPHANED)",
@@ -966,7 +975,12 @@ def lensnode_cleanup_task():
         | Q(last_activity_at__isnull=True, started_at__lt=idle_cutoff)
         | Q(started_at__lt=abs_cutoff)
     )
-    count = stale.count()
+    stale_ids = list(stale.values_list("id", flat=True))
+    count = len(stale_ids)
+    if count:
+        from .services import fail_running_steps_for_runs
+
+        fail_running_steps_for_runs(stale_ids)
     stale.update(
         status=Run.Status.FAILED,
         error="LENS_RUN_TIMEOUT",

--- a/backend/lens/tests/test_run_diagnostics.py
+++ b/backend/lens/tests/test_run_diagnostics.py
@@ -18,6 +18,7 @@ from lens.models import (
     Run,
     RunDiagnostic,
     RunDiagnosticEvidence,
+    RunExecution,
     RunStep,
     Session,
 )
@@ -138,7 +139,7 @@ class RunDiagnosticsTests(TestCase):
                 ],
             },
         )
-        self.run.error = "private raw failure details"
+        self.run.error = "Bearer private-token-xyz"
         self.run.save(update_fields=["error", "updated_at"])
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -160,7 +161,7 @@ class RunDiagnosticsTests(TestCase):
         self.assertNotIn("private-token", serialized)
         self.assertNotIn("assistant-secret", serialized)
         self.assertNotIn("event-secret", serialized)
-        self.assertNotIn("private raw failure details", serialized)
+        self.assertNotIn("Bearer private-token-xyz", serialized)
         self.assertEqual(
             evidence.payload["evidence"]["E-RUN"]["data"]["error_code"],
             "UNCLASSIFIED_RUN_ERROR",
@@ -223,21 +224,112 @@ class RunDiagnosticsTests(TestCase):
         with self.assertRaises(ValidationError):
             evidence.save()
 
+    def test_step_error_is_captured_in_evidence(self):
+        RunStep.objects.create(
+            run=self.run,
+            step_type=RunStep.StepType.RETRIEVAL,
+            sequence=1,
+            status=RunStep.Status.FAILED,
+            detail={"error": "'str' object has no attribute 'get'"},
+        )
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        serialized = json.dumps(diagnostic.evidence.payload)
+        self.assertIn("'str' object has no attribute 'get'", serialized)
+
+    def test_run_error_message_is_preserved_in_evidence(self):
+        self.run.error = "'str' object has no attribute 'get'"
+        self.run.save(update_fields=["error", "updated_at"])
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        error_code = diagnostic.evidence.payload["evidence"]["E-RUN"]["data"][
+            "error_code"
+        ]
+        self.assertEqual(error_code, "'str' object has no attribute 'get'")
+
+    def test_stale_running_diagnostic_is_reset_and_reenqueued(self):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        diagnostic.status = RunDiagnostic.Status.RUNNING
+        diagnostic.started_at = timezone.now() - timezone.timedelta(
+            minutes=11
+        )
+        diagnostic.save(update_fields=["status", "started_at", "updated_at"])
+
+        with patch(
+            "lens.run_diagnostics.enqueue_run_diagnostic"
+        ) as enqueue:
+            with self.captureOnCommitCallbacks(execute=True):
+                retried, should_enqueue = create_run_diagnostic(
+                    self.run,
+                    self.admin,
+                )
+
+        self.assertTrue(should_enqueue)
+        self.assertEqual(retried.pk, diagnostic.pk)
+        retried.refresh_from_db()
+        self.assertEqual(
+            retried.status,
+            RunDiagnostic.Status.QUEUED,
+        )
+        self.assertIsNone(retried.started_at)
+        enqueue.assert_called_once_with(retried.uuid)
+
+    def test_fresh_running_diagnostic_is_not_reset(self):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        diagnostic.status = RunDiagnostic.Status.RUNNING
+        diagnostic.started_at = timezone.now()
+        diagnostic.save(update_fields=["status", "started_at", "updated_at"])
+
+        with patch(
+            "lens.run_diagnostics.enqueue_run_diagnostic"
+        ) as enqueue:
+            with self.captureOnCommitCallbacks(execute=True):
+                retried, should_enqueue = create_run_diagnostic(
+                    self.run,
+                    self.admin,
+                )
+
+        retried.refresh_from_db()
+        self.assertEqual(retried.status, RunDiagnostic.Status.RUNNING)
+        self.assertFalse(should_enqueue)
+
+    def test_error_sanitizer_masks_credentials_only(self):
+        from lens.run_diagnostics import _safe_run_error_code
+
+        self.assertEqual(
+            _safe_run_error_code("The token limit of 500000 was exceeded"),
+            "The token limit of 500000 was exceeded",
+        )
+        self.assertEqual(
+            _safe_run_error_code("request body too large"),
+            "request body too large",
+        )
+        self.assertEqual(
+            _safe_run_error_code("Bearer eyJhbGciOiJIUzI1NiJ9"),
+            "UNCLASSIFIED_RUN_ERROR",
+        )
+        self.assertEqual(
+            _safe_run_error_code("access_token=abc123"),
+            "UNCLASSIFIED_RUN_ERROR",
+        )
+        self.assertEqual(
+            _safe_run_error_code("line1\nline2"),
+            "UNCLASSIFIED_RUN_ERROR",
+        )
+
     def test_result_rejects_unknown_evidence_reference(self):
         diagnostic, _created = create_run_diagnostic(self.run, self.admin)
         result = {
             "summary": "A bounded summary.",
             "severity": "high",
             "confidence": 0.8,
-            "findings": [
+            "events": [
                 {
-                    "kind": "fact",
-                    "title": "Failure",
-                    "statement": "The Run failed.",
-                    "confidence": 1.0,
+                    "title": "Tool call",
+                    "description": "The failing tool ran.",
+                    "status": "failed",
                     "evidence_refs": ["E-NOT-THERE"],
                 }
             ],
+            "root_cause": None,
             "cause_categories": ["execution"],
             "recommendations": [],
             "unknowns": [],
@@ -255,15 +347,19 @@ class RunDiagnosticsTests(TestCase):
             "summary": "The Run stopped after an execution failure.",
             "severity": "high",
             "confidence": 0.9,
-            "findings": [
+            "events": [
                 {
-                    "kind": "fact",
-                    "title": "Terminal failure",
-                    "statement": "The executor marked the Run failed.",
-                    "confidence": 1,
+                    "title": "Execution",
+                    "description": "The executor marked the Run failed.",
+                    "status": "failed",
                     "evidence_refs": ["E-RUN"],
                 }
             ],
+            "root_cause": {
+                "title": "Tool error",
+                "description": "The tool raised an error.",
+                "evidence_refs": ["E-RUN"],
+            },
             "cause_categories": ["execution"],
             "recommendations": [
                 {
@@ -289,21 +385,244 @@ class RunDiagnosticsTests(TestCase):
         self.assertEqual(diagnostic.usage, {"total_tokens": 321})
         completion.assert_called_once()
 
-    def test_result_requires_citations_for_conclusions(self):
+    @patch("lens.run_diagnostics.run_completion")
+    def test_execute_diagnostic_accepts_fenced_model_output(self, completion):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        result = {
+            "summary": "The Run stopped after an execution failure.",
+            "severity": "high",
+            "confidence": 0.9,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": ["execution"],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=(
+                "Here is the analysis:\n```json\n"
+                + json.dumps(result)
+                + "\n```\nEnd of report."
+            ),
+            usage={},
+            metered=True,
+        )
+
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.status, RunDiagnostic.Status.COMPLETED)
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_severity_synonyms_are_normalized(self, completion):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        result = {
+            "summary": "The Run stopped after an execution failure.",
+            "severity": "info",
+            "confidence": 0.9,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.result["severity"], "low")
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_event_status_synonyms_are_normalized(self, completion):
         diagnostic, _created = create_run_diagnostic(self.run, self.admin)
         result = {
             "summary": "A bounded summary.",
             "severity": "low",
             "confidence": 0.5,
-            "findings": [
+            "events": [
                 {
-                    "kind": "hypothesis",
-                    "title": "Possible cause",
-                    "statement": "More evidence is required.",
-                    "confidence": 0.5,
+                    "title": "Retrieval",
+                    "description": "Sources loaded.",
+                    "status": "Success",
                     "evidence_refs": [],
                 }
             ],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.result["events"][0]["status"], "ok")
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_recommendation_accepts_statement_key(self, completion):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        result = {
+            "summary": "A bounded summary.",
+            "severity": "low",
+            "confidence": 0.5,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [
+                {
+                    "title": "Inspect the trace",
+                    "statement": "Review the failed execution events.",
+                    "evidence_refs": ["E-RUN"],
+                }
+            ],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(
+            diagnostic.result["recommendations"][0]["action"],
+            "Review the failed execution events.",
+        )
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_diagnosis_language_matches_request_language(self, completion):
+        from django.utils import translation
+
+        result = {
+            "summary": "A bounded summary.",
+            "severity": "low",
+            "confidence": 0.5,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+        translation.activate("zh-hans")
+        try:
+            diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+            completed = execute_diagnostic(diagnostic.uuid)
+        finally:
+            translation.deactivate()
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.language, "zh-hans")
+        self.assertEqual(
+            diagnostic.deterministic_findings[0]["title"],
+            "终端运行状态",
+        )
+        _, kwargs = completion.call_args
+        self.assertIn("Simplified Chinese", kwargs["system"])
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_execute_diagnostic_tracks_progress(self, completion):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        result = {
+            "summary": "A bounded summary.",
+            "severity": "low",
+            "confidence": 0.5,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.progress["stage"], "completed")
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_diagnosis_succeeds_without_execution_record(self, completion):
+        run = self.run
+        run.execution = None
+        run.save(update_fields=["updated_at"])
+        RunExecution.objects.filter(run=run).delete()
+        result = {
+            "summary": "A bounded summary.",
+            "severity": "low",
+            "confidence": 0.5,
+            "events": [],
+            "root_cause": None,
+            "cause_categories": [],
+            "recommendations": [],
+            "unknowns": [],
+        }
+        completion.return_value = LensLLMResult(
+            content=json.dumps(result),
+            usage={},
+            metered=True,
+        )
+
+        diagnostic, created = create_run_diagnostic(run, self.admin)
+        self.assertTrue(created)
+        completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertTrue(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.status, RunDiagnostic.Status.COMPLETED)
+
+    @patch("lens.run_diagnostics.run_completion")
+    def test_invalid_model_output_is_failed_and_logged(self, completion):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        completion.return_value = LensLLMResult(
+            content="Sorry, here is a summary without valid JSON.",
+            usage={},
+            metered=True,
+        )
+
+        with self.assertLogs("lens.run_diagnostics", level="WARNING") as logs:
+            completed = execute_diagnostic(diagnostic.uuid)
+
+        self.assertFalse(completed)
+        diagnostic.refresh_from_db()
+        self.assertEqual(diagnostic.status, RunDiagnostic.Status.FAILED)
+        self.assertEqual(diagnostic.error_code, "MODEL_RESPONSE_INVALID")
+        self.assertIn("MODEL_RESPONSE_INVALID", logs.output[0])
+        self.assertIn("Sorry, here is a summary", logs.output[0])
+
+    def test_root_cause_must_be_object_or_null(self):
+        diagnostic, _created = create_run_diagnostic(self.run, self.admin)
+        result = {
+            "summary": "A bounded summary.",
+            "severity": "low",
+            "confidence": 0.5,
+            "events": [],
+            "root_cause": "tool error",
             "cause_categories": [],
             "recommendations": [],
             "unknowns": [],
@@ -322,7 +641,8 @@ class RunDiagnosticsTests(TestCase):
             "summary": "The Run failed after a tool error.",
             "severity": "high",
             "confidence": 0.8,
-            "findings": [],
+            "events": [],
+            "root_cause": None,
             "cause_categories": [],
             "recommendations": [],
             "unknowns": [],

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -6,9 +6,17 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
-from lens.models import Assistant, LensNode, Run, RunExecution, Session
+from lens.models import (
+    Assistant,
+    LensNode,
+    Run,
+    RunExecution,
+    RunStep,
+    Session,
+)
 from lens.services import (
     create_execution_run,
+    fail_active_runs_for_lensnode,
     reconcile_lensnode_active_runs,
     record_lensnode_run_event,
     touch_run_activity,
@@ -209,6 +217,45 @@ class RunLifecycleTests(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, Run.Status.FAILED)
         self.assertEqual(run.error, "LENSNODE_RECONNECT_ORPHANED")
+
+    def test_confirm_reconcile_orphan_finalizes_running_steps(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        step = RunStep.objects.create(
+            run=run,
+            step_type=RunStep.StepType.GENERAL_CHAT,
+            sequence=1,
+            status=RunStep.Status.RUNNING,
+        )
+
+        confirm_reconcile_orphan(str(run.uuid))
+
+        step.refresh_from_db()
+        self.assertEqual(step.status, RunStep.Status.FAILED)
+
+    def test_fail_active_runs_for_lensnode_finalizes_steps(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        step = RunStep.objects.create(
+            run=run,
+            step_type=RunStep.StepType.GENERAL_CHAT,
+            sequence=1,
+            status=RunStep.Status.RUNNING,
+        )
+
+        fail_active_runs_for_lensnode(self.lensnode.uuid)
+
+        run.refresh_from_db()
+        step.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_DISCONNECTED")
+        self.assertEqual(step.status, RunStep.Status.FAILED)
 
     def test_confirm_reconcile_orphan_noops_if_already_terminal(self):
         # The normal completion path (a late but durably-delivered run_done)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,6 +60,9 @@ services:
       - ./.env.dev
     environment:
       WORKSPACE_ROOT: /opt/backend
+      # Development login must not depend on the external Turnstile service.
+      TURNSTILE_ENABLED: "false"
+      TURNSTILE_SECRET_KEY: ""
     volumes:
       - ./data.dev/logs/worker:/var/log/celery
       - ./data.dev/storage:/opt/storage
@@ -84,6 +87,10 @@ services:
     restart: unless-stopped
     env_file:
       - ./.env.dev
+    environment:
+      # Development login must not depend on the external Turnstile service.
+      TURNSTILE_ENABLED: "false"
+      TURNSTILE_SECRET_KEY: ""
     volumes:
       - ./data.dev/logs/scheduler:/var/log/celery
       - ./backend:/opt/backend

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -90,7 +90,30 @@
     "diagnosisEmptyTitle": "No diagnosis yet",
     "diagnosisEmptyDescription": "Generate a read-only analysis from the immutable evidence captured for this Run.",
     "diagnosisRunning": "Analyzing Run evidence",
-    "diagnosisRunningDescription": "Deterministic checks and bounded model analysis are running asynchronously.",
+    "diagnosisStageTitles": {
+      "queued": "Diagnosis queued, waiting to run",
+      "deterministic_checks": "Running deterministic checks",
+      "model_analysis": "Analyzing with the model",
+      "validating": "Validating diagnosis"
+    },
+    "diagnosisStages": {
+      "queued": "Queued",
+      "deterministic_checks": "Deterministic checks",
+      "model_analysis": "Model analysis",
+      "validating": "Validating"
+    },
+    "diagnosisElapsed": "Elapsed {n}s",
+    "diagnosisModelAnalysisDetail": "{n} deterministic checks done, calling the analysis model…",
+    "timelineTitle": "Execution timeline",
+    "timelineEventStatus": {
+      "ok": "OK",
+      "failed": "Failed",
+      "recovered": "Recovered",
+      "unknown": "Unknown"
+    },
+    "rootCauseTitle": "Root cause",
+    "noRootCauseTitle": "No failure found",
+    "noRootCauseDescription": "No clear failure point was found during execution.",
     "diagnosisFailed": "Diagnosis failed",
     "diagnosisFailedDescription": "The diagnosis could not be completed. The Run itself was not changed.",
     "diagnosisSummary": "Diagnosis summary",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -90,7 +90,30 @@
     "diagnosisEmptyTitle": "尚未生成诊断",
     "diagnosisEmptyDescription": "基于为此 Run 捕获的不可变证据，生成只读诊断分析。",
     "diagnosisRunning": "正在分析 Run 证据",
-    "diagnosisRunningDescription": "确定性检查和受限模型分析正在异步执行。",
+    "diagnosisStageTitles": {
+      "queued": "诊断已排队，等待执行",
+      "deterministic_checks": "正在执行确定性检查",
+      "model_analysis": "正在调用模型分析",
+      "validating": "正在校验诊断结果"
+    },
+    "diagnosisStages": {
+      "queued": "等待执行",
+      "deterministic_checks": "确定性检查",
+      "model_analysis": "模型分析",
+      "validating": "校验结果"
+    },
+    "diagnosisElapsed": "已耗时 {n}s",
+    "diagnosisModelAnalysisDetail": "已完成 {n} 项确定性检查，正在调用模型分析…",
+    "timelineTitle": "执行时间线",
+    "timelineEventStatus": {
+      "ok": "成功",
+      "failed": "失败",
+      "recovered": "已恢复",
+      "unknown": "未知"
+    },
+    "rootCauseTitle": "出错定位",
+    "noRootCauseTitle": "未发现错误",
+    "noRootCauseDescription": "执行过程中未发现明确的失败点。",
     "diagnosisFailed": "诊断失败",
     "diagnosisFailedDescription": "诊断未能完成，原 Run 不会因此发生变化。",
     "diagnosisSummary": "诊断摘要",

--- a/frontend/src/admin/pages/lens/RunDiagnosisPanel.vue
+++ b/frontend/src/admin/pages/lens/RunDiagnosisPanel.vue
@@ -36,23 +36,47 @@
       <template v-else>
         <section
           v-if="isPending"
-          class="rounded-xl border border-blue-200 bg-blue-50 p-5"
+          class="runtime-progress-live rounded-xl border p-4"
           aria-live="polite"
         >
-          <div class="flex items-center gap-3">
-            <span
-              class="h-4 w-4 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600"
-              aria-hidden="true"
-            />
-            <div>
-              <h3 class="text-sm font-semibold text-blue-900">
-                {{ t('lensRuns.diagnosisRunning') }}
-              </h3>
-              <p class="mt-1 text-xs text-blue-700">
-                {{ t('lensRuns.diagnosisRunningDescription') }}
-              </p>
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex min-w-0 items-baseline gap-2">
+              <span class="runtime-card-title text-sm">{{ runningTitle }}</span>
+              <span class="runtime-progress-summary-text">
+                {{ elapsedText }}
+              </span>
+            </div>
+            <BaseButton
+              v-if="isStalePending"
+              variant="outline"
+              size="sm"
+              :loading="generating"
+              @click="generate"
+            >
+              {{ t('lensRuns.retryDiagnosis') }}
+            </BaseButton>
+          </div>
+          <div class="mt-2 space-y-0.5">
+            <div
+              v-for="(stage, index) in diagnosisStages"
+              :key="stage"
+              class="runtime-plan-step"
+            >
+              <span
+                class="runtime-plan-status"
+                :class="stepStatusClass(index)"
+                aria-hidden="true"
+              >
+                {{ stepStatusIcon(index) }}
+              </span>
+              <span :class="stepLabelClass(index)">
+                {{ stageLabel(stage) }}
+              </span>
             </div>
           </div>
+          <p v-if="progressDetail" class="mt-2 text-xs text-slate-500">
+            {{ progressDetail }}
+          </p>
         </section>
 
         <section
@@ -87,19 +111,23 @@
         </section>
 
         <template v-else-if="latest.status === 'completed'">
-          <section class="rounded-xl border border-gray-200 bg-white p-5">
+          <section
+            class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
+          >
             <div class="flex flex-wrap items-start justify-between gap-3">
-              <div>
+              <div class="min-w-0 flex-1">
                 <p
                   class="text-xs font-medium uppercase tracking-wide text-gray-500"
                 >
                   {{ t('lensRuns.diagnosisSummary') }}
                 </p>
-                <h3 class="mt-2 text-base font-semibold text-gray-900">
+                <h3
+                  class="mt-2 whitespace-pre-wrap break-words text-sm font-medium leading-6 text-gray-700"
+                >
                   {{ latest.result.summary }}
                 </h3>
               </div>
-              <div class="flex items-center gap-2">
+              <div class="flex shrink-0 items-center gap-2">
                 <span :class="severityClass(latest.result.severity)">
                   {{ severityLabel(latest.result.severity) }}
                 </span>
@@ -110,7 +138,7 @@
                 </span>
               </div>
             </div>
-            <p class="mt-4 text-xs text-gray-500">
+            <p class="mt-3 text-xs text-gray-500">
               {{ t('lensRuns.evidenceSnapshot') }}
               <span class="font-mono">{{
                 shortHash(latest.evidence_hash)
@@ -118,54 +146,113 @@
             </p>
           </section>
 
+          <!-- Timeline: what happened during the Run -->
           <section
-            v-if="latest.deterministic_findings?.length"
-            class="rounded-xl border border-gray-200 bg-white p-5"
+            v-if="latest.result.events?.length"
+            class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
           >
             <h3 class="text-sm font-semibold text-gray-900">
-              {{ t('lensRuns.deterministicChecks') }}
+              {{ t('lensRuns.timelineTitle') }}
             </h3>
-            <div class="mt-3 space-y-3">
-              <article
-                v-for="(finding, index) in latest.deterministic_findings"
-                :key="`deterministic-${index}`"
-                class="rounded-lg bg-gray-50 p-3"
+            <ol class="mt-4">
+              <li
+                v-for="(event, index) in latest.result.events"
+                :key="`event-${index}`"
+                class="relative flex gap-3 pb-5 last:pb-0"
               >
-                <div class="flex items-start gap-2">
-                  <CheckCircle2
-                    :size="16"
-                    class="mt-0.5 shrink-0 text-green-600"
-                    aria-hidden="true"
-                  />
-                  <div class="min-w-0">
+                <span
+                  v-if="index < latest.result.events.length - 1"
+                  class="absolute bottom-0 left-3 top-6 w-px bg-gray-200"
+                />
+                <span
+                  class="timeline-node"
+                  :class="eventNodeClass(event.status)"
+                  aria-hidden="true"
+                >
+                  {{ eventNodeIcon(event.status) }}
+                </span>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
                     <p class="text-sm font-medium text-gray-900">
-                      {{ finding.title }}
+                      {{ event.title }}
                     </p>
-                    <p class="mt-1 text-sm leading-6 text-gray-600">
-                      {{ finding.statement }}
-                    </p>
-                    <EvidenceLinks
-                      :refs="finding.evidence_refs"
-                      @navigate="navigateToEvidence"
-                    />
+                    <span
+                      class="rounded-full px-2 py-0.5 text-xs font-semibold"
+                      :class="eventStatusClass(event.status)"
+                    >
+                      {{ eventStatusLabel(event.status) }}
+                    </span>
                   </div>
+                  <p
+                    v-if="event.description"
+                    class="mt-1 whitespace-pre-wrap break-words text-xs leading-5 text-gray-600"
+                  >
+                    {{ event.description }}
+                  </p>
+                  <EvidenceLinks
+                    :refs="event.evidence_refs"
+                    @navigate="navigateToEvidence"
+                  />
                 </div>
-              </article>
-            </div>
+              </li>
+            </ol>
           </section>
 
+          <!-- Root cause: where the Run went wrong -->
           <section
-            v-if="latest.result.findings?.length"
-            class="rounded-xl border border-gray-200 bg-white p-5"
+            v-if="latest.result.root_cause"
+            class="rounded-xl border border-red-200 bg-red-50/60 p-5"
+            data-testid="diagnosis-root-cause"
+          >
+            <h3
+              class="flex items-center gap-2 text-sm font-semibold text-red-900"
+            >
+              <AlertTriangle :size="16" aria-hidden="true" />
+              {{ t('lensRuns.rootCauseTitle') }}
+            </h3>
+            <p class="mt-2 text-sm font-medium text-red-900">
+              {{ latest.result.root_cause.title }}
+            </p>
+            <p
+              class="mt-1 whitespace-pre-wrap break-words text-sm leading-6 text-red-800"
+            >
+              {{ latest.result.root_cause.description }}
+            </p>
+            <EvidenceLinks
+              :refs="latest.result.root_cause.evidence_refs"
+              @navigate="navigateToEvidence"
+            />
+          </section>
+          <section
+            v-else-if="latest.result.events?.length"
+            class="rounded-xl border border-green-200 bg-green-50/60 p-5"
+          >
+            <h3
+              class="flex items-center gap-2 text-sm font-semibold text-green-900"
+            >
+              <CheckCircle2 :size="16" aria-hidden="true" />
+              {{ t('lensRuns.noRootCauseTitle') }}
+            </h3>
+            <p class="mt-1 text-sm text-green-800">
+              {{ t('lensRuns.noRootCauseDescription') }}
+            </p>
+          </section>
+
+          <!-- Fallback for diagnoses created before the timeline schema -->
+          <section
+            v-if="
+              !latest.result.events?.length && latest.result.findings?.length
+            "
+            class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
           >
             <h3 class="text-sm font-semibold text-gray-900">
               {{ t('lensRuns.findings') }}
             </h3>
-            <div class="mt-3 space-y-3">
+            <div class="mt-4 space-y-4">
               <article
                 v-for="(finding, index) in latest.result.findings"
                 :key="`finding-${index}`"
-                class="rounded-lg border border-gray-100 p-4"
+                class="rounded-lg border border-gray-100 bg-gray-50/40 p-4"
               >
                 <div class="flex items-center gap-2">
                   <span :class="kindClass(finding.kind)">
@@ -175,11 +262,11 @@
                     {{ confidenceText(finding.confidence) }}
                   </span>
                 </div>
-                <h4 class="mt-2 text-sm font-semibold text-gray-900">
+                <h4 class="mt-2.5 text-sm font-semibold text-gray-900">
                   {{ finding.title }}
                 </h4>
                 <p
-                  class="mt-1 whitespace-pre-wrap text-sm leading-6 text-gray-600"
+                  class="mt-1.5 whitespace-pre-wrap break-words text-sm leading-6 text-gray-600"
                 >
                   {{ finding.statement }}
                 </p>
@@ -241,6 +328,43 @@
                 />
               </li>
             </ul>
+          </section>
+
+          <!-- Deterministic evidence checks -->
+          <section
+            v-if="latest.deterministic_findings?.length"
+            class="rounded-xl border border-gray-200 bg-white p-5"
+          >
+            <h3 class="text-sm font-semibold text-gray-900">
+              {{ t('lensRuns.deterministicChecks') }}
+            </h3>
+            <div class="mt-3 space-y-3">
+              <article
+                v-for="(finding, index) in latest.deterministic_findings"
+                :key="`deterministic-${index}`"
+                class="rounded-lg bg-gray-50 p-3"
+              >
+                <div class="flex items-start gap-2">
+                  <CheckCircle2
+                    :size="16"
+                    class="mt-0.5 shrink-0 text-green-600"
+                    aria-hidden="true"
+                  />
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-900">
+                      {{ finding.title }}
+                    </p>
+                    <p class="mt-1 text-sm leading-6 text-gray-600">
+                      {{ finding.statement }}
+                    </p>
+                    <EvidenceLinks
+                      :refs="finding.evidence_refs"
+                      @navigate="navigateToEvidence"
+                    />
+                  </div>
+                </div>
+              </article>
+            </div>
           </section>
 
           <section
@@ -365,6 +489,92 @@ const latest = computed(() => diagnostics.value[0] || null)
 const isPending = computed(() =>
   ['queued', 'running'].includes(latest.value?.status)
 )
+const isStalePending = computed(() => {
+  if (!isPending.value) return false
+  const start = latest.value?.started_at || latest.value?.created_at
+  if (!start) return false
+  return Date.now() - new Date(start).getTime() > 10 * 60 * 1000
+})
+
+const diagnosisStages = [
+  'queued',
+  'deterministic_checks',
+  'model_analysis',
+  'validating'
+]
+const stageIndex = computed(() => {
+  const idx = diagnosisStages.indexOf(latest.value?.progress?.stage)
+  return idx === -1 ? 0 : idx
+})
+const runningTitle = computed(() =>
+  t(
+    `lensRuns.diagnosisStageTitles.${diagnosisStages[stageIndex.value]}`,
+    t('lensRuns.diagnosisRunning')
+  )
+)
+const progressDetail = computed(() => {
+  const progress = latest.value?.progress || {}
+  if (
+    progress.stage === 'model_analysis' &&
+    progress.deterministic_findings_count != null
+  ) {
+    return t('lensRuns.diagnosisModelAnalysisDetail', {
+      n: progress.deterministic_findings_count
+    })
+  }
+  return ''
+})
+const elapsedText = ref('')
+let elapsedTimer = null
+
+function stageLabel(stage) {
+  return t(`lensRuns.diagnosisStages.${stage}`, stage)
+}
+
+function stepStatusClass(index) {
+  if (index < stageIndex.value) return 'is-completed'
+  if (index === stageIndex.value) return 'is-in_progress'
+  return ''
+}
+
+function stepStatusIcon(index) {
+  if (index < stageIndex.value) return '✓'
+  if (index === stageIndex.value) return '●'
+  return '○'
+}
+
+function stepLabelClass(index) {
+  if (index < stageIndex.value) return 'text-xs font-medium text-slate-600'
+  if (index === stageIndex.value) return 'text-xs font-semibold text-slate-800'
+  return 'text-xs text-slate-400'
+}
+
+function updateElapsed() {
+  const start = latest.value?.started_at || latest.value?.created_at
+  if (!start) {
+    elapsedText.value = ''
+    return
+  }
+  const seconds = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(start).getTime()) / 1000)
+  )
+  elapsedText.value = t('lensRuns.diagnosisElapsed', { n: seconds })
+}
+
+function startElapsed() {
+  stopElapsed()
+  updateElapsed()
+  elapsedTimer = window.setInterval(updateElapsed, 1000)
+}
+
+function stopElapsed() {
+  if (elapsedTimer !== null) {
+    window.clearInterval(elapsedTimer)
+    elapsedTimer = null
+  }
+  elapsedText.value = ''
+}
 const hasPendingTurn = computed(() =>
   (latest.value?.turns || []).some((turn) =>
     ['queued', 'running'].includes(turn.status)
@@ -507,6 +717,45 @@ function kindClass(value) {
     : `${base} bg-purple-100 text-purple-800`
 }
 
+const EVENT_STATUS_STYLES = {
+  ok: {
+    icon: '✓',
+    node: 'bg-green-100 text-green-700 border-green-300',
+    pill: 'bg-green-100 text-green-800'
+  },
+  failed: {
+    icon: '✕',
+    node: 'bg-red-100 text-red-700 border-red-300',
+    pill: 'bg-red-100 text-red-800'
+  },
+  recovered: {
+    icon: '↻',
+    node: 'bg-amber-100 text-amber-700 border-amber-300',
+    pill: 'bg-amber-100 text-amber-800'
+  },
+  unknown: {
+    icon: '?',
+    node: 'bg-gray-100 text-gray-500 border-gray-300',
+    pill: 'bg-gray-100 text-gray-600'
+  }
+}
+
+function eventStatusLabel(status) {
+  return t(`lensRuns.timelineEventStatus.${status}`, status)
+}
+
+function eventNodeClass(status) {
+  return `timeline-node ${EVENT_STATUS_STYLES[status]?.node || EVENT_STATUS_STYLES.unknown.node}`
+}
+
+function eventNodeIcon(status) {
+  return EVENT_STATUS_STYLES[status]?.icon || '?'
+}
+
+function eventStatusClass(status) {
+  return EVENT_STATUS_STYLES[status]?.pill || EVENT_STATUS_STYLES.unknown.pill
+}
+
 watch(
   () => [props.runUuid, props.active],
   ([runUuid, active], previous) => {
@@ -523,7 +772,95 @@ watch(
   { immediate: true }
 )
 
-onBeforeUnmount(clearPoll)
+watch(
+  () => [latest.value?.status, latest.value?.progress],
+  () => {
+    if (isPending.value) startElapsed()
+    else stopElapsed()
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  clearPoll()
+  stopElapsed()
+})
 
 defineExpose({ generate, load })
 </script>
+
+<style scoped>
+/* Mirrors the chat runtime-progress visual language from Chat.vue so the
+   diagnosis progress stays consistent with the user Q&A experience. */
+.runtime-progress-live {
+  border-color: #d8dce8;
+  background: #f8f9fc;
+}
+.runtime-card-title {
+  color: #334155;
+  font-weight: 600;
+}
+.runtime-progress-summary-text {
+  min-width: 0;
+  color: #64748b;
+  font-size: 0.72rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.runtime-plan-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.18rem 0;
+}
+.runtime-plan-status {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  margin-top: 0.08rem;
+  color: #8b8378;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+.runtime-plan-status.is-in_progress {
+  width: 0.85rem;
+  height: 0.85rem;
+  margin: 0.15rem 0.075rem 0;
+  border: 2px solid #ead7b4;
+  border-top-color: #b7791f;
+  border-radius: 9999px;
+  color: transparent;
+  font-size: 0;
+  animation: spin 0.75s linear infinite;
+}
+.runtime-plan-status.is-completed {
+  color: #3f7a5c;
+}
+.runtime-plan-status.is-failed {
+  color: #b64949;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.timeline-node {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  margin-top: 0.1rem;
+  border: 1px solid;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+}
+</style>

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -353,16 +353,6 @@
               </span>
             </h2>
             <div class="flex shrink-0 items-center gap-2">
-              <BaseButton
-                v-if="canDiagnoseRun"
-                data-testid="generate-run-diagnosis"
-                size="sm"
-                variant="outline"
-                :disabled="!canGenerateDiagnosis"
-                @click="generateDiagnosis"
-              >
-                {{ t('lensRuns.generateDiagnosis') }}
-              </BaseButton>
               <button
                 data-testid="close-run-detail"
                 type="button"
@@ -404,16 +394,6 @@
                 </button>
                 <button
                   class="detail-tab"
-                  data-testid="run-diagnosis-tab"
-                  :class="
-                    activeDetailTab === 'diagnosis' ? 'detail-tab-active' : ''
-                  "
-                  @click="activeDetailTab = 'diagnosis'"
-                >
-                  {{ t('lensRuns.tabDiagnosis') }}
-                </button>
-                <button
-                  class="detail-tab"
                   :class="
                     activeDetailTab === 'trace' ? 'detail-tab-active' : ''
                   "
@@ -436,6 +416,16 @@
                   <span class="ml-1 text-xs text-gray-400">{{
                     (detail.output_files || []).length
                   }}</span>
+                </button>
+                <button
+                  class="detail-tab"
+                  data-testid="run-diagnosis-tab"
+                  :class="
+                    activeDetailTab === 'diagnosis' ? 'detail-tab-active' : ''
+                  "
+                  @click="activeDetailTab = 'diagnosis'"
+                >
+                  {{ t('lensRuns.tabDiagnosis') }}
                 </button>
               </div>
 
@@ -883,7 +873,6 @@
               <!-- Diagnosis tab -->
               <RunDiagnosisPanel
                 v-show="activeDetailTab === 'diagnosis'"
-                ref="diagnosisPanel"
                 :run-uuid="selectedUuid"
                 :active="activeDetailTab === 'diagnosis'"
                 @navigate="navigateFromEvidence"
@@ -1144,7 +1133,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { format } from 'date-fns'
@@ -1162,13 +1151,11 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import PaginationBar from '@/components/ui/PaginationBar.vue'
 import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
 import AuthImage from '@/components/ui/AuthImage.vue'
-import { useUserStore } from '@/store/user'
 
 const { t, locale } = useI18n()
 const { showError } = useToast()
 const route = useRoute()
 const router = useRouter()
-const userStore = useUserStore()
 
 const loading = ref(false)
 const runs = ref([])
@@ -1183,21 +1170,6 @@ const detail = ref(null)
 const selectedUuid = ref(null)
 const activeDetailTab = ref('overview')
 const previewFile = ref(null)
-const diagnosisPanel = ref(null)
-
-const canDiagnoseRun = computed(() => {
-  const user = userStore.userInfo
-  return Boolean(
-    user?.is_staff ||
-      user?.is_superuser ||
-      userStore.userHasPermission('lens.run_diagnostics')
-  )
-})
-const canGenerateDiagnosis = computed(
-  () =>
-    Boolean(detail.value) &&
-    ['done', 'failed', 'cancelled'].includes(detail.value.status)
-)
 
 const filters = ref({
   q: '',
@@ -1516,13 +1488,6 @@ function closeDetail() {
   selectedUuid.value = null
   detail.value = null
   previewFile.value = null
-}
-
-async function generateDiagnosis() {
-  if (!canGenerateDiagnosis.value) return
-  activeDetailTab.value = 'diagnosis'
-  await nextTick()
-  diagnosisPanel.value?.generate()
 }
 
 function navigateFromEvidence(evidenceRef) {


### PR DESCRIPTION
### **User description**
## Summary

Reworks the admin Run diagnosis from a static findings list into an ordered **timeline narrative** (what happened → where it failed → how to fix), adds execution progress tracking, and fixes several lifecycle/evidence issues surfaced during E2E testing.

### Backend (`lens`)
- **Timeline schema**: `findings` → ordered `events` (`ok|failed|recovered|unknown`) + nullable `root_cause`; validation with status synonym normalization; system prompt documents the exact schema
- **Progress tracking**: `RunDiagnostic.progress` stages (`queued → deterministic_checks → model_analysis → validating → completed/failed`); stale RUNNING recovery — a diagnosis/turn stuck for >10 min (worker death) resets to QUEUED and re-enqueues on retry
- **Language consistency**: captures the request UI language at creation, pins model output to it, translates deterministic findings
- **Evidence fixes**: relaxed error sanitizer keeps operational exception text (`'str' object has no attribute 'get'`) while masking credentials; step-level `detail.error` now captured in evidence; safe access to runs without an execution record
- **Lifecycle fix**: out-of-band run failures (`LENSNODE_RECONNECT_ORPHANED`, `LENSNODE_DISCONNECTED`, timeout sweep) now finalize in-flight `RunStep`s instead of leaving them stuck in RUNNING

### Frontend
- **Diagnosis tab**: timeline rendering (✓/✕/↻ nodes + status pills), root-cause card (red) or no-failure card (green), recommendations/unknowns, old-data fallback to findings
- **Progress UI**: stage-aware chat-style runtime-progress card (matches the Q&A look) with elapsed timer and retry button when stale
- **Run detail**: diagnosis tab moved last, header generate button removed
- **i18n**: zh-CN/en keys for timeline, stages, statuses

### Dev infra
- Turnstile bypass for `backend-worker`/`backend-scheduler` in `docker-compose.dev.yml` (previously crash-looping)

## Tests
- 385 lens tests pass (new: timeline schema, severity/event normalization, sanitizer boundaries, stale recovery, step finalization, language, fenced-JSON parsing, runs without execution)
- Frontend ESLint clean, `npm run build` succeeds
- E2E verified via ego-browser: done/failed/LENSNODE_RECONNECT_ORPHANED runs diagnose correctly (root cause pinpointed, incl. real Python exceptions)

## Migrations
- `lens.0035_rundiagnostic_language`, `lens.0036_rundiagnostic_progress`

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Replace findings with timeline events and root cause schema

- Add progress tracking and stale RUNNING recovery

- Pin model output to request UI language, translate deterministic findings

- Finalize in-flight RunSteps on out-of-band failure paths

- Update frontend with timeline rendering, progress UI, tab reorder

- Add Turnstile bypass for dev worker/scheduler services

- Add comprehensive tests for new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  frontend["Diagnosis UI: timeline, progress, i18n"] --> api["Django API: create_run_diagnostic"]
  api --> background["Celery: execute_diagnostic"]
  background --> milestones["Timeline events + root cause"]
  background --> progress["Progress stages: queued->deterministic_checks->model_analysis->validating->completed"]
  background --> i18n["Language capture & translation"]
  background --> lifecycle["Stale RUNNING recovery, step finalization"]
  lifecycle --> services["services.py: fail_running_steps_for_runs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Data model</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>0035_rundiagnostic_language.py</strong><dd><code>Add language field to RunDiagnostic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-0f14932cfbaebd9d7f83694e777e23e42b0244d7c43554516106c16f4d1a6512">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0036_rundiagnostic_progress.py</strong><dd><code>Add progress field to RunDiagnostic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-92d598737b27e7bec48c5d751f6806a59852d5c8c615e79398ecf3a4bd2506e9">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add language and progress fields to model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>run_diagnostics.py</strong><dd><code>Overhaul diagnosis logic: timeline, progress, i18n, sanitization</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-3fe99bc72112f985f883af449052db6da934d540afa9ade7289ceab958e37f63">+316/-61</a></td>

</tr>

<tr>
  <td><strong>RunDiagnosisPanel.vue</strong><dd><code>Rewrite diagnosis panel with timeline and progress UI</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-cac57a30ca6cdc973327f57102b4674fd26da198c65b87caae95ecbe6cf44c23">+387/-50</a></td>

</tr>

<tr>
  <td><strong>RunObservation.vue</strong><dd><code>Remove diagnosis tab header button, reorder tabs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+11/-46</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Add fail_running_steps_for_runs utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+25/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Finalize steps on orphan and timeout paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_run_diagnostics.py</strong><dd><code>Add tests for new diagnosis features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-458be82b98ee9861a790df6eb30d43b4f48a1265c8906d6cfb0ca4dc9045b60d">+339/-19</a></td>

</tr>

<tr>
  <td><strong>test_run_lifecycle.py</strong><dd><code>Add tests for step finalization on failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+48/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>docker-compose.dev.yml</strong><dd><code>Add Turnstile bypass for dev worker/scheduler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add i18n keys for timeline, stages, progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese i18n keys for timeline, stages, progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/230/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

