### PR TITLE
Show final-answer progress after plan completion

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -285,6 +285,7 @@
         "planProgress": "Completed {completed}/{total}",
         "planProgressCurrent": "Completed {completed}/{total} · Current: {currentTitle}",
         "planCompleted": "Completed {completed}/{total}",
+        "planCompletedAnswering": "Plan completed {completed}/{total} · Generating final answer…",
         "planEnded": "Ended {completed}/{total}",
         "stageProgress": "Completed {completed}/{total}",
         "stageProgressCurrent": "Completed {completed}/{total} · Current: {currentTitle}",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -285,6 +285,7 @@
         "planProgress": "已完成 {completed}/{total}",
         "planProgressCurrent": "已完成 {completed}/{total} · 当前：{currentTitle}",
         "planCompleted": "已完成 {completed}/{total}",
+        "planCompletedAnswering": "计划已完成 {completed}/{total} · 正在生成最终回答……",
         "planEnded": "已结束 {completed}/{total}",
         "stageProgress": "已完成 {completed}/{total}",
         "stageProgressCurrent": "已完成 {completed}/{total} · 当前：{currentTitle}",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1076,15 +1076,7 @@
                     </div>
                   </div>
                   <div class="runtime-progress-footer">
-                    <span>
-                      {{
-                        ['workflow', 'activity'].includes(
-                          liveStructuredProgress.kind
-                        )
-                          ? structuredProgressText(runtimeState)
-                          : liveProgressText
-                      }}
-                    </span>
+                    <span>{{ liveProgressText }}</span>
                     <span v-if="elapsedText"> · {{ elapsedText }}</span>
                   </div>
                 </div>
@@ -1984,16 +1976,40 @@ watch(
   }
 )
 
+const livePlanProgress = computed(() =>
+  summarizePlanProgress(runtimeState.value.plan)
+)
+
 const livePlanProgressText = computed(() =>
   planProgressText(runtimeState.value.plan)
 )
+
+const liveFinalAnswerProgressText = computed(() => {
+  const progress = livePlanProgress.value
+  if (
+    !isRunActive.value ||
+    !progress?.isComplete ||
+    runtimeState.value.phase !== 'answering'
+  ) {
+    return ''
+  }
+  return t('lens.chat.runtime.planCompletedAnswering', progress)
+})
 
 const liveStageProgressText = computed(() =>
   stageProgressText(runtimeState.value.stages)
 )
 
+const liveStructuredProgressText = computed(() =>
+  ['workflow', 'activity'].includes(liveStructuredProgress.value.kind)
+    ? structuredProgressText(runtimeState.value)
+    : ''
+)
+
 const liveProgressText = computed(() =>
   selectLiveProgressText({
+    finalAnswerProgressText: liveFinalAnswerProgressText.value,
+    structuredProgressText: liveStructuredProgressText.value,
     planProgressText: livePlanProgressText.value,
     stageProgressText: runtimeState.value.route
       ? ''

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -515,6 +515,8 @@ export function summarizeStageProgress(stages, { terminal = false } = {}) {
 }
 
 export function selectLiveProgressText({
+  finalAnswerProgressText,
+  structuredProgressText,
   planProgressText,
   stageProgressText,
   latestStep,
@@ -523,6 +525,8 @@ export function selectLiveProgressText({
   fallbackText
 }) {
   return (
+    finalAnswerProgressText ||
+    structuredProgressText ||
     planProgressText ||
     stageProgressText ||
     phaseText ||

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -17,6 +17,37 @@ test('active chat run exposes a localized stop action', async () => {
   assert.equal(chinese.common.stop, '停止')
 })
 
+test('final synthesis progress reacts to locale changes', async () => {
+  const [chat, english, chinese, { computed }, { createI18n }] =
+    await Promise.all([
+      source('pages/lens/Chat.vue'),
+      source('locales/en.json').then(JSON.parse),
+      source('locales/zh-CN.json').then(JSON.parse),
+      import('vue'),
+      import('vue-i18n')
+    ])
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: english, 'zh-CN': chinese }
+  })
+  const progress = { completed: 4, total: 4 }
+  const progressText = computed(() =>
+    i18n.global.t('lens.chat.runtime.planCompletedAnswering', progress)
+  )
+
+  assert.match(chat, /t\('lens\.chat\.runtime\.planCompletedAnswering'/)
+  assert.doesNotMatch(chat, /计划已完成|Generating final answer/)
+  assert.equal(
+    progressText.value,
+    'Plan completed 4/4 · Generating final answer…'
+  )
+
+  i18n.global.locale.value = 'zh-CN'
+
+  assert.equal(progressText.value, '计划已完成 4/4 · 正在生成最终回答……')
+})
+
 test('task statistics request all users unless a user is selected', async () => {
   const stats = await source('admin/pages/TaskManagement/Stats.vue')
   const fetchStart = stats.indexOf('async function fetchStats')

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -292,6 +292,19 @@ test('shows real plan completion before lower-level execution details', () => {
   )
 })
 
+test('shows final answer synthesis after all plan steps complete', () => {
+  assert.equal(
+    selectLiveProgressText({
+      finalAnswerProgressText: 'Plan completed 4/4 · Generating final answer…',
+      structuredProgressText: 'Completed 4/4',
+      planProgressText: 'Completed 4/4',
+      phaseText: 'Preparing the answer',
+      fallbackText: 'Generating'
+    }),
+    'Plan completed 4/4 · Generating final answer…'
+  )
+})
+
 test('keeps the legacy stage status for non-General Chat modes', () => {
   assert.equal(
     selectLiveProgressText({

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -3071,9 +3071,8 @@ def _emit_new_tool_calls(
                     "revision": 0
                 }
                 state["revision"] = int(state.get("revision") or 0) + 1
-                incoming_steps = _normalize_plan_steps(
-                    (call.get("args") or {}).get("todos")
-                )
+                todos = (call.get("args") or {}).get("todos") or []
+                incoming_steps = _normalize_plan_steps(todos)
                 initial_steps = state.get("steps") or []
                 if initial_steps:
                     incoming_by_id = {
@@ -3102,6 +3101,23 @@ def _emit_new_tool_calls(
                         },
                     },
                 )
+                if (
+                    todos
+                    and all(
+                        item.get("status") == "completed" for item in todos
+                    )
+                    and not state.get("answering_phase_emitted")
+                ):
+                    state["answering_phase_emitted"] = True
+                    state["execution_phase_emitted"] = True
+                    emit_event(
+                        "workflow.phase.changed",
+                        {
+                            "event_type": "phase.changed",
+                            "visibility": "user",
+                            "payload": {"phase": "answering"},
+                        },
+                    )
                 continue
             if (
                 plan_state is not None

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -392,9 +392,51 @@ def test_write_todos_preserves_full_completion_before_run_terminal():
             plan_state=plan_state,
         )
 
-    assert events[-1][1]["payload"]["steps"] == [
+    assert events[-2][1]["payload"]["steps"] == [
         {"id": "step-1", "title": "Query orders", "status": "completed"},
         {"id": "step-2", "title": "Return answer", "status": "completed"},
+    ]
+    assert events[-1] == (
+        "workflow.phase.changed",
+        {
+            "event_type": "phase.changed",
+            "visibility": "user",
+            "payload": {"phase": "answering"},
+        },
+    )
+
+
+def test_write_todos_does_not_answer_before_hidden_steps_complete():
+    events = []
+    todos = [
+        {
+            "content": f"Visible step {index}",
+            "status": "completed",
+        }
+        for index in range(1, 13)
+    ]
+    todos.append({"content": "Hidden step", "status": "pending"})
+
+    _emit_new_tool_calls(
+        [
+            _Msg(
+                "ai",
+                tool_calls=[
+                    {
+                        "id": "call-plan",
+                        "name": "write_todos",
+                        "args": {"todos": todos},
+                    }
+                ],
+            )
+        ],
+        set(),
+        lambda name, detail: events.append((name, detail)),
+        plan_state={"revision": 0},
+    )
+
+    assert [name for name, _detail in events] == [
+        "workflow.plan.updated"
     ]
 
 


### PR DESCRIPTION
### **User description**
## Summary
- emit a user-visible `answering` phase after the complete, untruncated plan finishes
- prioritize localized final-answer synthesis progress over the completed plan counter
- keep terminal runs and incomplete hidden plan steps from showing the synthesis state

Closes #223

## Test plan
- [x] `lensnode/.venv/bin/python -m pytest -q tests/test_history.py` (98 passed)
- [x] targeted frontend runtime and localization tests (4 passed)
- [x] ESLint for affected frontend files (0 errors)
- [x] `npm run build`
- [x] ego-browser task space 106: verified the active General Chat flow transitions from a completed plan to the final-answer progress message and then clears live progress at terminal state


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Emit answering phase event after plan completion

- Prioritize final-answer progress text over completed plan counter

- Add tests and locale strings for new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Plan steps completed (4/4)"] --> B["Emit answering phase event"]
  B --> C["UI: selectLiveProgressText picks finalAnswerProgressText"]
  C --> D["Display: 'Plan completed 4/4 · Generating final answer…'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Emit answering phase event after plan completes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Refactor progress text logic and add final answer computation</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+25/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English locale string for final answer progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese locale string for final answer progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_history.py</strong><dd><code>Add tests for answering phase emission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>regressionFixes.test.js</strong><dd><code>Add locale reactivity test for final answer progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-c6817d11aa2607c6dcdf8fef1d9bd8766a8fe8625f22ac8dbbf8d3181d0d1e06">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.test.js</strong><dd><code>Add test for final answer progress priority</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>runtimeEvents.js</strong><dd><code>Prioritize final answer progress text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/234/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

