### PR TITLE
Fix interrupted-answer Retry action

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -849,7 +849,7 @@
                     v-if="canRetryLastQuestion()"
                     type="button"
                     class="retry-hint-btn"
-                    @click="retryLastQuestion"
+                    @click="retryLastQuestion()"
                   >
                     {{ t('lens.chat.retryAction') }}
                   </button>

--- a/frontend/tests/chatMessageContext.test.js
+++ b/frontend/tests/chatMessageContext.test.js
@@ -17,6 +17,15 @@ test('passes the clicked assistant reply to the retry handler', async () => {
   assert.match(chat, /@click="retryLastQuestion\(message\)"/)
 })
 
+test('keeps empty-answer Retry clicks from becoming a message', async () => {
+  const chat = await readFile(
+    new URL('../src/pages/lens/Chat.vue', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(chat, /@click="retryLastQuestion\(\)"/)
+})
+
 test('finds the user question for a historical assistant reply', () => {
   const messages = [
     { uuid: 'question-1', role: 'user', content: 'First question' },


### PR DESCRIPTION
### **User description**
## Summary
- Invoke the empty-answer Retry handler without passing the click event as a chat message.
- Preserve the existing retry flow so the original question and Run retry metadata are reused.
- Add a regression test for the interrupted-answer Retry button binding.

Closes #222

## Test plan
- [x] node --test tests/chatMessageContext.test.js
- [x] npx eslint src/pages/lens/Chat.vue tests/chatMessageContext.test.js
- [x] npm run build
- [x] ego-browser task space 107: click Retry after an interrupted answer, confirm the original question is restored and focused, submit the retry, and confirm the retried answer is displayed.

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Retry button not invoking function properly

- Add regression test for empty-answer Retry binding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[User clicks Retry] --> B["call retryLastQuestion()"]
  B --> C[Resend original question]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Fix Retry button invocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Changed <code>@click="retryLastQuestion"</code> to <code>@click="retryLastQuestion()"</code><br> <li> Ensures the retry function is invoked with empty argument, preventing <br>the click event from being passed as a message</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/233/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatMessageContext.test.js</strong><dd><code>Add regression test for Retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatMessageContext.test.js

<ul><li>Added regression test to verify the empty-answer Retry button binding<br> <li> Asserts the template uses <code>@click="retryLastQuestion()"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/233/files#diff-70603dfd5e3eda6bd4623f27510bde074141b99aa0ed4ddfd2f0b98e796e29cc">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

