### PR TITLE
Add document conversion for managed workspace data sources

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -91,6 +91,10 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             await self._handle_datasource_sync_event(content)
         elif frame_type == "datasource_sync_done":
             await self._handle_datasource_sync_done(content)
+        elif frame_type == "datasource_convert_event":
+            await self._handle_datasource_sync_event(content)
+        elif frame_type == "datasource_convert_done":
+            await self._handle_datasource_conversion_done(content)
         else:
             await self.send_json(
                 {
@@ -725,6 +729,31 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         task_id = resolve_datasource_sync_task_id(request_id, content)
         if task_id:
             complete_datasource_sync_task(task_id, content)
+
+    async def _handle_datasource_conversion_done(self, content):
+        """Complete managed workspace conversion from LensNode result."""
+
+        request_id = content.get("request_id") or ""
+        task_id = content.get("task_id") or ""
+        if not request_id and not task_id:
+            return
+        await database_sync_to_async(
+            self._complete_datasource_conversion_done
+        )(request_id, content)
+
+    @staticmethod
+    def _complete_datasource_conversion_done(request_id, content):
+        from .tasks import (
+            complete_datasource_conversion_task,
+            resolve_datasource_conversion_task_id,
+        )
+
+        task_id = resolve_datasource_conversion_task_id(
+            request_id,
+            content,
+        )
+        if task_id:
+            complete_datasource_conversion_task(task_id, content)
 
     async def _send_bad_frame(self, message):
         await self.send_json(

--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -247,6 +247,51 @@ def dispatch_datasource_sync_async(datasource, task_id, trigger="scheduled"):
     return request_id
 
 
+def dispatch_datasource_conversion_async(
+    datasource,
+    task_id,
+    conversion,
+    force=False,
+):
+    """Dispatch managed workspace conversion without running sync adapters."""
+
+    datasource = DataSource.objects.select_related("lensnode").get(
+        pk=datasource.pk
+    )
+    if datasource.source_type != DataSource.SourceType.MANAGED_WORKSPACE:
+        raise DataSourceDispatchError("DATASOURCE_CONVERSION_NOT_SUPPORTED")
+    validate_datasource_lensnode(datasource.lensnode)
+    conversion = dict(conversion or {})
+    for key, value in datasource_conversion_defaults().items():
+        if value and not conversion.get(key):
+            conversion[key] = value
+    request_id = uuid.uuid4().hex
+    _send_lensnode_command(
+        datasource.lensnode,
+        {
+            "type": "datasource_convert",
+            "request_id": request_id,
+            "task_id": task_id,
+            "datasource_uuid": str(datasource.uuid),
+            "source_type": datasource.source_type,
+            "name": datasource.name,
+            "conversion": conversion,
+            "target_path": datasource.target_path,
+            "force": bool(force),
+            "max_workers": get_datasource_sync_max_workers(),
+            "excluded_datasource_roots": excluded_datasource_roots(
+                datasource
+            ),
+        },
+    )
+    cache.set(
+        f"lens:datasource_conversion_request:{request_id}",
+        task_id,
+        timeout=get_datasource_sync_timeout_s(),
+    )
+    return request_id
+
+
 def datasource_conversion_policy(sync_policy):
     """Return datasource conversion policy with global defaults applied."""
 

--- a/backend/lens/migrations/0037_datasource_conversion_status.py
+++ b/backend/lens/migrations/0037_datasource_conversion_status.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0036_rundiagnostic_progress"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="datasource",
+            name="last_conversion_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="datasource",
+            name="last_conversion_status",
+            field=models.CharField(blank=True, default="", max_length=20),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -410,6 +410,12 @@ class DataSource(TimestampedUUIDModel):
     )
     availability_checked_at = models.DateTimeField(null=True, blank=True)
     availability_message = models.TextField(blank=True, default="")
+    last_conversion_status = models.CharField(
+        max_length=20,
+        blank=True,
+        default="",
+    )
+    last_conversion_at = models.DateTimeField(null=True, blank=True)
     status = models.CharField(
         max_length=16,
         choices=Status.choices,

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -1049,6 +1049,8 @@ class DataSourceSerializer(serializers.ModelSerializer):
             "availability_status",
             "availability_checked_at",
             "availability_message",
+            "last_conversion_status",
+            "last_conversion_at",
             "status",
             "created_at",
             "updated_at",
@@ -1063,6 +1065,8 @@ class DataSourceSerializer(serializers.ModelSerializer):
             "availability_status",
             "availability_checked_at",
             "availability_message",
+            "last_conversion_status",
+            "last_conversion_at",
             "created_at",
             "updated_at",
         ]
@@ -1072,6 +1076,34 @@ class DataSourceSerializer(serializers.ModelSerializer):
                 "required": False,
             },
         }
+
+
+class DataSourceConversionRequestSerializer(serializers.Serializer):
+    """Validate one explicit managed workspace conversion request."""
+
+    conversion = serializers.JSONField(required=False)
+    force = serializers.BooleanField(required=False, default=False)
+
+    def validate(self, attrs):
+        """Apply the shared datasource conversion policy contract."""
+
+        conversion = attrs.get("conversion")
+        if conversion is None:
+            conversion = {"document": True}
+        _validate_conversion_policy(conversion, field_name="conversion")
+        if not any(
+            conversion.get(key)
+            for key in ["document", "image", "embedded_image"]
+        ):
+            raise serializers.ValidationError(
+                {
+                    "conversion": (
+                        "At least one conversion type must be enabled"
+                    )
+                }
+            )
+        attrs["conversion"] = conversion
+        return attrs
 
 
 def _validate_datasource_config_secret_fields(config):
@@ -1426,12 +1458,12 @@ def _validate_sync_policy(sync_policy):
         )
 
 
-def _validate_conversion_policy(conversion):
+def _validate_conversion_policy(conversion, field_name="sync_policy"):
     """Validate datasource conversion settings."""
 
     if not isinstance(conversion, dict):
         raise serializers.ValidationError(
-            {"sync_policy": "conversion must be an object"}
+            {field_name: "conversion must be an object"}
         )
     for key in [
         "document",
@@ -1444,12 +1476,12 @@ def _validate_conversion_policy(conversion):
         value = conversion.get(key)
         if value is not None and not isinstance(value, bool):
             raise serializers.ValidationError(
-                {"sync_policy": f"conversion.{key} must be a boolean"}
+                {field_name: f"conversion.{key} must be a boolean"}
             )
     if conversion.get("embedded_image") and not conversion.get("document"):
         raise serializers.ValidationError(
             {
-                "sync_policy": (
+                field_name: (
                     "conversion.embedded_image requires "
                     "conversion.document"
                 )
@@ -1469,7 +1501,7 @@ def _validate_conversion_policy(conversion):
             not isinstance(value, int) or value <= 0
         ):
             raise serializers.ValidationError(
-                {"sync_policy": f"conversion.{key} must be positive"}
+                {field_name: f"conversion.{key} must be positive"}
             )
     ratio = conversion.get("pdf_min_image_area_ratio")
     if ratio is not None and (
@@ -1477,7 +1509,7 @@ def _validate_conversion_policy(conversion):
     ):
         raise serializers.ValidationError(
             {
-                "sync_policy": (
+                field_name: (
                     "conversion.pdf_min_image_area_ratio must be "
                     "between 0 and 1"
                 )
@@ -1487,7 +1519,7 @@ def _validate_conversion_policy(conversion):
         value = conversion.get(key)
         if value is not None and not isinstance(value, str):
             raise serializers.ValidationError(
-                {"sync_policy": f"conversion.{key} must be a string"}
+                {field_name: f"conversion.{key} must be a string"}
             )
 
 

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -1198,6 +1198,27 @@ def cancel_datasource_sync_on_lensnode(lensnode, task_id):
     return None
 
 
+def cancel_datasource_conversion_on_lensnode(lensnode, task_id):
+    """Request safe cancellation of a managed workspace conversion."""
+
+    if lensnode is None or not task_id:
+        return None
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return None
+    async_to_sync(channel_layer.group_send)(
+        lensnode_group_name(lensnode.uuid),
+        {
+            "type": "lensnode.command",
+            "payload": {
+                "type": "datasource_convert_cancel",
+                "task_id": str(task_id),
+            },
+        },
+    )
+    return None
+
+
 RUN_ACTIVITY_THROTTLE_SECONDS = 15
 
 

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -5,11 +5,13 @@ from datetime import timedelta
 
 from celery import shared_task
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from .datasource_services import (
+    dispatch_datasource_conversion_async,
     dispatch_datasource_sync_async,
     get_datasource_sync_timeout_s,
 )
@@ -229,6 +231,47 @@ def register_datasource_sync_task(
     )
 
 
+def register_datasource_conversion_task(
+    datasource,
+    task_id,
+    conversion,
+    force=False,
+    created_by=None,
+    metadata=None,
+):
+    """Register managed workspace conversion before Celery starts it."""
+
+    from agentcore_task.adapters.django import TaskTracker
+
+    lensnode = datasource.lensnode
+    task_metadata = {
+        "type": "datasource_conversion",
+        "datasource_uuid": str(datasource.uuid),
+        "datasource_name": datasource.name,
+        "source_type": datasource.source_type,
+        "lensnode_uuid": str(lensnode.uuid) if lensnode else "",
+        "lensnode_name": lensnode.name if lensnode else "",
+        "target_path": datasource.target_path,
+        "conversion": dict(conversion or {}),
+        "force": bool(force),
+        "steps": [],
+        "logs": [],
+    }
+    task_metadata.update(metadata or {})
+    return TaskTracker.register_task(
+        task_id=task_id,
+        task_name=_datasource_conversion_task_name(datasource),
+        module="lens_datasource_conversion",
+        task_args=[str(datasource.uuid)],
+        task_kwargs={
+            "conversion": dict(conversion or {}),
+            "force": bool(force),
+        },
+        created_by=created_by,
+        metadata=task_metadata,
+    )
+
+
 def _datasource_sync_task_name(datasource):
     """Return a readable task name for one datasource sync."""
 
@@ -236,6 +279,15 @@ def _datasource_sync_task_name(datasource):
     if not name:
         return "datasource_sync"
     return f"datasource_sync:{name}"
+
+
+def _datasource_conversion_task_name(datasource):
+    """Return a readable task name for managed workspace conversion."""
+
+    name = str(getattr(datasource, "name", "") or "").strip()
+    if not name:
+        return "datasource_convert"
+    return f"datasource_convert:{name}"
 
 
 def _is_global_task_enabled(task_type, default=True):
@@ -359,6 +411,261 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
         raise
 
     return 0
+
+
+@shared_task(bind=True, name="lens.datasource_conversion", queue="lens")
+def datasource_conversion_task(
+    self,
+    datasource_uuid,
+    conversion,
+    force=False,
+    task_id=None,
+):
+    """Dispatch managed workspace conversion to its LensNode."""
+
+    from agentcore_task.adapters.django import TaskTracker
+    from agentcore_task.constants import TaskStatus
+
+    del self
+    task_id = task_id or uuid.uuid4().hex
+    datasource = DataSource.objects.select_related("lensnode").get(
+        uuid=datasource_uuid
+    )
+    if datasource.source_type != DataSource.SourceType.MANAGED_WORKSPACE:
+        return 0
+    task_execution = register_datasource_conversion_task(
+        datasource,
+        task_id,
+        conversion,
+        force=force,
+    )
+    if task_execution.status in TaskStatus.get_completed_statuses():
+        return 0
+    if datasource.status == DataSource.Status.DISABLED:
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.REVOKED,
+            error="DATASOURCE_DISABLED",
+        )
+        datasource.last_conversion_status = TaskStatus.REVOKED
+        datasource.last_conversion_at = timezone.now()
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
+            ]
+        )
+        return 0
+
+    TaskTracker.update_task_status(task_id, TaskStatus.STARTED)
+    datasource.last_conversion_status = TaskStatus.STARTED
+    datasource.save(update_fields=["last_conversion_status", "updated_at"])
+    _append_datasource_task_step(
+        task_id,
+        "prepare",
+        "running",
+        "Managed workspace conversion task started.",
+    )
+    try:
+        acquire_datasource_lock(
+            datasource.uuid,
+            token=task_id,
+            ttl_s=get_datasource_sync_timeout_s(),
+        )
+        _append_datasource_task_step(
+            task_id,
+            "dispatch",
+            "running",
+            "Dispatching managed workspace conversion to LensNode.",
+        )
+        request_id = dispatch_datasource_conversion_async(
+            datasource,
+            task_id=task_id,
+            conversion=conversion,
+            force=force,
+        )
+        from agentcore_task.adapters.django.models import TaskExecution
+
+        with transaction.atomic():
+            task_execution = TaskExecution.objects.select_for_update().get(
+                task_id=task_id
+            )
+            terminal_status = task_execution.status
+            if terminal_status not in TaskStatus.get_completed_statuses():
+                terminal_status = ""
+            if not terminal_status:
+                TaskTracker.update_task_status(
+                    task_id,
+                    TaskStatus.STARTED,
+                    metadata={
+                        "completion_source": "lensnode_callback",
+                        "datasource_conversion_request_id": request_id,
+                        "lock_token": task_id,
+                    },
+                )
+        if terminal_status:
+            release_datasource_lock(datasource.uuid, token=task_id)
+            if terminal_status == TaskStatus.REVOKED:
+                from .services import (
+                    cancel_datasource_conversion_on_lensnode,
+                )
+
+                cancel_datasource_conversion_on_lensnode(
+                    datasource.lensnode,
+                    task_id,
+                )
+            return 0
+    except SourceSyncBusy as exc:
+        datasource.last_conversion_status = TaskStatus.REVOKED
+        datasource.last_conversion_at = timezone.now()
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
+            ]
+        )
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.REVOKED,
+            error=str(exc),
+            metadata=_datasource_step_metadata(
+                task_id,
+                "lock",
+                "skipped",
+                str(exc),
+            ),
+        )
+        return 0
+    except Exception:
+        release_datasource_lock(datasource.uuid, token=task_id)
+        datasource.last_conversion_status = TaskStatus.FAILURE
+        datasource.last_conversion_at = timezone.now()
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
+            ]
+        )
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.FAILURE,
+            error="DATASOURCE_CONVERSION_FAILED",
+            metadata=_datasource_step_metadata(
+                task_id,
+                "failed",
+                "failed",
+                "DATASOURCE_CONVERSION_FAILED",
+            ),
+        )
+        raise
+    return 0
+
+
+def complete_datasource_conversion_task(task_id, result):
+    """Complete managed workspace conversion from LensNode callback."""
+
+    from agentcore_task.adapters.django import TaskTracker
+    from agentcore_task.adapters.django.models import TaskExecution
+    from agentcore_task.constants import TaskStatus
+
+    task = TaskExecution.objects.filter(task_id=task_id).first()
+    if task is None:
+        return None
+    metadata = task.metadata or {}
+    datasource_uuid = metadata.get("datasource_uuid")
+    datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
+    status_value = str(result.get("status") or "failed").lower()
+    status_map = {
+        "success": (TaskStatus.SUCCESS, "succeeded", ""),
+        "cancelled": (
+            TaskStatus.REVOKED,
+            "cancelled",
+            "DATASOURCE_CONVERSION_CANCELLED",
+        ),
+        "failed": (
+            TaskStatus.FAILURE,
+            "failed",
+            "DATASOURCE_CONVERSION_FAILED",
+        ),
+    }
+    task_status, overall_status, default_error = status_map.get(
+        status_value,
+        status_map["failed"],
+    )
+    error = str(result.get("error") or default_error)
+    conversion_summary = result.get("conversion_summary") or {}
+    if task.status in TaskStatus.get_completed_statuses():
+        if datasource_uuid:
+            release_datasource_lock(
+                datasource_uuid,
+                token=metadata.get("lock_token") or task_id,
+            )
+        return TaskTracker.update_task_status(
+            task_id,
+            task.status,
+            metadata={"conversion_summary": conversion_summary},
+        )
+    task_result = {
+        "overall_status": overall_status,
+        "conversion_summary": conversion_summary,
+    }
+    if datasource is not None:
+        datasource.last_conversion_status = task_status
+        datasource.last_conversion_at = timezone.now()
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
+            ]
+        )
+    lock_token = metadata.get("lock_token") or task_id
+    if datasource_uuid:
+        release_datasource_lock(datasource_uuid, token=lock_token)
+    step_status = "done" if task_status == TaskStatus.SUCCESS else "failed"
+    completion_metadata = _datasource_step_metadata(
+        task_id,
+        "completed" if task_status == TaskStatus.SUCCESS else overall_status,
+        step_status,
+        (
+            "Managed workspace conversion completed."
+            if task_status == TaskStatus.SUCCESS
+            else error
+        ),
+        progress_percent=100,
+    )
+    completion_metadata["conversion_summary"] = conversion_summary
+    return TaskTracker.update_task_status(
+        task_id,
+        task_status,
+        result=task_result,
+        error=error or None,
+        metadata=completion_metadata,
+    )
+
+
+def resolve_datasource_conversion_task_id(request_id, content):
+    """Resolve a managed workspace conversion task from callback data."""
+
+    task_id = content.get("task_id") or ""
+    if task_id:
+        return task_id
+    cached_task_id = cache.get(
+        f"lens:datasource_conversion_request:{request_id}"
+    )
+    if cached_task_id:
+        return cached_task_id
+
+    from agentcore_task.adapters.django.models import TaskExecution
+
+    task = TaskExecution.objects.filter(
+        module="lens_datasource_conversion",
+        metadata__datasource_conversion_request_id=request_id,
+    ).first()
+    return task.task_id if task else ""
 
 
 def complete_datasource_sync_task(task_id, result):
@@ -558,7 +865,7 @@ def _release_orphaned_datasource_lock(datasource_uuid):
 
     running_statuses = [TaskStatus.PENDING, *TaskStatus.get_running_statuses()]
     owner_exists = TaskExecution.objects.filter(
-        module="lens_datasource",
+        module__in=["lens_datasource", "lens_datasource_conversion"],
         status__in=running_statuses,
         metadata__datasource_uuid=str(datasource_uuid),
         metadata__lock_token=lock_token,
@@ -580,17 +887,20 @@ def release_datasource_lock(datasource_uuid, token=None):
 
 
 def cleanup_stale_datasource_sync_tasks(startup=False):
-    """Cancel timed-out datasource syncs and release orphaned sync locks.
+    """Cancel timed-out datasource work and release orphaned locks.
 
-    Datasource sync work is completed by LensNode callback after this Celery
-    task has dispatched it. A worker restart does not mean the external sync
-    was interrupted, so startup cleanup still honors the configured timeout.
+    Datasource work is completed by LensNode callback after this Celery task
+    has dispatched it. A worker restart does not mean the external work was
+    interrupted, so startup cleanup still honors the configured timeout.
     """
 
     from agentcore_task.adapters.django.models import TaskExecution
     from agentcore_task.constants import TaskStatus
 
-    from .services import cancel_datasource_sync_on_lensnode
+    from .services import (
+        cancel_datasource_conversion_on_lensnode,
+        cancel_datasource_sync_on_lensnode,
+    )
 
     now = timezone.now()
     timeout_s = get_datasource_sync_timeout_s()
@@ -598,7 +908,7 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
     running_statuses = [TaskStatus.PENDING, *TaskStatus.get_running_statuses()]
 
     stale = TaskExecution.objects.filter(
-        module="lens_datasource",
+        module__in=["lens_datasource", "lens_datasource_conversion"],
         status__in=running_statuses,
         metadata__datasource_uuid__isnull=False,
     ).filter(
@@ -611,18 +921,43 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
         metadata = dict(task.metadata or {})
         datasource_uuid = metadata.get("datasource_uuid")
         datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
+        is_conversion = task.module == "lens_datasource_conversion"
+        error = (
+            "DATASOURCE_CONVERSION_TIMEOUT"
+            if is_conversion
+            else "LENS_SOURCE_SYNC_TIMEOUT"
+        )
         if datasource is not None:
-            cancel_datasource_sync_on_lensnode(
-                datasource.lensnode,
-                task.task_id,
-            )
-            record = _get_or_create_source_sync_record(datasource)
-            record.last_status = ScheduledTask.Status.FAILED
-            record.last_error = "LENS_SOURCE_SYNC_TIMEOUT"
-            record.last_run_at = now
-            record.save(
-                update_fields=["last_status", "last_error", "last_run_at"]
-            )
+            if is_conversion:
+                cancel_datasource_conversion_on_lensnode(
+                    datasource.lensnode,
+                    task.task_id,
+                )
+                datasource.last_conversion_status = TaskStatus.FAILURE
+                datasource.last_conversion_at = now
+                datasource.save(
+                    update_fields=[
+                        "last_conversion_status",
+                        "last_conversion_at",
+                        "updated_at",
+                    ]
+                )
+            else:
+                cancel_datasource_sync_on_lensnode(
+                    datasource.lensnode,
+                    task.task_id,
+                )
+                record = _get_or_create_source_sync_record(datasource)
+                record.last_status = ScheduledTask.Status.FAILED
+                record.last_error = error
+                record.last_run_at = now
+                record.save(
+                    update_fields=[
+                        "last_status",
+                        "last_error",
+                        "last_run_at",
+                    ]
+                )
 
         release_datasource_lock(
             datasource_uuid,
@@ -631,13 +966,13 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
         metadata["timeout_cancelled_at"] = now.isoformat()
         task.status = TaskStatus.FAILURE
         task.finished_at = now
-        task.error = "LENS_SOURCE_SYNC_TIMEOUT"
+        task.error = error
         task.metadata = metadata
         task.save(update_fields=["status", "finished_at", "error", "metadata"])
         failed_count += 1
 
     completed = TaskExecution.objects.filter(
-        module="lens_datasource",
+        module__in=["lens_datasource", "lens_datasource_conversion"],
         status__in=TaskStatus.get_completed_statuses(),
         metadata__datasource_uuid__isnull=False,
         metadata__lock_token__isnull=False,
@@ -661,10 +996,16 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
                 uuid=datasource_uuid
             ).first()
             if datasource is not None:
-                cancel_datasource_sync_on_lensnode(
-                    datasource.lensnode,
-                    task.task_id,
-                )
+                if task.module == "lens_datasource_conversion":
+                    cancel_datasource_conversion_on_lensnode(
+                        datasource.lensnode,
+                        task.task_id,
+                    )
+                else:
+                    cancel_datasource_sync_on_lensnode(
+                        datasource.lensnode,
+                        task.task_id,
+                    )
 
     return {
         "failed": failed_count,

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -3368,6 +3368,178 @@ class LensApiTests(TestCase):
         )
         apply_async.assert_not_called()
 
+    def test_managed_workspace_conversion_registers_trackable_task(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        with patch(
+            "lens.views.datasources.datasource_conversion_task.apply_async"
+        ) as apply_async:
+            response = self.client.post(
+                f"/api/lens/admin/datasources/{datasource.uuid}/convert/",
+                {
+                    "conversion": {
+                        "document": True,
+                        "max_file_size_mb": 100,
+                    },
+                    "force": False,
+                },
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 202, response.data)
+        task_id = response.data["task_id"]
+        task = TaskExecution.objects.get(task_id=task_id)
+        self.assertEqual(response.data["task_execution_id"], task.id)
+        self.assertEqual(task.module, "lens_datasource_conversion")
+        self.assertEqual(task.status, "PENDING")
+        self.assertEqual(task.created_by, self.user)
+        self.assertEqual(
+            task.metadata["conversion"],
+            {"document": True, "max_file_size_mb": 100},
+        )
+        apply_async.assert_called_once_with(
+            args=[
+                str(datasource.uuid),
+                {"document": True, "max_file_size_mb": 100},
+                False,
+                task_id,
+            ],
+            task_id=ANY,
+        )
+        datasource.refresh_from_db()
+        self.assertEqual(datasource.last_conversion_status, "PENDING")
+        self.assertIsNone(datasource.last_conversion_at)
+        detail = self.client.get(
+            f"/api/lens/admin/datasources/{datasource.uuid}/"
+        )
+        self.assertEqual(detail.data["last_conversion_status"], "PENDING")
+        self.assertIsNone(detail.data["last_conversion_at"])
+        tasks = self.client.get(
+            f"/api/lens/admin/datasources/{datasource.uuid}/"
+            "conversion-tasks/"
+        )
+        self.assertEqual(tasks.status_code, 200)
+        self.assertEqual(tasks.data["results"][0]["task_id"], task_id)
+
+    def test_non_managed_datasource_conversion_is_rejected(self):
+        with patch(
+            "lens.views.datasources.datasource_conversion_task.apply_async"
+        ) as apply_async:
+            response = self.client.post(
+                f"/api/lens/admin/datasources/{self.datasource.uuid}/convert/",
+                {"conversion": {"document": True}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.data["detail"],
+            "DATASOURCE_CONVERSION_NOT_SUPPORTED",
+        )
+        apply_async.assert_not_called()
+
+    def test_managed_workspace_conversion_validates_policy(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        response = self.client.post(
+            f"/api/lens/admin/datasources/{datasource.uuid}/convert/",
+            {"conversion": {"document": "yes"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("conversion.document", response.data["conversion"][0])
+
+    def test_managed_workspace_conversion_requires_admin(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        user = User.objects.create_user(
+            username="regular-user",
+            email="regular-user@example.com",
+            password="pass12345",
+        )
+        self.client.force_authenticate(user)
+
+        response = self.client.post(
+            f"/api/lens/admin/datasources/{datasource.uuid}/convert/",
+            {"conversion": {"document": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_cancel_managed_workspace_conversion_releases_lock(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="STARTED",
+        )
+        task = TaskExecution.objects.create(
+            task_id="running-conversion",
+            task_name="datasource_convert:Managed Snapshot",
+            module="lens_datasource_conversion",
+            status="STARTED",
+            metadata={
+                "datasource_uuid": str(datasource.uuid),
+                "lock_token": "running-conversion",
+                "celery_task_id": "celery-conversion",
+            },
+        )
+        acquire_datasource_lock(
+            datasource.uuid,
+            token="running-conversion",
+            ttl_s=60,
+        )
+
+        with (
+            patch("core.celery.app.control.revoke") as revoke,
+            patch(
+                "lens.views.datasources."
+                "cancel_datasource_conversion_on_lensnode"
+            ) as cancel,
+        ):
+            response = self.client.post(
+                f"/api/lens/admin/datasources/{datasource.uuid}/"
+                "cancel-conversion/",
+                {},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        revoke.assert_called_once_with("celery-conversion", terminate=False)
+        cancel.assert_called_once_with(self.lensnode, "running-conversion")
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+        self.assertEqual(datasource.last_conversion_status, "REVOKED")
+        self.assertIsNotNone(datasource.last_conversion_at)
+
+        acquire_datasource_lock(
+            datasource.uuid,
+            token="new-conversion",
+            ttl_s=60,
+        )
+        release_datasource_lock(
+            datasource.uuid,
+            token="new-conversion",
+        )
+
     @patch("lens.views.datasources.check_datasource_path")
     def test_managed_workspace_refresh_updates_availability(self, check_path):
         datasource = DataSource.objects.create(

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -22,6 +22,7 @@ from core.periodic_registry import TASK_REGISTRY
 from lens.consumers import LensNodeConsumer
 from lens.datasource_services import (
     DataSourceDispatchError,
+    dispatch_datasource_conversion_async,
     dispatch_datasource_sync_async,
 )
 from lens.execution import execute_answer_run
@@ -64,9 +65,12 @@ from lens.services import (
 from lens.tasks import (
     acquire_datasource_lock,
     cleanup_stale_datasource_sync_tasks,
+    complete_datasource_conversion_task,
     complete_datasource_sync_task,
+    datasource_conversion_task,
     datasource_lock,
     lensnode_health_task,
+    register_datasource_conversion_task,
     register_datasource_sync_task,
     release_datasource_lock,
     source_sync_task,
@@ -1767,6 +1771,32 @@ class LensServiceTests(TransactionTestCase):
         )
         await communicator.disconnect()
 
+    async def _exercise_lensnode_conversion_done(self, token, task_id):
+        """Send a managed conversion completion frame over the node socket."""
+
+        communicator = WebsocketCommunicator(
+            application,
+            f"/ws/lens/lensnodes/?token={token}",
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        await communicator.receive_json_from()
+        await communicator.send_json_to(
+            {
+                "type": "datasource_convert_done",
+                "task_id": task_id,
+                "status": "success",
+                "conversion_summary": {
+                    "total": 1,
+                    "success": 1,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unsupported": 0,
+                },
+            }
+        )
+        await communicator.disconnect()
+
     def test_source_sync_task_dispatches_without_waiting_for_result(self):
         with patch("lens.tasks.dispatch_datasource_sync_async") as dispatch:
             dispatch.return_value = "request-1"
@@ -1844,6 +1874,317 @@ class LensServiceTests(TransactionTestCase):
                 datasource,
                 task_id="managed-sync",
             )
+
+    def test_managed_workspace_conversion_dispatches_without_sync_adapter(
+        self,
+    ):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+
+        with patch("lens.datasource_services._send_lensnode_command") as send:
+            request_id = dispatch_datasource_conversion_async(
+                datasource,
+                task_id="managed-conversion",
+                conversion={"document": True},
+                force=True,
+            )
+
+        self.assertTrue(request_id)
+        payload = send.call_args.args[1]
+        self.assertEqual(payload["type"], "datasource_convert")
+        self.assertEqual(payload["source_type"], "managed_workspace")
+        self.assertEqual(payload["conversion"], {"document": True})
+        self.assertTrue(payload["force"])
+        self.assertNotIn("config", payload)
+        self.assertNotIn("sync_policy", payload)
+
+    def test_managed_workspace_conversion_task_is_callback_completed(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        register_datasource_conversion_task(
+            datasource,
+            "managed-conversion",
+            {"document": True},
+            created_by=self.user,
+        )
+
+        with patch(
+            "lens.tasks.dispatch_datasource_conversion_async"
+        ) as dispatch:
+            dispatch.return_value = "conversion-request"
+            result = datasource_conversion_task(
+                str(datasource.uuid),
+                {"document": True},
+                False,
+                "managed-conversion",
+            )
+
+        self.assertEqual(result, 0)
+        task = TaskExecution.objects.get(task_id="managed-conversion")
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "STARTED")
+        self.assertEqual(
+            task.metadata["datasource_conversion_request_id"],
+            "conversion-request",
+        )
+        self.assertEqual(datasource.last_conversion_status, "STARTED")
+
+    def test_complete_managed_workspace_conversion_persists_summary(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        register_datasource_conversion_task(
+            datasource,
+            "managed-conversion",
+            {"document": True},
+        )
+
+        complete_datasource_conversion_task(
+            "managed-conversion",
+            {
+                "status": "success",
+                "conversion_summary": {
+                    "total": 3,
+                    "success": 1,
+                    "failed": 1,
+                    "skipped": 1,
+                    "unsupported": 0,
+                    "items": [
+                        {
+                            "path": "report.docx",
+                            "status": "converted",
+                            "reason": "",
+                        }
+                    ],
+                },
+            },
+        )
+
+        task = TaskExecution.objects.get(task_id="managed-conversion")
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "SUCCESS")
+        self.assertEqual(task.result["overall_status"], "succeeded")
+        self.assertEqual(task.result["conversion_summary"]["failed"], 1)
+        self.assertEqual(datasource.last_conversion_status, "SUCCESS")
+        self.assertIsNotNone(datasource.last_conversion_at)
+
+    def test_lensnode_conversion_done_frame_completes_task(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "conversion-frame",
+            {"document": True},
+        )
+        token = issue_lensnode_token(self.lensnode)
+
+        async_to_sync(self._exercise_lensnode_conversion_done)(
+            token,
+            task.task_id,
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, "SUCCESS")
+        self.assertEqual(task.result["overall_status"], "succeeded")
+        self.assertEqual(task.result["conversion_summary"]["success"], 1)
+
+    def test_late_conversion_callback_does_not_override_cancellation(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="REVOKED",
+            last_conversion_at=timezone.now(),
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "cancelled-conversion",
+            {"document": True},
+        )
+        task.status = "REVOKED"
+        task.finished_at = timezone.now()
+        task.save(update_fields=["status", "finished_at"])
+
+        complete_datasource_conversion_task(
+            task.task_id,
+            {
+                "status": "success",
+                "conversion_summary": {"success": 1},
+            },
+        )
+
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+        self.assertEqual(datasource.last_conversion_status, "REVOKED")
+        self.assertEqual(
+            task.metadata["conversion_summary"]["success"],
+            1,
+        )
+
+    def test_revoked_conversion_is_not_dispatched_when_celery_starts_late(
+        self,
+    ):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="REVOKED",
+            last_conversion_at=timezone.now(),
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "revoked-conversion",
+            {"document": True},
+        )
+        task.status = "REVOKED"
+        task.finished_at = timezone.now()
+        task.save(update_fields=["status", "finished_at"])
+
+        with patch(
+            "lens.tasks.dispatch_datasource_conversion_async"
+        ) as dispatch:
+            result = datasource_conversion_task(
+                str(datasource.uuid),
+                {"document": True},
+                False,
+                task.task_id,
+            )
+
+        self.assertEqual(result, 0)
+        dispatch.assert_not_called()
+        task.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+
+    def test_conversion_cancelled_during_dispatch_stays_revoked(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "cancelled-during-dispatch",
+            {"document": True},
+        )
+
+        def dispatch(*args, **kwargs):
+            del args, kwargs
+            execution = TaskExecution.objects.get(task_id=task.task_id)
+            execution.status = "REVOKED"
+            execution.finished_at = timezone.now()
+            execution.save(update_fields=["status", "finished_at"])
+            return "late-conversion-request"
+
+        with (
+            patch(
+                "lens.tasks.dispatch_datasource_conversion_async",
+                side_effect=dispatch,
+            ),
+            patch(
+                "lens.services."
+                "cancel_datasource_conversion_on_lensnode"
+            ) as cancel,
+        ):
+            datasource_conversion_task(
+                str(datasource.uuid),
+                {"document": True},
+                False,
+                task.task_id,
+            )
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+        cancel.assert_called_once_with(self.lensnode, task.task_id)
+
+    def test_conversion_callback_maps_safe_cancellation_to_revoked(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        register_datasource_conversion_task(
+            datasource,
+            "cancelled-by-node",
+            {"document": True},
+        )
+
+        complete_datasource_conversion_task(
+            "cancelled-by-node",
+            {
+                "status": "cancelled",
+                "error": "DATASOURCE_CONVERSION_CANCELLED",
+            },
+        )
+
+        task = TaskExecution.objects.get(task_id="cancelled-by-node")
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+        self.assertEqual(task.result["overall_status"], "cancelled")
+        self.assertEqual(datasource.last_conversion_status, "REVOKED")
+
+    def test_conversion_progress_persists_lifecycle_counts(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        register_datasource_conversion_task(
+            datasource,
+            "live-managed-conversion",
+            {"document": True},
+        )
+
+        LensNodeConsumer._record_datasource_sync_event(
+            "live-managed-conversion",
+            {
+                "step": "conversion_progress",
+                "status": "running",
+                "category": "conversion",
+                "message": "Converted 1/3 datasource files.",
+                "progress_total": 3,
+                "progress_current": 1,
+                "progress_percent": 33,
+                "summary": {
+                    "total": 3,
+                    "waiting": 1,
+                    "active": 1,
+                    "succeeded": 1,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unsupported": 0,
+                },
+                "current_file": "report.docx",
+                "current_status": "converted",
+            },
+        )
+
+        task = TaskExecution.objects.get(task_id="live-managed-conversion")
+        summary = task.metadata["conversion_summary"]
+        self.assertEqual(task.metadata["progress_percent"], 33)
+        self.assertEqual(summary["waiting"], 1)
+        self.assertEqual(summary["active"], 1)
+        self.assertEqual(summary["succeeded"], 1)
 
     def test_source_sync_task_reuses_registered_task_id(self):
         task_id = "manual-sync"
@@ -2255,6 +2596,65 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
         release_datasource_lock(self.datasource.uuid, token="new-sync")
+
+    def test_cleanup_stale_datasource_conversion_releases_lock(self):
+        GlobalSetting.objects.create(
+            key="lens.datasource_sync.timeout_s",
+            value="1",
+        )
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="STARTED",
+        )
+        task = TaskExecution.objects.create(
+            task_id="stale-conversion",
+            task_name="datasource_convert:Managed Snapshot",
+            module="lens_datasource_conversion",
+            status="STARTED",
+            started_at=timezone.now() - timedelta(seconds=2),
+            metadata={
+                "datasource_uuid": str(datasource.uuid),
+                "lock_token": "stale-conversion",
+            },
+        )
+        acquire_datasource_lock(
+            datasource.uuid,
+            token="stale-conversion",
+            ttl_s=60,
+        )
+
+        with patch(
+            "lens.services.cancel_datasource_conversion_on_lensnode"
+        ) as cancel:
+            result = cleanup_stale_datasource_sync_tasks()
+
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(result["failed"], 1)
+        self.assertEqual(task.status, "FAILURE")
+        self.assertEqual(task.error, "DATASOURCE_CONVERSION_TIMEOUT")
+        self.assertEqual(datasource.last_conversion_status, "FAILURE")
+        self.assertIsNotNone(datasource.last_conversion_at)
+        cancel.assert_called_once_with(self.lensnode, "stale-conversion")
+        self.assertFalse(
+            ScheduledTask.objects.filter(
+                target_type="datasource",
+                target_id=datasource.uuid,
+            ).exists()
+        )
+
+        acquire_datasource_lock(
+            datasource.uuid,
+            token="new-conversion",
+            ttl_s=60,
+        )
+        release_datasource_lock(
+            datasource.uuid,
+            token="new-conversion",
+        )
 
     def test_startup_cleanup_keeps_fresh_datasource_sync_running(self):
         GlobalSetting.objects.create(

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -17,9 +17,17 @@ from lens.datasource_services import (
 )
 from lens.models import DataSource, ScheduledTask
 from lens.periodic_tasks import ensure_datasource_periodic_task
-from lens.serializers import DataSourceSerializer
-from lens.services import cancel_datasource_sync_on_lensnode
+from lens.serializers import (
+    DataSourceConversionRequestSerializer,
+    DataSourceSerializer,
+)
+from lens.services import (
+    cancel_datasource_conversion_on_lensnode,
+    cancel_datasource_sync_on_lensnode,
+)
 from lens.tasks import (
+    datasource_conversion_task,
+    register_datasource_conversion_task,
     register_datasource_sync_task,
     release_datasource_lock,
     source_sync_task,
@@ -221,6 +229,56 @@ class DataSourceViewSet(BaseAdminViewSet):
             status=status.HTTP_202_ACCEPTED,
         )
 
+    @action(detail=True, methods=["post"])
+    def convert(self, request, uuid=None):
+        """Enqueue explicit conversion for a managed workspace."""
+
+        datasource = self.get_object()
+        if datasource.source_type != DataSource.SourceType.MANAGED_WORKSPACE:
+            return Response(
+                {"detail": "DATASOURCE_CONVERSION_NOT_SUPPORTED"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        if datasource.status == DataSource.Status.DISABLED:
+            return Response(
+                {"detail": "DATASOURCE_DISABLED"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        serializer = DataSourceConversionRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        conversion = serializer.validated_data["conversion"]
+        force = serializer.validated_data["force"]
+        task_id = uuid_mod.uuid4().hex
+        celery_task_id = uuid_mod.uuid4().hex
+        task_execution = register_datasource_conversion_task(
+            datasource,
+            task_id,
+            conversion,
+            force=force,
+            created_by=request.user,
+            metadata={"celery_task_id": celery_task_id},
+        )
+        datasource.last_conversion_status = "PENDING"
+        datasource.save(update_fields=["last_conversion_status", "updated_at"])
+        datasource_conversion_task.apply_async(
+            args=[
+                str(datasource.uuid),
+                conversion,
+                force,
+                task_id,
+            ],
+            task_id=celery_task_id,
+        )
+        return Response(
+            {
+                "uuid": str(datasource.uuid),
+                "task_id": task_id,
+                "task_execution_id": task_execution.id,
+                "status": task_execution.status,
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
     @action(detail=True, methods=["post"], url_path="set-enabled")
     def set_enabled(self, request, uuid=None):
         """Enable or disable a datasource and sync its schedule."""
@@ -309,6 +367,27 @@ class DataSourceViewSet(BaseAdminViewSet):
         serializer = TaskExecutionListSerializer(queryset, many=True)
         return Response(serializer.data)
 
+    @action(detail=True, methods=["get"], url_path="conversion-tasks")
+    def conversion_tasks(self, request, uuid=None):
+        """List managed workspace conversion tasks (paginated)."""
+
+        from agentcore_task.adapters.django.models import TaskExecution
+        from agentcore_task.adapters.django.serializers import (
+            TaskExecutionListSerializer,
+        )
+
+        datasource = self.get_object()
+        queryset = TaskExecution.objects.filter(
+            module="lens_datasource_conversion",
+            metadata__datasource_uuid=str(datasource.uuid),
+        ).order_by("-created_at")
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = TaskExecutionListSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = TaskExecutionListSerializer(queryset, many=True)
+        return Response(serializer.data)
+
     @action(detail=True, methods=["post"], url_path="cancel-sync")
     def cancel_sync(self, request, uuid=None):
         """Cancel the latest running synchronization for this datasource."""
@@ -355,6 +434,76 @@ class DataSourceViewSet(BaseAdminViewSet):
                 "finished_at",
                 "error",
                 "metadata",
+            ]
+        )
+        return Response(
+            {
+                "uuid": str(datasource.uuid),
+                "task_id": task.task_id,
+                "task_execution_id": task.id,
+                "status": task.status,
+            }
+        )
+
+    @action(detail=True, methods=["post"], url_path="cancel-conversion")
+    def cancel_conversion(self, request, uuid=None):
+        """Cancel the latest active managed workspace conversion."""
+
+        from agentcore_task.adapters.django.models import TaskExecution
+        from agentcore_task.constants import TaskStatus
+        from core.celery import app
+
+        datasource = self.get_object()
+        task = (
+            TaskExecution.objects.filter(
+                module="lens_datasource_conversion",
+                metadata__datasource_uuid=str(datasource.uuid),
+                status__in=[
+                    TaskStatus.PENDING,
+                    *TaskStatus.get_running_statuses(),
+                ],
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if task is None:
+            return Response(
+                {"detail": "No running datasource conversion task."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        metadata = dict(task.metadata or {})
+        celery_task_id = metadata.get("celery_task_id") or task.task_id
+        app.control.revoke(celery_task_id, terminate=False)
+        cancel_datasource_conversion_on_lensnode(
+            datasource.lensnode,
+            task.task_id,
+        )
+        release_datasource_lock(
+            datasource.uuid,
+            token=metadata.get("lock_token") or task.task_id,
+        )
+        now = timezone.now()
+        metadata["manual_revoked_at"] = now.isoformat()
+        metadata["manual_revoked_by"] = request.user.pk
+        task.status = TaskStatus.REVOKED
+        task.finished_at = now
+        task.error = "DATASOURCE_CONVERSION_CANCELLED"
+        task.metadata = metadata
+        task.save(
+            update_fields=[
+                "status",
+                "finished_at",
+                "error",
+                "metadata",
+            ]
+        )
+        datasource.last_conversion_status = TaskStatus.REVOKED
+        datasource.last_conversion_at = now
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
             ]
         )
         return Response(

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -10,7 +10,7 @@ from urllib import error, parse, request
 from .datasource_adapters import DataSourceAdapterRegistry
 from .datasource_adapters import FunctionDataSourceAdapter
 from . import datasource_manifest as manifest_store
-from .document_convert import post_process_documents
+from .document_convert import is_convertible, post_process_documents
 from .path_rules import normalize_excluded_roots
 from .path_rules import relative_path
 from .path_rules import safe_filename
@@ -232,6 +232,176 @@ def sync_datasource(command, workspace_path=WORKSPACE_ROOT, emit=None):
     return result
 
 
+def convert_managed_workspace(
+    command,
+    workspace_path=WORKSPACE_ROOT,
+    emit=None,
+):
+    """Convert files in a managed workspace without synchronizing it."""
+
+    if command.get("source_type") != "managed_workspace":
+        raise DataSourceSyncError("DATASOURCE_CONVERSION_NOT_SUPPORTED")
+    target = normalize_target_path(
+        command.get("target_path"),
+        workspace_path,
+    )
+    if not target.is_dir():
+        raise DataSourceSyncError("MANAGED_WORKSPACE_DIRECTORY_REQUIRED")
+
+    context = _sync_context(command, target)
+    items = _managed_workspace_conversion_items(target)
+    supported = [
+        item
+        for item in items
+        if is_convertible(target / item.local_path, context["conversion"])
+    ]
+    unsupported = [
+        item
+        for item in items
+        if not is_convertible(
+            target / item.local_path,
+            context["conversion"],
+        )
+    ]
+
+    def emit_progress(event):
+        if emit is None:
+            return
+        payload = dict(event)
+        current = int(payload.get("progress_current") or 0)
+        payload["summary"] = _managed_conversion_summary(
+            payload.get("summary") or {},
+            unsupported,
+            len(supported),
+            current,
+        )
+        payload["progress_total"] = len(items)
+        payload["progress_current"] = len(unsupported) + current
+        payload["progress_percent"] = _conversion_percent(
+            payload["progress_current"],
+            len(items),
+        )
+        emit(payload)
+
+    summary = post_process_documents(
+        context,
+        manifest_store.SyncResult(items=supported),
+        emit_progress,
+    )
+    summary = _managed_conversion_summary(
+        summary,
+        unsupported,
+        len(supported),
+        len(supported),
+    )
+    if summary["failed"]:
+        summary["warnings"] = list(
+            dict.fromkeys(
+                [
+                    *(summary.get("warnings") or []),
+                    "CONVERSION_PARTIAL_FAILED",
+                ]
+            )
+        )
+    _emit(
+        emit,
+        "conversion_complete",
+        "done",
+        "Managed workspace conversion completed.",
+        category="conversion",
+        progress_total=len(items),
+        progress_current=len(items),
+        progress_percent=100,
+        summary=summary,
+        conversion_summary=summary,
+    )
+    return {
+        "status": "success",
+        "target_path": str(target),
+        "conversion_summary": summary,
+        "warnings": summary.get("warnings") or [],
+    }
+
+
+def _managed_workspace_conversion_items(target):
+    """Return files found under a managed workspace conversion root."""
+
+    items = []
+    for path in sorted(target.rglob("*")):
+        if not path.is_file() or _is_generated_datasource_path(target, path):
+            continue
+        local_path = relative_path(target, path)
+        items.append(
+            manifest_store.SyncItem(
+                source_id=f"managed_workspace:{local_path}",
+                source_type="managed_workspace",
+                source_path=local_path,
+                local_path=local_path,
+                name=path.name,
+                kind="file",
+                extension=path.suffix.lower().lstrip("."),
+                status="cataloged",
+                metadata={"size": str(path.stat().st_size)},
+            )
+        )
+    return items
+
+
+def _managed_conversion_summary(
+    summary,
+    unsupported,
+    supported_total,
+    supported_current,
+):
+    """Add standalone conversion lifecycle counters and outcomes."""
+
+    result = dict(summary or {})
+    unsupported_items = [
+        {
+            "status": "unsupported",
+            "path": item.local_path,
+            "name": item.name,
+            "extension": item.extension,
+            "reason": "UNSUPPORTED_TYPE",
+            "stats": {},
+        }
+        for item in unsupported
+    ]
+    items = list(result.get("items") or [])
+    existing_paths = {item.get("path") for item in items}
+    items.extend(
+        item
+        for item in unsupported_items
+        if item["path"] not in existing_paths
+    )
+    completed = min(max(supported_current, 0), supported_total)
+    remaining = max(supported_total - completed, 0)
+    active = 1 if remaining else 0
+    result.update(
+        {
+            "total": supported_total + len(unsupported),
+            "waiting": max(remaining - active, 0),
+            "active": active,
+            "succeeded": int(result.get("success") or 0),
+            "unsupported": len(unsupported),
+            "items": items,
+        }
+    )
+    details = dict(result.get("details") or {})
+    if unsupported_items:
+        details["unsupported"] = unsupported_items[:DETAIL_ITEMS_LIMIT]
+    result["details"] = details
+    return result
+
+
+def _conversion_percent(current, total):
+    """Return a bounded integer conversion progress percentage."""
+
+    if total <= 0:
+        return 100
+    return min(100, int((current / total) * 100))
+
+
 def datasource_adapter_registry():
     """Return the datasource adapter registry."""
 
@@ -265,6 +435,8 @@ def _sync_context(command, target):
         "tls_skip_verify": bool(command.get("tls_skip_verify", False)),
         "tls_ca_file": command.get("tls_ca_file") or None,
         "vision_model_ref": conversion.get("vision_model_ref") or "",
+        "cancel_event": command.get("cancel_event"),
+        "on_activity": command.get("on_activity"),
     }
 
 

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -11,6 +11,7 @@ from .datasource_adapters import DataSourceAdapterRegistry
 from .datasource_adapters import FunctionDataSourceAdapter
 from . import datasource_manifest as manifest_store
 from .document_convert import is_convertible, post_process_documents
+from .path_rules import is_excluded_path
 from .path_rules import normalize_excluded_roots
 from .path_rules import relative_path
 from .path_rules import safe_filename
@@ -249,7 +250,10 @@ def convert_managed_workspace(
         raise DataSourceSyncError("MANAGED_WORKSPACE_DIRECTORY_REQUIRED")
 
     context = _sync_context(command, target)
-    items = _managed_workspace_conversion_items(target)
+    items = _managed_workspace_conversion_items(
+        target,
+        context["excluded_datasource_roots"],
+    )
     supported = [
         item
         for item in items
@@ -323,14 +327,19 @@ def convert_managed_workspace(
     }
 
 
-def _managed_workspace_conversion_items(target):
+def _managed_workspace_conversion_items(target, excluded_roots):
     """Return files found under a managed workspace conversion root."""
 
     items = []
     for path in sorted(target.rglob("*")):
         if not path.is_file() or _is_generated_datasource_path(target, path):
             continue
-        local_path = relative_path(target, path)
+        if is_excluded_path(path, excluded_roots):
+            continue
+        try:
+            local_path = relative_path(target, path)
+        except ValueError:
+            continue
         items.append(
             manifest_store.SyncItem(
                 source_id=f"managed_workspace:{local_path}",
@@ -369,11 +378,13 @@ def _managed_conversion_summary(
     ]
     items = list(result.get("items") or [])
     existing_paths = {item.get("path") for item in items}
-    items.extend(
+    available = max(DETAIL_ITEMS_LIMIT - len(items), 0)
+    new_items = [
         item
         for item in unsupported_items
         if item["path"] not in existing_paths
-    )
+    ]
+    items.extend(new_items[:available])
     completed = min(max(supported_current, 0), supported_total)
     remaining = max(supported_total - completed, 0)
     active = 1 if remaining else 0
@@ -385,6 +396,8 @@ def _managed_conversion_summary(
             "succeeded": int(result.get("success") or 0),
             "unsupported": len(unsupported),
             "items": items,
+            "items_truncated": int(result.get("items_truncated") or 0)
+            + max(len(new_items) - available, 0),
         }
     )
     details = dict(result.get("details") or {})
@@ -435,6 +448,7 @@ def _sync_context(command, target):
         "tls_skip_verify": bool(command.get("tls_skip_verify", False)),
         "tls_ca_file": command.get("tls_ca_file") or None,
         "vision_model_ref": conversion.get("vision_model_ref") or "",
+        "force": bool(command.get("force", False)),
         "cancel_event": command.get("cancel_event"),
         "on_activity": command.get("on_activity"),
     }

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -439,12 +439,27 @@ def post_process_documents(context, sync_result, emit=None):
                 merge_summary_stats(summary, result.get("stats") or {})
                 merge_cost_stats(summary["cost"], result.get("cost") or {})
         except Exception as exc:
+            from .gateway_model import RunCancelledError
+
+            if isinstance(exc, RunCancelledError):
+                raise
             current_status = "failed"
-            current_reason = str(exc)
+            current_reason = conversion_error_reason(exc)
             summary["failed"] += 1
             warnings.append("CONVERSION_FILE_FAILED")
-            write_failed_meta(target, path, item, context, str(exc))
-            append_conversion_detail(summary, item, "failed", str(exc))
+            write_failed_meta(
+                target,
+                path,
+                item,
+                context,
+                current_reason,
+            )
+            append_conversion_detail(
+                summary,
+                item,
+                "failed",
+                current_reason,
+            )
         emit_conversion(
             emit,
             "conversion_progress",
@@ -472,6 +487,17 @@ def post_process_documents(context, sync_result, emit=None):
         current=total,
     )
     return summary
+
+
+def conversion_error_reason(exc):
+    """Return a safe machine-readable reason for conversion failures."""
+
+    message = str(exc or "").upper()
+    if "PASSWORD" in message or "ENCRYPT" in message:
+        return "PASSWORD_PROTECTED"
+    if "EMPTY" in message or "NO EXTRACTABLE" in message:
+        return "NO_EXTRACTABLE_TEXT"
+    return "CONVERSION_FILE_FAILED"
 
 
 def append_conversion_detail(summary, item, status, reason="", stats=None):

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -115,7 +115,8 @@ class MarkItDownDocumentConverter(BaseConverter):
         result = MarkItDown().convert(str(path))
         _check_runtime_cancelled(context)
         _touch_runtime_activity(context)
-        text = getattr(result, "text_content", "") or str(result)
+        text_content = getattr(result, "text_content", None)
+        text = str(result) if text_content is None else text_content
         stats = document_stats(path)
         cost = empty_cost_stats()
         image_context = document_image_context(context, path, text)
@@ -126,6 +127,13 @@ class MarkItDownDocumentConverter(BaseConverter):
             text = f"{text.rstrip()}\n\n{embedded['markdown']}"
         stats.update(embedded["stats"])
         merge_cost_stats(cost, embedded["cost"])
+        if not text.strip():
+            return ConversionOutput(
+                skipped=True,
+                reason="NO_EXTRACTABLE_TEXT",
+                stats=stats,
+                cost=cost,
+            )
         return ConversionOutput(text=text, stats=stats, cost=cost)
 
     def version(self):
@@ -745,6 +753,20 @@ def convert_one(target, path, item, context):
     if size > limits["max_file_size"]:
         write_skipped_meta(target, path, item, context, "FILE_TOO_LARGE")
         return {"skipped": True, "reason": "FILE_TOO_LARGE"}
+    page_count = pdf_page_count(path)
+    if page_count > limits["max_pages"]:
+        write_skipped_meta(
+            target,
+            path,
+            item,
+            context,
+            "PAGE_LIMIT_EXCEEDED",
+        )
+        return {
+            "skipped": True,
+            "reason": "PAGE_LIMIT_EXCEEDED",
+            "stats": {"pdf_pages": page_count},
+        }
 
     digest = source_sha256(path)
     fingerprint = conversion_fingerprint(path, digest, context)
@@ -752,7 +774,8 @@ def convert_one(target, path, item, context):
     content_path = sidecar_path(path) / "content.md"
     meta = read_json(meta_path)
     if (
-        meta.get("conversion", {}).get("fingerprint") == fingerprint
+        not context.get("force")
+        and meta.get("conversion", {}).get("fingerprint") == fingerprint
         and meta.get("conversion", {}).get("status") == "success"
         and content_path.is_file()
     ):
@@ -836,6 +859,25 @@ def document_stats(path):
     if suffix == ".xlsx":
         return xlsx_stats(path)
     return {"pages": 0}
+
+
+def pdf_page_count(path):
+    """Return a PDF page count when it can be inspected safely."""
+
+    if Path(path).suffix.lower() != ".pdf":
+        return 0
+    try:
+        import fitz
+
+        document = fitz.open(path)
+        try:
+            if document.needs_pass:
+                return 0
+            return int(document.page_count or 0)
+        finally:
+            document.close()
+    except Exception:
+        return 0
 
 
 def xlsx_stats(path):
@@ -976,6 +1018,13 @@ def conversion_fingerprint(path, digest, context):
             "image": bool(conversion.get("image")),
             "embedded_image": bool(conversion.get("embedded_image")),
             "document_model_ref": conversion.get("document_model_ref") or "",
+            "max_file_size_mb": int(
+                conversion.get("max_file_size_mb") or DEFAULT_MAX_FILE_SIZE_MB
+            ),
+            "max_images": int(
+                conversion.get("max_images") or DEFAULT_MAX_IMAGES
+            ),
+            "max_pages": int(conversion.get("max_pages") or DEFAULT_MAX_PAGES),
             "image_jpeg_quality": int(
                 conversion.get("image_jpeg_quality")
                 or DEFAULT_IMAGE_JPEG_QUALITY

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import signal
+import threading
 from urllib.parse import urlencode
 
 import httpx
@@ -11,9 +12,11 @@ from websockets.asyncio.client import connect
 
 from .config import load_config
 from .datasource_sync import DataSourceSyncError
+from .datasource_sync import convert_managed_workspace
 from .datasource_sync import inspect_datasource_path, sync_datasource
 from .datasource_sync import test_datasource_connection
 from .executor import TASKS, LensNodeExecutor
+from .gateway_model import RunCancelledError
 from .logging_utils import (
     elapsed_since,
     format_duration,
@@ -63,6 +66,7 @@ class LensNodeClient:
         self.heartbeat_count = 0
         self.last_report_signature = None
         self.running_tasks = {}
+        self.datasource_conversion_cancels = {}
         # Durable outbound buffer, persistent across reconnects. A run started
         # on one connection keeps executing across a blue/green API recycle and
         # emits run_event/run_output/run_done frames while the socket is down;
@@ -361,6 +365,21 @@ class LensNodeClient:
             await self._handle_datasource_test_connection(message)
         elif message_type == "datasource_sync":
             await self._start_datasource_sync(message)
+        elif message_type == "datasource_convert":
+            await self._start_datasource_conversion(message)
+        elif message_type == "datasource_convert_cancel":
+            task_id = str(message.get("task_id") or "")
+            cancel_event = self.datasource_conversion_cancels.get(task_id)
+            if cancel_event is not None:
+                cancel_event.set()
+            LOGGER.info(
+                task_log(
+                    (
+                        "Requested safe cancellation for command "
+                        f"datasource_convert {task_id}."
+                    )
+                )
+            )
         elif message_type == "datasource_cancel":
             task_id = str(message.get("task_id") or "")
             task_key = f"datasource:{task_id}"
@@ -614,6 +633,102 @@ class LensNodeClient:
         finally:
             self.running_tasks.pop(task_key, None)
 
+    async def _start_datasource_conversion(self, message):
+        """Start one managed workspace conversion in a worker thread."""
+
+        request_id = str(message.get("request_id") or "")
+        task_id = str(message.get("task_id") or request_id)
+        if not task_id:
+            return
+        task_key = f"datasource-convert:{task_id}"
+        if task_key in self.running_tasks:
+            return
+        cancel_event = threading.Event()
+        self.datasource_conversion_cancels[task_id] = cancel_event
+        task = asyncio.create_task(
+            self._execute_datasource_conversion(
+                {**message, "cancel_event": cancel_event}
+            )
+        )
+        self.running_tasks[task_key] = task
+        task.add_done_callback(lambda item: self._consume_task_exception(item))
+
+    async def _execute_datasource_conversion(self, message):
+        """Execute managed workspace conversion and emit safe results."""
+
+        request_id = str(message.get("request_id") or "")
+        task_id = str(message.get("task_id") or request_id)
+        task_key = f"datasource-convert:{task_id}"
+        loop = asyncio.get_running_loop()
+
+        def emit(event):
+            payload = {
+                "type": "datasource_convert_event",
+                "request_id": request_id,
+                "task_id": task_id,
+                **event,
+            }
+            loop.call_soon_threadsafe(self._enqueue, payload)
+
+        try:
+            command = {
+                **message,
+                "ai_gateway_url": self.config.ai_gateway_url,
+                "lensnode_token": self.config.token,
+                "gateway_http_client": self.gateway_http_client,
+                "tls_skip_verify": getattr(
+                    self.config,
+                    "tls_skip_verify",
+                    False,
+                ),
+                "tls_ca_file": getattr(
+                    self.config,
+                    "tls_ca_file",
+                    None,
+                ),
+            }
+            result = await asyncio.to_thread(
+                convert_managed_workspace,
+                command,
+                self.config.workspace_path,
+                emit,
+            )
+            self._enqueue(
+                {
+                    "type": "datasource_convert_done",
+                    "request_id": request_id,
+                    "task_id": task_id,
+                    **result,
+                }
+            )
+        except RunCancelledError:
+            self._enqueue(
+                {
+                    "type": "datasource_convert_done",
+                    "request_id": request_id,
+                    "task_id": task_id,
+                    "status": "cancelled",
+                    "error": "DATASOURCE_CONVERSION_CANCELLED",
+                }
+            )
+        except Exception:
+            LOGGER.exception(
+                "Managed datasource conversion failed task_id=%s",
+                task_id,
+            )
+            self._enqueue(
+                {
+                    "type": "datasource_convert_done",
+                    "request_id": request_id,
+                    "task_id": task_id,
+                    "status": "failed",
+                    "error": "DATASOURCE_CONVERSION_FAILED",
+                }
+            )
+        finally:
+            self.datasource_conversion_cancels.pop(task_id, None)
+            self.running_tasks.pop(task_key, None)
+
     async def _send_busy(self, run_uuid, reason):
         """Report a run that cannot start because local capacity is full."""
 
@@ -682,7 +797,7 @@ class LensNodeClient:
         active_runs = {
             key
             for key in self.running_tasks
-            if not key.startswith("datasource:")
+            if not key.startswith(("datasource:", "datasource-convert:"))
         }
         active_runs.update(
             str(payload["run_uuid"])

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -1,10 +1,13 @@
 import asyncio
 import json
 import subprocess
+import threading
+import time
 
 from lensnode.agent_tools import _skill_script_environment, build_agent_tools
 from lensnode.agent_runtime import _system_prompt
 from lensnode.executor import LensNodeExecutor
+from lensnode.gateway_model import RunCancelledError
 from lensnode.main import LensNodeClient
 from lensnode.runtime_resources import cleanup_runtime_resources
 from lensnode.runtime_resources import prepare_runtime_resources
@@ -671,5 +674,80 @@ def test_lensnode_run_cancel_cancels_running_task():
 
         await asyncio.wait_for(executor.cancelled.wait(), timeout=1)
         assert run_uuid not in client.running_tasks
+
+    asyncio.run(exercise())
+
+
+def test_lensnode_datasource_conversion_reports_safe_cancellation(
+    monkeypatch,
+):
+    """Managed conversion cancellation stops at a cooperative boundary."""
+
+    started = threading.Event()
+
+    def convert_managed_workspace(command, workspace_path, emit):
+        del workspace_path, emit
+        started.set()
+        while not command["cancel_event"].is_set():
+            time.sleep(0.01)
+        raise RunCancelledError("cancelled")
+
+    monkeypatch.setattr(
+        "lensnode.main.convert_managed_workspace",
+        convert_managed_workspace,
+    )
+
+    async def exercise():
+        config = type(
+            "Config",
+            (),
+            {
+                "name": "test-node",
+                "request_timeout_s": 240,
+                "max_concurrent_runs": 1,
+                "workspace_path": "/workspace",
+                "ai_gateway_url": "http://gateway",
+                "token": "node-token",
+            },
+        )()
+        client = LensNodeClient(config)
+        task_id = "conversion-task"
+
+        await client._handle_message(
+            json.dumps(
+                {
+                    "type": "datasource_convert",
+                    "request_id": "conversion-request",
+                    "task_id": task_id,
+                    "source_type": "managed_workspace",
+                    "target_path": "/workspace/documents",
+                    "conversion": {"document": True},
+                }
+            )
+        )
+        await asyncio.wait_for(
+            asyncio.to_thread(started.wait),
+            timeout=1,
+        )
+
+        await client._handle_message(
+            json.dumps(
+                {
+                    "type": "datasource_convert_cancel",
+                    "task_id": task_id,
+                }
+            )
+        )
+        task = client.running_tasks[f"datasource-convert:{task_id}"]
+        await asyncio.wait_for(task, timeout=1)
+
+        done = [
+            item
+            for item in client._outbox
+            if item.get("type") == "datasource_convert_done"
+        ]
+        assert done[-1]["status"] == "cancelled"
+        assert done[-1]["error"] == "DATASOURCE_CONVERSION_CANCELLED"
+        assert f"datasource-convert:{task_id}" not in client.running_tasks
 
     asyncio.run(exercise())

--- a/lensnode/tests/test_managed_conversion.py
+++ b/lensnode/tests/test_managed_conversion.py
@@ -1,0 +1,121 @@
+import sys
+import threading
+import types
+
+import pytest
+
+from lensnode.datasource_sync import convert_managed_workspace
+from lensnode.gateway_model import RunCancelledError
+
+
+def install_fake_markitdown(monkeypatch, failing_name=""):
+    """Install a deterministic MarkItDown test double."""
+
+    class FakeMarkItDown:
+        """Return text unless the configured filename must fail."""
+
+        def convert(self, path):
+            if failing_name and str(path).endswith(failing_name):
+                raise RuntimeError("PASSWORD_PROTECTED")
+            return types.SimpleNamespace(text_content="Converted document.")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "markitdown",
+        types.SimpleNamespace(
+            MarkItDown=FakeMarkItDown,
+            __version__="test",
+        ),
+    )
+
+
+def conversion_command(target, cancel_event=None):
+    """Return a managed workspace conversion command."""
+
+    return {
+        "datasource_uuid": "managed-1",
+        "name": "Managed documents",
+        "source_type": "managed_workspace",
+        "target_path": str(target),
+        "conversion": {"document": True},
+        "cancel_event": cancel_event,
+    }
+
+
+def test_managed_conversion_writes_sidecars_and_skips_unchanged(
+    tmp_path,
+    monkeypatch,
+):
+    """Managed conversion preserves originals and reuses fingerprints."""
+
+    install_fake_markitdown(monkeypatch)
+    document = tmp_path / "report.docx"
+    original = b"external document bytes"
+    document.write_bytes(original)
+    (tmp_path / "notes.txt").write_text("Not a supported document.")
+
+    first = convert_managed_workspace(
+        conversion_command(tmp_path),
+        workspace_path=tmp_path.parent,
+    )
+    second = convert_managed_workspace(
+        conversion_command(tmp_path),
+        workspace_path=tmp_path.parent,
+    )
+
+    assert first["status"] == "success"
+    assert first["conversion_summary"]["success"] == 1
+    assert first["conversion_summary"]["unsupported"] == 1
+    assert document.read_bytes() == original
+    assert (tmp_path / "report.docx.sourcelens/content.md").is_file()
+    assert (tmp_path / "report.docx.sourcelens/meta.json").is_file()
+    assert second["conversion_summary"]["skipped"] == 1
+    reasons = {
+        item["reason"] for item in second["conversion_summary"]["items"]
+    }
+    assert reasons == {"UNCHANGED", "UNSUPPORTED_TYPE"}
+
+
+def test_managed_conversion_continues_after_one_file_failure(
+    tmp_path,
+    monkeypatch,
+):
+    """A per-file failure does not fail the managed conversion batch."""
+
+    install_fake_markitdown(monkeypatch, failing_name="protected.docx")
+    (tmp_path / "ok.docx").write_bytes(b"ok")
+    (tmp_path / "protected.docx").write_bytes(b"protected")
+
+    result = convert_managed_workspace(
+        conversion_command(tmp_path),
+        workspace_path=tmp_path.parent,
+    )
+
+    summary = result["conversion_summary"]
+    assert result["status"] == "success"
+    assert summary["success"] == 1
+    assert summary["failed"] == 1
+    assert "CONVERSION_PARTIAL_FAILED" in summary["warnings"]
+    failed = next(item for item in summary["items"] if item["status"] == "failed")
+    assert failed["reason"] == "PASSWORD_PROTECTED"
+
+
+def test_managed_conversion_stops_at_safe_boundary_when_cancelled(
+    tmp_path,
+    monkeypatch,
+):
+    """Cancellation prevents new sidecars from being written."""
+
+    install_fake_markitdown(monkeypatch)
+    document = tmp_path / "cancelled.docx"
+    document.write_bytes(b"cancelled")
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    with pytest.raises(RunCancelledError):
+        convert_managed_workspace(
+            conversion_command(tmp_path, cancel_event=cancel_event),
+            workspace_path=tmp_path.parent,
+        )
+
+    assert not (tmp_path / "cancelled.docx.sourcelens").exists()

--- a/lensnode/tests/test_managed_conversion.py
+++ b/lensnode/tests/test_managed_conversion.py
@@ -8,7 +8,11 @@ from lensnode.datasource_sync import convert_managed_workspace
 from lensnode.gateway_model import RunCancelledError
 
 
-def install_fake_markitdown(monkeypatch, failing_name=""):
+def install_fake_markitdown(
+    monkeypatch,
+    failing_name="",
+    text="Converted document.",
+):
     """Install a deterministic MarkItDown test double."""
 
     class FakeMarkItDown:
@@ -17,7 +21,7 @@ def install_fake_markitdown(monkeypatch, failing_name=""):
         def convert(self, path):
             if failing_name and str(path).endswith(failing_name):
                 raise RuntimeError("PASSWORD_PROTECTED")
-            return types.SimpleNamespace(text_content="Converted document.")
+            return types.SimpleNamespace(text_content=text)
 
     monkeypatch.setitem(
         sys.modules,
@@ -62,6 +66,12 @@ def test_managed_conversion_writes_sidecars_and_skips_unchanged(
         conversion_command(tmp_path),
         workspace_path=tmp_path.parent,
     )
+    forced_command = conversion_command(tmp_path)
+    forced_command["force"] = True
+    forced = convert_managed_workspace(
+        forced_command,
+        workspace_path=tmp_path.parent,
+    )
 
     assert first["status"] == "success"
     assert first["conversion_summary"]["success"] == 1
@@ -74,6 +84,40 @@ def test_managed_conversion_writes_sidecars_and_skips_unchanged(
         item["reason"] for item in second["conversion_summary"]["items"]
     }
     assert reasons == {"UNCHANGED", "UNSUPPORTED_TYPE"}
+    assert forced["conversion_summary"]["success"] == 1
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("max_file_size_mb", 1),
+        ("max_pages", 1),
+        ("max_images", 1),
+    ],
+)
+def test_managed_conversion_policy_change_invalidates_fingerprint(
+    tmp_path,
+    monkeypatch,
+    option,
+    value,
+):
+    """A changed conversion limit must not reuse an older sidecar."""
+
+    install_fake_markitdown(monkeypatch)
+    (tmp_path / "report.docx").write_bytes(b"external document bytes")
+    convert_managed_workspace(
+        conversion_command(tmp_path),
+        workspace_path=tmp_path.parent,
+    )
+    command = conversion_command(tmp_path)
+    command["conversion"][option] = value
+
+    result = convert_managed_workspace(
+        command,
+        workspace_path=tmp_path.parent,
+    )
+
+    assert result["conversion_summary"]["success"] == 1
 
 
 def test_managed_conversion_continues_after_one_file_failure(
@@ -119,3 +163,53 @@ def test_managed_conversion_stops_at_safe_boundary_when_cancelled(
         )
 
     assert not (tmp_path / "cancelled.docx.sourcelens").exists()
+
+
+def test_managed_conversion_reports_oversized_and_empty_documents(
+    tmp_path,
+    monkeypatch,
+):
+    """Policy limits and empty extraction have distinct safe reasons."""
+
+    install_fake_markitdown(monkeypatch, text="")
+    (tmp_path / "empty.docx").write_bytes(b"empty")
+    (tmp_path / "large.docx").write_bytes(b"x" * (1024 * 1024 + 1))
+    command = conversion_command(tmp_path)
+    command["conversion"]["max_file_size_mb"] = 1
+
+    result = convert_managed_workspace(
+        command,
+        workspace_path=tmp_path.parent,
+    )
+
+    summary = result["conversion_summary"]
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 2
+    assert {item["reason"] for item in summary["items"]} == {
+        "FILE_TOO_LARGE",
+        "NO_EXTRACTABLE_TEXT",
+    }
+
+
+def test_managed_conversion_enforces_pdf_page_limit(tmp_path, monkeypatch):
+    """PDFs above max_pages are skipped before MarkItDown conversion."""
+
+    fitz = pytest.importorskip("fitz")
+    install_fake_markitdown(monkeypatch)
+    document = fitz.open()
+    document.new_page()
+    document.new_page()
+    pdf = tmp_path / "long.pdf"
+    document.save(pdf)
+    document.close()
+    command = conversion_command(tmp_path)
+    command["conversion"]["max_pages"] = 1
+
+    result = convert_managed_workspace(
+        command,
+        workspace_path=tmp_path.parent,
+    )
+
+    summary = result["conversion_summary"]
+    assert summary["skipped"] == 1
+    assert summary["items"][0]["reason"] == "PAGE_LIMIT_EXCEEDED"


### PR DESCRIPTION
### **User description**
## Summary

- add an admin-only conversion action for `managed_workspace` data sources backed by durable task execution
- expose conversion status, progress, history, cancellation, and terminal summaries without invoking Git or Feishu sync
- reuse LensNode sidecar conversion, fingerprint caching, force conversion, and safe per-file outcome codes
- protect conversion lifecycle state from cancellation races, late callbacks, and stale-task timeouts

Closes #229

## Test plan

- [x] `lensnode/.venv/bin/pytest -q lensnode/tests/test_managed_conversion.py lensnode/tests/test_executor.py`
- [x] focused backend managed workspace and conversion tests
- [x] `python manage.py check`
- [x] `python manage.py makemigrations --check --dry-run`
- [x] `git diff --check origin/main...HEAD`


___

### **PR Type**
Enhancement


___

### **Description**
- Add conversion API for managed workspace data sources

- Implement LensNode conversion command reusing document pipeline

- Track conversion status and history on DataSource model

- Support cancellation, progress events, and per-file outcomes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  API["Convert API"] --> Celery["datasource_conversion_task"]
  Celery --> LensNode["LensNode: convert_managed_workspace"]
  LensNode --> |Progress| Event["datasource_convert_event"]
  LensNode --> |Result| Done["datasource_convert_done"]
  Done --> Callback["complete_datasource_conversion_task"]
  Callback --> Model["DataSource.last_conversion_*"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>consumers.py</strong><dd><code>Handle datasource_convert_event and datasource_convert_done frames</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_services.py</strong><dd><code>Add dispatch_datasource_conversion_async function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0037_datasource_conversion_status.py</strong><dd><code>Add last_conversion_status and last_conversion_at fields</code>&nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-480b9f3e1b5c33b0bdfe325762c8bc16dc288a7e19052b79a5d7f1df0a2384c9">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add conversion status fields to DataSource model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add DataSourceConversionRequestSerializer and update validation</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+39/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add cancel_datasource_conversion_on_lensnode function</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Add datasource_conversion_task and related helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+365/-24</a></td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Add convert and cancel-conversion endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+151/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Add convert_managed_workspace function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+187/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>document_convert.py</strong><dd><code>Improve error handling, page limit, and fingerprint updates</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+80/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Handle datasource_convert and datasource_convert_cancel messages</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+116/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for conversion API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+172/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add tests for conversion lifecycle, cancellation, and cleanup</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+400/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Add test for conversion cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_managed_conversion.py</strong><dd><code>Add comprehensive tests for managed conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/237/files#diff-69f85a55d756c077f54bae8a7ba7e4397e5b2bde0fc0b847f07b2b25ba8891e5">+215/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

