### PR TITLE
Prevent false blocked outcomes from capability mismatch

### DIFF
--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -353,6 +353,7 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
         self.capability_correction_counts = defaultdict(int)
         self.success_count = 0
         self.successful_capabilities = set()
+        self.successful_evidence = []
         self.failed_capabilities = set()
         self.recovered_capabilities = set()
         self.correction_recovery_count = 0
@@ -494,11 +495,35 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
                 },
             )
 
-    def _record_success(self, capability, tool_name):
+    @staticmethod
+    def _evidence_source(capability, tool_name, request):
+        """Return a secret-safe source label for verified evidence."""
+
+        tool_call = request.tool_call or {}
+        arguments = tool_call.get("args") or {}
+        if capability == "skill" and isinstance(arguments, dict):
+            skill = str(arguments.get("skill") or "").strip()[:128]
+            if skill:
+                return f"skill:{skill}"
+        return tool_name
+
+    def _record_success(self, capability, tool_name, request):
         if capability is None:
             return
         self.success_count += 1
         self.successful_capabilities.add(capability)
+        self.successful_evidence.append(
+            {
+                "capability": capability,
+                "tool": tool_name,
+                "source": self._evidence_source(
+                    capability,
+                    tool_name,
+                    request,
+                ),
+                "request_sha256": self._normalized_arguments(request),
+            }
+        )
         self._record_recovery(capability, tool_name)
 
     def _record_warning(self, key, capability, error_type, tool_name):
@@ -589,11 +614,11 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             if not tool_name.startswith("mcp__"):
                 return result
             if getattr(result, "status", None) != "error":
-                self._record_success("mcp", tool_name)
+                self._record_success("mcp", tool_name, request)
                 return result
             payload = {"ok": False, "error": "MCP_TOOL_FAILED"}
         if payload.get("ok") is True:
-            self._record_success(capability, tool_name)
+            self._record_success(capability, tool_name, request)
             if payload.get("call_budget_exhausted") is True:
                 self.blocked_tools.add(tool_name)
             return result
@@ -1238,6 +1263,7 @@ class LensDeepAgentRuntime:
                         resources.context_skill_contents
                     ),
                     available_tools=[*tools, *mcp_tools],
+                    has_bound_skills=bool(resources.skill_paths),
                 )
                 command = {
                     **command,
@@ -1784,15 +1810,21 @@ def _select_general_chat_route(
     history=None,
     context_skill_contents=None,
     available_tools=None,
+    has_bound_skills=None,
 ):
     """Classify one General Chat request without exposing control output."""
 
     skills = "\n\n".join(context_skill_contents or [])[:16000]
+    if has_bound_skills is None:
+        has_bound_skills = bool(context_skill_contents)
     tool_inventory = []
     seen_tools = set()
     for tool in available_tools or []:
         name = str(getattr(tool, "name", "") or "").strip()[:128]
         if not name or name in seen_tools:
+            continue
+        capability = CapabilityBoundaryMiddleware._evidence_capability(name)
+        if capability == "skill" and not has_bound_skills:
             continue
         seen_tools.add(name)
         description = str(
@@ -1848,6 +1880,7 @@ def _select_general_chat_route(
                 *_build_initial_messages(history, question),
             ],
             runtime_control_call=True,
+            temperature=0,
         )
     except RunCancelledError:
         raise
@@ -1858,10 +1891,16 @@ def _select_general_chat_route(
     return _normalize_route_evidence_capabilities(
         decision,
         available_tools,
+        has_bound_skills=has_bound_skills,
     )
 
 
-def _normalize_route_evidence_capabilities(decision, available_tools):
+def _normalize_route_evidence_capabilities(
+    decision,
+    available_tools,
+    *,
+    has_bound_skills=True,
+):
     """Repair incomplete route evidence using available evidence families."""
 
     normalized = dict(decision)
@@ -1877,19 +1916,47 @@ def _normalize_route_evidence_capabilities(decision, available_tools):
         if capability in capability_order
     ]
     evidence_requirement = normalized.get("evidence_requirement")
+    available_capabilities = {
+        CapabilityBoundaryMiddleware._evidence_capability(
+            str(getattr(tool, "name", "") or "")
+        )
+        for tool in available_tools or []
+    }
+    available_capabilities.discard(None)
+    if not has_bound_skills:
+        available_capabilities.discard("skill")
     if evidence_requirement == "tool_result":
         required = [
             capability
             for capability in required
             if capability in {"skill", "mcp", "workspace"}
         ]
+        discarded = [
+            capability
+            for capability in required
+            if capability not in available_capabilities
+        ]
+        required = [
+            capability
+            for capability in required
+            if capability in available_capabilities
+        ]
+        if discarded:
+            derived = [
+                capability
+                for capability in capability_order
+                if capability in {"skill", "mcp", "workspace"}
+                and capability in available_capabilities
+                and capability not in required
+            ]
+            required.extend(derived)
+            normalized["capability_repair"] = {
+                "discarded": discarded,
+                "derived": derived,
+            }
+            if not required:
+                normalized["route"] = "capability_unavailable"
     if evidence_requirement == "tool_result" and not required:
-        available_capabilities = {
-            CapabilityBoundaryMiddleware._evidence_capability(
-                str(getattr(tool, "name", "") or "")
-            )
-            for tool in available_tools or []
-        }
         required.extend(
             capability
             for capability in capability_order
@@ -1966,13 +2033,27 @@ def _finalize_runtime_outcome(
             }
         return "completed", {}
 
-    successful = set(
-        getattr(
-            capability_middleware,
-            "successful_capabilities",
-            set(),
-        )
+    successful_evidence = getattr(
+        capability_middleware,
+        "successful_evidence",
+        None,
     )
+    if successful_evidence is None:
+        successful = set(
+            getattr(
+                capability_middleware,
+                "successful_capabilities",
+                set(),
+            )
+        )
+    else:
+        successful = {
+            str(evidence.get("capability") or "")
+            for evidence in successful_evidence
+            if isinstance(evidence, dict)
+            and evidence.get("tool")
+            and evidence.get("request_sha256")
+        }
     required = {
         capability
         for capability in required_capabilities or []
@@ -2461,7 +2542,13 @@ def _general_chat_system_prompt(command, context_skill_contents=None):
         "preflight authentication; run "
         "an auth command only after a business command reports that auth is "
         "required. Choose the needed result scope and output format before "
-        "the first business query. If a tool reports a request, usage, or "
+        "the first business query. When a loaded Skill documents a typed "
+        "command for the requested record type and filter, use that command "
+        "before unrelated discovery queries. For requests naming multiple "
+        "identifiers, cover every requested identifier or state which one "
+        "was not queried; ask a concise clarification question before "
+        "claiming a complete result when the record type is ambiguous. If a "
+        "tool reports a request, usage, or "
         "invalid-argument error, reread the Skill command reference and "
         "retry only with documented arguments. Never invent flags.\n\n"
         "Always end with a written answer to the user; never finish with an "

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -10,6 +10,7 @@ import shlex
 import stat
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from itertools import islice
@@ -1017,11 +1018,8 @@ def build_general_chat_tools(
     artifact_calls = {"count": 0}
     artifact_output_refs = []
     artifact_request_counts = {}
-    artifact_progress = {
-        "last_signature": None,
-        "streak": 0,
-        "stalled": False,
-    }
+    artifact_progress = {}
+    artifact_state_lock = threading.Lock()
     structured_analysis_max_calls = min(
         _positive_int(
             tool_policy.get("structured_analysis_max_calls"),
@@ -1949,9 +1947,55 @@ def build_general_chat_tools(
             return _json({"ok": False, "error": error})
 
         display_name = f"{skill_dir.name}/{artifact_name}"
-        artifact_calls["count"] += 1
-        call_count = artifact_calls["count"]
-        if call_count > artifact_max_calls:
+        request_signature = hashlib.sha256(
+            json.dumps(
+                [
+                    skill_dir.name,
+                    artifact_name,
+                    args,
+                    hashlib.sha256(stdin.encode("utf-8")).hexdigest(),
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        command_family = []
+        for value in args:
+            if value.startswith("-"):
+                break
+            command_family.append(value.casefold())
+            if len(command_family) >= 2:
+                break
+        progress_family = (
+            skill_dir.name,
+            artifact_name,
+            tuple(command_family),
+        )
+        with artifact_state_lock:
+            artifact_calls["count"] += 1
+            call_count = artifact_calls["count"]
+            request_count = (
+                artifact_request_counts.get(request_signature, 0) + 1
+            )
+            artifact_request_counts[request_signature] = request_count
+            progress_state = artifact_progress.setdefault(
+                progress_family,
+                {
+                    "result_counts": {},
+                    "stalled": False,
+                    "in_flight": 0,
+                },
+            )
+            progress_stalled = progress_state["stalled"]
+            call_limit_exceeded = call_count > artifact_max_calls
+            request_repeated = request_count > 2
+            if not (
+                call_limit_exceeded
+                or request_repeated
+                or progress_stalled
+            ):
+                progress_state["in_flight"] += 1
+        if call_limit_exceeded:
             detail = {
                 "skill": skill_dir.name,
                 "artifact": artifact_name,
@@ -1975,45 +2019,7 @@ def build_general_chat_tools(
                     ),
                 }
             )
-        if artifact_progress["stalled"]:
-            detail = {
-                "skill": skill_dir.name,
-                "artifact": artifact_name,
-                "args_redacted": _redact_command_args(args),
-                "call_count": call_count,
-                "max_calls": artifact_max_calls,
-                "invocation_id": invocation_id,
-                "summary": f"{display_name} · progress stalled",
-            }
-            emit("tool.run_skill_artifact.stalled", detail)
-            return _json(
-                {
-                    "ok": False,
-                    "error": "ARTIFACT_STALLED",
-                    "call_count": call_count,
-                    "max_calls": artifact_max_calls,
-                    "available_output_refs": artifact_output_refs,
-                    "instruction": (
-                        "Artifact results stopped changing. Stop calling it "
-                        "and synthesize the answer from existing evidence."
-                    ),
-                }
-            )
-        request_signature = hashlib.sha256(
-            json.dumps(
-                [
-                    skill_dir.name,
-                    artifact_name,
-                    args,
-                    hashlib.sha256(stdin.encode("utf-8")).hexdigest(),
-                ],
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ).encode("utf-8")
-        ).hexdigest()
-        request_count = artifact_request_counts.get(request_signature, 0) + 1
-        artifact_request_counts[request_signature] = request_count
-        if request_count > 2:
+        if request_repeated:
             detail = {
                 "skill": skill_dir.name,
                 "artifact": artifact_name,
@@ -2037,6 +2043,31 @@ def build_general_chat_tools(
                         "This exact Artifact request has already been run. "
                         "Stop repeating it and synthesize the answer from "
                         "the existing results."
+                    ),
+                }
+            )
+        if progress_stalled:
+            detail = {
+                "skill": skill_dir.name,
+                "artifact": artifact_name,
+                "args_redacted": _redact_command_args(args),
+                "call_count": call_count,
+                "max_calls": artifact_max_calls,
+                "invocation_id": invocation_id,
+                "summary": f"{display_name} · progress stalled",
+            }
+            emit("tool.run_skill_artifact.stalled", detail)
+            return _json(
+                {
+                    "ok": False,
+                    "error": "ARTIFACT_STALLED",
+                    "call_count": call_count,
+                    "max_calls": artifact_max_calls,
+                    "available_output_refs": artifact_output_refs,
+                    "instruction": (
+                        "Artifact results stopped changing for this command "
+                        "family. Stop calling it and synthesize the answer "
+                        "from existing evidence."
                     ),
                 }
             )
@@ -2066,6 +2097,8 @@ def build_general_chat_tools(
                 timeout=timeout_s,
             )
         except subprocess.TimeoutExpired as exc:
+            with artifact_state_lock:
+                artifact_progress[progress_family]["in_flight"] -= 1
             duration_ms = int((time.monotonic() - started) * 1000)
             stdout = _persist_large_tool_output(
                 resources.root,
@@ -2111,6 +2144,8 @@ def build_general_chat_tools(
                 }
             )
         except OSError:
+            with artifact_state_lock:
+                artifact_progress[progress_family]["in_flight"] -= 1
             emit(
                 "tool.run_skill_artifact.failed",
                 {
@@ -2152,14 +2187,20 @@ def build_general_chat_tools(
             payload["stdout_sha256"],
             payload["stderr_sha256"],
         )
-        if progress_signature == artifact_progress["last_signature"]:
-            artifact_progress["streak"] += 1
-        else:
-            artifact_progress["last_signature"] = progress_signature
-            artifact_progress["streak"] = 1
-        artifact_progress["stalled"] = artifact_progress["streak"] >= 3
-        payload["progress_streak"] = artifact_progress["streak"]
-        payload["progress_stalled"] = artifact_progress["stalled"]
+        with artifact_state_lock:
+            progress_state = artifact_progress[progress_family]
+            result_counts = progress_state["result_counts"]
+            progress_streak = result_counts.get(progress_signature, 0) + 1
+            result_counts[progress_signature] = progress_streak
+            progress_state["in_flight"] -= 1
+            progress_stalled = (
+                progress_state["in_flight"] == 0
+                and len(result_counts) == 1
+                and progress_streak >= 3
+            )
+            progress_state["stalled"] = progress_stalled
+        payload["progress_streak"] = progress_streak
+        payload["progress_stalled"] = progress_stalled
         if payload["stdout_truncated"]:
             artifact_output_refs.append(payload["stdout_ref"])
             if payload["stdout_format"] == "json":
@@ -2174,10 +2215,11 @@ def build_general_chat_tools(
                     "bounded view. Do not rerun the Artifact merely to "
                     "change pagination or output format."
                 )
-        if artifact_progress["stalled"]:
+        if progress_stalled:
             payload["instruction"] = (
-                "Artifact results have stopped changing. Stop calling it "
-                "and synthesize the answer from the evidence collected."
+                "Artifact results have stopped changing for this command "
+                "family. Stop calling it and synthesize the answer from the "
+                "evidence collected."
             )
         emit(
             "tool.run_skill_artifact.done",
@@ -2194,8 +2236,8 @@ def build_general_chat_tools(
                 "stderr_bytes": payload["stderr_bytes"],
                 "stderr_ref": payload["stderr_ref"],
                 "stderr_truncated": payload["stderr_truncated"],
-                "progress_streak": artifact_progress["streak"],
-                "progress_stalled": artifact_progress["stalled"],
+                "progress_streak": progress_streak,
+                "progress_stalled": progress_stalled,
                 "summary": f"{display_name} · rc={completed.returncode}",
             },
         )

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import ClassVar
 
+import pytest
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
@@ -473,9 +474,11 @@ def test_route_selection_matches_intent_against_skill_and_tool_capabilities():
     class Model:
         def __init__(self):
             self.messages = []
+            self.options = {}
 
-        def invoke(self, messages, **_kwargs):
+        def invoke(self, messages, **kwargs):
             self.messages = messages
+            self.options = kwargs
             return SimpleNamespace(
                 content=(
                     '{"intent":"action","complexity":"simple",'
@@ -505,6 +508,7 @@ def test_route_selection_matches_intent_against_skill_and_tool_capabilities():
     assert "query existing orders only" in prompt
     assert "run_skill_artifact" in prompt
     assert "creating an order" in prompt
+    assert model.options["temperature"] == 0
 
 
 def test_route_selection_recovers_missing_tool_evidence_capabilities():
@@ -537,6 +541,68 @@ def test_route_selection_recovers_missing_tool_evidence_capabilities():
 
     assert decision["evidence_requirement"] == "tool_result"
     assert decision["required_capabilities"] == ["skill"]
+
+
+def test_route_selection_repairs_impossible_mcp_evidence_to_skill():
+    class Model:
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"action","complexity":"simple",'
+                    '"route":"direct_execute",'
+                    '"required_capabilities":["mcp"],'
+                    '"evidence_requirement":"tool_result"}'
+                )
+            )
+
+    decision = agent_runtime._select_general_chat_route(
+        Model(),
+        "查询 agione-fabric 的充值记录",
+        context_skill_contents=[
+            "Use the Income Artifact payment list command for recharge data."
+        ],
+        available_tools=[
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
+    )
+
+    assert decision["route"] == "direct_execute"
+    assert decision["required_capabilities"] == ["skill"]
+    assert decision["capability_repair"] == {
+        "discarded": ["mcp"],
+        "derived": ["skill"],
+    }
+
+
+def test_route_selection_does_not_derive_an_unbound_skill_capability():
+    class Model:
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"action","complexity":"simple",'
+                    '"route":"direct_execute",'
+                    '"required_capabilities":["mcp"],'
+                    '"evidence_requirement":"tool_result"}'
+                )
+            )
+
+    decision = agent_runtime._select_general_chat_route(
+        Model(),
+        "查询充值记录",
+        context_skill_contents=[],
+        available_tools=[
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
+    )
+
+    assert decision["route"] == "capability_unavailable"
+    assert decision["required_capabilities"] == []
 
 
 def test_route_selection_requires_delivery_for_artifact_evidence():
@@ -616,7 +682,12 @@ def test_route_selection_uses_history_to_resolve_an_action_follow_up():
             },
         ],
         context_skill_contents=["This Skill can query Income orders."],
-        available_tools=[],
+        available_tools=[
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
     )
 
     assert decision["route"] == "direct_execute"
@@ -815,9 +886,11 @@ def test_unmatched_capability_returns_before_any_tool_call(monkeypatch):
     assert tool_calls["count"] == 0
 
 
+@pytest.mark.parametrize("classified_capabilities", [[], ["mcp"]])
 def test_successful_skill_evidence_preserves_the_final_answer(
     monkeypatch,
     tmp_path,
+    classified_capabilities,
 ):
     captured = {}
 
@@ -830,11 +903,14 @@ def test_successful_skill_evidence_preserves_the_final_answer(
 
         def invoke(self, _messages, **_kwargs):
             return SimpleNamespace(
-                content=(
-                    '{"intent":"action","complexity":"complex",'
-                    '"route":"plan_execute",'
-                    '"required_capabilities":[],'
-                    '"evidence_requirement":"tool_result"}'
+                content=json.dumps(
+                    {
+                        "intent": "action",
+                        "complexity": "complex",
+                        "route": "plan_execute",
+                        "required_capabilities": classified_capabilities,
+                        "evidence_requirement": "tool_result",
+                    }
                 )
             )
 
@@ -918,6 +994,20 @@ def test_successful_skill_evidence_preserves_the_final_answer(
             "artifact_delivery",
             "skill",
         }
+        captured["boundary"].successful_evidence = [
+            {
+                "capability": "skill",
+                "tool": "run_skill_artifact",
+                "source": "skill:income",
+                "request_sha256": "1" * 64,
+            },
+            {
+                "capability": "artifact_delivery",
+                "tool": "save_deliverable",
+                "source": "save_deliverable",
+                "request_sha256": "2" * 64,
+            },
+        ]
         return "已生成并交付订单流程图。", True, "token_budget_wrapup"
 
     monkeypatch.setattr(
@@ -1535,6 +1625,8 @@ def test_general_chat_prompt_forbids_unverified_business_results():
     assert "Never invent flags" in prompt
     assert "validate_records" in prompt
     assert "Do not fan out per-record detail calls" in prompt
+    assert "cover every requested identifier" in prompt
+    assert "typed command" in prompt
 
 
 def test_general_chat_prompt_repeats_configured_language_requirement():
@@ -2295,7 +2387,11 @@ def test_capability_boundary_counts_raw_mcp_success_as_evidence():
     middleware = agent_runtime.CapabilityBoundaryMiddleware()
     request = SimpleNamespace(
         tool=SimpleNamespace(name="mcp__orders__lookup"),
-        tool_call={"name": "mcp__orders__lookup", "id": "call-1"},
+        tool_call={
+            "name": "mcp__orders__lookup",
+            "id": "call-1",
+            "args": {"order_id": "HWINSTAD2025071509"},
+        },
     )
 
     middleware.wrap_tool_call(
@@ -2309,6 +2405,31 @@ def test_capability_boundary_counts_raw_mcp_success_as_evidence():
 
     assert middleware.success_count == 1
     assert middleware.successful_capabilities == {"mcp"}
+    assert len(middleware.successful_evidence) == 1
+    evidence = middleware.successful_evidence[0]
+    assert evidence["capability"] == "mcp"
+    assert evidence["tool"] == "mcp__orders__lookup"
+    assert evidence["source"] == "mcp__orders__lookup"
+    assert len(evidence["request_sha256"]) == 64
+    assert "HWINSTAD2025071509" not in json.dumps(evidence)
+
+
+def test_finalization_ignores_success_without_invocation_provenance():
+    middleware = agent_runtime.CapabilityBoundaryMiddleware(
+        required_capabilities=["skill"]
+    )
+    middleware.successful_capabilities.add("skill")
+
+    outcome, termination_detail = _finalize_runtime_outcome(
+        capability_middleware=middleware,
+        evidence_requirement="tool_result",
+        required_capabilities=["skill"],
+        truncated=False,
+        stop_reason=None,
+    )
+
+    assert outcome == "blocked"
+    assert termination_detail["reason"] == "evidence_unavailable"
 
 
 def test_capability_boundary_rejects_raw_mcp_error_as_evidence():

--- a/lensnode/tests/test_skill_artifacts.py
+++ b/lensnode/tests/test_skill_artifacts.py
@@ -3,6 +3,7 @@ import io
 import json
 import platform
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -282,7 +283,12 @@ def test_run_skill_artifact_stops_after_results_stagnate(tmp_path):
                 {
                     "skill": "income-cli",
                     "artifact": "income",
-                    "args": [str(index)],
+                    "args": [
+                        "payment",
+                        "list",
+                        "--search",
+                        str(index),
+                    ],
                 }
             )
         )
@@ -292,6 +298,102 @@ def test_run_skill_artifact_stops_after_results_stagnate(tmp_path):
     assert results[2]["progress_stalled"] is True
     assert "synthesize" in results[2]["instruction"]
     assert results[3]["error"] == "ARTIFACT_STALLED"
+
+
+def test_identical_empty_results_from_different_families_do_not_stall(
+    tmp_path,
+):
+    resources = _resources(tmp_path, b"#!/bin/sh\nprintf '[]'\n")
+    artifact = _artifact_tool(resources)
+    commands = [
+        ["product", "list", "--search", "fabric"],
+        ["enterprise", "list", "--search", "fabric"],
+        ["order", "list", "--search", "agione-fabric"],
+        ["payment", "list", "--search", "agione-fabric"],
+    ]
+
+    results = [
+        json.loads(
+            artifact.invoke(
+                {
+                    "skill": "income-cli",
+                    "artifact": "income",
+                    "args": command,
+                }
+            )
+        )
+        for command in commands
+    ]
+
+    assert all(result["ok"] is True for result in results)
+    assert all(result["progress_stalled"] is False for result in results)
+    assert [result["progress_streak"] for result in results] == [1, 1, 1, 1]
+
+
+def test_artifact_stagnation_is_deterministic_across_parallel_completion(
+    tmp_path,
+):
+    resources = _resources(tmp_path, b"#!/bin/sh\nprintf '[]'\n")
+    artifact = _artifact_tool(resources)
+    resource_names = ["product", "enterprise", "order"]
+
+    def invoke(resource):
+        return json.loads(
+            artifact.invoke(
+                {
+                    "skill": "income-cli",
+                    "artifact": "income",
+                    "args": [
+                        resource,
+                        "list",
+                        "--search",
+                        "fabric",
+                    ],
+                }
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        results = list(executor.map(invoke, resource_names))
+
+    payment = invoke("payment")
+
+    assert all(result["progress_streak"] == 1 for result in results)
+    assert all(result["progress_stalled"] is False for result in results)
+    assert payment["ok"] is True
+    assert payment["progress_streak"] == 1
+
+
+def test_parallel_progress_prevents_same_family_from_stalling(tmp_path):
+    content = (
+        b"#!/bin/sh\n"
+        b"case \"$4\" in\n"
+        b"  a|b|c) printf 'same' ;;\n"
+        b"  *) printf '%s' \"$4\" ;;\n"
+        b"esac\n"
+    )
+    resources = _resources(tmp_path, content)
+    artifact = _artifact_tool(resources)
+
+    def invoke(search):
+        return json.loads(
+            artifact.invoke(
+                {
+                    "skill": "income-cli",
+                    "artifact": "income",
+                    "args": ["payment", "list", "--search", search],
+                }
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(invoke, ["a", "b", "c", "different"]))
+
+    next_result = invoke("next")
+
+    assert {result["stdout"] for result in results} == {"same", "different"}
+    assert next_result["ok"] is True
+    assert next_result["stdout"] == "next"
 
 
 def test_run_skill_artifact_redacts_sensitive_args_in_history(tmp_path):


### PR DESCRIPTION
### **User description**
## Summary
- validate route evidence capabilities against the actual per-run Skill, MCP, and workspace inventory and make route classification deterministic
- retain secret-safe invocation provenance for successful evidence before terminal outcome finalization
- isolate Artifact stagnation by Skill, Artifact, and semantic command family while preserving exact-repeat and global call limits
- strengthen typed-command and multi-identifier execution guidance and document implementation decisions for Issue #210

Closes #210

## Test plan
- [x] `uv run --python 3.12 --project lensnode --extra dev pytest -q lensnode/tests/test_history.py lensnode/tests/test_skill_artifacts.py` (124 passed)
- [x] `uv run --python 3.12 --project lensnode --extra dev --with 'mcp==1.26.0' pytest -q lensnode/tests` (319 passed)
- [x] `git diff --check origin/main...HEAD`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Validate route capabilities against actual tool inventory and repair mismatches

- Isolate artifact stagnation by per-family progress state instead of global streak

- Retain secret-safe invocation provenance for successful evidence before finalization

- Strengthen typed-command and multi-identifier execution guidance in system prompt

- Add comprehensive tests for new capability validation paths and artifact changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Route classification"] --> B{"Required capabilities match inventory?"}
  B -- "Yes" --> C["Execute Artifact with per-family progress"]
  B -- "No" --> D["Repair: discard impossible, derive available"]
  D --> E{"Capability available?"}
  E -- "Yes" --> C
  E -- "No" --> F["Route: capability_unavailable"]
  C --> G["Record successful evidence with provenance"]
  G --> H["Finalization: verify evidence against required capabilities"]
  H -- "Match" --> I["Answer preserved"]
  H -- "Mismatch" --> J["Blocked"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent_runtime.py</strong><dd><code>Validate and repair capability contract; add evidence provenance</code></dd></summary>
<hr>

lensnode/lensnode/agent_runtime.py

<ul><li>Added <code>successful_evidence</code> list to track secret-safe provenance for <br>every successful tool call.<br> <li> Modified <code>_normalize_route_evidence_capabilities</code> to validate required <br>capabilities against the actual per-run inventory; discards impossible <br>families and derives available ones, setting route to <br><code>capability_unavailable</code> if none remain.<br> <li> Updated <code>_record_success</code> to store capability, tool, source (e.g., skill <br>name), and normalized request hash.<br> <li> Changed <code>_finalize_runtime_outcome</code> to use <code>successful_evidence</code> instead <br>of plain <code>successful_capabilities</code> set; only evidence with a tool and <br>request hash counts.<br> <li> Modified <code>_select_general_chat_route</code> to accept <code>has_bound_skills</code> flag, <br>filter out skill tools from the inventory when no skills are bound, <br>and set <code>temperature=0</code> for deterministic output.<br> <li> Enhanced system prompt to guide the model to use typed commands for <br>known record types, cover all requested identifiers, and ask for <br>clarification on ambiguity.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/238/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+104/-17</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent_tools.py</strong><dd><code>Isolate artifact stagnation per command family</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_tools.py

<ul><li>Replaced global <code>artifact_progress</code> dictionary with per-family state <br>keyed by <code>(skill, artifact, command_family)</code>.<br> <li> Added <code>artifact_state_lock</code> (threading.Lock) to protect concurrent <br>access to progress state.<br> <li> Modified stagnation detection: uses <code>result_counts</code> per family, only <br>stalls when <code>in_flight</code> is zero, only one distinct result signature <br>appears, and the streak reaches 3. Different families no longer <br>interfere.<br> <li> Separated exact-repeat detection: uses <code>request_signature</code> independent <br>of family progress; repeats beyond 2 return <code>ARTIFACT_REPEATED_CALL</code>.<br> <li> Updated error messages to be family-specific (e.g., "Artifact results <br>stopped changing for this command family").<br> <li> Decremented <code>in_flight</code> counter on timeout and OSError paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/238/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+92/-50</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Add tests for capability repair, evidence provenance, and prompt </code><br><code>guidance</code></dd></summary>
<hr>

lensnode/tests/test_history.py

<ul><li>Added test <br><code>test_route_selection_repairs_impossible_mcp_evidence_to_skill</code> <br>verifying that a classifier returning <code>["mcp"]</code> with only skill tools <br>yields <code>["skill"]</code> and a <code>capability_repair</code> field.<br> <li> Added test <br><code>test_route_selection_does_not_derive_an_unbound_skill_capability</code> <br>verifying that when no skills are bound, an impossible MCP requirement <br>results in <code>capability_unavailable</code>.<br> <li> Updated <br><code>test_route_selection_matches_intent_against_skill_and_tool_capabilities</code> <br>to assert <code>temperature=0</code> in model options.<br> <li> Updated <code>test_route_selection_requires_delivery_for_artifact_evidence</code> <br>to include a skill tool in available_tools.<br> <li> Parametrized <code>test_successful_skill_evidence_preserves_the_final_answer</code> <br>with <code>classified_capabilities</code> of <code>[]</code> and <code>["mcp"]</code>; added <br><code>successful_evidence</code> to verify the fix.<br> <li> Added <code>test_finalization_ignores_success_without_invocation_provenance</code>.<br> <li> Updated <code>test_general_chat_prompt_forbids_unverified_business_results</code> <br>to assert new prompt content about typed commands and identifier <br>coverage.<br> <li> Updated <code>test_capability_boundary_counts_raw_mcp_success_as_evidence</code> to <br>include <code>args</code> in tool_call and assert <code>successful_evidence</code> fields and <br>secret safety.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/238/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+129/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_skill_artifacts.py</strong><dd><code>Add tests for per-family stagnation, parallel determinism, and </code><br><code>cross-family isolation</code></dd></summary>
<hr>

lensnode/tests/test_skill_artifacts.py

Add tests for per-family stagnation, parallel determinism, and <br>cross-family isolation


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/238/files#diff-7d2c34e525ee5acc16e3f9bf3eedd8c83cdcf794f34b410f01f1e28057e4fe7d">+103/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

