### PR TITLE
Fix pagination truncation across admin views

### DIFF
--- a/backend/accounts/tests/pytest_management_pagination.py
+++ b/backend/accounts/tests/pytest_management_pagination.py
@@ -397,6 +397,32 @@ class TestManagementUsersPagination:
         assert data["page_size"] == 10
         assert len(data["results"]) == 10
 
+    def test_users_list_allows_bulk_reads_up_to_one_thousand(self):
+        admin = User.objects.create_user(
+            username="admin_for_bulk_user_read",
+            password="x",
+            is_staff=True,
+        )
+        User.objects.bulk_create(
+            [
+                User(username=f"bulk_user_{idx}")
+                for idx in range(101)
+            ]
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.get(
+            "/api/v1/management/users/",
+            {"compact": "true", "page": 1, "page_size": 1000},
+        )
+
+        assert response.status_code == 200
+        data = _payload(response)
+        assert data["count"] == 102
+        assert data["page_size"] == 1000
+        assert len(data["results"]) == 102
+
     def test_users_list_invalid_pagination_falls_back_and_caps(self):
         admin = User.objects.create_user(
             username="admin_for_users_invalid",
@@ -419,7 +445,7 @@ class TestManagementUsersPagination:
         assert response.status_code == 200
         data = _payload(response)
         assert data["page"] == 1
-        assert data["page_size"] == 100
+        assert data["page_size"] == 1000
         assert "results" in data
 
     def test_users_list_non_positive_page_is_clamped_to_one(self):
@@ -544,6 +570,29 @@ class TestManagementGroupsPagination:
         assert data["page"] == 2
         assert data["page_size"] == 10
         assert len(data["results"]) == 10
+
+    def test_groups_list_allows_bulk_reads_up_to_one_thousand(self):
+        admin = User.objects.create_user(
+            username="admin_for_bulk_group_read",
+            password="x",
+            is_staff=True,
+        )
+        Group.objects.bulk_create(
+            [Group(name=f"bulk_group_{idx}") for idx in range(101)]
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.get(
+            "/api/v1/management/groups/",
+            {"compact": "true", "page": 1, "page_size": 1000},
+        )
+
+        assert response.status_code == 200
+        data = _payload(response)
+        assert data["count"] == 101
+        assert data["page_size"] == 1000
+        assert len(data["results"]) == 101
 
     def test_groups_list_non_positive_page_is_clamped_to_one(self):
         admin = User.objects.create_user(

--- a/backend/accounts/views/management.py
+++ b/backend/accounts/views/management.py
@@ -162,6 +162,7 @@ class ManagementUserListView(APIView):
         page_size = _safe_int(
             request.query_params.get('page_size'),
             default=20,
+            max_value=1000,
         )
         compact = str(
             request.query_params.get('compact') or ''
@@ -485,6 +486,7 @@ class ManagementGroupListView(APIView):
         page_size = _safe_int(
             request.query_params.get('page_size'),
             default=20,
+            max_value=1000,
         )
         compact = str(
             request.query_params.get('compact') or ''
@@ -674,6 +676,7 @@ class ManagementRoleListView(APIView):
         page_size = _safe_int(
             request.query_params.get('page_size'),
             default=20,
+            max_value=1000,
         )
         qs = Role.objects.annotate(
             user_count=Count('users', distinct=True),

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -548,6 +548,23 @@ class LensApiTests(TestCase):
             "016d5cf7-2245-4015-b242-d6323e795b58",
         )
 
+    def test_global_setting_list_returns_every_setting(self):
+        GlobalSetting.objects.bulk_create(
+            [
+                GlobalSetting(
+                    key=f"pagination.test.{index}",
+                    value=index,
+                )
+                for index in range(11)
+            ]
+        )
+
+        response = self.client.get("/api/lens/admin/global-settings/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(len(response.data), 11)
+
     def test_skill_beautify_requires_generator_model(self):
         response = self.client.post(
             "/api/lens/admin/skills/beautify/",

--- a/backend/lens/views/global_settings.py
+++ b/backend/lens/views/global_settings.py
@@ -17,6 +17,7 @@ class GlobalSettingViewSet(BaseAdminViewSet):
     """CRUD for global settings."""
 
     queryset = GlobalSetting.objects.all()
+    pagination_class = None
     serializer_class = GlobalSettingSerializer
     lookup_field = "key"
     lookup_value_regex = "[^/]+"

--- a/frontend/src/admin/api/management.js
+++ b/frontend/src/admin/api/management.js
@@ -2,6 +2,7 @@
  * Management portal API (admin-only): user list, etc.
  */
 import apiClient from '@/api/index'
+import { collectPaginatedResults } from '@/api/pagination'
 
 function extractData(res) {
   const body = res?.data
@@ -14,6 +15,17 @@ export const managementApi = {
     return apiClient
       .get('/v1/management/users/', { ...config, params })
       .then(extractData)
+  },
+
+  getAllUsers(params = {}, config = {}) {
+    return collectPaginatedResults((page) =>
+      apiClient
+        .get('/v1/management/users/', {
+          ...config,
+          params: { page_size: 1000, ...params, page }
+        })
+        .then(extractData)
+    )
   },
 
   createUser(body) {
@@ -36,6 +48,17 @@ export const managementApi = {
     return apiClient
       .get('/v1/management/groups/', { ...config, params })
       .then(extractData)
+  },
+
+  getAllGroups(params = {}, config = {}) {
+    return collectPaginatedResults((page) =>
+      apiClient
+        .get('/v1/management/groups/', {
+          ...config,
+          params: { page_size: 1000, ...params, page }
+        })
+        .then(extractData)
+    )
   },
 
   createGroup(body) {

--- a/frontend/src/admin/pages/Management/Groups.vue
+++ b/frontend/src/admin/pages/Management/Groups.vue
@@ -302,6 +302,7 @@ const currentPage = ref(1)
 const pageSize = ref(20)
 const totalCount = ref(0)
 const userOptions = ref([])
+const userOptionsLoaded = ref(false)
 const deleteTarget = ref(null)
 const deletingId = ref(null)
 const bulkLoadingKey = ref('')
@@ -414,9 +415,10 @@ function openGroupHistory(assistant) {
 }
 
 async function loadUsers() {
+  userOptionsLoaded.value = false
   try {
-    const data = await managementApi.getUsers({ page: 1, page_size: 1000 })
-    userOptions.value = Array.isArray(data) ? data : (data?.results ?? [])
+    userOptions.value = await managementApi.getAllUsers()
+    userOptionsLoaded.value = true
   } catch {
     userOptions.value = []
   }
@@ -476,9 +478,11 @@ async function submitGroup() {
 
   submitLoading.value = true
   try {
-    const payload = {
-      name,
-      user_ids: Array.isArray(form.value.user_ids) ? form.value.user_ids : []
+    const payload = { name }
+    if (userOptionsLoaded.value) {
+      payload.user_ids = Array.isArray(form.value.user_ids)
+        ? form.value.user_ids
+        : []
     }
     if (mode.value === 'create') {
       await managementApi.createGroup(payload)

--- a/frontend/src/admin/pages/Management/Users.vue
+++ b/frontend/src/admin/pages/Management/Users.vue
@@ -554,13 +554,9 @@ function openUserHistory(assistant) {
 
 async function loadOptions() {
   try {
-    const groupsData = await managementApi.getGroups({
-      page: 1,
-      page_size: 1000
+    groupOptions.value = await managementApi.getAllGroups({
+      compact: 'true'
     })
-    groupOptions.value = Array.isArray(groupsData)
-      ? groupsData
-      : (groupsData?.results ?? [])
   } catch {
     groupOptions.value = []
   }

--- a/frontend/src/admin/pages/TaskManagement/List.vue
+++ b/frontend/src/admin/pages/TaskManagement/List.vue
@@ -509,12 +509,7 @@ function toUserLabel(u) {
 
 async function fetchUserOptions() {
   try {
-    const data = await managementApi.getUsers({ page_size: 200 })
-    const list = Array.isArray(data)
-      ? data
-      : Array.isArray(data?.results)
-        ? data.results
-        : []
+    const list = await managementApi.getAllUsers({ compact: 'true' })
     userOptions.value = list.map((u) => ({ id: u.id, label: toUserLabel(u) }))
   } catch {
     userOptions.value = []

--- a/frontend/src/admin/pages/lens/ShareReview.vue
+++ b/frontend/src/admin/pages/lens/ShareReview.vue
@@ -71,7 +71,7 @@
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white">
                 <tr
-                  v-for="row in pagedRows"
+                  v-for="row in rows"
                   :key="row.uuid"
                   class="cursor-pointer transition-colors hover:bg-gray-50"
                   @click="openDetail(row)"
@@ -190,7 +190,7 @@
             v-if="!loading"
             v-model:page-size="pageSize"
             :current-page="currentPage"
-            :total="rows.length"
+            :total="totalCount"
             @page-size-change="handlePageSizeChange"
             @prev="goPrevPage"
             @next="goNextPage"
@@ -319,6 +319,7 @@ const { t } = useI18n()
 const { showSuccess, showError } = useToast()
 
 const rows = ref([])
+const totalCount = ref(0)
 const loading = ref(true)
 const activeTab = ref('pending')
 const currentPage = ref(1)
@@ -336,25 +337,24 @@ const tabs = computed(() => [
 ])
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(rows.value.length / pageSize.value))
+  Math.max(1, Math.ceil(totalCount.value / pageSize.value))
 )
-const pagedRows = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return rows.value.slice(start, start + pageSize.value)
-})
 
 function handlePageSizeChange() {
   currentPage.value = 1
+  load()
 }
 
 function goPrevPage() {
   if (currentPage.value <= 1) return
   currentPage.value -= 1
+  load()
 }
 
 function goNextPage() {
   if (currentPage.value >= totalPages.value) return
   currentPage.value += 1
+  load()
 }
 
 const TAB_PARAMS = {
@@ -373,10 +373,18 @@ function extractRows(data) {
 async function load() {
   loading.value = true
   try {
-    const data = await listAdminShares(TAB_PARAMS[activeTab.value])
+    const data = await listAdminShares({
+      ...TAB_PARAMS[activeTab.value],
+      page: currentPage.value,
+      page_size: pageSize.value
+    })
     rows.value = extractRows(data)
+    totalCount.value = Array.isArray(data)
+      ? data.length
+      : Number(data?.count ?? rows.value.length)
   } catch {
     rows.value = []
+    totalCount.value = 0
   } finally {
     loading.value = false
   }

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -17,8 +17,12 @@ function unwrapList(payload) {
 }
 
 export async function listAssistants(params = {}) {
-  const response = await api.get('/lens/assistants/', { params })
-  return unwrapList(unwrapResponse(response))
+  return collectPaginatedResults(async (page) => {
+    const response = await api.get('/lens/assistants/', {
+      params: { page_size: 1000, ...params, page }
+    })
+    return unwrapResponse(response)
+  })
 }
 
 export async function getPublicAssistant(slug) {
@@ -52,8 +56,14 @@ export async function restoreAssistant(uuid) {
 }
 
 export async function listLensNodes() {
-  const response = await api.get('/lens/admin/lensnodes/')
-  return unwrapList(unwrapResponse(response))
+  return collectPaginatedResults(async (page) =>
+    listLensNodePage({ page, page_size: 1000 })
+  )
+}
+
+export async function listLensNodePage(params = {}) {
+  const response = await api.get('/lens/admin/lensnodes/', { params })
+  return unwrapResponse(response)
 }
 
 export async function getAdminRuns(params = {}) {

--- a/frontend/src/pages/lens/LensNodes.vue
+++ b/frontend/src/pages/lens/LensNodes.vue
@@ -18,7 +18,7 @@
                 {{
                   t('lensAdmin.total', {
                     label: t('lensAdmin.pages.lensnodes.label'),
-                    count: lensnodes.length
+                    count: totalLensNodes
                   })
                 }}
               </span>
@@ -69,7 +69,7 @@
               </thead>
               <tbody class="divide-y divide-line bg-surface">
                 <tr
-                  v-for="row in pagedLensNodes"
+                  v-for="row in lensnodes"
                   :key="row.uuid"
                   class="transition-colors hover:bg-line-soft"
                 >
@@ -169,7 +169,7 @@
             v-if="!loading"
             v-model:page-size="pageSize"
             :current-page="currentPage"
-            :total="lensnodes.length"
+            :total="totalLensNodes"
             @page-size-change="handlePageSizeChange"
             @prev="goPrevPage"
             @next="goNextPage"
@@ -274,7 +274,7 @@ import {
   deleteLensNode,
   issueLensNodeToken,
   listGlobalSettings,
-  listLensNodes,
+  listLensNodePage,
   rejectLensNode,
   revokeLensNodeToken
 } from '@/api/lens'
@@ -303,6 +303,7 @@ const { showSuccess, showError } = useToast()
 const formatDateTime = useShortDateTime()
 
 const lensnodes = ref([])
+const totalLensNodes = ref(0)
 const currentPage = ref(1)
 const pageSize = ref(20)
 const globalSettings = ref([])
@@ -332,25 +333,24 @@ const columns = computed(() =>
 )
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(lensnodes.value.length / pageSize.value))
+  Math.max(1, Math.ceil(totalLensNodes.value / pageSize.value))
 )
-const pagedLensNodes = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return lensnodes.value.slice(start, start + pageSize.value)
-})
 
 function handlePageSizeChange() {
   currentPage.value = 1
+  load()
 }
 
 function goPrevPage() {
   if (currentPage.value <= 1) return
   currentPage.value -= 1
+  load()
 }
 
 function goNextPage() {
   if (currentPage.value >= totalPages.value) return
   currentPage.value += 1
+  load()
 }
 
 const composeConfig = computed(() =>
@@ -375,10 +375,15 @@ async function load() {
   loading.value = true
   try {
     const [lensnodeRows, settingRows] = await Promise.all([
-      listLensNodes(),
+      listLensNodePage({
+        page: currentPage.value,
+        page_size: pageSize.value
+      }),
       listGlobalSettings()
     ])
     lensnodes.value = normalizeList(lensnodeRows)
+    const total = lensnodeRows?.count ?? lensnodes.value.length
+    totalLensNodes.value = Number(total)
     globalSettings.value = normalizeList(settingRows)
   } catch (error) {
     showError(extractErrorMessage(error, t('lensAdmin.messages.loadFailed')))

--- a/frontend/tests/paginationTruncation.test.js
+++ b/frontend/tests/paginationTruncation.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readSource = (path) =>
+  readFile(new URL(`../src/${path}`, import.meta.url), 'utf8')
+
+test('complete assistant and LensNode reads collect every API page', async () => {
+  const source = await readSource('api/lens.js')
+  const assistants = source.slice(
+    source.indexOf('export async function listAssistants'),
+    source.indexOf('export async function getPublicAssistant')
+  )
+  const lensnodes = source.slice(
+    source.indexOf('export async function listLensNodes'),
+    source.indexOf('export async function getAdminRuns')
+  )
+
+  assert.match(assistants, /collectPaginatedResults/)
+  assert.match(lensnodes, /collectPaginatedResults/)
+})
+
+test('shared Q&A review uses backend pagination metadata', async () => {
+  const source = await readSource('admin/pages/lens/ShareReview.vue')
+
+  assert.match(source, /const totalCount = ref\(0\)/)
+  assert.match(source, /page: currentPage\.value/)
+  assert.match(source, /page_size: pageSize\.value/)
+  assert.match(source, /:total="totalCount"/)
+  assert.match(source, /goPrevPage[\s\S]*load\(\)/)
+  assert.match(source, /goNextPage[\s\S]*load\(\)/)
+})
+
+test('management selectors collect all user and group pages', async () => {
+  const [api, groups, users, tasks] = await Promise.all([
+    readSource('admin/api/management.js'),
+    readSource('admin/pages/Management/Groups.vue'),
+    readSource('admin/pages/Management/Users.vue'),
+    readSource('admin/pages/TaskManagement/List.vue')
+  ])
+
+  assert.match(api, /getAllUsers[\s\S]*collectPaginatedResults/)
+  assert.match(api, /getAllGroups[\s\S]*collectPaginatedResults/)
+  assert.match(groups, /managementApi\.getAllUsers/)
+  assert.match(groups, /const userOptionsLoaded = ref\(false\)/)
+  assert.match(
+    groups,
+    /if \(userOptionsLoaded\.value\)[\s\S]*payload\.user_ids/
+  )
+  assert.match(users, /managementApi\.getAllGroups/)
+  assert.match(tasks, /managementApi\.getAllUsers/)
+})


### PR DESCRIPTION
### **User description**
## Summary
- allow management bulk reads up to 1,000 items and return the complete global settings collection
- use complete or server-paginated frontend reads for assistants, LensNodes, shared Q&A reviews, and management selectors
- preserve group membership when user options fail to load and add backend/frontend regression coverage

Closes #224

## Test plan
- [x] `pytest accounts/tests/pytest_management_pagination.py` (22 passed)
- [x] `python manage.py test lens.tests.test_api.LensApiTests.test_global_setting_list_returns_every_setting`
- [x] `python manage.py check`
- [x] `node --test tests/paginationTruncation.test.js` (3 passed)
- [x] ESLint on affected frontend files
- [x] `npm run build`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Increase backend bulk read limit to 1000 and disable pagination for global settings

- Use complete paginated frontend reads for assistants, LensNodes, shared Q&A, and management selectors

- Preserve group membership when user options fail to load

- Add regression tests for pagination behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Backend["Backend: raise bulk read limit, disable pagination for global settings"] --> Frontend["Frontend: use paginated APIs for truncation-prone views"]
  Frontend --> Tests["Backend & frontend regression tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>pytest_management_pagination.py</strong><dd><code>Add tests for bulk user and group reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-510318fc08e9214da4a264f66d4d11d1fd86ebfb1a3b4c06326ca8e1d15737a5">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_api.py</strong><dd><code>Add test for global setting list completeness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paginationTruncation.test.js</strong><dd><code>Add frontend regression tests for pagination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-5ea11f42bc8491da3cb7b4f2ace3138e82663a4d0b0657ddbcad62e357cab120">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>management.py</strong><dd><code>Increase _safe_int max_value to 1000</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-c8ff6aa3f2a08e9d0358540ad8d66a0851d8fb9c8b66d0f7280fc39fd76ef0ca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>global_settings.py</strong><dd><code>Disable pagination for GlobalSettingViewSet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-7adc0e542da77bb84a906e20f59b3efe1ff44f54d45e1e1ee888485ba1f42daf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Groups.vue</strong><dd><code>Preserve group membership on user load failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-0d6ca0089db600204daad8a5eabd59d85aa6e6bc0746701d57447bd8fab96992">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>Users.vue</strong><dd><code>Use getAllGroups for complete group options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-bd17c5feba4852cd6103733e18ec32304f0c2f48fcf10c9612260b209f19ed88">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>List.vue</strong><dd><code>Use getAllUsers for complete user options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-9573e719d33c6b67423e2c85781bb26e4c7c79b4fbb7e747665133ed590e9d69">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ShareReview.vue</strong><dd><code>Implement server-side pagination for shared Q&A</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-1c41598417355cdc78248a58622d628210f52898531e2314e54c7a99541881e4">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LensNodes.vue</strong><dd><code>Implement server-side pagination for LensNode list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-f7afcfd603e553cabbc7cd736f5358104d08477666bb7ce900a796508ba14d8d">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>management.js</strong><dd><code>Add getAllUsers and getAllGroups pagination helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-e475eee7965feb99b1b120cd3cf52fcb73a82b08e320c6a6c4e3c30be4d1b96b">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add paginated collection for assistants and LensNodes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/235/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

