### PR TITLE
Resume runs after LensNode restarts

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -15,6 +15,7 @@ from .services import (
     lensnode_group_name,
     reconcile_lensnode_active_runs,
     record_lensnode_run_event,
+    resume_awaiting_runs_for_lensnode,
     schedule_lensnode_disconnect_grace_check,
 )
 
@@ -199,10 +200,17 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         )
 
     async def _handle_hello(self, content):
+        active_runs = content.get("active_runs") or []
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self._update_lensnode_report(content, require_versions=True)
         await database_sync_to_async(reconcile_lensnode_active_runs)(
-            self.lensnode.uuid, content.get("active_runs") or []
+            self.lensnode.uuid, active_runs
+        )
+        # A node that (re)connected may own RUNNING runs with a resume
+        # deadline whose checkpoints survived on its workspace volume.
+        await database_sync_to_async(resume_awaiting_runs_for_lensnode)(
+            self.lensnode.uuid,
+            active_runs,
         )
         await self.send_json({"type": "hello_ack"})
 
@@ -327,7 +335,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         status = content.get("status") or Run.Status.DONE
         if status not in [Run.Status.DONE, Run.Status.FAILED]:
             status = Run.Status.FAILED
-        await database_sync_to_async(finish_lensnode_run)(
+        run = await database_sync_to_async(finish_lensnode_run)(
             run_uuid,
             status,
             error=content.get("error") or "",
@@ -340,6 +348,17 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             status,
             content.get("error") or "",
         )
+        if run.status in [
+            Run.Status.DONE,
+            Run.Status.FAILED,
+            Run.Status.CANCELLED,
+        ]:
+            await self.send_json(
+                {
+                    "type": "run_done_ack",
+                    "run_uuid": str(run_uuid),
+                }
+            )
 
     def _parse_uuid(self, value):
         """Parse a UUID value or return None."""

--- a/backend/lens/migrations/0038_run_awaiting_resume.py
+++ b/backend/lens/migrations/0038_run_awaiting_resume.py
@@ -1,0 +1,18 @@
+"""Add the backward-compatible run resume deadline."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("lens", "0037_datasource_conversion_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="run",
+            name="resume_by",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -771,6 +771,7 @@ class Run(models.Model):
     started_at = models.DateTimeField(null=True, blank=True)
     finished_at = models.DateTimeField(null=True, blank=True)
     last_activity_at = models.DateTimeField(null=True, blank=True)
+    resume_by = models.DateTimeField(null=True, blank=True)
     idempotency_key = models.CharField(max_length=128, blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -2177,6 +2177,7 @@ class RunSerializer(serializers.ModelSerializer):
             "feedback_updated_at",
             "started_at",
             "finished_at",
+            "resume_by",
             "created_at",
             "idempotency_key",
             "steps",

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 from datetime import timedelta
 from time import sleep
 
@@ -57,6 +58,8 @@ STREAM_PING_INTERVAL_SECONDS = 15
 BUSY_RETRY_INTERVAL_S = 5
 BUSY_RETRY_WINDOW_S = 120
 DOCUMENT_ATTACHMENT_CAPABILITY = "run_document_attachments"
+RUN_CHECKPOINT_RESUME_CAPABILITY = "run_checkpoint_resume"
+RUN_CHECKPOINT_TTL_HOURS_CAPABILITY = "run_checkpoint_ttl_hours"
 
 HISTORY_MAX_PAIRS = 5
 HISTORY_MAX_MESSAGE_CHARS = 2000
@@ -161,16 +164,84 @@ def schedule_lensnode_disconnect_grace_check(lensnode_uuid, disconnected_at):
         )
 
 
-def fail_active_runs_for_lensnode(lensnode_uuid):
-    """Mark all non-terminal runs for a lensnode as failed.
+AWAITING_RESUME_TTL_HOURS = 24
 
-    Called from the grace-period check once a node is confirmed still gone
-    (see lens.tasks.check_lensnode_disconnect_grace_period), NOT directly on
-    every disconnect — a brief drop during a blue/green switch must not fail
-    runs the node is still executing and will report on reconnect. The
-    status=RUNNING/STREAMING filter is itself the guard against a run that
-    finished (left those states) while the node was reconnecting.
+
+def get_awaiting_resume_ttl_hours(lensnode=None):
+    """Return how long an orphaned run waits for its node to come back.
+
+    Admin-tunable via the GlobalSetting key ``lensnode.resume_ttl_h``. Once
+    the deadline passes, the run is failed by the idle sweep instead of
+    waiting indefinitely for a node that may never return. The deadline is
+    capped by the node's advertised local checkpoint retention so the control
+    plane never promises a resume after the checkpoint may have been deleted.
     """
+
+    setting = GlobalSetting.objects.filter(
+        key="lensnode.resume_ttl_h"
+    ).first()
+    try:
+        value = int(setting.value if setting else AWAITING_RESUME_TTL_HOURS)
+    except (TypeError, ValueError):
+        value = AWAITING_RESUME_TTL_HOURS
+    labels = lensnode.labels if lensnode else {}
+    try:
+        node_ttl = float(
+            labels.get(
+                RUN_CHECKPOINT_TTL_HOURS_CAPABILITY,
+                AWAITING_RESUME_TTL_HOURS,
+            )
+            if isinstance(labels, dict)
+            else AWAITING_RESUME_TTL_HOURS
+        )
+    except (TypeError, ValueError):
+        node_ttl = AWAITING_RESUME_TTL_HOURS
+    if not math.isfinite(node_ttl):
+        node_ttl = AWAITING_RESUME_TTL_HOURS
+    return min(max(1, value), max(1, node_ttl))
+
+
+def get_run_resume_deadline(run, now=None):
+    """Bound checkpoint retention by the Run's original wall-clock budget."""
+
+    current = now or timezone.now()
+    ttl_deadline = current + timedelta(
+        hours=get_awaiting_resume_ttl_hours(run.lensnode)
+    )
+    if run.started_at is None:
+        return ttl_deadline
+    try:
+        execution = run.execution
+    except RunExecution.DoesNotExist:
+        return ttl_deadline
+    timeout_s = execution.run_timeout_s
+    if not timeout_s:
+        timeout_s = run_timeout_for_rounds(execution.agent_rounds)
+    run_deadline = run.started_at + timedelta(seconds=timeout_s)
+    return min(ttl_deadline, run_deadline)
+
+
+def schedule_awaiting_run_expiration(run_uuid, resume_by):
+    """Schedule precise expiry for one checkpoint-resumable Run."""
+
+    from .tasks import expire_awaiting_run
+
+    countdown_s = max((resume_by - timezone.now()).total_seconds(), 0)
+    try:
+        expire_awaiting_run.apply_async(
+            args=[str(run_uuid)],
+            countdown=countdown_s,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to schedule awaiting-resume expiration for run %s; "
+            "it will be reaped by the idle sweep instead",
+            run_uuid,
+        )
+
+
+def fail_active_runs_for_lensnode(lensnode_uuid):
+    """Fail active runs when their node cannot provide durable resume."""
 
     now = timezone.now()
     run_ids = list(
@@ -184,11 +255,217 @@ def fail_active_runs_for_lensnode(lensnode_uuid):
     Run.objects.filter(id__in=run_ids).update(
         status=Run.Status.FAILED,
         error="LENSNODE_DISCONNECTED",
+        resume_by=None,
         finished_at=now,
         updated_at=now,
     )
     fail_running_steps_for_runs(run_ids)
     return len(run_ids)
+
+
+def mark_active_runs_awaiting_resume(lensnode_uuid):
+    """Mark a confirmed-gone node's active runs as awaiting resume.
+
+    Called from the grace-period check once a node is confirmed still gone
+    (see lens.tasks.check_lensnode_disconnect_grace_period), NOT directly on
+    every disconnect — a brief drop during a blue/green switch must not fail
+    runs the node is still executing and will report on reconnect. The
+    status=RUNNING/STREAMING filter is itself the guard against a run that
+    finished (left those states) while the node was reconnecting.
+
+    Waiting is represented by RUNNING plus a non-null resume_by deadline.
+    Older application versions therefore continue to count the Run as active
+    during a blue/green rollback instead of silently ignoring a new status.
+    """
+
+    lensnode = LensNode.objects.filter(uuid=lensnode_uuid).first()
+    if not supports_run_checkpoint_resume(lensnode):
+        return fail_active_runs_for_lensnode(lensnode_uuid)
+
+    now = timezone.now()
+    runs = list(
+        Run.objects.filter(
+            lensnode__uuid=lensnode_uuid,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        ).select_related("execution", "lensnode")
+    )
+    if not runs:
+        return 0
+    updated_ids = []
+    expired_ids = []
+    scheduled_expirations = []
+    for run in runs:
+        resume_by = get_run_resume_deadline(run, now=now)
+        updates = {
+            "status": Run.Status.RUNNING,
+            "resume_by": resume_by,
+            "updated_at": now,
+        }
+        if resume_by <= now:
+            updates.update(
+                status=Run.Status.FAILED,
+                error="LENSNODE_RESUME_EXPIRED",
+                resume_by=None,
+                finished_at=now,
+            )
+        updated = Run.objects.filter(
+            id=run.id,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        ).update(**updates)
+        if not updated:
+            continue
+        updated_ids.append(run.id)
+        if resume_by <= now:
+            expired_ids.append(run.id)
+        else:
+            scheduled_expirations.append((run.uuid, resume_by))
+    fail_running_steps_for_runs(updated_ids)
+    if expired_ids:
+        RunExecution.objects.filter(
+            run_id__in=expired_ids,
+            status__in=[
+                RunExecution.Status.QUEUED,
+                RunExecution.Status.DISPATCHED,
+                RunExecution.Status.RUNNING,
+            ],
+        ).update(status=RunExecution.Status.FAILED, finished_at=now)
+    for run_uuid, resume_by in scheduled_expirations:
+        schedule_awaiting_run_expiration(run_uuid, resume_by)
+    return len(updated_ids)
+
+
+def resume_awaiting_runs_for_lensnode(
+    lensnode_uuid,
+    reported_active_run_uuids=(),
+):
+    """Re-dispatch a reconnected node's awaiting-resume runs.
+
+    Runs whose node died mid-answer keep RUNNING plus a resume deadline, with
+    their checkpoints preserved on the node's workspace volume. When the node
+    reconnects (fresh hello), each such run is dispatched again with the
+    same run_uuid; the node's checkpointer resumes the run from its last
+    checkpoint instead of starting over.
+
+    Runs reported active by the reconnecting node are not re-dispatched. This
+    includes both executions that survived the connection drop and completed
+    runs whose durable terminal frame is still waiting in the node outbox.
+    A failed dispatch is unexpected; the run is kept waiting so a later
+    reconnect retries it.
+    """
+
+    reported_active = {
+        str(run_uuid) for run_uuid in reported_active_run_uuids or ()
+    }
+    lensnode = LensNode.objects.filter(uuid=lensnode_uuid).first()
+    if not supports_run_checkpoint_resume(lensnode):
+        now = timezone.now()
+        unsupported = Run.objects.filter(
+            lensnode=lensnode,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+            resume_by__isnull=False,
+        ).exclude(uuid__in=reported_active)
+        run_ids = list(unsupported.values_list("id", flat=True))
+        unsupported.update(
+            status=Run.Status.FAILED,
+            error="LENSNODE_RESUME_UNSUPPORTED",
+            resume_by=None,
+            finished_at=now,
+            updated_at=now,
+        )
+        if run_ids:
+            fail_running_steps_for_runs(run_ids)
+            RunExecution.objects.filter(
+                run_id__in=run_ids,
+                status__in=[
+                    RunExecution.Status.QUEUED,
+                    RunExecution.Status.DISPATCHED,
+                    RunExecution.Status.RUNNING,
+                ],
+            ).update(
+                status=RunExecution.Status.FAILED,
+                finished_at=now,
+            )
+        return 0
+
+    report_at = lensnode.updated_at
+    awaiting_status = Q(status=Run.Status.RUNNING) | Q(
+        status=Run.Status.STREAMING,
+        last_activity_at__lt=report_at,
+    ) | Q(
+        status=Run.Status.STREAMING,
+        last_activity_at__isnull=True,
+    )
+    run_ids = (
+        Run.objects.filter(
+            lensnode__uuid=lensnode_uuid,
+            resume_by__gt=timezone.now(),
+        )
+        .exclude(uuid__in=reported_active)
+        .filter(awaiting_status)
+        .values_list("id", flat=True)
+    )
+    resumed = 0
+    for run_id in run_ids:
+        try:
+            with transaction.atomic():
+                run = (
+                    Run.objects.select_related(
+                        "execution",
+                        "input_message",
+                    )
+                    .select_for_update(of=("self",))
+                    .filter(
+                        id=run_id,
+                        lensnode__uuid=lensnode_uuid,
+                    )
+                    .first()
+                )
+                claimed_on_current_report = bool(
+                    run is not None
+                    and run.status == Run.Status.STREAMING
+                    and (
+                        run.last_activity_at is None
+                        or run.last_activity_at >= report_at
+                    )
+                )
+                if (
+                    run is None
+                    or run.status
+                    not in [Run.Status.RUNNING, Run.Status.STREAMING]
+                    or claimed_on_current_report
+                    or run.resume_by is None
+                    or run.resume_by <= timezone.now()
+                ):
+                    continue
+                now = timezone.now()
+                run.status = Run.Status.STREAMING
+                run.last_activity_at = now
+                run.save(
+                    update_fields=[
+                        "status",
+                        "last_activity_at",
+                        "updated_at",
+                    ]
+                )
+                if hasattr(run, "execution"):
+                    run.execution.status = RunExecution.Status.RUNNING
+                    run.execution.save(update_fields=["status"])
+                dispatch_run_to_lensnode(
+                    run,
+                    run.input_message.content,
+                    resume=True,
+                )
+        except Exception:
+            logger.exception(
+                "run %s: resume dispatch failed; keeping it awaiting",
+                run_id,
+            )
+            continue
+        logger.info(
+            "run %s: resumed on lensnode %s", run.uuid, lensnode_uuid
+        )
+        resumed += 1
+    return resumed
 
 
 def fail_running_steps_for_runs(run_ids):
@@ -237,7 +514,10 @@ def get_reconcile_confirm_grace_seconds():
     return max(1, value)
 
 
-def schedule_reconcile_orphan_confirmation(run_uuid):
+def schedule_reconcile_orphan_confirmation(
+    run_uuid,
+    minimum_countdown_s=0,
+):
     """Schedule the delayed check that fails a run if it's still non-terminal.
 
     Called from reconcile_lensnode_active_runs for each candidate instead of
@@ -252,11 +532,14 @@ def schedule_reconcile_orphan_confirmation(run_uuid):
 
     from .tasks import confirm_reconcile_orphan
 
-    grace_s = get_reconcile_confirm_grace_seconds()
+    countdown_s = max(
+        get_reconcile_confirm_grace_seconds(),
+        minimum_countdown_s,
+    )
     try:
         confirm_reconcile_orphan.apply_async(
             args=[str(run_uuid)],
-            countdown=grace_s,
+            countdown=countdown_s,
         )
     except Exception:
         logger.exception(
@@ -277,25 +560,43 @@ def reconcile_lensnode_active_runs(lensnode_uuid, active_run_uuids):
     legitimately unreported while its result is still in flight. Rather than
     failing candidates inline, this schedules a delayed confirmation per
     candidate so the normal completion path gets a chance to resolve it
-    first (see schedule_reconcile_orphan_confirmation). A short grace window
-    on run age avoids even considering a run that was just dispatched but
-    not yet started node-side.
+    first (see schedule_reconcile_orphan_confirmation). A run that was just
+    dispatched is checked only after it reaches the age guard, so a fast node
+    restart cannot make it disappear from both reconciliation and resume.
     """
 
     active = {str(value) for value in (active_run_uuids or [])}
     now = timezone.now()
-    candidates = (
-        Run.objects.filter(
-            lensnode__uuid=lensnode_uuid,
-            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
-            started_at__lt=now - timedelta(seconds=RECONCILE_GRACE_SECONDS),
+    lensnode = LensNode.objects.filter(uuid=lensnode_uuid).first()
+    candidates = Run.objects.filter(
+        lensnode=lensnode,
+        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        execution__status__in=[
+            RunExecution.Status.DISPATCHED,
+            RunExecution.Status.RUNNING,
+        ],
+        resume_by__isnull=True,
+    ).exclude(uuid__in=active)
+    if not supports_run_checkpoint_resume(lensnode):
+        age_cutoff = now - timedelta(seconds=RECONCILE_GRACE_SECONDS)
+        candidates = candidates.filter(
+            Q(started_at__isnull=True) | Q(started_at__lte=age_cutoff)
         )
-        .exclude(uuid__in=active)
-        .values_list("uuid", flat=True)
-    )
+    candidates = candidates.values_list("uuid", "started_at")
     count = 0
-    for run_uuid in candidates:
-        schedule_reconcile_orphan_confirmation(run_uuid)
+    for run_uuid, started_at in candidates:
+        run_age_s = (
+            max((now - started_at).total_seconds(), 0)
+            if started_at is not None
+            else 0
+        )
+        schedule_reconcile_orphan_confirmation(
+            run_uuid,
+            minimum_countdown_s=max(
+                RECONCILE_GRACE_SECONDS - run_age_s,
+                0,
+            ),
+        )
         count += 1
     return count
 
@@ -451,6 +752,16 @@ def supports_document_attachments(lensnode):
     return bool(
         isinstance(labels, dict)
         and labels.get(DOCUMENT_ATTACHMENT_CAPABILITY) is True
+    )
+
+
+def supports_run_checkpoint_resume(lensnode):
+    """Return whether a LensNode can safely continue a checkpointed Run."""
+
+    labels = lensnode.labels if lensnode else {}
+    return bool(
+        isinstance(labels, dict)
+        and labels.get(RUN_CHECKPOINT_RESUME_CAPABILITY) is True
     )
 
 
@@ -1081,8 +1392,14 @@ def dispatch_run_to_lensnode(
     run,
     rewritten_question,
     subject_documents=None,
+    resume=False,
 ):
-    """Send a run_start command to the connected LensNode."""
+    """Send a run_start command to the connected LensNode.
+
+    ``resume`` marks a re-dispatch of a run that already has a checkpoint on
+    the node: the node skips re-injecting the question/history and continues
+    the run from its last checkpoint.
+    """
 
     execution = run.execution
     runtime_snapshot = execution.runtime_snapshot or {}
@@ -1118,6 +1435,12 @@ def dispatch_run_to_lensnode(
     run_timeout_s = execution.run_timeout_s or run_timeout_for_rounds(
         agent_rounds
     )
+    elapsed_s = (
+        max((timezone.now() - run.started_at).total_seconds(), 0)
+        if run.started_at
+        else 0
+    )
+    remaining_run_timeout_s = max(run_timeout_s - elapsed_s, 0)
     profile = getattr(run.session.user, "profile", None)
     answer_language = normalize_answer_language(
         runtime_snapshot.get("answer_language")
@@ -1150,7 +1473,9 @@ def dispatch_run_to_lensnode(
                 ),
                 "max_agent_turns": AGENT_TURNS_BY_ROUNDS.get(agent_rounds, 26),
                 "agent_rounds": agent_rounds,
+                "resume": resume,
                 "run_timeout_s": run_timeout_s,
+                "remaining_run_timeout_s": remaining_run_timeout_s,
                 "trace_context": {
                     "trace_id": trace_id_for_run(run.uuid),
                     "root_observation_id": root_observation_id_for_run(
@@ -1304,6 +1629,11 @@ def record_lensnode_run_event(run_uuid, step_type, status, detail):
             run.status,
         )
         return None
+    if run.resume_by is not None and status == RunStep.Status.RUNNING:
+        Run.objects.filter(pk=run.pk, resume_by__isnull=False).update(
+            resume_by=None
+        )
+        run.resume_by = None
     sequence = _step_sequence(step_type)
     step, _ = RunStep.objects.get_or_create(
         run=run,
@@ -1350,7 +1680,36 @@ def finish_lensnode_run(
         return run
     now = timezone.now()
 
-    if status == Run.Status.FAILED and error == "LENSNODE_BUSY":
+    retryable_admission_error = error == "LENSNODE_BUSY" or (
+        error == "LENSNODE_DRAINING" and run.resume_by is not None
+    )
+    if status == Run.Status.FAILED and retryable_admission_error:
+        if run.resume_by is not None:
+            logger.info(
+                "run %s: resume admission rejected; keeping it awaiting",
+                run_uuid,
+            )
+            run.status = Run.Status.RUNNING
+            run.error = ""
+            run.outcome = ""
+            run.termination_detail = {}
+            run.save(
+                update_fields=[
+                    "status",
+                    "error",
+                    "outcome",
+                    "termination_detail",
+                    "updated_at",
+                ]
+            )
+            if run.resume_by > now:
+                from .tasks import retry_awaiting_run_resume
+
+                retry_awaiting_run_resume.apply_async(
+                    args=[str(run.uuid)],
+                    countdown=BUSY_RETRY_INTERVAL_S,
+                )
+            return run
         elapsed = (now - run.created_at).total_seconds()
         if elapsed < BUSY_RETRY_WINDOW_S:
             logger.warning(
@@ -1410,6 +1769,7 @@ def finish_lensnode_run(
     run.termination_detail = sanitize_termination_detail(
         termination_detail or {}
     )
+    run.resume_by = None
     run.finished_at = now
     run.save(
         update_fields=[
@@ -1417,6 +1777,7 @@ def finish_lensnode_run(
             "error",
             "outcome",
             "termination_detail",
+            "resume_by",
             "finished_at",
             "updated_at",
         ]
@@ -1526,6 +1887,7 @@ def stream_run_events(run):
     emitted_steps = set()
     emitted_content = ""
     last_status = None
+    last_resume_by = None
     last_queue_position = None
     last_ping_at = timezone.now()
 
@@ -1539,11 +1901,14 @@ def stream_run_events(run):
         run = _load_run_stream_state(run.pk)
         content = _run_content(run)
 
-        if run.status != last_status:
+        resume_by = run.resume_by.isoformat() if run.resume_by else None
+        if run.status != last_status or resume_by != last_resume_by:
             last_status = run.status
+            last_resume_by = resume_by
             yield {
                 "type": "status",
                 "status": run.status,
+                "resume_by": resume_by,
                 "ts": timezone.now().isoformat(),
             }
 
@@ -1611,6 +1976,7 @@ async def stream_run_events_async(run):
     emitted_steps = set()
     emitted_content = ""
     last_status = None
+    last_resume_by = None
     last_queue_position = None
     last_ping_at = timezone.now()
     run_pk = run.pk
@@ -1625,11 +1991,14 @@ async def stream_run_events_async(run):
         run = await sync_to_async(_load_run_stream_state)(run_pk)
         content = _run_content(run)
 
-        if run.status != last_status:
+        resume_by = run.resume_by.isoformat() if run.resume_by else None
+        if run.status != last_status or resume_by != last_resume_by:
             last_status = run.status
+            last_resume_by = resume_by
             yield {
                 "type": "status",
                 "status": run.status,
+                "resume_by": resume_by,
                 "ts": timezone.now().isoformat(),
             }
 
@@ -1725,6 +2094,7 @@ def _build_sync_event(run):
     return {
         "type": "sync",
         "status": run.status,
+        "resume_by": run.resume_by.isoformat() if run.resume_by else None,
         "outcome": run.outcome,
         "termination_detail": sanitize_termination_detail(
             run.termination_detail

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -1180,14 +1180,14 @@ def check_lensnode_disconnect_grace_period(lensnode_uuid, disconnected_at_iso):
     if node.status == LensNode.Status.ONLINE or not is_same_episode():
         return
 
-    from .services import fail_active_runs_for_lensnode
+    from .services import mark_active_runs_awaiting_resume
 
     logger.warning(
-        "LensNode %s still disconnected after the grace period; failing its "
-        "RUNNING/STREAMING runs",
+        "LensNode %s still disconnected after the grace period; marking "
+        "its RUNNING/STREAMING runs as awaiting resume",
         lensnode_uuid,
     )
-    fail_active_runs_for_lensnode(lensnode_uuid)
+    mark_active_runs_awaiting_resume(lensnode_uuid)
 
 
 @shared_task(
@@ -1196,7 +1196,7 @@ def check_lensnode_disconnect_grace_period(lensnode_uuid, disconnected_at_iso):
     ignore_result=True,
 )
 def confirm_reconcile_orphan(run_uuid):
-    """Fail a run only if it's still non-terminal after the confirm window.
+    """Park a run only if it's still non-terminal after the confirm window.
 
     Scheduled (with a countdown) by
     lens.services.schedule_reconcile_orphan_confirmation when a reconnecting
@@ -1209,18 +1209,52 @@ def confirm_reconcile_orphan(run_uuid):
     overwritable LensNode.disconnected_at field): this only ever acts on the
     one run_uuid it was scheduled for, and a run that already left
     RUNNING/STREAMING simply won't match the filter.
+
+    The run stays RUNNING with resume_by set rather than introducing a new
+    persisted status that an older blue/green rollback cannot understand.
     """
 
     now = timezone.now()
-    updated = Run.objects.filter(
-        uuid=run_uuid,
-        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
-    ).update(
-        status=Run.Status.FAILED,
-        error="LENSNODE_RECONNECT_ORPHANED",
-        finished_at=now,
-        updated_at=now,
+    from .services import (
+        get_reconcile_confirm_grace_seconds,
+        get_run_resume_deadline,
+        schedule_awaiting_run_expiration,
     )
+
+    activity_cutoff = now - timedelta(
+        seconds=get_reconcile_confirm_grace_seconds()
+    )
+    stale_activity = Q(last_activity_at__isnull=True) | Q(
+        last_activity_at__lte=activity_cutoff
+    )
+    run = (
+        Run.objects.select_related("lensnode", "execution")
+        .filter(
+            uuid=run_uuid,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        )
+        .filter(stale_activity)
+        .first()
+    )
+    if run is None:
+        return
+    resume_by = get_run_resume_deadline(run, now=now)
+    updates = {
+        "status": Run.Status.RUNNING,
+        "resume_by": resume_by,
+        "updated_at": now,
+    }
+    if resume_by <= now:
+        updates.update(
+            status=Run.Status.FAILED,
+            error="LENSNODE_RESUME_EXPIRED",
+            resume_by=None,
+            finished_at=now,
+        )
+    updated = Run.objects.filter(
+        pk=run.pk,
+        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+    ).filter(stale_activity).update(**updates)
     if updated:
         from .services import fail_running_steps_for_runs
 
@@ -1231,11 +1265,113 @@ def confirm_reconcile_orphan(run_uuid):
         )
         if run_id:
             fail_running_steps_for_runs([run_id])
+        if resume_by <= now:
+            RunExecution.objects.filter(
+                run_id=run_id,
+                status__in=[
+                    RunExecution.Status.QUEUED,
+                    RunExecution.Status.DISPATCHED,
+                    RunExecution.Status.RUNNING,
+                ],
+            ).update(
+                status=RunExecution.Status.FAILED,
+                finished_at=now,
+            )
         logger.warning(
             "Run %s still non-terminal after the reconcile confirm grace "
-            "window; marking it failed (LENSNODE_RECONNECT_ORPHANED)",
+            "window; %s",
             run_uuid,
+            (
+                "parking it as awaiting resume"
+                if resume_by > now
+                else "its original timeout has expired"
+            ),
         )
+        if resume_by > now:
+            schedule_awaiting_run_expiration(run.uuid, resume_by)
+        if resume_by > now and LensNode.objects.filter(
+            pk=run.lensnode_id,
+            status=LensNode.Status.ONLINE,
+        ).exists():
+            from .services import resume_awaiting_runs_for_lensnode
+
+            resume_awaiting_runs_for_lensnode(run.lensnode.uuid)
+
+
+@shared_task(
+    name="lens.expire_awaiting_run",
+    queue="lens",
+    ignore_result=True,
+)
+def expire_awaiting_run(run_uuid):
+    """Fail one parked Run when its precise resume deadline passes."""
+
+    now = timezone.now()
+    run = (
+        Run.objects.filter(
+            uuid=run_uuid,
+            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+            resume_by__isnull=False,
+        )
+        .values("id", "resume_by")
+        .first()
+    )
+    if run is None:
+        return 0
+    if run["resume_by"] > now:
+        from .services import schedule_awaiting_run_expiration
+
+        schedule_awaiting_run_expiration(run_uuid, run["resume_by"])
+        return 0
+    updated = Run.objects.filter(
+        id=run["id"],
+        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        resume_by__lte=now,
+    ).update(
+        status=Run.Status.FAILED,
+        error="LENSNODE_RESUME_EXPIRED",
+        resume_by=None,
+        finished_at=now,
+        updated_at=now,
+    )
+    if not updated:
+        return 0
+    from .services import fail_running_steps_for_runs
+
+    fail_running_steps_for_runs([run["id"]])
+    RunExecution.objects.filter(
+        run_id=run["id"],
+        status__in=[
+            RunExecution.Status.QUEUED,
+            RunExecution.Status.DISPATCHED,
+            RunExecution.Status.RUNNING,
+        ],
+    ).update(status=RunExecution.Status.FAILED, finished_at=now)
+    return 1
+
+
+@shared_task(
+    name="lens.retry_awaiting_run_resume",
+    queue="lens",
+    ignore_result=True,
+)
+def retry_awaiting_run_resume(run_uuid):
+    """Retry checkpoint admission while its bounded deadline remains valid."""
+
+    run = (
+        Run.objects.select_related("lensnode")
+        .filter(
+            uuid=run_uuid,
+            status=Run.Status.RUNNING,
+            resume_by__gt=timezone.now(),
+        )
+        .first()
+    )
+    if run is None or run.lensnode is None:
+        return 0
+    from .services import resume_awaiting_runs_for_lensnode
+
+    return resume_awaiting_runs_for_lensnode(run.lensnode.uuid)
 
 
 @shared_task(name="lens.lensnode_health", queue="lens")
@@ -1311,6 +1447,7 @@ def lensnode_cleanup_task():
     abs_cutoff = now - timedelta(seconds=timeout_s)
     stale = Run.objects.filter(
         status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        resume_by__isnull=True,
     ).filter(
         Q(last_activity_at__lt=idle_cutoff)
         | Q(last_activity_at__isnull=True, started_at__lt=idle_cutoff)
@@ -1325,6 +1462,25 @@ def lensnode_cleanup_task():
     stale.update(
         status=Run.Status.FAILED,
         error="LENS_RUN_TIMEOUT",
+        finished_at=now,
+        updated_at=now,
+    )
+    # Fail awaiting-resume runs whose node never came back before the resume
+    # deadline (see services.get_awaiting_resume_ttl_hours).
+    expired_resume = Run.objects.filter(
+        status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
+        resume_by__lt=now,
+    )
+    expired_resume_ids = list(expired_resume.values_list("id", flat=True))
+    expired_count = len(expired_resume_ids)
+    if expired_count:
+        from .services import fail_running_steps_for_runs
+
+        fail_running_steps_for_runs(expired_resume_ids)
+    expired_resume.update(
+        status=Run.Status.FAILED,
+        error="LENSNODE_RESUME_EXPIRED",
+        resume_by=None,
         finished_at=now,
         updated_at=now,
     )
@@ -1344,6 +1500,7 @@ def lensnode_cleanup_task():
     record.last_status = ScheduledTask.Status.SUCCESS
     record.last_metrics = {
         "failed": count,
+        "resume_expired": expired_count,
         "idle_timeout_s": idle_timeout_s,
         "timeout_s": timeout_s,
         "datasource_sync": datasource_sync_metrics,

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -5,6 +5,7 @@ import tempfile
 import threading
 import uuid
 import zipfile
+from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
@@ -2940,6 +2941,10 @@ class LensApiTests(TestCase):
         self.assertEqual(run_response.status_code, 201)
         self.assertEqual(run_response.data["status"], "queued")
         self.assertIsNotNone(run_response.data["created_at"])
+        Run.objects.filter(uuid=run_response.data["uuid"]).update(
+            status=Run.Status.RUNNING,
+            resume_by=timezone.now() + timedelta(hours=1),
+        )
 
         cancel_response = self.client.post(
             f"/api/lens/runs/{run_response.data['uuid']}/cancel/"
@@ -2947,6 +2952,7 @@ class LensApiTests(TestCase):
 
         self.assertEqual(cancel_response.status_code, 200)
         self.assertEqual(cancel_response.data["status"], "cancelled")
+        self.assertIsNone(cancel_response.data["resume_by"])
         self.assertEqual(
             cancel_response.data["execution"]["status"],
             RunExecution.Status.CANCELLED,

--- a/backend/lens/tests/test_disconnect_grace.py
+++ b/backend/lens/tests/test_disconnect_grace.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 from asgiref.sync import async_to_sync
@@ -12,6 +13,7 @@ from lens.models import (
     GlobalSetting,
     LensNode,
     Run,
+    RunExecution,
     Session,
 )
 from lens.services import (
@@ -19,6 +21,7 @@ from lens.services import (
     RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT,
     create_execution_run,
     get_lensnode_disconnect_grace_seconds,
+    get_awaiting_resume_ttl_hours,
     get_reconcile_confirm_grace_seconds,
 )
 from lens.tasks import check_lensnode_disconnect_grace_period
@@ -47,6 +50,10 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
             workspace_path="/workspace",
             available_dirs=[{"path": "/workspace/repo"}],
             tasks=[{"name": "knowledge_qa"}],
+            labels={
+                "run_checkpoint_resume": True,
+                "run_checkpoint_ttl_hours": 24,
+            },
         )
         self.assistant = Assistant.objects.create(
             name="Advisor",
@@ -90,7 +97,17 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         )
         self.assertEqual(get_reconcile_confirm_grace_seconds(), 7)
 
-    def test_check_fails_runs_when_still_offline(self):
+    def test_resume_ttl_is_capped_by_node_retention(self):
+        GlobalSetting.objects.create(key="lensnode.resume_ttl_h", value=48)
+        self.lensnode.labels["run_checkpoint_ttl_hours"] = 12
+        self.lensnode.save(update_fields=["labels"])
+
+        self.assertEqual(
+            get_awaiting_resume_ttl_hours(self.lensnode),
+            12,
+        )
+
+    def test_check_parks_runs_when_still_offline(self):
         run = self._make_running_run()
         stamp = timezone.now()
         self.lensnode.status = LensNode.Status.OFFLINE
@@ -102,8 +119,50 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         )
 
         run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertIsNotNone(run.resume_by)
+
+    def test_check_expires_run_past_original_wall_clock_budget(self):
+        run = self._make_running_run()
+        run.started_at = timezone.now() - timedelta(seconds=61)
+        run.execution.run_timeout_s = 60
+        run.execution.status = RunExecution.Status.RUNNING
+        run.execution.save(update_fields=["run_timeout_s", "status"])
+        run.save(update_fields=["started_at"])
+        stamp = timezone.now()
+        self.lensnode.status = LensNode.Status.OFFLINE
+        self.lensnode.disconnected_at = stamp
+        self.lensnode.save(update_fields=["status", "disconnected_at"])
+
+        check_lensnode_disconnect_grace_period(
+            str(self.lensnode.uuid), stamp.isoformat()
+        )
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_RESUME_EXPIRED")
+        self.assertIsNone(run.resume_by)
+        self.assertEqual(run.execution.status, RunExecution.Status.FAILED)
+
+    def test_check_fails_run_when_node_cannot_resume_checkpoint(self):
+        run = self._make_running_run()
+        stamp = timezone.now()
+        self.lensnode.status = LensNode.Status.OFFLINE
+        self.lensnode.disconnected_at = stamp
+        self.lensnode.labels = {}
+        self.lensnode.save(
+            update_fields=["status", "disconnected_at", "labels"]
+        )
+
+        check_lensnode_disconnect_grace_period(
+            str(self.lensnode.uuid), stamp.isoformat()
+        )
+
+        run.refresh_from_db()
         self.assertEqual(run.status, Run.Status.FAILED)
         self.assertEqual(run.error, "LENSNODE_DISCONNECTED")
+        self.assertIsNone(run.resume_by)
 
     def test_check_noops_when_node_reconnected(self):
         run = self._make_running_run()

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -1117,6 +1117,31 @@ class DocumentAttachmentTests(TestCase):
         self.assertEqual(response.data["detail"], "ATTACHMENT_IN_USE")
         self.assertIsNotNone(get_document_attachment(metadata["uuid"]))
 
+    def test_owner_cannot_delete_document_bound_to_awaiting_run(self):
+        metadata = store_document_attachment(
+            self.session,
+            self.user,
+            _pdf_upload(),
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Analyze it",
+            enqueue=False,
+            attachment_uuids=[metadata["uuid"]],
+        )
+        run.status = Run.Status.RUNNING
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["status", "resume_by"])
+        self.client.force_authenticate(self.user)
+
+        response = self.client.delete(
+            f"/api/lens/attachments/{metadata['uuid']}/"
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data["detail"], "ATTACHMENT_IN_USE")
+        self.assertIsNotNone(get_document_attachment(metadata["uuid"]))
+
     def test_owner_can_delete_document_after_run_finishes(self):
         metadata = store_document_attachment(
             self.session,

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -1,11 +1,13 @@
 import uuid
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
+from lens.consumers import LensNodeConsumer
 from lens.models import (
     Assistant,
     LensNode,
@@ -16,18 +18,29 @@ from lens.models import (
 )
 from lens.services import (
     create_execution_run,
-    fail_active_runs_for_lensnode,
+    finish_lensnode_run,
+    mark_active_runs_awaiting_resume,
     reconcile_lensnode_active_runs,
     record_lensnode_run_event,
+    resume_awaiting_runs_for_lensnode,
     touch_run_activity,
 )
-from lens.tasks import confirm_reconcile_orphan, lensnode_cleanup_task
+from lens.tasks import (
+    confirm_reconcile_orphan,
+    expire_awaiting_run,
+    lensnode_cleanup_task,
+)
 
 User = get_user_model()
 
 
 class RunLifecycleTests(TestCase):
     def setUp(self):
+        expiration_patcher = patch(
+            "lens.tasks.expire_awaiting_run.apply_async"
+        )
+        self.expiration_apply_async = expiration_patcher.start()
+        self.addCleanup(expiration_patcher.stop)
         self.user = User.objects.create_user(
             username="rl-user",
             email="rl-user@example.com",
@@ -38,6 +51,7 @@ class RunLifecycleTests(TestCase):
             status=LensNode.Status.ONLINE,
             enrollment_status=LensNode.EnrollmentStatus.APPROVED,
             workspace_path="/workspace",
+            labels={"run_checkpoint_resume": True},
         )
         self.assistant = Assistant.objects.create(
             name="Code Advisor",
@@ -114,6 +128,25 @@ class RunLifecycleTests(TestCase):
         self.assertIsNotNone(step)
         self.assertEqual(run.steps.count(), 1)
 
+    def test_first_resume_event_acknowledges_node_admission(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        record_lensnode_run_event(
+            run.uuid,
+            "retrieval",
+            "running",
+            {"message": "accepted"},
+        )
+
+        run.refresh_from_db()
+        self.assertIsNone(run.resume_by)
+
     def test_idle_reaper_fails_silent_run(self):
         run = self._run(
             Run.Status.STREAMING,
@@ -166,6 +199,8 @@ class RunLifecycleTests(TestCase):
             timedelta(minutes=5),
             timedelta(minutes=5),
         )
+        run.execution.status = RunExecution.Status.RUNNING
+        run.execution.save(update_fields=["status"])
 
         with patch(
             "lens.tasks.confirm_reconcile_orphan.apply_async"
@@ -180,7 +215,24 @@ class RunLifecycleTests(TestCase):
         self.assertEqual(kwargs["args"][0], str(run.uuid))
         self.assertIn("countdown", kwargs)
 
-    def test_reconcile_keeps_claimed_and_fresh_runs(self):
+    def test_reconcile_skips_run_already_awaiting_resume(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.tasks.confirm_reconcile_orphan.apply_async"
+        ) as apply_async:
+            count = reconcile_lensnode_active_runs(self.lensnode.uuid, [])
+
+        self.assertEqual(count, 0)
+        apply_async.assert_not_called()
+
+    def test_reconcile_keeps_claimed_and_defers_fresh_run(self):
         claimed = self._run(
             Run.Status.STREAMING,
             timedelta(minutes=5),
@@ -191,21 +243,65 @@ class RunLifecycleTests(TestCase):
             timedelta(seconds=10),
             timedelta(seconds=10),
         )
+        for run in (claimed, fresh):
+            run.execution.status = RunExecution.Status.RUNNING
+            run.execution.save(update_fields=["status"])
 
         with patch(
             "lens.tasks.confirm_reconcile_orphan.apply_async"
         ) as apply_async:
-            reconcile_lensnode_active_runs(
+            count = reconcile_lensnode_active_runs(
                 self.lensnode.uuid, [str(claimed.uuid)]
             )
 
         claimed.refresh_from_db()
         fresh.refresh_from_db()
+        self.assertEqual(count, 1)
         self.assertEqual(claimed.status, Run.Status.STREAMING)
+        self.assertEqual(fresh.status, Run.Status.RUNNING)
+        apply_async.assert_called_once()
+        kwargs = apply_async.call_args.kwargs
+        self.assertEqual(kwargs["args"], [str(fresh.uuid)])
+        self.assertGreater(kwargs["countdown"], 40)
+
+    def test_reconcile_skips_fresh_run_on_legacy_node(self):
+        self.lensnode.labels = {}
+        self.lensnode.save(update_fields=["labels"])
+        fresh = self._run(
+            Run.Status.RUNNING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        fresh.execution.status = RunExecution.Status.RUNNING
+        fresh.execution.save(update_fields=["status"])
+
+        with patch(
+            "lens.tasks.confirm_reconcile_orphan.apply_async"
+        ) as apply_async:
+            count = reconcile_lensnode_active_runs(self.lensnode.uuid, [])
+
+        fresh.refresh_from_db()
+        self.assertEqual(count, 0)
         self.assertEqual(fresh.status, Run.Status.RUNNING)
         apply_async.assert_not_called()
 
-    def test_confirm_reconcile_orphan_fails_still_running_run(self):
+    def test_reconcile_skips_run_that_has_not_been_dispatched(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        with patch(
+            "lens.tasks.confirm_reconcile_orphan.apply_async"
+        ) as apply_async:
+            count = reconcile_lensnode_active_runs(self.lensnode.uuid, [])
+
+        self.assertEqual(run.execution.status, RunExecution.Status.QUEUED)
+        self.assertEqual(count, 0)
+        apply_async.assert_not_called()
+
+    def test_confirm_reconcile_orphan_parks_still_running_run(self):
         run = self._run(
             Run.Status.STREAMING,
             timedelta(minutes=5),
@@ -215,8 +311,8 @@ class RunLifecycleTests(TestCase):
         confirm_reconcile_orphan(str(run.uuid))
 
         run.refresh_from_db()
-        self.assertEqual(run.status, Run.Status.FAILED)
-        self.assertEqual(run.error, "LENSNODE_RECONNECT_ORPHANED")
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertIsNotNone(run.resume_by)
 
     def test_confirm_reconcile_orphan_finalizes_running_steps(self):
         run = self._run(
@@ -236,7 +332,20 @@ class RunLifecycleTests(TestCase):
         step.refresh_from_db()
         self.assertEqual(step.status, RunStep.Status.FAILED)
 
-    def test_fail_active_runs_for_lensnode_finalizes_steps(self):
+    def test_confirm_reconcile_orphan_skips_recent_resume_activity(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(minutes=5),
+            timedelta(seconds=1),
+        )
+
+        confirm_reconcile_orphan(str(run.uuid))
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.STREAMING)
+        self.assertIsNone(run.resume_by)
+
+    def test_mark_active_runs_awaiting_resume_finalizes_steps(self):
         run = self._run(
             Run.Status.RUNNING,
             timedelta(minutes=5),
@@ -249,13 +358,351 @@ class RunLifecycleTests(TestCase):
             status=RunStep.Status.RUNNING,
         )
 
-        fail_active_runs_for_lensnode(self.lensnode.uuid)
+        mark_active_runs_awaiting_resume(self.lensnode.uuid)
+
+        run.refresh_from_db()
+        step.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertIsNotNone(run.resume_by)
+        self.assertEqual(step.status, RunStep.Status.FAILED)
+        self.expiration_apply_async.assert_called_once()
+
+    def test_mark_active_runs_awaiting_resume_skips_terminal_runs(self):
+        done = self._run(
+            Run.Status.DONE,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        mark_active_runs_awaiting_resume(self.lensnode.uuid)
+
+        done.refresh_from_db()
+        self.assertEqual(done.status, Run.Status.DONE)
+
+    def test_resume_awaiting_runs_redispatch(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode"
+        ) as dispatch:
+            count = resume_awaiting_runs_for_lensnode(
+                self.lensnode.uuid
+            )
+
+        run.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertEqual(dispatch.call_count, 1)
+        args, kwargs = dispatch.call_args
+        self.assertEqual(str(args[0].uuid), str(run.uuid))
+        self.assertEqual(kwargs["resume"], True)
+        self.assertEqual(run.status, Run.Status.STREAMING)
+        self.assertIsNotNone(run.resume_by)
+
+    def test_resume_skips_run_reported_active_by_reconnected_node(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode"
+        ) as dispatch:
+            count = resume_awaiting_runs_for_lensnode(
+                self.lensnode.uuid,
+                [str(run.uuid)],
+            )
+
+        run.refresh_from_db()
+        self.assertEqual(count, 0)
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertIsNotNone(run.resume_by)
+        dispatch.assert_not_called()
+
+    def test_resume_claim_prevents_reentrant_duplicate_dispatch(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        nested_counts = []
+
+        def dispatch_once(*args, **kwargs):
+            del args, kwargs
+            if not nested_counts:
+                nested_counts.append(
+                    resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+                )
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode",
+            side_effect=dispatch_once,
+        ) as dispatch:
+            count = resume_awaiting_runs_for_lensnode(
+                self.lensnode.uuid
+            )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(nested_counts, [0])
+        self.assertEqual(dispatch.call_count, 1)
+
+    def test_new_node_report_retries_unacknowledged_resume_claim(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(minutes=5),
+            timedelta(minutes=1),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        LensNode.objects.filter(pk=self.lensnode.pk).update(
+            updated_at=timezone.now()
+        )
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode"
+        ) as dispatch:
+            count = resume_awaiting_runs_for_lensnode(
+                self.lensnode.uuid
+            )
+
+        self.assertEqual(count, 1)
+        dispatch.assert_called_once()
+
+    def test_confirm_orphan_resumes_when_node_is_still_online(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode"
+        ) as dispatch:
+            confirm_reconcile_orphan(str(run.uuid))
+
+        run.refresh_from_db()
+        self.assertEqual(dispatch.call_count, 1)
+        self.assertEqual(run.status, Run.Status.STREAMING)
+        self.assertIsNotNone(run.resume_by)
+
+    def test_resume_awaiting_runs_keeps_run_parked_on_failure(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode",
+            side_effect=Exception("boom"),
+        ):
+            count = resume_awaiting_runs_for_lensnode(
+                self.lensnode.uuid
+            )
+
+        run.refresh_from_db()
+        self.assertEqual(count, 0)
+        self.assertEqual(run.status, Run.Status.RUNNING)
+
+    def test_resume_fails_safely_when_node_lacks_capability(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        self.lensnode.labels = {}
+        self.lensnode.save(update_fields=["labels"])
+
+        with patch("lens.services.dispatch_run_to_lensnode") as dispatch:
+            count = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+
+        run.refresh_from_db()
+        self.assertEqual(count, 0)
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_RESUME_UNSUPPORTED")
+        self.assertIsNone(run.resume_by)
+        dispatch.assert_not_called()
+
+    def test_resume_busy_response_keeps_run_awaiting(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(hours=1),
+            timedelta(minutes=5),
+        )
+        deadline = timezone.now() + timedelta(hours=1)
+        run.resume_by = deadline
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.tasks.retry_awaiting_run_resume.apply_async"
+        ) as retry:
+            record_lensnode_run_event(
+                run.uuid,
+                "retrieval",
+                "failed",
+                {"error": "LENSNODE_BUSY"},
+            )
+            finish_lensnode_run(
+                run.uuid,
+                Run.Status.FAILED,
+                error="LENSNODE_BUSY",
+            )
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertEqual(run.resume_by, deadline)
+        retry.assert_called_once_with(
+            args=[str(run.uuid)],
+            countdown=5,
+        )
+
+    def test_resume_draining_response_keeps_run_awaiting(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(hours=1),
+            timedelta(minutes=5),
+        )
+        deadline = timezone.now() + timedelta(hours=1)
+        run.resume_by = deadline
+        run.save(update_fields=["resume_by"])
+
+        with patch(
+            "lens.tasks.retry_awaiting_run_resume.apply_async"
+        ) as retry:
+            finish_lensnode_run(
+                run.uuid,
+                Run.Status.FAILED,
+                error="LENSNODE_DRAINING",
+            )
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.RUNNING)
+        self.assertEqual(run.resume_by, deadline)
+        retry.assert_called_once_with(
+            args=[str(run.uuid)],
+            countdown=5,
+        )
+
+    def test_buffered_terminal_frame_clears_resume_deadline(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+
+        finish_lensnode_run(run.uuid, Run.Status.DONE)
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, Run.Status.DONE)
+        self.assertIsNone(run.resume_by)
+
+    def test_busy_resume_result_is_not_acknowledged_as_terminal(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(hours=1),
+            timedelta(minutes=5),
+        )
+        consumer = LensNodeConsumer()
+        consumer.send_json = AsyncMock()
+
+        with patch(
+            "lens.consumers.finish_lensnode_run",
+            return_value=run,
+        ):
+            async_to_sync(consumer._handle_run_done)(
+                {
+                    "run_uuid": str(run.uuid),
+                    "status": Run.Status.FAILED,
+                    "error": "LENSNODE_BUSY",
+                }
+            )
+
+        consumer.send_json.assert_not_awaited()
+
+    def test_cancelled_completion_race_is_acknowledged(self):
+        run = self._run(
+            Run.Status.CANCELLED,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        consumer = LensNodeConsumer()
+        consumer.send_json = AsyncMock()
+
+        with patch(
+            "lens.consumers.finish_lensnode_run",
+            return_value=run,
+        ):
+            async_to_sync(consumer._handle_run_done)(
+                {
+                    "run_uuid": str(run.uuid),
+                    "status": Run.Status.DONE,
+                }
+            )
+
+        consumer.send_json.assert_awaited_once_with(
+            {
+                "type": "run_done_ack",
+                "run_uuid": str(run.uuid),
+            }
+        )
+
+    def test_idle_reaper_expires_stale_awaiting_resume(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(hours=25),
+            timedelta(hours=25),
+        )
+        run.resume_by = timezone.now() - timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        step = RunStep.objects.create(
+            run=run,
+            step_type=RunStep.StepType.GENERAL_CHAT,
+            sequence=1,
+            status=RunStep.Status.RUNNING,
+        )
+
+        lensnode_cleanup_task()
 
         run.refresh_from_db()
         step.refresh_from_db()
         self.assertEqual(run.status, Run.Status.FAILED)
-        self.assertEqual(run.error, "LENSNODE_DISCONNECTED")
+        self.assertEqual(run.error, "LENSNODE_RESUME_EXPIRED")
         self.assertEqual(step.status, RunStep.Status.FAILED)
+
+    def test_deadline_task_expires_one_awaiting_resume_run(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(hours=1),
+            timedelta(hours=1),
+        )
+        run.resume_by = timezone.now() - timedelta(seconds=1)
+        run.save(update_fields=["resume_by"])
+
+        count = expire_awaiting_run(str(run.uuid))
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_RESUME_EXPIRED")
+        self.assertIsNone(run.resume_by)
+        self.assertEqual(run.execution.status, RunExecution.Status.FAILED)
 
     def test_confirm_reconcile_orphan_noops_if_already_terminal(self):
         # The normal completion path (a late but durably-delivered run_done)

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -588,6 +588,30 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(retry.retry_of_run, first)
         self.assertEqual(self.session.message_set.count(), 4)
 
+    def test_awaiting_resume_run_counts_toward_assistant_concurrency(self):
+        self.assistant.max_concurrency = 1
+        self.assistant.save(update_fields=["max_concurrency"])
+        awaiting = create_execution_run(
+            session=self.session,
+            question="First",
+            enqueue=False,
+        )
+        awaiting.status = Run.Status.RUNNING
+        awaiting.resume_by = timezone.now() + timedelta(hours=1)
+        awaiting.save(update_fields=["status", "resume_by"])
+        queued = create_execution_run(
+            session=self.session,
+            question="Second",
+            enqueue=False,
+        )
+
+        with patch("lens.tasks.enqueue_answer_run_task") as enqueue:
+            execute_answer_run(queued, dispatch=False)
+
+        queued.refresh_from_db()
+        self.assertEqual(queued.status, Run.Status.QUEUED)
+        enqueue.assert_called_once_with(queued.uuid, 0, countdown=3)
+
     def test_execute_answer_run_creates_execution_snapshot(self):
         self.assistant.agent_rounds = "max"
         self.assistant.token_budget_profile = "deep"
@@ -746,16 +770,23 @@ class LensServiceTests(TransactionTestCase):
             question="Analyze everything",
             enqueue=False,
         )
+        run.started_at = timezone.now() - timedelta(minutes=5)
+        run.save(update_fields=["started_at"])
         execution = run.execution
 
         self.assistant.agent_rounds = "flash"
         self.assistant.save(update_fields=["agent_rounds"])
-        dispatch_run_to_lensnode(run, "Analyze everything")
+        with patch(
+            "lens.services.timezone.now",
+            return_value=run.started_at + timedelta(minutes=5),
+        ):
+            dispatch_run_to_lensnode(run, "Analyze everything")
 
         payload = sender.call_args.args[1]["payload"]
         self.assertEqual(payload["agent_rounds"], "max")
         self.assertEqual(payload["max_agent_turns"], 100)
         self.assertEqual(payload["run_timeout_s"], 3600)
+        self.assertEqual(payload["remaining_run_timeout_s"], 3300)
         self.assertEqual(execution.agent_rounds, "max")
         self.assertEqual(execution.run_timeout_s, 3600)
 
@@ -772,6 +803,8 @@ class LensServiceTests(TransactionTestCase):
             "22222222-2222-2222-2222-222222222222"
         )
         self.assistant.settings = {"runtime_mode": "original"}
+        self.user.profile.language = "zh-CN"
+        self.user.profile.save(update_fields=["language"])
         self.assistant.save(
             update_fields=[
                 "agent_model_ref",
@@ -788,6 +821,8 @@ class LensServiceTests(TransactionTestCase):
         self.assistant.agent_model_ref = "33333333-3333-3333-3333-333333333333"
         self.assistant.multimodal_model_ref = None
         self.assistant.settings = {"runtime_mode": "changed"}
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
         self.assistant.save(
             update_fields=[
                 "agent_model_ref",
@@ -806,6 +841,7 @@ class LensServiceTests(TransactionTestCase):
             payload["vision_model_ref"],
             "22222222-2222-2222-2222-222222222222",
         )
+        self.assertEqual(payload["answer_language"], "zh-CN")
         self.assertEqual(payload["settings"], {"runtime_mode": "original"})
 
     @patch("lens.services.async_to_sync")
@@ -960,10 +996,13 @@ class LensServiceTests(TransactionTestCase):
                 ],
             },
         )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
 
         event = _build_sync_event(run)
         detail = event["steps"][0]["detail"]
 
+        self.assertEqual(event["resume_by"], run.resume_by.isoformat())
         self.assertNotIn("secret", str(detail))
         self.assertNotIn("Authorization", str(detail))
         self.assertEqual(
@@ -1795,6 +1834,13 @@ class LensServiceTests(TransactionTestCase):
                 "run_uuid": str(run.uuid),
                 "status": "done",
             }
+        )
+        self.assertEqual(
+            await communicator.receive_json_from(),
+            {
+                "type": "run_done_ack",
+                "run_uuid": str(run.uuid),
+            },
         )
         await communicator.disconnect()
 

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -545,8 +545,16 @@ class RunViewSet(BaseAuthenticatedViewSet):
         now = timezone.now()
         with transaction.atomic():
             run.status = Run.Status.CANCELLED
+            run.resume_by = None
             run.finished_at = now
-            run.save(update_fields=["status", "finished_at", "updated_at"])
+            run.save(
+                update_fields=[
+                    "status",
+                    "resume_by",
+                    "finished_at",
+                    "updated_at",
+                ]
+            )
             if hasattr(run, "execution"):
                 run.execution.status = RunExecution.Status.CANCELLED
                 run.execution.finished_at = now

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -276,6 +276,7 @@
       "queued": "Queued, please wait",
       "queuedNext": "Almost your turn",
       "queuedPosition": "{position} ahead of you in the queue",
+      "awaitingResume": "Node disconnected, waiting to resume…",
       "running": "Analyzing",
       "generating": "Generating",
       "agentActivity": "Agent activity",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -276,6 +276,7 @@
       "queued": "排队中，请稍候",
       "queuedNext": "即将为您处理",
       "queuedPosition": "您前面还有 {position} 人在排队",
+      "awaitingResume": "节点中断，等待恢复运行…",
       "running": "正在分析",
       "generating": "正在生成",
       "agentActivity": "Agent 活动",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1727,6 +1727,9 @@ const showCursor = computed(
 )
 
 const liveStatusText = computed(() => {
+  if (currentRun.value?.resume_by) {
+    return t('lens.chat.awaitingResume')
+  }
   if (currentRun.value?.status === 'streaming') {
     return t('lens.chat.generating')
   }
@@ -2006,8 +2009,14 @@ const liveStructuredProgressText = computed(() =>
     : ''
 )
 
-const liveProgressText = computed(() =>
-  selectLiveProgressText({
+const liveProgressText = computed(() => {
+  if (currentRun.value?.resume_by) {
+    // The node owning this run is disconnected; its progress is frozen
+    // (and the run may resume on a reconnect), so surface that state
+    // instead of the stale plan/stage text.
+    return t('lens.chat.awaitingResume')
+  }
+  return selectLiveProgressText({
     finalAnswerProgressText: liveFinalAnswerProgressText.value,
     structuredProgressText: liveStructuredProgressText.value,
     planProgressText: livePlanProgressText.value,
@@ -2017,7 +2026,7 @@ const liveProgressText = computed(() =>
     phaseText: runtimePhaseText.value,
     fallbackText: liveStatusText.value
   })
-)
+})
 
 function runtimeStateFor(thinking) {
   let state = createRuntimeState()
@@ -2978,7 +2987,11 @@ async function readSse(runUuid) {
 function handleEvent(event) {
   runtimeState.value = applyRuntimeEvent(runtimeState.value, event)
   if (event.type === 'sync' || event.type === 'status') {
-    currentRun.value = { ...currentRun.value, status: event.status }
+    currentRun.value = {
+      ...currentRun.value,
+      status: event.status,
+      resume_by: event.resume_by ?? null
+    }
     if (event.status !== 'queued') queuePosition.value = null
     if (event.type === 'sync') {
       event.steps?.forEach((step) => handleStepEvent(step, event.ts))

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -82,10 +82,15 @@ _POTENTIALLY_SIDE_EFFECTING_TOOLS = {
 }
 
 
-def _pending_checkpoint_tool_calls(messages):
+def _pending_checkpoint_tool_calls(
+    messages,
+    pending_write_tool_call_ids=(),
+):
     """Return tool calls whose result is absent from checkpoint messages."""
 
-    completed = set()
+    completed = {
+        str(tool_call_id) for tool_call_id in pending_write_tool_call_ids
+    }
     for message in reversed(tuple(messages or ())):
         if isinstance(message, ToolMessage):
             tool_call_id = getattr(message, "tool_call_id", None)
@@ -103,7 +108,11 @@ def _pending_checkpoint_tool_calls(messages):
     return []
 
 
-def _reject_unsafe_resume_tool_replay(messages, tools):
+def _reject_unsafe_resume_tool_replay(
+    messages,
+    tools,
+    pending_write_tool_call_ids=(),
+):
     """Fail closed if resume could repeat an external write operation."""
 
     tools_by_name = {
@@ -121,7 +130,10 @@ def _reject_unsafe_resume_tool_replay(messages, tools):
                     "Cannot resume a checkpoint that depends on ephemeral "
                     "Skill API session values."
                 )
-    for call in _pending_checkpoint_tool_calls(messages):
+    for call in _pending_checkpoint_tool_calls(
+        messages,
+        pending_write_tool_call_ids,
+    ):
         name = str(call.get("name") or "")
         tool = tools_by_name.get(name)
         if tool is None:
@@ -1381,11 +1393,29 @@ class LensDeepAgentRuntime:
             on_activity=on_activity,
         )
         try:
+            initial_messages = _build_initial_messages(
+                command.get("history"),
+                question,
+            )
+            history_assistant_turns = sum(
+                1
+                for item in command.get("history") or []
+                if item.get("role") == "assistant"
+            )
             runtime_evidence = dict(
                 resume_state.runtime_evidence if resume_state else {}
             )
             capability_middleware = None
             checkpoint_ready = resume_state is not None
+            initial_checkpoint_seeded = False
+            resume_from_graph_checkpoint = resume_state is not None
+            if (
+                runtime_mode.execution_gates
+                and resume_state is not None
+                and resume_state.checkpoint_step < 0
+            ):
+                initial_checkpoint_seeded = True
+                resume_from_graph_checkpoint = False
 
             def persist_execution_state(
                 capability_state=None,
@@ -1494,17 +1524,41 @@ class LensDeepAgentRuntime:
                 _reject_unsafe_resume_tool_replay(
                     resume_state.messages,
                     [*tools, *mcp_tools],
+                    resume_state.pending_write_tool_call_ids,
                 )
             evidence_requirement = "none"
             required_capabilities = []
             if runtime_mode.execution_gates:
-                if resume_state is not None:
+                route_was_resumed = bool(
+                    resume_state is not None
+                    and resume_state.route_decision.get("route")
+                )
+                if route_was_resumed:
                     route_decision = resume_state.route_decision
-                    if not route_decision.get("route"):
-                        raise CheckpointResumeError(
-                            "Resume checkpoint has no runtime route."
-                        )
                 else:
+                    if resume_state is None and checkpoint_enabled():
+                        try:
+                            get_checkpoint_saver(
+                                self.config.workspace_path
+                            )
+                            save_resume_metadata(
+                                run_uuid,
+                                self.config.workspace_path,
+                                history_assistant_turns=(
+                                    history_assistant_turns
+                                ),
+                            )
+                            save_initial_checkpoint(
+                                run_uuid,
+                                self.config.workspace_path,
+                                initial_messages,
+                            )
+                            checkpoint_ready = True
+                            initial_checkpoint_seeded = True
+                        except Exception:
+                            LOGGER.exception(
+                                "Failed to enable route checkpoint"
+                            )
                     route_decision = _select_general_chat_route(
                         model,
                         question,
@@ -1515,6 +1569,14 @@ class LensDeepAgentRuntime:
                         available_tools=[*tools, *mcp_tools],
                         has_bound_skills=bool(resources.skill_paths),
                     )
+                    if checkpoint_ready:
+                        save_resume_metadata(
+                            run_uuid,
+                            self.config.workspace_path,
+                            route_decision=route_decision,
+                            history_assistant_turns=history_assistant_turns,
+                        )
+                        persist_execution_state()
                 command = {
                     **command,
                     "runtime_route": route_decision["route"],
@@ -1522,7 +1584,7 @@ class LensDeepAgentRuntime:
                 emit_user_event(
                     (
                         "route.resumed"
-                        if resume_state is not None
+                        if route_was_resumed
                         else "route.selected"
                     ),
                     route_decision,
@@ -1533,38 +1595,6 @@ class LensDeepAgentRuntime:
                 required_capabilities = route_decision[
                     "required_capabilities"
                 ]
-                if (
-                    route_decision["route"]
-                    in {"capability_unavailable", "direct_answer"}
-                    and resume_state is None
-                    and checkpoint_enabled()
-                ):
-                    try:
-                        get_checkpoint_saver(self.config.workspace_path)
-                        initial_messages = _build_initial_messages(
-                            command.get("history"),
-                            question,
-                        )
-                        save_resume_metadata(
-                            run_uuid,
-                            self.config.workspace_path,
-                            route_decision=route_decision,
-                            history_assistant_turns=sum(
-                                1
-                                for item in command.get("history") or []
-                                if item.get("role") == "assistant"
-                            ),
-                        )
-                        save_initial_checkpoint(
-                            run_uuid,
-                            self.config.workspace_path,
-                            initial_messages,
-                        )
-                        checkpoint_ready = True
-                    except Exception:
-                        LOGGER.exception(
-                            "Failed to enable direct run checkpoint"
-                        )
                 if route_decision["route"] == "capability_unavailable":
                     required = route_decision["required_capabilities"]
                     capability = next(
@@ -1760,6 +1790,10 @@ class LensDeepAgentRuntime:
                         self.config.workspace_path
                     )
                     checkpoint_ready = True
+                elif checkpoint_ready:
+                    kwargs["checkpointer"] = get_checkpoint_saver(
+                        self.config.workspace_path
+                    )
                 else:
                     try:
                         kwargs["checkpointer"] = get_checkpoint_saver(
@@ -1773,10 +1807,8 @@ class LensDeepAgentRuntime:
                                 if runtime_mode.execution_gates
                                 else {}
                             ),
-                            history_assistant_turns=sum(
-                                1
-                                for item in command.get("history") or []
-                                if item.get("role") == "assistant"
+                            history_assistant_turns=(
+                                history_assistant_turns
                             ),
                         )
                         checkpoint_ready = True
@@ -1804,9 +1836,7 @@ class LensDeepAgentRuntime:
                 "deepagents.agent.invoke",
                 invoke_detail,
             )
-            messages = _build_initial_messages(
-                command.get("history"), question
-            )
+            messages = initial_messages
             turn_baseline_ai = None
             event_baseline_ai = None
             if resume_state is not None:
@@ -1838,7 +1868,7 @@ class LensDeepAgentRuntime:
                 thread=checkpoint_thread,
                 turn_baseline_ai=turn_baseline_ai,
                 event_baseline_ai=event_baseline_ai,
-                resume_from_checkpoint=resume_state is not None,
+                resume_from_checkpoint=resume_from_graph_checkpoint,
                 emit_event=emit_agent_event,
                 answer_language=_command_answer_language(command),
                 cancel_event=cancel_event,
@@ -1846,6 +1876,10 @@ class LensDeepAgentRuntime:
                     wrapup_event if runtime_mode.execution_gates else None
                 ),
                 token_budget_wrapup_event=token_budget_wrapup_event,
+                on_checkpoint_state=(
+                    persist_execution_state if checkpoint_ready else None
+                ),
+                input_checkpoint_seeded=initial_checkpoint_seeded,
             )
             if truncated:
                 emit_agent_event(
@@ -3143,6 +3177,8 @@ def _run_agent_with_turn_limit(
     cancel_event=None,
     wrapup_event=None,
     token_budget_wrapup_event=None,
+    on_checkpoint_state=None,
+    input_checkpoint_seeded=False,
 ):
     """Stream agent events and stop after max_turns NEW AI turns.
 
@@ -3186,7 +3222,12 @@ def _run_agent_with_turn_limit(
     )
     seeded_baseline = False
 
-    graph_input = None if resume_from_checkpoint else {"messages": messages}
+    if resume_from_checkpoint:
+        graph_input = None
+    elif input_checkpoint_seeded:
+        graph_input = {"messages": []}
+    else:
+        graph_input = {"messages": messages}
     for state in agent.stream(
         graph_input,
         stream_mode="values",
@@ -3200,6 +3241,8 @@ def _run_agent_with_turn_limit(
                 "Run was cancelled; stopping the agent loop."
             )
         last_state = state
+        if on_checkpoint_state is not None:
+            on_checkpoint_state()
         current = state.get("messages", [])
         if not seeded_baseline:
             # Seed the historical assistant turns by their (now-assigned)

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -32,6 +32,16 @@ from .agent_tools import (
     build_agent_tools,
     build_general_chat_tools,
 )
+from .checkpoint import (
+    CheckpointResumeError,
+    checkpoint_enabled,
+    get_checkpoint_saver,
+    load_resume_state,
+    save_initial_checkpoint,
+    save_resume_metadata,
+    save_runtime_state,
+    thread_config,
+)
 from .gateway_model import (
     LensGatewayChatModel,
     RunCancelledError,
@@ -61,6 +71,86 @@ class EmptyAgentResponseError(RuntimeError):
     """The agent and its one recovery attempt both returned no text."""
 
     code = "EMPTY_AGENT_RESPONSE"
+
+
+_POTENTIALLY_SIDE_EFFECTING_TOOLS = {
+    "call_skill_api",
+    "run_skill_artifact",
+    "run_skill_script",
+    "run_skill_transform",
+    "save_deliverable",
+}
+
+
+def _pending_checkpoint_tool_calls(messages):
+    """Return tool calls whose result is absent from checkpoint messages."""
+
+    completed = set()
+    for message in reversed(tuple(messages or ())):
+        if isinstance(message, ToolMessage):
+            tool_call_id = getattr(message, "tool_call_id", None)
+            if tool_call_id:
+                completed.add(str(tool_call_id))
+            continue
+        tool_calls = getattr(message, "tool_calls", None) or []
+        pending = [
+            call
+            for call in tool_calls
+            if str(call.get("id") or "") not in completed
+        ]
+        if pending:
+            return pending
+    return []
+
+
+def _reject_unsafe_resume_tool_replay(messages, tools):
+    """Fail closed if resume could repeat an external write operation."""
+
+    tools_by_name = {
+        str(getattr(tool, "name", "") or ""): tool for tool in tools or []
+    }
+    for message in tuple(messages or ()):
+        for call in getattr(message, "tool_calls", None) or []:
+            arguments = call.get("args") or {}
+            if (
+                call.get("name") == "call_skill_api"
+                and isinstance(arguments, dict)
+                and arguments.get("capture")
+            ):
+                raise CheckpointResumeError(
+                    "Cannot resume a checkpoint that depends on ephemeral "
+                    "Skill API session values."
+                )
+    for call in _pending_checkpoint_tool_calls(messages):
+        name = str(call.get("name") or "")
+        tool = tools_by_name.get(name)
+        if tool is None:
+            raise CheckpointResumeError(
+                "Cannot resume a checkpoint with an unclassified pending "
+                "tool operation."
+            )
+        metadata = getattr(tool, "metadata", None) or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        if metadata.get("idempotent") is True:
+            continue
+        if (
+            metadata.get("read_only") is True
+            or metadata.get("operation") == "read"
+        ):
+            continue
+        is_write = (
+            metadata.get("operation") == "write"
+            or metadata.get("read_only") is False
+            or metadata.get("side_effects") is True
+            or name.startswith("mcp__")
+            or name in _POTENTIALLY_SIDE_EFFECTING_TOOLS
+        )
+        if is_write:
+            raise CheckpointResumeError(
+                "Cannot resume a checkpoint with a pending non-idempotent "
+                "write operation."
+            )
 
 
 class TraceObservationMiddleware(AgentMiddleware):
@@ -341,10 +431,12 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
         emit_event=None,
         required_capabilities=None,
         require_initial_plan=False,
+        on_state_change=None,
     ):
         self.emit_event = emit_event
         self.required_capabilities = set(required_capabilities or [])
         self.require_initial_plan = require_initial_plan
+        self.on_state_change = on_state_change
         self.initial_plan_exists = False
         self.blocked_tools = set()
         self.blocked_capabilities = set()
@@ -361,6 +453,113 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
         self.termination_detail = {}
         self.exhaustion_details = []
         self.failure_records = {}
+
+    def export_state(self):
+        """Return a JSON-safe snapshot of execution-gate state."""
+
+        return {
+            "initial_plan_exists": self.initial_plan_exists,
+            "blocked_tools": sorted(self.blocked_tools),
+            "blocked_capabilities": sorted(self.blocked_capabilities),
+            "failure_counts": [
+                [*key, count]
+                for key, count in sorted(self.failure_counts.items())
+            ],
+            "capability_failure_counts": dict(
+                self.capability_failure_counts
+            ),
+            "capability_correction_counts": dict(
+                self.capability_correction_counts
+            ),
+            "success_count": self.success_count,
+            "successful_capabilities": sorted(
+                self.successful_capabilities
+            ),
+            "successful_evidence": [
+                dict(item) for item in self.successful_evidence
+            ],
+            "failed_capabilities": sorted(self.failed_capabilities),
+            "recovered_capabilities": sorted(
+                self.recovered_capabilities
+            ),
+            "correction_recovery_count": self.correction_recovery_count,
+            "alternative_recovery_count": self.alternative_recovery_count,
+            "termination_detail": dict(self.termination_detail),
+            "exhaustion_details": list(self.exhaustion_details),
+            "failure_records": [
+                [*key, detail]
+                for key, detail in self.failure_records.items()
+            ],
+        }
+
+    def restore_state(self, state):
+        """Restore a previously exported execution-gate snapshot."""
+
+        if not isinstance(state, dict):
+            raise CheckpointResumeError(
+                "Resume checkpoint has invalid execution-gate state."
+            )
+        try:
+            self.initial_plan_exists = bool(
+                state.get("initial_plan_exists", False)
+            )
+            self.blocked_tools = set(state.get("blocked_tools") or [])
+            self.blocked_capabilities = set(
+                state.get("blocked_capabilities") or []
+            )
+            self.failure_counts = defaultdict(
+                int,
+                {
+                    tuple(item[:3]): int(item[3])
+                    for item in state.get("failure_counts") or []
+                },
+            )
+            self.capability_failure_counts = defaultdict(
+                int,
+                state.get("capability_failure_counts") or {},
+            )
+            self.capability_correction_counts = defaultdict(
+                int,
+                state.get("capability_correction_counts") or {},
+            )
+            self.success_count = int(state.get("success_count") or 0)
+            self.successful_capabilities = set(
+                state.get("successful_capabilities") or []
+            )
+            self.successful_evidence = [
+                dict(item)
+                for item in state.get("successful_evidence") or []
+            ]
+            self.failed_capabilities = set(
+                state.get("failed_capabilities") or []
+            )
+            self.recovered_capabilities = set(
+                state.get("recovered_capabilities") or []
+            )
+            self.correction_recovery_count = int(
+                state.get("correction_recovery_count") or 0
+            )
+            self.alternative_recovery_count = int(
+                state.get("alternative_recovery_count") or 0
+            )
+            self.termination_detail = dict(
+                state.get("termination_detail") or {}
+            )
+            self.exhaustion_details = list(
+                state.get("exhaustion_details") or []
+            )
+            self.failure_records = {
+                tuple(item[:3]): dict(item[3])
+                for item in state.get("failure_records") or []
+            }
+        except (TypeError, ValueError, IndexError) as exc:
+            raise CheckpointResumeError(
+                "Resume checkpoint has invalid execution-gate state."
+            ) from exc
+
+    def _notify_state_change(self):
+        if self.on_state_change is not None:
+            self.on_state_change(self.export_state())
 
     @property
     def warning_count(self):
@@ -578,12 +777,7 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
         )
         if not is_write:
             return False
-        arguments = (request.tool_call or {}).get("args") or {}
-        has_idempotency_key = bool(
-            isinstance(arguments, dict)
-            and arguments.get("idempotency_key")
-        )
-        return not (metadata.get("idempotent") or has_idempotency_key)
+        return metadata.get("idempotent") is not True
 
     def _failure_budget(self, request, error_type):
         if error_type == "transient" and self._is_non_idempotent_write(
@@ -810,7 +1004,9 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             return self._deny_blocked_call(request)
         result = handler(request)
         self._observe_plan_call(request, result)
-        return self._record_result(request, result)
+        result = self._record_result(request, result)
+        self._notify_state_change()
+        return result
 
     async def awrap_tool_call(self, request, handler):
         """Classify one asynchronous tool result and enforce its budget."""
@@ -822,7 +1018,9 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             return self._deny_blocked_call(request)
         result = await handler(request)
         self._observe_plan_call(request, result)
-        return self._record_result(request, result)
+        result = self._record_result(request, result)
+        self._notify_state_change()
+        return result
 
 
 SCENARIOS = {
@@ -1102,6 +1300,13 @@ class LensDeepAgentRuntime:
 
         started_at = utc_now()
         question = command.get("question", "")
+        run_uuid = str(command.get("run_uuid") or "")
+        resume_state = None
+        if command.get("resume"):
+            resume_state = load_resume_state(
+                run_uuid,
+                self.config.workspace_path,
+            )
         scenario = _scenario_for_task(command.get("task"))
         runtime_mode = runtime_mode_for(command)
         model_ref = command.get("agent_model_ref")
@@ -1176,8 +1381,31 @@ class LensDeepAgentRuntime:
             on_activity=on_activity,
         )
         try:
-            run_uuid = str(command.get("run_uuid") or "")
-            runtime_evidence = {}
+            runtime_evidence = dict(
+                resume_state.runtime_evidence if resume_state else {}
+            )
+            capability_middleware = None
+            checkpoint_ready = resume_state is not None
+
+            def persist_execution_state(
+                capability_state=None,
+                guardrail_state=None,
+            ):
+                if not checkpoint_ready:
+                    return
+                if capability_state is None and capability_middleware:
+                    capability_state = capability_middleware.export_state()
+                save_runtime_state(
+                    run_uuid,
+                    self.config.workspace_path,
+                    capability_state=capability_state or {},
+                    runtime_evidence=runtime_evidence,
+                    guardrail_state=(
+                        guardrail_state
+                        if guardrail_state is not None
+                        else model.export_runtime_state()
+                    ),
+                )
             token_budget = _resolve_token_budget(self.config, command)
             token_budget_wrapup_event = (
                 threading.Event() if runtime_mode.execution_gates else None
@@ -1210,7 +1438,15 @@ class LensDeepAgentRuntime:
                     0.8,
                 ),
                 token_budget_wrapup_event=token_budget_wrapup_event,
+                on_runtime_state_change=lambda state: (
+                    persist_execution_state(guardrail_state=state)
+                ),
             )
+            if resume_state is not None:
+                model.restore_runtime_state(
+                    resume_state.messages,
+                    resume_state.guardrail_state,
+                )
             if runtime_mode.general_chat:
                 tools = build_general_chat_tools(
                     command,
@@ -1218,6 +1454,9 @@ class LensDeepAgentRuntime:
                     self.config,
                     emit_event=emit_agent_event,
                     runtime_evidence=runtime_evidence,
+                    on_runtime_evidence=lambda _state: (
+                        persist_execution_state()
+                    ),
                 )
             else:
                 tools = build_agent_tools(
@@ -1251,31 +1490,81 @@ class LensDeepAgentRuntime:
                 )
             )
             tools.extend(registered_mcp_tools)
-            capability_middleware = None
+            if resume_state is not None:
+                _reject_unsafe_resume_tool_replay(
+                    resume_state.messages,
+                    [*tools, *mcp_tools],
+                )
             evidence_requirement = "none"
             required_capabilities = []
             if runtime_mode.execution_gates:
-                route_decision = _select_general_chat_route(
-                    model,
-                    question,
-                    history=command.get("history"),
-                    context_skill_contents=(
-                        resources.context_skill_contents
-                    ),
-                    available_tools=[*tools, *mcp_tools],
-                    has_bound_skills=bool(resources.skill_paths),
-                )
+                if resume_state is not None:
+                    route_decision = resume_state.route_decision
+                    if not route_decision.get("route"):
+                        raise CheckpointResumeError(
+                            "Resume checkpoint has no runtime route."
+                        )
+                else:
+                    route_decision = _select_general_chat_route(
+                        model,
+                        question,
+                        history=command.get("history"),
+                        context_skill_contents=(
+                            resources.context_skill_contents
+                        ),
+                        available_tools=[*tools, *mcp_tools],
+                        has_bound_skills=bool(resources.skill_paths),
+                    )
                 command = {
                     **command,
                     "runtime_route": route_decision["route"],
                 }
-                emit_user_event("route.selected", route_decision)
+                emit_user_event(
+                    (
+                        "route.resumed"
+                        if resume_state is not None
+                        else "route.selected"
+                    ),
+                    route_decision,
+                )
                 evidence_requirement = route_decision[
                     "evidence_requirement"
                 ]
                 required_capabilities = route_decision[
                     "required_capabilities"
                 ]
+                if (
+                    route_decision["route"]
+                    in {"capability_unavailable", "direct_answer"}
+                    and resume_state is None
+                    and checkpoint_enabled()
+                ):
+                    try:
+                        get_checkpoint_saver(self.config.workspace_path)
+                        initial_messages = _build_initial_messages(
+                            command.get("history"),
+                            question,
+                        )
+                        save_resume_metadata(
+                            run_uuid,
+                            self.config.workspace_path,
+                            route_decision=route_decision,
+                            history_assistant_turns=sum(
+                                1
+                                for item in command.get("history") or []
+                                if item.get("role") == "assistant"
+                            ),
+                        )
+                        save_initial_checkpoint(
+                            run_uuid,
+                            self.config.workspace_path,
+                            initial_messages,
+                        )
+                        checkpoint_ready = True
+                    except Exception:
+                        LOGGER.exception(
+                            "Failed to enable direct run checkpoint"
+                        )
                 if route_decision["route"] == "capability_unavailable":
                     required = route_decision["required_capabilities"]
                     capability = next(
@@ -1318,6 +1607,8 @@ class LensDeepAgentRuntime:
                     }
                 if route_decision["route"] == "direct_answer":
                     emit_user_event("phase.changed", {"phase": "answering"})
+                    if resume_state is not None and emit_output is not None:
+                        emit_output("", reset=True)
                     runtime_mode.emit_model_round(
                         emit_agent_event,
                         "start",
@@ -1331,6 +1622,11 @@ class LensDeepAgentRuntime:
                                 scenario,
                                 command,
                                 resources.context_skill_contents,
+                            ),
+                            messages=(
+                                resume_state.messages
+                                if resume_state is not None
+                                else None
                             ),
                             emit_event=emit_agent_event,
                             emit_output=emit_output,
@@ -1369,7 +1665,12 @@ class LensDeepAgentRuntime:
                     require_initial_plan=(
                         route_decision["route"] == "plan_execute"
                     ),
+                    on_state_change=persist_execution_state,
                 )
+                if resume_state is not None:
+                    capability_middleware.restore_state(
+                        resume_state.capability_state
+                    )
                 phase = (
                     "planning"
                     if route_decision["route"] == "plan_execute"
@@ -1452,6 +1753,38 @@ class LensDeepAgentRuntime:
                     "mcp_config_path": str(resources.mcp_config_path),
                 },
             )
+            checkpoint_thread = thread_config(run_uuid)
+            if checkpoint_enabled():
+                if resume_state is not None:
+                    kwargs["checkpointer"] = get_checkpoint_saver(
+                        self.config.workspace_path
+                    )
+                    checkpoint_ready = True
+                else:
+                    try:
+                        kwargs["checkpointer"] = get_checkpoint_saver(
+                            self.config.workspace_path
+                        )
+                        save_resume_metadata(
+                            run_uuid,
+                            self.config.workspace_path,
+                            route_decision=(
+                                route_decision
+                                if runtime_mode.execution_gates
+                                else {}
+                            ),
+                            history_assistant_turns=sum(
+                                1
+                                for item in command.get("history") or []
+                                if item.get("role") == "assistant"
+                            ),
+                        )
+                        checkpoint_ready = True
+                    except Exception:
+                        kwargs.pop("checkpointer", None)
+                        LOGGER.exception(
+                            "Failed to enable agent run checkpoints"
+                        )
             agent = create_deep_agent(**kwargs)
             max_turns = command.get("max_agent_turns", 26)
             invoke_detail = {"max_agent_turns": max_turns}
@@ -1474,6 +1807,25 @@ class LensDeepAgentRuntime:
             messages = _build_initial_messages(
                 command.get("history"), question
             )
+            turn_baseline_ai = None
+            event_baseline_ai = None
+            if resume_state is not None:
+                if emit_output is not None:
+                    emit_output("", reset=True)
+                messages = list(resume_state.messages)
+                turn_baseline_ai = resume_state.history_assistant_turns
+                event_baseline_ai = sum(
+                    1
+                    for message in resume_state.messages
+                    if getattr(message, "type", "") == "ai"
+                )
+                emit_agent_event(
+                    "deepagents.runtime.resume",
+                    {
+                        "checkpoint_ai_turns": event_baseline_ai,
+                        "history_ai_turns": turn_baseline_ai,
+                    },
+                )
             (
                 answer,
                 truncated,
@@ -1483,6 +1835,10 @@ class LensDeepAgentRuntime:
                 messages,
                 max_turns,
                 model=model,
+                thread=checkpoint_thread,
+                turn_baseline_ai=turn_baseline_ai,
+                event_baseline_ai=event_baseline_ai,
+                resume_from_checkpoint=resume_state is not None,
                 emit_event=emit_agent_event,
                 answer_language=_command_answer_language(command),
                 cancel_event=cancel_event,
@@ -1554,7 +1910,8 @@ class LensDeepAgentRuntime:
                 "termination_detail": termination_detail,
             }
         finally:
-            cleanup_runtime_resources(resources)
+            if cancel_event is None or not cancel_event.is_set():
+                cleanup_runtime_resources(resources)
 
 
 def _resolve_token_budget(config, command):
@@ -2287,6 +2644,7 @@ def _answer_general_chat_directly(
     model,
     command,
     system_prompt,
+    messages=None,
     emit_event=None,
     emit_output=None,
 ):
@@ -2301,9 +2659,13 @@ def _answer_general_chat_directly(
     )
     messages = [
         SystemMessage(content=direct_prompt),
-        *_build_initial_messages(
-            command.get("history"),
-            command.get("question", ""),
+        *(
+            list(messages)
+            if messages is not None
+            else _build_initial_messages(
+                command.get("history"),
+                command.get("question", ""),
+            )
         ),
     ]
     response = model.invoke(messages, runtime_control_call=True)
@@ -2772,6 +3134,10 @@ def _run_agent_with_turn_limit(
     messages,
     max_turns,
     model=None,
+    thread=None,
+    turn_baseline_ai=None,
+    event_baseline_ai=None,
+    resume_from_checkpoint=False,
     emit_event=None,
     answer_language="English",
     cancel_event=None,
@@ -2783,6 +3149,10 @@ def _run_agent_with_turn_limit(
     `messages` may be prefixed with prior conversation turns. Historical
     assistant turns are excluded from both the turn count and event
     emission, so the limit and trace reflect only the current run.
+
+    On resume, ``turn_baseline_ai`` remains the original history count so
+    turns already consumed by this Run still count. ``event_baseline_ai``
+    suppresses re-emitting model events already present in the checkpoint.
 
     A subagent ``task`` delegation runs to completion inside a single
     parent-graph step (deepagents calls it via a plain, synchronous
@@ -2798,19 +3168,32 @@ def _run_agent_with_turn_limit(
     preserves the gate that requested wrap-up.
     """
 
-    last_state = None
+    last_state = {"messages": messages} if resume_from_checkpoint else None
     truncated = False
     truncation_reason = None
     seen_tool_calls = set()
     seen_model_calls = set()
     plan_state = {"revision": 0}
-    baseline_ai = sum(1 for m in messages if m.get("role") == "assistant")
+    baseline_ai = (
+        turn_baseline_ai
+        if turn_baseline_ai is not None
+        else sum(1 for m in messages if m.get("role") == "assistant")
+    )
+    emitted_baseline_ai = (
+        event_baseline_ai
+        if event_baseline_ai is not None
+        else baseline_ai
+    )
     seeded_baseline = False
 
+    graph_input = None if resume_from_checkpoint else {"messages": messages}
     for state in agent.stream(
-        {"messages": messages},
+        graph_input,
         stream_mode="values",
-        config={"recursion_limit": 500},
+        config={
+            "recursion_limit": 500,
+            **(thread or {}),
+        },
     ):
         if cancel_event is not None and cancel_event.is_set():
             raise RunCancelledError(
@@ -2820,18 +3203,26 @@ def _run_agent_with_turn_limit(
         current = state.get("messages", [])
         if not seeded_baseline:
             # Seed the historical assistant turns by their (now-assigned)
-            # message id so they are never emitted or counted as new turns.
-            # Dedup keys on message id, so an integer preseed would never
-            # match and would re-emit the carried-over history.
+            # message and tool-call ids so they are never emitted or counted
+            # as new turns. Reusing the tool event reducer also restores its
+            # plan revision/state without publishing the old events again.
+            baseline_messages = []
             ai_count = 0
             for message in current:
                 if getattr(message, "type", "") != "ai":
                     continue
                 ai_count += 1
-                if ai_count <= baseline_ai:
+                if ai_count <= emitted_baseline_ai:
+                    baseline_messages.append(message)
                     seen_model_calls.add(
                         getattr(message, "id", None) or id(message)
                     )
+            _emit_new_tool_calls(
+                baseline_messages,
+                seen_tool_calls,
+                lambda _name, _detail: None,
+                plan_state=plan_state,
+            )
             seeded_baseline = True
         if emit_event is not None:
             _emit_new_model_calls(current, seen_model_calls, emit_event)

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -974,6 +974,7 @@ def build_general_chat_tools(
     config=None,
     emit_event=None,
     runtime_evidence=None,
+    on_runtime_evidence=None,
 ):
     """Build tools for General Chat without workspace retrieval tools."""
 
@@ -1239,6 +1240,8 @@ def build_general_chat_tools(
 
         if normalized_operation == "validate_records":
             runtime_evidence["record_validation"] = result
+            if on_runtime_evidence is not None:
+                on_runtime_evidence(runtime_evidence)
 
         duration_ms = int((time.monotonic() - started) * 1000)
         output = _persist_json_analysis_output(

--- a/lensnode/lensnode/checkpoint.py
+++ b/lensnode/lensnode/checkpoint.py
@@ -20,12 +20,14 @@ import threading
 import time
 from dataclasses import dataclass, field
 
+from langchain_core.messages import ToolMessage
 from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 LOGGER = logging.getLogger("lensnode")
 
 _CHECKPOINT_FILE = "lensnode.sqlite"
+_METADATA_SCHEMA_VERSION = 1
 _saver = None
 _saver_lock = threading.Lock()
 _database_lock = threading.RLock()
@@ -44,9 +46,13 @@ class ResumeState:
     messages: tuple
     route_decision: dict
     history_assistant_turns: int
+    checkpoint_step: int = -1
     capability_state: dict = field(default_factory=dict)
     runtime_evidence: dict = field(default_factory=dict)
     guardrail_state: dict = field(default_factory=dict)
+    pending_write_tool_call_ids: frozenset = field(
+        default_factory=frozenset
+    )
 
 
 def checkpoint_enabled() -> bool:
@@ -109,6 +115,8 @@ def get_checkpoint_saver(workspace_path) -> SqliteSaver:
                         route_decision TEXT NOT NULL,
                         history_assistant_turns INTEGER NOT NULL,
                         runtime_state TEXT NOT NULL DEFAULT '{}',
+                        checkpoint_id TEXT,
+                        schema_version INTEGER NOT NULL DEFAULT 1,
                         updated_at REAL NOT NULL,
                         orphaned_at REAL
                     )
@@ -130,6 +138,17 @@ def get_checkpoint_saver(workspace_path) -> SqliteSaver:
                         "ALTER TABLE lensnode_run_metadata "
                         "ADD COLUMN orphaned_at REAL"
                     )
+                if "checkpoint_id" not in columns:
+                    connection.execute(
+                        "ALTER TABLE lensnode_run_metadata "
+                        "ADD COLUMN checkpoint_id TEXT"
+                    )
+                if "schema_version" not in columns:
+                    connection.execute(
+                        "ALTER TABLE lensnode_run_metadata "
+                        "ADD COLUMN schema_version INTEGER "
+                        "NOT NULL DEFAULT 1"
+                    )
                 # A fresh process means every retained thread may have just
                 # become orphaned. Start a full local retention window now so
                 # it cannot expire before the control plane's advertised
@@ -146,6 +165,19 @@ def get_checkpoint_saver(workspace_path) -> SqliteSaver:
                 _saver = saver
                 LOGGER.info("Agent run checkpoints enabled: %s", path)
     return _saver
+
+
+def close_checkpoint_saver() -> bool:
+    """Close and clear the process-wide checkpoint saver."""
+
+    global _saver
+    with _saver_lock:
+        if _saver is None:
+            return False
+        with _database_lock:
+            _saver.conn.close()
+            _saver = None
+    return True
 
 
 def thread_config(run_uuid):
@@ -172,7 +204,7 @@ def save_resume_metadata(
     with _database_lock:
         saver.conn.execute(
             """
-            INSERT OR REPLACE INTO lensnode_run_metadata (
+            INSERT INTO lensnode_run_metadata (
                 run_uuid,
                 route_decision,
                 history_assistant_turns,
@@ -180,6 +212,11 @@ def save_resume_metadata(
                 updated_at,
                 orphaned_at
             ) VALUES (?, ?, ?, ?, ?, NULL)
+            ON CONFLICT(run_uuid) DO UPDATE SET
+                route_decision = excluded.route_decision,
+                history_assistant_turns = excluded.history_assistant_turns,
+                updated_at = excluded.updated_at,
+                orphaned_at = NULL
             """,
             (
                 str(run_uuid),
@@ -198,12 +235,33 @@ def save_initial_checkpoint(run_uuid, workspace_path, messages):
     saver = get_checkpoint_saver(workspace_path)
     saved = empty_checkpoint()
     saved["channel_values"] = {"messages": list(messages or [])}
-    saver.put(
-        thread_config(run_uuid),
-        saved,
-        {"source": "input", "step": -1, "parents": {}},
-        {},
-    )
+    with _database_lock:
+        saved_config = saver.put(
+            thread_config(run_uuid),
+            saved,
+            {"source": "input", "step": -1, "parents": {}},
+            {},
+        )
+        checkpoint_id = _config_checkpoint_id(saved_config)
+        cursor = saver.conn.execute(
+            """
+            UPDATE lensnode_run_metadata
+            SET checkpoint_id = ?, schema_version = ?, updated_at = ?
+            WHERE run_uuid = ?
+            """,
+            (
+                checkpoint_id,
+                _METADATA_SCHEMA_VERSION,
+                time.time(),
+                str(run_uuid),
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise CheckpointResumeError(
+                "Cannot bind checkpoint without checkpoint metadata."
+            )
+        saver.conn.commit()
+    return saved_config
 
 
 def save_runtime_state(
@@ -223,13 +281,26 @@ def save_runtime_state(
         "guardrail_state": guardrail_state or {},
     }
     with _database_lock:
+        snapshot = saver.get_tuple(thread_config(run_uuid))
+        if snapshot is None:
+            raise CheckpointResumeError(
+                "Cannot persist runtime state without a checkpoint."
+            )
+        checkpoint_id = _config_checkpoint_id(snapshot.config)
         cursor = saver.conn.execute(
             """
             UPDATE lensnode_run_metadata
-            SET runtime_state = ?, updated_at = ?
+            SET runtime_state = ?, checkpoint_id = ?, schema_version = ?,
+                updated_at = ?
             WHERE run_uuid = ?
             """,
-            (json.dumps(payload, sort_keys=True), time.time(), str(run_uuid)),
+            (
+                json.dumps(payload, sort_keys=True),
+                checkpoint_id,
+                _METADATA_SCHEMA_VERSION,
+                time.time(),
+                str(run_uuid),
+            ),
         )
         if cursor.rowcount != 1:
             raise CheckpointResumeError(
@@ -251,12 +322,23 @@ def load_resume_state(run_uuid, workspace_path) -> ResumeState:
             snapshot = saver.get_tuple(thread_config(run_uuid))
             row = saver.conn.execute(
                 """
-                SELECT route_decision, history_assistant_turns, runtime_state
+                SELECT route_decision, history_assistant_turns, runtime_state,
+                       checkpoint_id, schema_version
                 FROM lensnode_run_metadata
                 WHERE run_uuid = ?
                 """,
                 (str(run_uuid),),
             ).fetchone()
+            checkpoint_version_valid = bool(
+                snapshot is not None
+                and row is not None
+                and row[3]
+                and _checkpoint_is_ancestor(
+                    saver,
+                    str(row[3]),
+                    snapshot,
+                )
+            )
     except CheckpointResumeError:
         raise
     except Exception as exc:
@@ -271,6 +353,15 @@ def load_resume_state(run_uuid, workspace_path) -> ResumeState:
         raise CheckpointResumeError(
             "Cannot resume run because its checkpoint metadata is missing."
         )
+    if row[4] != _METADATA_SCHEMA_VERSION:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint schema is unsupported."
+        )
+    if not checkpoint_version_valid:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint version does not match "
+            "its runtime metadata."
+        )
     try:
         route_decision = json.loads(row[0])
         runtime_state = json.loads(row[2])
@@ -283,14 +374,74 @@ def load_resume_state(run_uuid, workspace_path) -> ResumeState:
             "Cannot resume run because its runtime state is invalid."
         )
     channel_values = snapshot.checkpoint.get("channel_values") or {}
+    checkpoint_step = (snapshot.metadata or {}).get("step", -1)
+    if not isinstance(checkpoint_step, int) or isinstance(
+        checkpoint_step,
+        bool,
+    ):
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint step is invalid."
+        )
     return ResumeState(
         messages=tuple(channel_values.get("messages") or ()),
         route_decision=route_decision,
         history_assistant_turns=max(int(row[1] or 0), 0),
+        checkpoint_step=checkpoint_step,
         capability_state=runtime_state.get("capability_state") or {},
         runtime_evidence=runtime_state.get("runtime_evidence") or {},
         guardrail_state=runtime_state.get("guardrail_state") or {},
+        pending_write_tool_call_ids=_pending_write_tool_call_ids(
+            snapshot.pending_writes
+        ),
     )
+
+
+def _config_checkpoint_id(config):
+    """Return the required checkpoint identifier from a saver config."""
+
+    configurable = (config or {}).get("configurable") or {}
+    checkpoint_id = configurable.get("checkpoint_id")
+    if not checkpoint_id:
+        raise CheckpointResumeError("Checkpoint has no version identifier.")
+    return str(checkpoint_id)
+
+
+def _checkpoint_is_ancestor(saver, ancestor_id, snapshot):
+    """Return whether metadata is bound to this head or an ancestor."""
+
+    current = snapshot
+    visited = set()
+    while current is not None:
+        checkpoint_id = _config_checkpoint_id(current.config)
+        if checkpoint_id == ancestor_id:
+            return True
+        if checkpoint_id in visited or current.parent_config is None:
+            return False
+        visited.add(checkpoint_id)
+        current = saver.get_tuple(current.parent_config)
+    return False
+
+
+def _pending_write_tool_call_ids(pending_writes):
+    """Return tool call IDs whose results are durable pending writes."""
+
+    tool_call_ids = set()
+
+    def collect(value):
+        if isinstance(value, ToolMessage):
+            tool_call_id = getattr(value, "tool_call_id", None)
+            if tool_call_id:
+                tool_call_ids.add(str(tool_call_id))
+            return
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                collect(item)
+
+    for pending_write in pending_writes or ():
+        if len(pending_write) < 3 or pending_write[1] != "messages":
+            continue
+        collect(pending_write[2])
+    return frozenset(tool_call_ids)
 
 
 def _cleanup_expired_checkpoints(saver, active_run_uuids=()):

--- a/lensnode/lensnode/checkpoint.py
+++ b/lensnode/lensnode/checkpoint.py
@@ -1,0 +1,384 @@
+"""Durable agent-run checkpoints for in-flight resume after a node restart.
+
+Checkpoints are written to a SQLite file under the workspace (a host
+persistent volume), so a node process crash or container recreate keeps
+them as long as the volume survives. Each run is one LangGraph thread keyed
+by its run_uuid; on a terminal state the thread is deleted so checkpoints
+never accumulate.
+
+The saver is a process-wide singleton: SqliteSaver 3.x serializes its own
+access across threads, and checkpointing happens at agent node boundaries
+so the local writes are cheap.
+"""
+
+import json
+import logging
+import math
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+
+from langgraph.checkpoint.base import empty_checkpoint
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+LOGGER = logging.getLogger("lensnode")
+
+_CHECKPOINT_FILE = "lensnode.sqlite"
+_saver = None
+_saver_lock = threading.Lock()
+_database_lock = threading.RLock()
+
+
+class CheckpointResumeError(RuntimeError):
+    """A resume command cannot be proven safe from durable state."""
+
+    code = "CHECKPOINT_UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class ResumeState:
+    """Checkpoint and immutable runtime metadata needed for a resume."""
+
+    messages: tuple
+    route_decision: dict
+    history_assistant_turns: int
+    capability_state: dict = field(default_factory=dict)
+    runtime_evidence: dict = field(default_factory=dict)
+    guardrail_state: dict = field(default_factory=dict)
+
+
+def checkpoint_enabled() -> bool:
+    """Return whether run checkpoints are enabled for this node."""
+
+    raw = os.getenv("LENSNODE_CHECKPOINT_ENABLED", "1").strip().lower()
+    return raw not in {"0", "false", "off", "no"}
+
+
+def checkpoint_ttl_hours() -> float:
+    """Return the effective local retention window for orphan checkpoints."""
+
+    raw = os.getenv("LENSNODE_CHECKPOINT_TTL_HOURS", "24")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 24.0
+    return max(value, 1.0) if math.isfinite(value) else 24.0
+
+
+def checkpoint_dir(workspace_path) -> str:
+    """Return the directory holding the checkpoint SQLite file."""
+
+    configured = os.getenv("LENSNODE_CHECKPOINT_DIR", "").strip()
+    if configured:
+        return configured
+    return os.path.join(workspace_path, ".checkpoints")
+
+
+def get_checkpoint_saver(workspace_path) -> SqliteSaver:
+    """Return the process-wide SqliteSaver, creating it on first use."""
+
+    global _saver
+    if _saver is None:
+        with _saver_lock:
+            if _saver is None:
+                directory = checkpoint_dir(workspace_path)
+                os.makedirs(directory, mode=0o700, exist_ok=True)
+                os.chmod(directory, 0o700)
+                path = os.path.join(directory, _CHECKPOINT_FILE)
+                connection = sqlite3.connect(
+                    path, check_same_thread=False
+                )
+                os.chmod(path, 0o600)
+                # Rollback journal, not WAL: WAL coordination across the
+                # Docker Desktop bind mount can leave commits invisible to
+                # other connections, which makes terminal cleanup appear to
+                # not run. The checkpoint writes are small and local, so
+                # rollback journal is plenty.
+                saver = SqliteSaver(connection)
+                # Metadata and LangGraph checkpoints share one connection,
+                # so every transaction must also share one re-entrant lock.
+                saver.lock = _database_lock
+                saver.setup()
+                connection.execute("PRAGMA journal_mode=DELETE")
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS lensnode_run_metadata (
+                        run_uuid TEXT PRIMARY KEY,
+                        route_decision TEXT NOT NULL,
+                        history_assistant_turns INTEGER NOT NULL,
+                        runtime_state TEXT NOT NULL DEFAULT '{}',
+                        updated_at REAL NOT NULL,
+                        orphaned_at REAL
+                    )
+                    """
+                )
+                columns = {
+                    row[1]
+                    for row in connection.execute(
+                        "PRAGMA table_info(lensnode_run_metadata)"
+                    ).fetchall()
+                }
+                if "runtime_state" not in columns:
+                    connection.execute(
+                        "ALTER TABLE lensnode_run_metadata "
+                        "ADD COLUMN runtime_state TEXT NOT NULL DEFAULT '{}'"
+                    )
+                if "orphaned_at" not in columns:
+                    connection.execute(
+                        "ALTER TABLE lensnode_run_metadata "
+                        "ADD COLUMN orphaned_at REAL"
+                    )
+                # A fresh process means every retained thread may have just
+                # become orphaned. Start a full local retention window now so
+                # it cannot expire before the control plane's advertised
+                # resume deadline.
+                connection.execute(
+                    """
+                    UPDATE lensnode_run_metadata
+                    SET orphaned_at = ?
+                    WHERE orphaned_at IS NULL
+                    """,
+                    (time.time(),),
+                )
+                connection.commit()
+                _saver = saver
+                LOGGER.info("Agent run checkpoints enabled: %s", path)
+    return _saver
+
+
+def thread_config(run_uuid):
+    """Return the LangGraph invoke config that pins a run to its thread."""
+
+    return {
+        "configurable": {
+            "thread_id": str(run_uuid),
+            "checkpoint_ns": "",
+        },
+    }
+
+
+def save_resume_metadata(
+    run_uuid,
+    workspace_path,
+    *,
+    route_decision=None,
+    history_assistant_turns=0,
+):
+    """Persist the runtime decisions that must not change on resume."""
+
+    saver = get_checkpoint_saver(workspace_path)
+    with _database_lock:
+        saver.conn.execute(
+            """
+            INSERT OR REPLACE INTO lensnode_run_metadata (
+                run_uuid,
+                route_decision,
+                history_assistant_turns,
+                runtime_state,
+                updated_at,
+                orphaned_at
+            ) VALUES (?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                str(run_uuid),
+                json.dumps(route_decision or {}, sort_keys=True),
+                max(int(history_assistant_turns or 0), 0),
+                "{}",
+                time.time(),
+            ),
+        )
+        saver.conn.commit()
+
+
+def save_initial_checkpoint(run_uuid, workspace_path, messages):
+    """Persist a resumable state before a non-graph model call starts."""
+
+    saver = get_checkpoint_saver(workspace_path)
+    saved = empty_checkpoint()
+    saved["channel_values"] = {"messages": list(messages or [])}
+    saver.put(
+        thread_config(run_uuid),
+        saved,
+        {"source": "input", "step": -1, "parents": {}},
+        {},
+    )
+
+
+def save_runtime_state(
+    run_uuid,
+    workspace_path,
+    *,
+    capability_state=None,
+    runtime_evidence=None,
+    guardrail_state=None,
+):
+    """Persist execution-gate state that must survive a process restart."""
+
+    saver = get_checkpoint_saver(workspace_path)
+    payload = {
+        "capability_state": capability_state or {},
+        "runtime_evidence": runtime_evidence or {},
+        "guardrail_state": guardrail_state or {},
+    }
+    with _database_lock:
+        cursor = saver.conn.execute(
+            """
+            UPDATE lensnode_run_metadata
+            SET runtime_state = ?, updated_at = ?
+            WHERE run_uuid = ?
+            """,
+            (json.dumps(payload, sort_keys=True), time.time(), str(run_uuid)),
+        )
+        if cursor.rowcount != 1:
+            raise CheckpointResumeError(
+                "Cannot persist runtime state without checkpoint metadata."
+            )
+        saver.conn.commit()
+
+
+def load_resume_state(run_uuid, workspace_path) -> ResumeState:
+    """Load a complete checkpoint or reject the resume without executing."""
+
+    if not checkpoint_enabled():
+        raise CheckpointResumeError(
+            "Cannot resume run because checkpointing is disabled."
+        )
+    try:
+        saver = get_checkpoint_saver(workspace_path)
+        with _database_lock:
+            snapshot = saver.get_tuple(thread_config(run_uuid))
+            row = saver.conn.execute(
+                """
+                SELECT route_decision, history_assistant_turns, runtime_state
+                FROM lensnode_run_metadata
+                WHERE run_uuid = ?
+                """,
+                (str(run_uuid),),
+            ).fetchone()
+    except CheckpointResumeError:
+        raise
+    except Exception as exc:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint could not be read."
+        ) from exc
+    if snapshot is None:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint is missing."
+        )
+    if row is None:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint metadata is missing."
+        )
+    try:
+        route_decision = json.loads(row[0])
+        runtime_state = json.loads(row[2])
+    except (TypeError, ValueError) as exc:
+        raise CheckpointResumeError(
+            "Cannot resume run because its checkpoint metadata is invalid."
+        ) from exc
+    if not isinstance(runtime_state, dict):
+        raise CheckpointResumeError(
+            "Cannot resume run because its runtime state is invalid."
+        )
+    channel_values = snapshot.checkpoint.get("channel_values") or {}
+    return ResumeState(
+        messages=tuple(channel_values.get("messages") or ()),
+        route_decision=route_decision,
+        history_assistant_turns=max(int(row[1] or 0), 0),
+        capability_state=runtime_state.get("capability_state") or {},
+        runtime_evidence=runtime_state.get("runtime_evidence") or {},
+        guardrail_state=runtime_state.get("guardrail_state") or {},
+    )
+
+
+def _cleanup_expired_checkpoints(saver, active_run_uuids=()):
+    """Remove locally orphaned checkpoints after the bounded resume TTL."""
+
+    now = time.time()
+    cutoff = now - checkpoint_ttl_hours() * 3600
+    active = {str(run_uuid) for run_uuid in active_run_uuids}
+    with _database_lock:
+        rows = saver.conn.execute(
+            """
+            SELECT run_uuid, orphaned_at
+            FROM lensnode_run_metadata
+            """
+        ).fetchall()
+        for run_uuid, orphaned_at in rows:
+            if run_uuid in active:
+                if orphaned_at is not None:
+                    saver.conn.execute(
+                        """
+                        UPDATE lensnode_run_metadata
+                        SET orphaned_at = NULL
+                        WHERE run_uuid = ?
+                        """,
+                        (run_uuid,),
+                    )
+            elif orphaned_at is None:
+                saver.conn.execute(
+                    """
+                    UPDATE lensnode_run_metadata
+                    SET orphaned_at = ?
+                    WHERE run_uuid = ?
+                    """,
+                    (now, run_uuid),
+                )
+        run_uuids = [
+            run_uuid
+            for run_uuid, orphaned_at in rows
+            if run_uuid not in active
+            and orphaned_at is not None
+            and orphaned_at < cutoff
+        ]
+        for run_uuid in run_uuids:
+            saver.delete_thread(run_uuid)
+        if run_uuids:
+            saver.conn.executemany(
+                "DELETE FROM lensnode_run_metadata WHERE run_uuid = ?",
+                [(run_uuid,) for run_uuid in run_uuids],
+            )
+        saver.conn.commit()
+    return len(run_uuids)
+
+
+def cleanup_expired_checkpoints(workspace_path, active_run_uuids=()):
+    """Periodically remove expired checkpoints not active in this process."""
+
+    if not checkpoint_enabled() or not workspace_path:
+        return 0
+    try:
+        saver = get_checkpoint_saver(workspace_path)
+        return _cleanup_expired_checkpoints(saver, active_run_uuids)
+    except Exception:
+        LOGGER.exception("Failed to clean up expired run checkpoints")
+        return 0
+
+
+def cleanup_run_checkpoint(run_uuid, workspace_path=None):
+    """Delete the checkpoint thread for a terminal run, if any."""
+
+    if not checkpoint_enabled():
+        return
+    if workspace_path is None:
+        LOGGER.debug(
+            "Skipping checkpoint cleanup for %s: no workspace path",
+            run_uuid,
+        )
+        return
+    try:
+        saver = get_checkpoint_saver(workspace_path)
+        with _database_lock:
+            saver.delete_thread(str(run_uuid))
+            saver.conn.execute(
+                "DELETE FROM lensnode_run_metadata WHERE run_uuid = ?",
+                (str(run_uuid),),
+            )
+            saver.conn.commit()
+        LOGGER.info("Cleaned up checkpoint for run %s", run_uuid)
+    except Exception:
+        LOGGER.exception(
+            "Failed to clean up checkpoint for run %s", run_uuid
+        )

--- a/lensnode/lensnode/executor.py
+++ b/lensnode/lensnode/executor.py
@@ -271,6 +271,18 @@ class LensNodeExecutor:
         asyncio.create_task(cleanup())
         return True
 
+    async def drain_pending_workers(self):
+        """Wait until cancelled synchronous Run workers have unwound."""
+
+        while True:
+            pending_workers = getattr(self, "_pending_workers", {})
+            tasks = [
+                task for task in pending_workers.values() if not task.done()
+            ]
+            if not tasks:
+                return
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def execute(self, command, emit):
         """Execute one run_start command and emit protocol frames."""
 
@@ -465,9 +477,10 @@ class LensNodeExecutor:
                         )
             except asyncio.CancelledError:
                 # run_cancel cancels this coroutine, which does not cancel
-                # answer_task or its worker thread on its own. Signal both
-                # so the agent stops issuing model calls for a dead run.
+                # answer_task or its worker thread on its own. Signal the
+                # worker and track it until it stops issuing model calls.
                 cancel_event.set()
+                self._track_pending_worker(run_uuid, answer_task)
                 if command.get("_explicit_cancel"):
                     cleanup_deferred = True
                     workspace_path = getattr(
@@ -482,8 +495,6 @@ class LensNodeExecutor:
                             workspace_path,
                         )
                     )
-                else:
-                    answer_task.cancel()
                 raise
             samples = result.get("samples") or []
             sample_paths = [item["path"] for item in samples]

--- a/lensnode/lensnode/executor.py
+++ b/lensnode/lensnode/executor.py
@@ -2,9 +2,12 @@ import asyncio
 import logging
 import math
 import threading
+from datetime import datetime, timezone
 
 from .agent_runtime import LensDeepAgentRuntime
+from .checkpoint import cleanup_run_checkpoint
 from .logging_utils import elapsed_since, format_duration, task_log, utc_now
+from .runtime_resources import cleanup_run_runtime_resources
 
 LOGGER = logging.getLogger("lensnode")
 
@@ -36,6 +39,34 @@ def _run_timeout_seconds(command):
         agent_rounds,
         RUN_TIMEOUT_SECONDS_BY_ROUNDS["balanced"],
     )
+
+
+def _remaining_run_timeout_seconds(command, now=None):
+    """Return the unspent wall-clock budget from the original Run start."""
+
+    timeout_s = _run_timeout_seconds(command)
+    remaining = command.get("remaining_run_timeout_s")
+    if (
+        isinstance(remaining, (int, float))
+        and not isinstance(remaining, bool)
+        and math.isfinite(remaining)
+        and remaining >= 0
+    ):
+        return min(remaining, timeout_s)
+    raw_started_at = command.get("run_started_at")
+    if not isinstance(raw_started_at, str) or not raw_started_at.strip():
+        return timeout_s
+    try:
+        started_at = datetime.fromisoformat(
+            raw_started_at.strip().replace("Z", "+00:00")
+        )
+    except ValueError:
+        return timeout_s
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    elapsed_s = max((current - started_at).total_seconds(), 0)
+    return max(timeout_s - elapsed_s, 0)
 
 
 def _wrapup_grace_seconds(timeout_s):
@@ -97,6 +128,27 @@ def _execution_step_type(command):
     if command.get("task") == "general_chat":
         return "general_chat"
     return "retrieval"
+
+
+async def _cleanup_after_cancelled_worker(
+    answer_task,
+    run_uuid,
+    workspace_path,
+):
+    """Clean durable Run state after its synchronous worker has stopped."""
+
+    while True:
+        try:
+            await asyncio.shield(answer_task)
+            break
+        except asyncio.CancelledError:
+            if answer_task.done():
+                break
+            continue
+        except Exception:
+            break
+    cleanup_run_checkpoint(run_uuid, workspace_path)
+    cleanup_run_runtime_resources(workspace_path, run_uuid)
 
 
 TASKS = [
@@ -170,6 +222,54 @@ class LensNodeExecutor:
 
     def __init__(self, config, http_client=None):
         self.agent = LensDeepAgentRuntime(config, http_client=http_client)
+        self._pending_workers = {}
+        self._pending_cleanup_runs = set()
+
+    def _track_pending_worker(self, run_uuid, worker_task):
+        """Track a timed-out agent task until its worker has stopped."""
+
+        pending_workers = getattr(self, "_pending_workers", None)
+        if pending_workers is None:
+            pending_workers = {}
+            self._pending_workers = pending_workers
+        pending_workers[run_uuid] = worker_task
+
+        def discard_finished_worker(task):
+            try:
+                task.exception()
+            except asyncio.CancelledError:
+                pass
+            if pending_workers.get(run_uuid) is task:
+                pending_workers.pop(run_uuid, None)
+
+        worker_task.add_done_callback(discard_finished_worker)
+
+    def defer_cleanup_until_worker_stops(self, run_uuid, workspace_path):
+        """Defer acknowledged terminal cleanup for an active worker."""
+
+        worker_task = getattr(self, "_pending_workers", {}).get(run_uuid)
+        if worker_task is None or worker_task.done():
+            return False
+        cleanup_runs = getattr(self, "_pending_cleanup_runs", None)
+        if cleanup_runs is None:
+            cleanup_runs = set()
+            self._pending_cleanup_runs = cleanup_runs
+        if run_uuid in cleanup_runs:
+            return True
+        cleanup_runs.add(run_uuid)
+
+        async def cleanup():
+            try:
+                await _cleanup_after_cancelled_worker(
+                    worker_task,
+                    run_uuid,
+                    workspace_path,
+                )
+            finally:
+                cleanup_runs.discard(run_uuid)
+
+        asyncio.create_task(cleanup())
+        return True
 
     async def execute(self, command, emit):
         """Execute one run_start command and emit protocol frames."""
@@ -180,6 +280,8 @@ class LensNodeExecutor:
         step_type = _execution_step_type(command)
         target_dirs = command.get("target_dirs") or []
         timeout_s = _run_timeout_seconds(command)
+        cleanup_deferred = False
+        remaining_timeout_s = _remaining_run_timeout_seconds(command)
         idle_timeout_s = getattr(
             self.agent.config, "run_idle_timeout_s", 180
         )
@@ -190,6 +292,7 @@ class LensNodeExecutor:
             (
                 f"Starting to run command: {task}({run_uuid}). "
                 f"Run timeout {format_duration(timeout_s)}, "
+                f"remaining {format_duration(remaining_timeout_s)}, "
                 f"idle timeout {format_duration(idle_timeout_s)}."
             ),
             started_at,
@@ -211,6 +314,7 @@ class LensNodeExecutor:
                     "task": task,
                     "target_dirs": target_dirs,
                     "run_timeout_s": timeout_s,
+                    "remaining_run_timeout_s": remaining_timeout_s,
                     "idle_timeout_s": idle_timeout_s,
                 },
             }
@@ -222,7 +326,7 @@ class LensNodeExecutor:
                     f"Running command {task}({run_uuid}). Current status is "
                     "running Deep Agents. Elapsed time so far: "
                     f"{elapsed_since(started_at)}. Remaining Timeout: "
-                    f"{format_duration(timeout_s)}."
+                    f"{format_duration(remaining_timeout_s)}."
                 )
             )
             LOGGER.info(progress_message)
@@ -240,8 +344,10 @@ class LensNodeExecutor:
 
             loop = asyncio.get_running_loop()
             activity = {"at": loop.time()}
-            deadline_at = loop.time() + timeout_s
-            wrapup_at = deadline_at - _wrapup_grace_seconds(timeout_s)
+            deadline_at = loop.time() + remaining_timeout_s
+            wrapup_at = deadline_at - _wrapup_grace_seconds(
+                remaining_timeout_s
+            )
             cancel_event = threading.Event()
             wrapup_event = threading.Event()
 
@@ -300,21 +406,17 @@ class LensNodeExecutor:
                 )
             )
 
-            async def cancel_answer_task():
-                """Stop the coroutine and signal its worker thread."""
+            def stop_answer_task():
+                """Signal a timed-out worker and track it until it exits."""
 
                 cancel_event.set()
-                answer_task.cancel()
-                try:
-                    await answer_task
-                except (asyncio.CancelledError, Exception):
-                    pass
+                self._track_pending_worker(run_uuid, answer_task)
 
             try:
                 while True:
                     remaining_s = deadline_at - loop.time()
                     if remaining_s <= 0:
-                        await cancel_answer_task()
+                        stop_answer_task()
                         raise RunDeadlineExceededError(
                             "Run exceeded total wall-clock timeout of "
                             f"{format_duration(timeout_s)}."
@@ -350,13 +452,13 @@ class LensNodeExecutor:
                         result = answer_task.result()
                         break
                     if loop.time() >= deadline_at:
-                        await cancel_answer_task()
+                        stop_answer_task()
                         raise RunDeadlineExceededError(
                             "Run exceeded total wall-clock timeout of "
                             f"{format_duration(timeout_s)}."
                         )
                     if loop.time() - activity["at"] > idle_timeout_s:
-                        await cancel_answer_task()
+                        stop_answer_task()
                         raise RunStalledError(
                             "Run saw no gateway activity for "
                             f"{format_duration(idle_timeout_s)}; aborting."
@@ -366,7 +468,22 @@ class LensNodeExecutor:
                 # answer_task or its worker thread on its own. Signal both
                 # so the agent stops issuing model calls for a dead run.
                 cancel_event.set()
-                answer_task.cancel()
+                if command.get("_explicit_cancel"):
+                    cleanup_deferred = True
+                    workspace_path = getattr(
+                        self.agent.config,
+                        "workspace_path",
+                        None,
+                    )
+                    asyncio.create_task(
+                        _cleanup_after_cancelled_worker(
+                            answer_task,
+                            run_uuid,
+                            workspace_path,
+                        )
+                    )
+                else:
+                    answer_task.cancel()
                 raise
             samples = result.get("samples") or []
             sample_paths = [item["path"] for item in samples]
@@ -467,3 +584,15 @@ class LensNodeExecutor:
                     },
                 }
             )
+        finally:
+            if command.get("_explicit_cancel") and not cleanup_deferred:
+                workspace_path = getattr(
+                    self.agent.config,
+                    "workspace_path",
+                    None,
+                )
+                cleanup_run_checkpoint(
+                    run_uuid,
+                    workspace_path,
+                )
+                cleanup_run_runtime_resources(workspace_path, run_uuid)

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -189,6 +189,7 @@ class LensGatewayChatModel(BaseChatModel):
     token_budget_final_reserve_tokens: int = 40000
     token_budget_warn_ratio: float = 0.8
     token_budget_wrapup_event: Optional[Any] = None
+    on_runtime_state_change: Optional[Any] = None
     loop_repeat_warn: int = 3
     loop_repeat_hard: int = 5
     loop_tool_warn: int = 30
@@ -242,6 +243,116 @@ class LensGatewayChatModel(BaseChatModel):
 
         with self._usage_lock:
             return self._stop_reason
+
+    def export_runtime_state(self):
+        """Return cumulative guardrails for durable checkpoint metadata."""
+
+        with self._usage_lock:
+            return {
+                "run_token_usage": dict(self._run_token_usage),
+                "stop_reason": self._stop_reason,
+                "tool_call_history": list(self._tool_call_history),
+                "tool_name_history": list(self._tool_name_history),
+                "loop_warned": sorted(self._loop_warned),
+                "tool_warned": sorted(self._tool_warned),
+                "budget_warned": self._budget_warned,
+            }
+
+    def _notify_runtime_state_change(self):
+        """Persist updated guardrails when checkpointing is active."""
+
+        if self.on_runtime_state_change is not None:
+            self.on_runtime_state_change(self.export_runtime_state())
+
+    def restore_runtime_state(self, messages, runtime_state=None):
+        """Restore cumulative guardrails from checkpointed AI messages."""
+
+        usage = None
+        stop_reason = None
+        fingerprints = []
+        tool_names = []
+        durable_state = runtime_state if isinstance(runtime_state, dict) else {}
+        if durable_state:
+            candidate = durable_state.get("run_token_usage")
+            if isinstance(candidate, dict):
+                usage = candidate
+            stop_reason = durable_state.get("stop_reason") or None
+            fingerprints = list(durable_state.get("tool_call_history") or [])
+            tool_names = list(durable_state.get("tool_name_history") or [])
+        else:
+            for message in messages or []:
+                if getattr(message, "type", "") != "ai":
+                    continue
+                metadata = getattr(message, "response_metadata", None) or {}
+                for key, reason in (
+                    ("token_capped", "token_capped"),
+                    ("loop_capped", "loop_capped"),
+                    ("safety_terminated", "safety_terminated"),
+                    ("model_length_capped", "model_length_capped"),
+                ):
+                    if metadata.get(key):
+                        stop_reason = reason
+                        break
+                candidate = metadata.get("run_token_usage")
+                if isinstance(candidate, dict):
+                    usage = candidate
+                calls = list(getattr(message, "tool_calls", None) or [])
+                if calls:
+                    fingerprints.append(_tool_call_fingerprint(calls))
+                    tool_names.extend(
+                        str(call.get("name") or "") for call in calls
+                    )
+
+        with self._usage_lock:
+            if stop_reason is not None:
+                self._stop_reason = stop_reason
+            if usage is not None:
+                self._run_token_usage = {
+                    "prompt_tokens": _usage_int(usage, "prompt_tokens"),
+                    "completion_tokens": _usage_int(
+                        usage,
+                        "completion_tokens",
+                    ),
+                    "total_tokens": _usage_int(usage, "total_tokens"),
+                }
+            self._tool_call_history.extend(fingerprints)
+            self._tool_name_history.extend(tool_names)
+            self._loop_warned.update(durable_state.get("loop_warned") or [])
+            self._tool_warned.update(durable_state.get("tool_warned") or [])
+            self._budget_warned = bool(durable_state.get("budget_warned"))
+
+            repeat_warn = max(int(self.loop_repeat_warn or 1), 1)
+            frequencies = Counter(self._tool_call_history)
+            self._loop_warned.update(
+                fingerprint
+                for fingerprint, count in frequencies.items()
+                if count >= repeat_warn
+            )
+            tool_warn = max(int(self.loop_tool_warn or 1), 1)
+            tool_frequencies = Counter(self._tool_name_history)
+            self._tool_warned.update(
+                name
+                for name, count in tool_frequencies.items()
+                if count >= tool_warn
+            )
+
+            limit = max(int(self.token_budget_max_tokens or 0), 0)
+            reserve = min(
+                max(int(self.token_budget_final_reserve_tokens or 0), 0),
+                limit,
+            )
+            total = self._run_token_usage["total_tokens"]
+            if limit and total >= limit:
+                self._stop_reason = "token_capped"
+                if self.token_budget_wrapup_event is not None:
+                    self.token_budget_wrapup_event.set()
+            elif limit and reserve and total >= limit - reserve:
+                self._stop_reason = "token_budget_wrapup"
+                if self.token_budget_wrapup_event is not None:
+                    self.token_budget_wrapup_event.set()
+            elif limit and total >= limit * self.token_budget_warn_ratio:
+                self._budget_warned = True
+                self._budget_warning_pending = True
 
     def bind_tools(
         self,
@@ -384,6 +495,7 @@ class LensGatewayChatModel(BaseChatModel):
         )
         message = self._apply_token_budget(message, data.get("usage") or {})
         message = self._apply_loop_detection(message)
+        self._notify_runtime_state_change()
         self._finish_model_observation(observation_id, "done")
         return ChatResult(
             generations=[ChatGeneration(message=message)],
@@ -550,6 +662,7 @@ class LensGatewayChatModel(BaseChatModel):
         )
         message = self._apply_token_budget(message, usage)
         message = self._apply_loop_detection(message)
+        self._notify_runtime_state_change()
         return ChatResult(
             generations=[ChatGeneration(message=message)],
             llm_output={"usage": usage},

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -279,11 +279,13 @@ class LensGatewayChatModel(BaseChatModel):
             stop_reason = durable_state.get("stop_reason") or None
             fingerprints = list(durable_state.get("tool_call_history") or [])
             tool_names = list(durable_state.get("tool_name_history") or [])
-        else:
-            for message in messages or []:
-                if getattr(message, "type", "") != "ai":
-                    continue
-                metadata = getattr(message, "response_metadata", None) or {}
+        message_fingerprints = []
+        message_tool_names = []
+        for message in messages or []:
+            if getattr(message, "type", "") != "ai":
+                continue
+            metadata = getattr(message, "response_metadata", None) or {}
+            if stop_reason is None:
                 for key, reason in (
                     ("token_capped", "token_capped"),
                     ("loop_capped", "loop_capped"),
@@ -293,15 +295,36 @@ class LensGatewayChatModel(BaseChatModel):
                     if metadata.get(key):
                         stop_reason = reason
                         break
-                candidate = metadata.get("run_token_usage")
-                if isinstance(candidate, dict):
-                    usage = candidate
-                calls = list(getattr(message, "tool_calls", None) or [])
-                if calls:
-                    fingerprints.append(_tool_call_fingerprint(calls))
-                    tool_names.extend(
-                        str(call.get("name") or "") for call in calls
+            candidate = metadata.get("run_token_usage")
+            if isinstance(candidate, dict):
+                usage = {
+                    key: max(
+                        _usage_int(usage or {}, key),
+                        _usage_int(candidate, key),
                     )
+                    for key in (
+                        "prompt_tokens",
+                        "completion_tokens",
+                        "total_tokens",
+                    )
+                }
+            calls = list(getattr(message, "tool_calls", None) or [])
+            if calls:
+                message_fingerprints.append(
+                    _tool_call_fingerprint(calls)
+                )
+                message_tool_names.extend(
+                    str(call.get("name") or "") for call in calls
+                )
+
+        fingerprints = _merge_runtime_history(
+            fingerprints,
+            message_fingerprints,
+        )
+        tool_names = _merge_runtime_history(
+            tool_names,
+            message_tool_names,
+        )
 
         with self._usage_lock:
             if stop_reason is not None:
@@ -1241,6 +1264,22 @@ def _usage_int(usage, key, fallback_key=None):
         return max(int(value or 0), 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _merge_runtime_history(durable_values, message_values):
+    """Merge histories without double-counting checkpointed calls."""
+
+    durable = list(durable_values or [])
+    messages = list(message_values or [])
+    target_counts = Counter(messages)
+    current_counts = Counter(durable)
+    merged = list(durable)
+    for value in messages:
+        if current_counts[value] >= target_counts[value]:
+            continue
+        merged.append(value)
+        current_counts[value] += 1
+    return merged
 
 
 def _tool_call_fingerprint(tool_calls):

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -13,6 +13,7 @@ from websockets.asyncio.client import connect
 from .checkpoint import (
     checkpoint_enabled,
     checkpoint_ttl_hours,
+    close_checkpoint_saver,
     cleanup_expired_checkpoints,
     cleanup_run_checkpoint,
     get_checkpoint_saver,
@@ -245,9 +246,13 @@ class LensNodeClient:
         try:
             await self._drain_running_tasks()
             await self._flush_outbox()
+        finally:
             self.stopping.set()
             if self.websocket is not None:
-                await self.websocket.close()
+                try:
+                    await self.websocket.close()
+                except Exception:
+                    LOGGER.exception("Failed to close LensNode websocket")
             for task in list(self.running_tasks.values()):
                 task.cancel()
             if self.running_tasks:
@@ -255,8 +260,11 @@ class LensNodeClient:
                     *self.running_tasks.values(),
                     return_exceptions=True,
                 )
-        finally:
-            self.gateway_http_client.close()
+            await self.executor.drain_pending_workers()
+            try:
+                close_checkpoint_saver()
+            finally:
+                self.gateway_http_client.close()
 
     async def _drain_running_tasks(self):
         """Wait for in-flight runs to finish, bounded by the drain timeout."""

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -10,6 +10,13 @@ from urllib.parse import urlencode
 import httpx
 from websockets.asyncio.client import connect
 
+from .checkpoint import (
+    checkpoint_enabled,
+    checkpoint_ttl_hours,
+    cleanup_expired_checkpoints,
+    cleanup_run_checkpoint,
+    get_checkpoint_saver,
+)
 from .config import load_config
 from .datasource_sync import DataSourceSyncError
 from .datasource_sync import convert_managed_workspace
@@ -24,7 +31,10 @@ from .logging_utils import (
     task_log,
     utc_now,
 )
-from .runtime_resources import cleanup_stale_runtime_resources
+from .runtime_resources import (
+    cleanup_run_runtime_resources,
+    cleanup_stale_runtime_resources,
+)
 from .tls import create_config_ssl_context
 from .tls import warn_if_verification_disabled
 from .workspace import available_dirs
@@ -40,7 +50,10 @@ class LensNodeClient:
         self.config = config
         workspace_path = getattr(config, "workspace_path", None)
         if workspace_path:
-            cleanup_stale_runtime_resources(workspace_path)
+            cleanup_stale_runtime_resources(
+                workspace_path,
+                max_age_s=int(checkpoint_ttl_hours() * 3600),
+            )
         self.ssl_context = create_config_ssl_context(config)
         self.gateway_http_client = httpx.Client(
             timeout=config.request_timeout_s,
@@ -67,6 +80,8 @@ class LensNodeClient:
         self.last_report_signature = None
         self.running_tasks = {}
         self.datasource_conversion_cancels = {}
+        self.running_commands = {}
+        self._checkpoint_resume_ready = None
         # Durable outbound buffer, persistent across reconnects. A run started
         # on one connection keeps executing across a blue/green API recycle and
         # emits run_event/run_output/run_done frames while the socket is down;
@@ -178,6 +193,17 @@ class LensNodeClient:
             await asyncio.to_thread(
                 cleanup_stale_runtime_resources,
                 workspace_path,
+                int(checkpoint_ttl_hours() * 3600),
+            )
+            active_run_uuids = [
+                run_uuid
+                for run_uuid in self.running_tasks
+                if not run_uuid.startswith("datasource:")
+            ]
+            await asyncio.to_thread(
+                cleanup_expired_checkpoints,
+                workspace_path,
+                active_run_uuids,
             )
 
     async def stop(self):
@@ -397,8 +423,29 @@ class LensNodeClient:
         elif message_type == "run_cancel":
             run_uuid = str(message.get("run_uuid") or "")
             task = self.running_tasks.get(run_uuid)
+            command = None
             if task is not None:
-                task.cancel()
+                command = self.running_commands.get(run_uuid)
+                if command is not None:
+                    if not command.get("_explicit_cancel"):
+                        command["_explicit_cancel"] = True
+                        task.cancel()
+                else:
+                    task.cancel()
+            if task is None:
+                cleanup_run_checkpoint(
+                    run_uuid,
+                    getattr(self.config, "workspace_path", None),
+                )
+                cleanup_run_runtime_resources(
+                    getattr(self.config, "workspace_path", None),
+                    run_uuid,
+                )
+            elif command is None:
+                cleanup_run_checkpoint(
+                    run_uuid,
+                    getattr(self.config, "workspace_path", None),
+                )
             LOGGER.info(
                 task_log(
                     (
@@ -407,6 +454,16 @@ class LensNodeClient:
                     )
                 )
             )
+        elif message_type == "run_done_ack":
+            run_uuid = str(message.get("run_uuid") or "")
+            workspace_path = getattr(self.config, "workspace_path", None)
+            cleanup_deferred = self.executor.defer_cleanup_until_worker_stops(
+                run_uuid,
+                workspace_path,
+            )
+            if not cleanup_deferred:
+                cleanup_run_checkpoint(run_uuid, workspace_path)
+                cleanup_run_runtime_resources(workspace_path, run_uuid)
         elif message_type == "connected":
             LOGGER.info(
                 task_log(
@@ -456,6 +513,12 @@ class LensNodeClient:
             await self._send_busy(run_uuid, "LENSNODE_DRAINING")
             return
         if run_uuid in self.running_tasks:
+            if message.get("resume"):
+                LOGGER.info(
+                    "Ignored duplicate resume for active run %s.",
+                    run_uuid,
+                )
+                return
             await self._send_busy(run_uuid, "LENSNODE_RUN_ACTIVE")
             return
         max_runs = max(1, int(getattr(self.config, "max_concurrent_runs", 1)))
@@ -475,6 +538,7 @@ class LensNodeClient:
         task = asyncio.create_task(
             self._execute_command(run_uuid, message)
         )
+        self.running_commands[run_uuid] = message
         self.running_tasks[run_uuid] = task
         task.add_done_callback(lambda item: self._consume_task_exception(item))
 
@@ -780,6 +844,7 @@ class LensNodeClient:
                     await asyncio.sleep(0)
             finally:
                 self.running_tasks.pop(run_uuid, None)
+                self.running_commands.pop(run_uuid, None)
 
     def _consume_task_exception(self, task):
         """Consume task exceptions so cancelled runs do not leak warnings."""
@@ -833,6 +898,7 @@ class LensNodeClient:
             )
         )
         active_runs = self._reported_active_runs()
+        checkpoint_resume_ready = self._checkpoint_resume_available()
         await self.websocket.send(
             json.dumps(
                 {
@@ -847,11 +913,33 @@ class LensNodeClient:
                     "labels": {
                         "mode": "local",
                         "run_document_attachments": True,
+                        "run_checkpoint_resume": checkpoint_resume_ready,
+                        "run_checkpoint_ttl_hours": checkpoint_ttl_hours(),
                     },
                 },
                 ensure_ascii=False,
             )
         )
+
+    def _checkpoint_resume_available(self):
+        """Return whether durable checkpoint storage is usable."""
+
+        if self._checkpoint_resume_ready is not None:
+            return self._checkpoint_resume_ready
+        workspace_path = getattr(self.config, "workspace_path", None)
+        if not checkpoint_enabled() or not workspace_path:
+            self._checkpoint_resume_ready = False
+            return False
+        try:
+            get_checkpoint_saver(workspace_path)
+        except Exception:
+            LOGGER.exception(
+                "Disabling run checkpoint resume: storage is unavailable"
+            )
+            self._checkpoint_resume_ready = False
+            return False
+        self._checkpoint_resume_ready = True
+        return True
 
     async def _heartbeat_loop(self):
         """Periodically report workspace state while connected.

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -406,6 +406,21 @@ def cleanup_runtime_resources(resources):
     shutil.rmtree(resources.root, ignore_errors=True)
 
 
+def cleanup_run_runtime_resources(workspace_path, run_uuid):
+    """Remove one Run's deterministic runtime directory."""
+
+    if not workspace_path or not run_uuid:
+        return
+    runtime_root = (
+        Path(workspace_path)
+        / ".sourcelens"
+        / "runtime"
+        / "runs"
+        / str(run_uuid)
+    )
+    shutil.rmtree(runtime_root, ignore_errors=True)
+
+
 def cleanup_stale_runtime_resources(
     workspace_path,
     max_age_s=STALE_RUNTIME_MAX_AGE_S,

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -5,6 +5,7 @@ import json
 import multiprocessing
 import os
 import queue
+import re
 import shutil
 import stat
 import tempfile
@@ -27,6 +28,7 @@ MAX_FILENAME_COMPONENT_BYTES = 255
 STALE_RUNTIME_MAX_AGE_S = 24 * 60 * 60
 RUNTIME_ACTIVITY_INTERVAL_S = 15
 RUNTIME_CONVERSION_POLL_S = 0.25
+RUN_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 
 @dataclass(frozen=True)
@@ -56,7 +58,7 @@ def prepare_runtime_resources(
     workspace = Path(config.workspace_path)
     base = workspace / ".sourcelens"
     cache_root = base / "cache"
-    runtime_root = base / "runtime" / "runs" / command["run_uuid"]
+    runtime_root = _run_runtime_path(workspace, command["run_uuid"])
     skills_root = runtime_root / "skills"
     mcp_root = runtime_root / "mcp"
 
@@ -410,15 +412,39 @@ def cleanup_run_runtime_resources(workspace_path, run_uuid):
     """Remove one Run's deterministic runtime directory."""
 
     if not workspace_path or not run_uuid:
-        return
-    runtime_root = (
-        Path(workspace_path)
-        / ".sourcelens"
-        / "runtime"
-        / "runs"
-        / str(run_uuid)
-    )
+        return False
+    try:
+        runtime_root = _run_runtime_path(workspace_path, run_uuid)
+    except (OSError, ValueError):
+        return False
     shutil.rmtree(runtime_root, ignore_errors=True)
+    return not runtime_root.exists()
+
+
+def _run_runtime_path(workspace_path, run_uuid):
+    """Return a contained runtime path for one validated Run identifier."""
+
+    identifier = str(run_uuid).strip()
+    if not RUN_IDENTIFIER_PATTERN.fullmatch(identifier):
+        raise ValueError("Invalid Run identifier")
+
+    workspace_root = Path(workspace_path).resolve()
+    runs_root = workspace_root / ".sourcelens" / "runtime" / "runs"
+    resolved_runs_root = runs_root.resolve()
+    try:
+        resolved_runs_root.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError("Runtime root escapes workspace") from exc
+
+    runtime_root = runs_root / identifier
+    if runtime_root.is_symlink():
+        raise ValueError("Run runtime path cannot be a symlink")
+    resolved_runtime_root = runtime_root.resolve()
+    try:
+        resolved_runtime_root.relative_to(resolved_runs_root)
+    except ValueError as exc:
+        raise ValueError("Run runtime path escapes runtime root") from exc
+    return resolved_runtime_root
 
 
 def cleanup_stale_runtime_resources(

--- a/lensnode/lensnode/workspace.py
+++ b/lensnode/lensnode/workspace.py
@@ -36,6 +36,9 @@ DEFAULT_EXCLUDED_EXTENSIONS = {
     ".map",
 }
 
+INTERNAL_CHECKPOINT_DIR = ".checkpoints"
+INTERNAL_RUN_PATH = (".sourcelens", "runtime", "runs")
+
 DEFAULT_CONTEXT_LINES = 2
 DEFAULT_MAX_SEARCH_MATCHES = 50
 MAX_SEARCH_MATCHES = 200
@@ -376,7 +379,7 @@ def _run_rg(cmd):
     return completed.stdout
 
 
-def _rg_glob_args(scope, policy, glob):
+def _rg_glob_args(root, scope, policy, glob):
     """Build ripgrep -g include/exclude args from scope and an extra glob.
 
     The trivial "**/*" include is skipped: ripgrep unions include globs,
@@ -393,7 +396,7 @@ def _rg_glob_args(scope, policy, glob):
         args.extend(["-g", pattern])
     if glob:
         args.extend(["-g", glob])
-    for pattern in _exclude_globs(scope, policy):
+    for pattern in _exclude_globs(root, scope, policy):
         args.extend(["-g", f"!{pattern}"])
     return args
 
@@ -436,7 +439,7 @@ def _rg_line_matches(
         str(max(1, max_line_chars)),
         "--max-columns-preview",
     ])
-    cmd.extend(_rg_glob_args(scope, policy, glob))
+    cmd.extend(_rg_glob_args(root, scope, policy, glob))
     for pattern in patterns:
         cmd.extend(["-e", pattern])
     cmd.append(str(root))
@@ -464,7 +467,7 @@ def _rg_files_with_matches(
         cmd.append("-i")
     if fixed:
         cmd.append("-F")
-    cmd.extend(_rg_glob_args(scope, policy, glob))
+    cmd.extend(_rg_glob_args(root, scope, policy, glob))
     for pattern in patterns:
         cmd.extend(["-e", pattern])
     cmd.append(str(root))
@@ -487,7 +490,7 @@ def _rg_counts(
         cmd.append("-i")
     if fixed:
         cmd.append("-F")
-    cmd.extend(_rg_glob_args(scope, policy, glob))
+    cmd.extend(_rg_glob_args(root, scope, policy, glob))
     for pattern in patterns:
         cmd.extend(["-e", pattern])
     cmd.append(str(root))
@@ -725,6 +728,13 @@ def is_path_excluded(root, path, scope, policy):
         relative = path if root is None else path.relative_to(root)
     except ValueError:
         return True
+    if INTERNAL_CHECKPOINT_DIR in path.parts:
+        return True
+    if (
+        _contains_path_parts(path.parts, INTERNAL_RUN_PATH)
+        and not _is_subject_runtime_root(root, scope)
+    ):
+        return True
     if _include_hidden(scope, policy):
         hidden_parts = ()
     elif _is_subject_runtime_root(root, scope):
@@ -764,10 +774,22 @@ def _is_subject_runtime_root(root, scope):
     )
 
 
-def _exclude_globs(scope, policy):
+def _contains_path_parts(parts, expected):
+    """Return whether expected appears contiguously in path parts."""
+
+    width = len(expected)
+    return any(
+        tuple(parts[index : index + width]) == expected
+        for index in range(len(parts) - width + 1)
+    )
+
+
+def _exclude_globs(root, scope, policy):
     """Build ripgrep glob exclusions from scope and policy."""
 
-    globs = []
+    globs = [f"**/{INTERNAL_CHECKPOINT_DIR}/**"]
+    if not _is_subject_runtime_root(root, scope):
+        globs.append("**/.sourcelens/runtime/runs/**")
     exclude_dirs = _option(scope, policy, "exclude_dirs", DEFAULT_EXCLUDED_DIRS)
     for dirname in exclude_dirs:
         globs.append(f"**/{dirname}/**")

--- a/lensnode/pyproject.toml
+++ b/lensnode/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "langchain-anthropic>=1.4.6,<1.5.0",
     "langchain-core>=1.4.6,<1.5.0",
     "langchain-mcp-adapters>=0.2.2,<0.4.0",
+    "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
     "markitdown[docx,pdf,pptx,xlsx]>=0.1.2",
     "openpyxl>=3.1.0",
     "pillow>=10.0.0",

--- a/lensnode/tests/test_checkpoint.py
+++ b/lensnode/tests/test_checkpoint.py
@@ -1,0 +1,334 @@
+"""Tests for durable LensNode run checkpoints."""
+
+import os
+import threading
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.base import empty_checkpoint
+
+from lensnode import checkpoint
+
+
+def test_checkpoint_saver_uses_rollback_journal(tmp_path, monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+
+    try:
+        saver.setup()
+        journal_mode = saver.conn.execute(
+            "PRAGMA journal_mode"
+        ).fetchone()[0]
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert journal_mode == "delete"
+
+
+def test_checkpoint_storage_is_private(tmp_path, monkeypatch):
+    directory = tmp_path / "checkpoints"
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(directory))
+    checkpoint._saver = None
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+
+    try:
+        database = directory / "lensnode.sqlite"
+        assert os.stat(directory).st_mode & 0o777 == 0o700
+        assert os.stat(database).st_mode & 0o777 == 0o600
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_resume_fails_closed_without_checkpoint(tmp_path, monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+
+    with pytest.raises(
+        checkpoint.CheckpointResumeError,
+        match="checkpoint is missing",
+    ):
+        checkpoint.load_resume_state("missing-run", str(tmp_path))
+
+    checkpoint._saver.conn.close()
+    checkpoint._saver = None
+
+
+def test_resume_fails_closed_when_checkpointing_is_disabled(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_ENABLED", "0")
+
+    with pytest.raises(
+        checkpoint.CheckpointResumeError,
+        match="checkpointing is disabled",
+    ):
+        checkpoint.load_resume_state("run", str(tmp_path))
+
+
+def test_resume_loads_checkpoint_and_frozen_runtime_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000013"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    saved = empty_checkpoint()
+    saved["channel_values"] = {
+        "messages": [AIMessage(content="checkpoint answer")]
+    }
+    checkpoint.save_resume_metadata(
+        run_uuid,
+        str(tmp_path),
+        route_decision={"route": "plan_execute"},
+        history_assistant_turns=2,
+    )
+    checkpoint.save_runtime_state(
+        run_uuid,
+        str(tmp_path),
+        capability_state={"successful_capabilities": ["skill"]},
+        runtime_evidence={"record_validation": {"valid": True}},
+        guardrail_state={
+            "run_token_usage": {"total_tokens": 42},
+            "tool_call_history": ["search:one"],
+        },
+    )
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        saved,
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
+
+    try:
+        state = checkpoint.load_resume_state(run_uuid, str(tmp_path))
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert state.messages[0].content == "checkpoint answer"
+    assert state.route_decision == {"route": "plan_execute"}
+    assert state.history_assistant_turns == 2
+    assert state.capability_state == {
+        "successful_capabilities": ["skill"]
+    }
+    assert state.runtime_evidence == {
+        "record_validation": {"valid": True}
+    }
+    assert state.guardrail_state == {
+        "run_token_usage": {"total_tokens": 42},
+        "tool_call_history": ["search:one"],
+    }
+
+
+def test_checkpoint_and_metadata_writes_share_one_connection_lock(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    run_uuids = [f"concurrent-run-{index}" for index in range(4)]
+    for run_uuid in run_uuids:
+        checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    errors = []
+
+    def write_graph(run_uuid):
+        try:
+            for _index in range(50):
+                saver.put(
+                    checkpoint.thread_config(run_uuid),
+                    empty_checkpoint(),
+                    {"source": "loop", "step": 1, "parents": {}},
+                    {},
+                )
+        except Exception as exc:
+            errors.append(exc)
+
+    def write_metadata(run_uuid):
+        try:
+            for index in range(50):
+                checkpoint.save_runtime_state(
+                    run_uuid,
+                    str(tmp_path),
+                    capability_state={"index": index},
+                )
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        thread
+        for run_uuid in run_uuids
+        for thread in (
+            threading.Thread(target=write_graph, args=(run_uuid,)),
+            threading.Thread(target=write_metadata, args=(run_uuid,)),
+        )
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert errors == []
+
+
+def test_expired_local_checkpoint_is_garbage_collected(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_TTL_HOURS", "1")
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000015"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    saved = empty_checkpoint()
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        saved,
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
+    saver.conn.execute(
+        "UPDATE lensnode_run_metadata SET orphaned_at = 0"
+    )
+    saver.conn.commit()
+
+    checkpoint.cleanup_expired_checkpoints(str(tmp_path))
+
+    try:
+        assert saver.get_tuple(checkpoint.thread_config(run_uuid)) is None
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_periodic_cleanup_preserves_active_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_TTL_HOURS", "1")
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000016"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    saved = empty_checkpoint()
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        saved,
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
+    saver.conn.execute(
+        "UPDATE lensnode_run_metadata SET orphaned_at = 0"
+    )
+    saver.conn.commit()
+
+    checkpoint.cleanup_expired_checkpoints(
+        str(tmp_path),
+        active_run_uuids=[run_uuid],
+    )
+
+    try:
+        assert saver.get_tuple(checkpoint.thread_config(run_uuid)) is not None
+        orphaned_at = saver.conn.execute(
+            """
+            SELECT orphaned_at
+            FROM lensnode_run_metadata
+            WHERE run_uuid = ?
+            """,
+            (run_uuid,),
+        ).fetchone()[0]
+        assert orphaned_at is None
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_cleanup_starts_ttl_when_checkpoint_becomes_orphaned(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_TTL_HOURS", "1")
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000017"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    saved = empty_checkpoint()
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        saved,
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
+    saver.conn.execute(
+        "UPDATE lensnode_run_metadata SET updated_at = 0"
+    )
+    saver.conn.commit()
+
+    checkpoint.cleanup_expired_checkpoints(str(tmp_path))
+    saver.conn.close()
+    checkpoint._saver = None
+    restarted_saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+
+    try:
+        assert (
+            restarted_saver.get_tuple(checkpoint.thread_config(run_uuid))
+            is not None
+        )
+        orphaned_at = restarted_saver.conn.execute(
+            """
+            SELECT orphaned_at
+            FROM lensnode_run_metadata
+            WHERE run_uuid = ?
+            """,
+            (run_uuid,),
+        ).fetchone()[0]
+        assert orphaned_at is not None
+    finally:
+        restarted_saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_restart_preserves_existing_orphan_timestamp(tmp_path, monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    run_uuid = "00000000-0000-0000-0000-000000000018"
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    saver.conn.execute(
+        "UPDATE lensnode_run_metadata SET orphaned_at = ? WHERE run_uuid = ?",
+        (1234.0, run_uuid),
+    )
+    saver.conn.commit()
+    saver.conn.close()
+    checkpoint._saver = None
+
+    restarted_saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+
+    try:
+        orphaned_at = restarted_saver.conn.execute(
+            """
+            SELECT orphaned_at
+            FROM lensnode_run_metadata
+            WHERE run_uuid = ?
+            """,
+            (run_uuid,),
+        ).fetchone()[0]
+        assert orphaned_at == 1234.0
+    finally:
+        restarted_saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_checkpoint_ttl_hours_uses_effective_environment(monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_TTL_HOURS", "6.5")
+
+    assert checkpoint.checkpoint_ttl_hours() == 6.5

--- a/lensnode/tests/test_checkpoint.py
+++ b/lensnode/tests/test_checkpoint.py
@@ -1,10 +1,11 @@
 """Tests for durable LensNode run checkpoints."""
 
 import os
+import sqlite3
 import threading
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.checkpoint.base import empty_checkpoint
 
 from lensnode import checkpoint
@@ -40,6 +41,71 @@ def test_checkpoint_storage_is_private(tmp_path, monkeypatch):
     finally:
         saver.conn.close()
         checkpoint._saver = None
+
+
+def test_checkpoint_saver_close_is_explicit_and_idempotent(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+
+    assert checkpoint.close_checkpoint_saver() is True
+    assert checkpoint._saver is None
+    assert checkpoint.close_checkpoint_saver() is False
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        saver.conn.execute("SELECT 1")
+
+
+def test_checkpoint_metadata_schema_is_upgraded_additively(
+    tmp_path,
+    monkeypatch,
+):
+    database = tmp_path / "lensnode.sqlite"
+    connection = sqlite3.connect(database)
+    connection.execute(
+        """
+        CREATE TABLE lensnode_run_metadata (
+            run_uuid TEXT PRIMARY KEY,
+            route_decision TEXT NOT NULL,
+            history_assistant_turns INTEGER NOT NULL,
+            runtime_state TEXT NOT NULL DEFAULT '{}',
+            updated_at REAL NOT NULL,
+            orphaned_at REAL
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO lensnode_run_metadata (
+            run_uuid,
+            route_decision,
+            history_assistant_turns,
+            runtime_state,
+            updated_at
+        ) VALUES ('legacy-run', '{}', 0, '{}', 1)
+        """
+    )
+    connection.commit()
+    connection.close()
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    columns = {
+        row[1]
+        for row in saver.conn.execute(
+            "PRAGMA table_info(lensnode_run_metadata)"
+        ).fetchall()
+    }
+    legacy_row = saver.conn.execute(
+        "SELECT run_uuid FROM lensnode_run_metadata"
+    ).fetchone()
+    checkpoint.close_checkpoint_saver()
+
+    assert {"checkpoint_id", "schema_version"} <= columns
+    assert legacy_row == ("legacy-run",)
 
 
 def test_resume_fails_closed_without_checkpoint(tmp_path, monkeypatch):
@@ -87,6 +153,12 @@ def test_resume_loads_checkpoint_and_frozen_runtime_metadata(
         route_decision={"route": "plan_execute"},
         history_assistant_turns=2,
     )
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        saved,
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
     checkpoint.save_runtime_state(
         run_uuid,
         str(tmp_path),
@@ -96,12 +168,6 @@ def test_resume_loads_checkpoint_and_frozen_runtime_metadata(
             "run_token_usage": {"total_tokens": 42},
             "tool_call_history": ["search:one"],
         },
-    )
-    saver.put(
-        checkpoint.thread_config(run_uuid),
-        saved,
-        {"source": "loop", "step": 1, "parents": {}},
-        {},
     )
 
     try:
@@ -113,6 +179,7 @@ def test_resume_loads_checkpoint_and_frozen_runtime_metadata(
     assert state.messages[0].content == "checkpoint answer"
     assert state.route_decision == {"route": "plan_execute"}
     assert state.history_assistant_turns == 2
+    assert state.checkpoint_step == 1
     assert state.capability_state == {
         "successful_capabilities": ["skill"]
     }
@@ -125,6 +192,159 @@ def test_resume_loads_checkpoint_and_frozen_runtime_metadata(
     }
 
 
+def test_route_update_preserves_runtime_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000019"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    checkpoint.save_initial_checkpoint(run_uuid, str(tmp_path), [])
+    checkpoint.save_runtime_state(
+        run_uuid,
+        str(tmp_path),
+        guardrail_state={"run_token_usage": {"total_tokens": 17}},
+    )
+    checkpoint.save_resume_metadata(
+        run_uuid,
+        str(tmp_path),
+        route_decision={"route": "direct_answer"},
+    )
+
+    try:
+        state = checkpoint.load_resume_state(run_uuid, str(tmp_path))
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert state.route_decision == {"route": "direct_answer"}
+    assert state.guardrail_state == {
+        "run_token_usage": {"total_tokens": 17}
+    }
+
+
+def test_resume_rejects_runtime_state_for_a_stale_checkpoint_head(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000020"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    checkpoint.save_initial_checkpoint(run_uuid, str(tmp_path), [])
+    checkpoint.save_runtime_state(
+        run_uuid,
+        str(tmp_path),
+        guardrail_state={"run_token_usage": {"total_tokens": 17}},
+    )
+    saver.put(
+        checkpoint.thread_config(run_uuid),
+        empty_checkpoint(),
+        {"source": "loop", "step": 1, "parents": {}},
+        {},
+    )
+
+    try:
+        with pytest.raises(
+            checkpoint.CheckpointResumeError,
+            match="checkpoint version does not match",
+        ):
+            checkpoint.load_resume_state(run_uuid, str(tmp_path))
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+
+def test_resume_accepts_metadata_bound_to_checkpoint_ancestor(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000023"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    initial_config = checkpoint.save_initial_checkpoint(
+        run_uuid,
+        str(tmp_path),
+        [],
+    )
+    checkpoint.save_runtime_state(
+        run_uuid,
+        str(tmp_path),
+        guardrail_state={"run_token_usage": {"total_tokens": 17}},
+    )
+    advanced = empty_checkpoint()
+    advanced["channel_values"] = {
+        "messages": [AIMessage(content="advanced checkpoint")]
+    }
+    saver.put(
+        initial_config,
+        advanced,
+        {"source": "loop", "step": 0, "parents": {}},
+        {},
+    )
+
+    try:
+        state = checkpoint.load_resume_state(run_uuid, str(tmp_path))
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert state.messages[0].content == "advanced checkpoint"
+    assert state.checkpoint_step == 0
+    assert state.guardrail_state == {
+        "run_token_usage": {"total_tokens": 17}
+    }
+
+
+def test_resume_loads_persisted_pending_tool_results(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_DIR", str(tmp_path))
+    checkpoint._saver = None
+    run_uuid = "00000000-0000-0000-0000-000000000021"
+    saver = checkpoint.get_checkpoint_saver(str(tmp_path))
+    checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+    saved_config = checkpoint.save_initial_checkpoint(
+        run_uuid,
+        str(tmp_path),
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "mcp__billing__create_invoice",
+                        "args": {"amount": 100},
+                        "id": "write-1",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        ],
+    )
+    checkpoint.save_runtime_state(run_uuid, str(tmp_path))
+    saver.put_writes(
+        saved_config,
+        [
+            (
+                "messages",
+                ToolMessage(content="created", tool_call_id="write-1"),
+            )
+        ],
+        task_id="tool-task-1",
+    )
+
+    try:
+        state = checkpoint.load_resume_state(run_uuid, str(tmp_path))
+    finally:
+        saver.conn.close()
+        checkpoint._saver = None
+
+    assert state.pending_write_tool_call_ids == frozenset({"write-1"})
+
+
 def test_checkpoint_and_metadata_writes_share_one_connection_lock(
     tmp_path,
     monkeypatch,
@@ -135,6 +355,7 @@ def test_checkpoint_and_metadata_writes_share_one_connection_lock(
     run_uuids = [f"concurrent-run-{index}" for index in range(4)]
     for run_uuid in run_uuids:
         checkpoint.save_resume_metadata(run_uuid, str(tmp_path))
+        checkpoint.save_initial_checkpoint(run_uuid, str(tmp_path), [])
     errors = []
 
     def write_graph(run_uuid):

--- a/lensnode/tests/test_drain.py
+++ b/lensnode/tests/test_drain.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from types import SimpleNamespace
 
 from lensnode.main import LensNodeClient
 
@@ -73,6 +74,35 @@ def test_drain_lets_in_flight_run_finish_then_stops():
         send_task.cancel()
 
     asyncio.run(exercise())
+
+
+def test_stop_closes_checkpoint_after_workers_finish(monkeypatch):
+    actions = []
+
+    async def exercise():
+        client = _make_client()
+
+        async def flush_outbox():
+            return None
+
+        async def drain_pending_workers():
+            actions.append("workers")
+
+        client._flush_outbox = flush_outbox
+        client.executor.drain_pending_workers = drain_pending_workers
+        client.gateway_http_client = SimpleNamespace(
+            close=lambda: actions.append("gateway")
+        )
+        monkeypatch.setattr(
+            "lensnode.main.close_checkpoint_saver",
+            lambda: actions.append("checkpoint"),
+        )
+
+        await client.stop()
+
+    asyncio.run(exercise())
+
+    assert actions == ["workers", "checkpoint", "gateway"]
 
 
 def test_drain_rejects_new_runs():

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -3,10 +3,12 @@ import json
 import subprocess
 import threading
 import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
-from lensnode.agent_tools import _skill_script_environment, build_agent_tools
 from lensnode.agent_runtime import _system_prompt
-from lensnode.executor import LensNodeExecutor
+from lensnode.agent_tools import _skill_script_environment, build_agent_tools
+from lensnode.executor import LensNodeExecutor, _remaining_run_timeout_seconds
 from lensnode.gateway_model import RunCancelledError
 from lensnode.main import LensNodeClient
 from lensnode.runtime_resources import cleanup_runtime_resources
@@ -88,6 +90,229 @@ def test_executor_emits_streamed_output_delta():
         "reason": "capability_unavailable",
         "capability": "skill",
     }
+
+
+def test_terminal_result_retains_checkpoint_until_acknowledged():
+    executor = LensNodeExecutor.__new__(LensNodeExecutor)
+    executor.agent = FakeAgent()
+
+    with (
+        patch(
+            "lensnode.executor.cleanup_run_checkpoint"
+        ) as checkpoint_cleanup,
+        patch(
+            "lensnode.executor.cleanup_run_runtime_resources"
+        ) as runtime_cleanup,
+    ):
+        asyncio.run(
+            executor.execute(
+                {
+                    "run_uuid": "00000000-0000-0000-0000-000000000017",
+                    "task": "knowledge_qa",
+                    "target_dirs": [],
+                },
+                lambda _payload: None,
+            )
+        )
+
+    checkpoint_cleanup.assert_not_called()
+    runtime_cleanup.assert_not_called()
+
+
+def test_executor_cancellation_preserves_checkpoint():
+    started = asyncio.Event()
+
+    class CancellableAgent:
+        class Config:
+            request_timeout_s = 240
+            workspace_path = "/workspace"
+
+        config = Config()
+
+        async def answer(self, command, **kwargs):
+            del command, kwargs
+            started.set()
+            await asyncio.sleep(3600)
+
+    async def exercise():
+        executor = LensNodeExecutor.__new__(LensNodeExecutor)
+        executor.agent = CancellableAgent()
+        task = asyncio.create_task(
+            executor.execute(
+                {
+                    "run_uuid": "00000000-0000-0000-0000-000000000009",
+                    "task": "knowledge_qa",
+                    "target_dirs": [],
+                },
+                lambda payload: None,
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    with patch("lensnode.executor.cleanup_run_checkpoint") as cleanup:
+        asyncio.run(exercise())
+
+    cleanup.assert_not_called()
+
+
+def test_explicit_cancellation_cleans_after_agent_stops():
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    release = asyncio.Event()
+
+    class CancelAwareAgent:
+        class Config:
+            request_timeout_s = 240
+            workspace_path = "/workspace"
+
+        config = Config()
+
+        async def answer(self, command, cancel_event=None, **kwargs):
+            del command, kwargs
+            started.set()
+            while not cancel_event.is_set():
+                await asyncio.sleep(0)
+            await release.wait()
+            stopped.set()
+
+    cleanup_observations = []
+
+    async def exercise():
+        executor = LensNodeExecutor.__new__(LensNodeExecutor)
+        executor.agent = CancelAwareAgent()
+        command = {
+            "run_uuid": "00000000-0000-0000-0000-000000000016",
+            "task": "knowledge_qa",
+            "target_dirs": [],
+            "_explicit_cancel": True,
+        }
+        task = asyncio.create_task(executor.execute(command, lambda _p: None))
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        await asyncio.wait_for(
+            asyncio.gather(task, return_exceptions=True),
+            timeout=1,
+        )
+        assert not stopped.is_set()
+        release.set()
+        await asyncio.wait_for(stopped.wait(), timeout=1)
+        while len(cleanup_observations) < 2:
+            await asyncio.sleep(0)
+
+    def observe_cleanup(*_args):
+        cleanup_observations.append(stopped.is_set())
+
+    with (
+        patch(
+            "lensnode.executor.cleanup_run_checkpoint",
+            side_effect=observe_cleanup,
+        ),
+        patch(
+            "lensnode.executor.cleanup_run_runtime_resources",
+            side_effect=observe_cleanup,
+        ),
+    ):
+        asyncio.run(exercise())
+
+    assert cleanup_observations == [True, True]
+
+
+def test_duplicate_resume_for_active_run_is_idempotent():
+    async def exercise():
+        config = type(
+            "Config",
+            (),
+            {
+                "name": "test-node",
+                "request_timeout_s": 240,
+                "max_concurrent_runs": 1,
+            },
+        )()
+        client = LensNodeClient(config)
+        executor = BlockingExecutor()
+        client.executor = executor
+        run_uuid = "00000000-0000-0000-0000-000000000010"
+        message = {
+            "type": "run_start",
+            "run_uuid": run_uuid,
+            "task": "knowledge_qa",
+            "target_dirs": [],
+            "resume": True,
+        }
+
+        await client._handle_message(json.dumps(message))
+        await asyncio.wait_for(executor.started.wait(), timeout=1)
+        await client._handle_message(json.dumps(message))
+
+        assert not any(
+            frame.get("error") == "LENSNODE_RUN_ACTIVE"
+            for frame in client._outbox
+        )
+        client.running_tasks[run_uuid].cancel()
+        await asyncio.gather(
+            client.running_tasks[run_uuid],
+            return_exceptions=True,
+        )
+
+    asyncio.run(exercise())
+
+
+def test_control_plane_cancel_cleans_idle_checkpoint_and_runtime_files():
+    async def exercise():
+        config = type(
+            "Config",
+            (),
+            {
+                "name": "test-node",
+                "request_timeout_s": 240,
+                "workspace_path": "/workspace",
+            },
+        )()
+        client = LensNodeClient(config)
+        run_uuid = "00000000-0000-0000-0000-000000000011"
+
+        await client._handle_message(
+            json.dumps({"type": "run_cancel", "run_uuid": run_uuid})
+        )
+
+    with (
+        patch("lensnode.main.cleanup_run_checkpoint") as checkpoint_cleanup,
+        patch(
+            "lensnode.main.cleanup_run_runtime_resources"
+        ) as runtime_cleanup,
+    ):
+        asyncio.run(exercise())
+
+    checkpoint_cleanup.assert_called_once_with(
+        "00000000-0000-0000-0000-000000000011",
+        "/workspace",
+    )
+    runtime_cleanup.assert_called_once_with(
+        "/workspace",
+        "00000000-0000-0000-0000-000000000011",
+    )
+
+
+def test_resume_uses_remaining_original_wall_clock_budget():
+    now = datetime(2026, 8, 1, 8, 0, tzinfo=timezone.utc)
+    started_at = now - timedelta(seconds=70)
+
+    remaining = _remaining_run_timeout_seconds(
+        {
+            "run_timeout_s": 100,
+            "remaining_run_timeout_s": 30,
+            "run_started_at": started_at.isoformat(),
+            "resume": True,
+        },
+        now=now,
+    )
+
+    assert remaining == 30
 
 
 def test_executor_derives_run_timeout_from_agent_rounds():

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -684,6 +684,41 @@ def test_resume_restores_terminal_guardrail_reason(
     assert model.stop_reason == expected_reason
 
 
+def test_resume_reconciles_newer_message_usage_with_durable_state():
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+    )
+    message = AIMessage(
+        content="checkpointed answer",
+        response_metadata={
+            "run_token_usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 30,
+                "total_tokens": 80,
+            }
+        },
+    )
+
+    model.restore_runtime_state(
+        [message],
+        {
+            "run_token_usage": {
+                "prompt_tokens": 25,
+                "completion_tokens": 15,
+                "total_tokens": 40,
+            }
+        },
+    )
+
+    assert model.token_usage == {
+        "prompt_tokens": 50,
+        "completion_tokens": 30,
+        "total_tokens": 80,
+    }
+
+
 def test_final_synthesis_is_preserved_when_it_crosses_hard_budget(monkeypatch):
     responses = [
         {

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -587,6 +587,103 @@ def test_run_token_budget_warns_then_suppresses_new_tool_calls(monkeypatch):
     }
 
 
+def test_resume_restores_token_and_loop_guardrail_state(monkeypatch):
+    def handler(_request):
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "content": "",
+                    "finish_reason": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "id": "call_3",
+                            "type": "function",
+                            "function": {
+                                "name": "search_workspace",
+                                "arguments": '{"query":"same"}',
+                            },
+                        }
+                    ],
+                },
+                "usage": {"total_tokens": 30},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    previous_model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        general_chat_execution_gates=True,
+        loop_repeat_warn=2,
+        loop_repeat_hard=3,
+    )
+    repeated_call = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "search_workspace",
+                "args": {"query": "same"},
+            }
+        ],
+    )
+    previous_model._apply_loop_detection(repeated_call)
+    previous_model._apply_loop_detection(repeated_call)
+    durable_state = previous_model.export_runtime_state()
+    durable_state["run_token_usage"] = {"total_tokens": 80}
+    persisted = []
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        general_chat_execution_gates=True,
+        token_budget_max_tokens=200,
+        token_budget_final_reserve_tokens=10,
+        loop_repeat_warn=2,
+        loop_repeat_hard=3,
+        on_runtime_state_change=persisted.append,
+    )
+    model.restore_runtime_state(
+        [AIMessage(content="compacted summary")],
+        durable_state,
+    )
+
+    result = model._generate([HumanMessage(content="continue")])
+    message = result.generations[0].message
+
+    assert model.token_usage["total_tokens"] == 110
+    assert message.tool_calls == []
+    assert message.response_metadata["loop_capped"] is True
+    assert len(persisted[-1]["tool_call_history"]) == 3
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_reason"),
+    [
+        ({"loop_capped": True}, "loop_capped"),
+        ({"safety_terminated": True}, "safety_terminated"),
+        ({"model_length_capped": True}, "model_length_capped"),
+    ],
+)
+def test_resume_restores_terminal_guardrail_reason(
+    metadata,
+    expected_reason,
+):
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+    )
+
+    model.restore_runtime_state(
+        [AIMessage(content="partial", response_metadata=metadata)]
+    )
+
+    assert model.stop_reason == expected_reason
+
+
 def test_final_synthesis_is_preserved_when_it_crosses_hard_budget(monkeypatch):
     responses = [
         {

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -214,6 +214,116 @@ def test_general_chat_resume_reuses_frozen_route(monkeypatch, tmp_path):
     assert cleanup_called["value"] is False
 
 
+def test_general_chat_resume_reselects_incomplete_route_checkpoint(
+    monkeypatch,
+    tmp_path,
+):
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 0}
+
+        def __init__(self, **_kwargs):
+            self.calls = 0
+
+        def restore_runtime_state(self, *_args):
+            pass
+
+        def export_runtime_state(self):
+            return {"run_token_usage": {"total_tokens": 8}}
+
+        def invoke(self, _messages, **_kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(
+                    content=(
+                        '{"intent":"informational","complexity":"simple",'
+                        '"route":"direct_answer",'
+                        '"required_capabilities":[],'
+                        '"evidence_requirement":"none"}'
+                    )
+                )
+            return SimpleNamespace(content="recovered answer")
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=[],
+        mcp_configs=[],
+        skill_paths=[],
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+    )
+    state = ResumeState(
+        messages=(HumanMessage(content="question"),),
+        route_decision={},
+        history_assistant_turns=0,
+        checkpoint_step=-1,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_resume_state",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_resume_metadata",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_runtime_state",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000022",
+            "resume": True,
+            "task": "general_chat",
+            "question": "question",
+            "agent_model_ref": "model-ref",
+        }
+    )
+
+    assert result["answer"] == "recovered answer"
+
+
 def test_resume_rejects_pending_non_idempotent_write():
     messages = (
         AIMessage(
@@ -289,6 +399,32 @@ def test_resume_allows_pending_write_with_trusted_idempotent_metadata():
     )
 
     agent_runtime._reject_unsafe_resume_tool_replay(messages, [tool])
+
+
+def test_resume_allows_write_with_a_persisted_pending_tool_result():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "mcp__billing__create_invoice",
+                    "args": {"amount": 100},
+                    "id": "write-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    )
+    tool = SimpleNamespace(
+        name="mcp__billing__create_invoice",
+        metadata={"operation": "write"},
+    )
+
+    agent_runtime._reject_unsafe_resume_tool_replay(
+        messages,
+        [tool],
+        pending_write_tool_call_ids={"write-1"},
+    )
 
 
 def test_resume_rejects_pending_tool_missing_from_safety_inventory():
@@ -1217,11 +1353,13 @@ def test_direct_answer_persists_resume_state_before_model_call(
         calls = 0
 
         def __init__(self, **_kwargs):
-            pass
+            self.runtime_state = {}
 
         def invoke(self, _messages, **_kwargs):
             self.calls += 1
             if self.calls == 1:
+                actions.append("route_model")
+                self.runtime_state = {"consumed_tokens": 17}
                 return SimpleNamespace(
                     content=(
                         '{"intent":"informational","complexity":"simple",'
@@ -1232,6 +1370,9 @@ def test_direct_answer_persists_resume_state_before_model_call(
                 )
             actions.append("model")
             return SimpleNamespace(content="直接回答")
+
+        def export_runtime_state(self):
+            return self.runtime_state
 
     resources = SimpleNamespace(
         root=tmp_path,
@@ -1290,6 +1431,13 @@ def test_direct_answer_persists_resume_state_before_model_call(
     )
     monkeypatch.setattr(
         agent_runtime,
+        "save_runtime_state",
+        lambda *_args, **kwargs: actions.append(
+            ("runtime_state", kwargs["guardrail_state"])
+        ),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
         "save_initial_checkpoint",
         lambda *_args, **_kwargs: actions.append("checkpoint"),
     )
@@ -1304,7 +1452,15 @@ def test_direct_answer_persists_resume_state_before_model_call(
     )
 
     assert result["answer"] == "直接回答"
-    assert actions == ["saver", "metadata", "checkpoint", "model"]
+    assert actions == [
+        "saver",
+        "metadata",
+        "checkpoint",
+        "route_model",
+        "metadata",
+        ("runtime_state", {"consumed_tokens": 17}),
+        "model",
+    ]
 
 
 def test_unmatched_capability_returns_before_any_tool_call(monkeypatch):
@@ -3436,6 +3592,34 @@ def test_turn_limit_excludes_historical_assistant_turns():
     assert termination_reason == "turn_limit"
     # stops at the 3rd NEW turn; without baseline it would stop at the 2nd
     assert "answer 3" in answer
+
+
+def test_streamed_state_rebinds_runtime_metadata_to_checkpoint_head():
+    agent = _FakeStreamAgent([], new_ai_turns=2)
+    persisted = []
+
+    _run_agent_with_turn_limit(
+        agent,
+        [],
+        max_turns=3,
+        on_checkpoint_state=lambda: persisted.append(True),
+    )
+
+    assert persisted == [True, True]
+
+
+def test_seeded_checkpoint_starts_graph_without_duplicating_messages():
+    messages = [{"role": "user", "content": "question"}]
+    agent = _FakeStreamAgent([], new_ai_turns=1)
+
+    _run_agent_with_turn_limit(
+        agent,
+        messages,
+        max_turns=3,
+        input_checkpoint_seeded=True,
+    )
+
+    assert agent.input == {"messages": []}
 
 
 def test_resume_keeps_consumed_turns_in_original_run_budget():

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -23,6 +23,7 @@ from lensnode.agent_runtime import (
     _strip_dangling_tool_call,
     _synthesize_wrapup_answer,
 )
+from lensnode.checkpoint import CheckpointResumeError, ResumeState
 
 
 class _Msg:
@@ -79,12 +80,387 @@ class _FakeStreamAgent:
     def __init__(self, prefix, new_ai_turns):
         self._prefix = prefix
         self._new_ai_turns = new_ai_turns
+        self.input = None
 
-    def stream(self, _inp, stream_mode=None, config=None):
+    def stream(self, inp, stream_mode=None, config=None):
+        self.input = inp
         messages = list(self._prefix)
         for index in range(self._new_ai_turns):
             messages = messages + [_Msg("ai", f"answer {index + 1}")]
             yield {"messages": list(messages)}
+
+
+def test_resume_checkpoint_is_validated_before_loading_resources(monkeypatch):
+    config = SimpleNamespace(workspace_path="/workspace")
+    runtime = agent_runtime.LensDeepAgentRuntime(config)
+    resources_loaded = {"value": False}
+
+    def reject_resume(*_args, **_kwargs):
+        raise CheckpointResumeError("missing checkpoint")
+
+    def load_resources(*_args, **_kwargs):
+        resources_loaded["value"] = True
+
+    monkeypatch.setattr(agent_runtime, "load_resume_state", reject_resume)
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        load_resources,
+    )
+
+    with pytest.raises(
+        CheckpointResumeError,
+        match="missing checkpoint",
+    ):
+        runtime._answer_sync(
+            {
+                "run_uuid": "00000000-0000-0000-0000-000000000012",
+                "resume": True,
+            }
+        )
+
+    assert resources_loaded["value"] is False
+
+
+def test_general_chat_resume_reuses_frozen_route(monkeypatch, tmp_path):
+    cleanup_called = {"value": False}
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 0}
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def restore_runtime_state(self, *_args):
+            pass
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=[],
+        mcp_configs=[],
+        skill_paths=[],
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+    )
+    state = ResumeState(
+        messages=(),
+        route_decision={
+            "route": "capability_unavailable",
+            "evidence_requirement": "tool_result",
+            "required_capabilities": ["skill"],
+        },
+        history_assistant_turns=0,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_resume_state",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: cleanup_called.__setitem__("value", True),
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_select_general_chat_route",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("resume must not reroute")
+        ),
+    )
+
+    cancel_event = threading.Event()
+    cancel_event.set()
+    result = agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000014",
+            "resume": True,
+            "task": "general_chat",
+            "question": "continue",
+            "agent_model_ref": "model-ref",
+        },
+        cancel_event=cancel_event,
+    )
+
+    assert result["outcome"] == "blocked"
+    assert cleanup_called["value"] is False
+
+
+def test_resume_rejects_pending_non_idempotent_write():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "mcp__billing__create_invoice",
+                    "args": {"amount": 100},
+                    "id": "write-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    )
+    tool = SimpleNamespace(
+        name="mcp__billing__create_invoice",
+        metadata={"operation": "write"},
+    )
+
+    with pytest.raises(
+        CheckpointResumeError,
+        match="non-idempotent write",
+    ):
+        agent_runtime._reject_unsafe_resume_tool_replay(messages, [tool])
+
+
+def test_resume_rejects_pending_write_with_untrusted_idempotency_key():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "mcp__billing__create_invoice",
+                    "args": {
+                        "amount": 100,
+                        "idempotency_key": "invoice-1",
+                    },
+                    "id": "write-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    )
+    tool = SimpleNamespace(
+        name="mcp__billing__create_invoice",
+        metadata={"operation": "write"},
+    )
+
+    with pytest.raises(
+        CheckpointResumeError,
+        match="non-idempotent write",
+    ):
+        agent_runtime._reject_unsafe_resume_tool_replay(messages, [tool])
+
+
+def test_resume_allows_pending_write_with_trusted_idempotent_metadata():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "mcp__billing__create_invoice",
+                    "args": {"amount": 100},
+                    "id": "write-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    )
+    tool = SimpleNamespace(
+        name="mcp__billing__create_invoice",
+        metadata={"operation": "write", "idempotent": True},
+    )
+
+    agent_runtime._reject_unsafe_resume_tool_replay(messages, [tool])
+
+
+def test_resume_rejects_pending_tool_missing_from_safety_inventory():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "task",
+                    "args": {"description": "delegate work"},
+                    "id": "task-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    )
+
+    with pytest.raises(
+        CheckpointResumeError,
+        match="unclassified pending tool",
+    ):
+        agent_runtime._reject_unsafe_resume_tool_replay(messages, [])
+
+
+def test_resume_rejects_ephemeral_skill_api_session_values():
+    messages = (
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "call_skill_api",
+                    "args": {
+                        "skill": "billing",
+                        "capture": {"access_token": "data.access"},
+                    },
+                    "id": "login-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+        ToolMessage(
+            content='{"ok": true, "captured": ["access_token"]}',
+            tool_call_id="login-1",
+        ),
+    )
+
+    with pytest.raises(
+        CheckpointResumeError,
+        match="ephemeral Skill API session values",
+    ):
+        agent_runtime._reject_unsafe_resume_tool_replay(messages, [])
+
+
+def test_completed_checkpoint_resume_reuses_final_answer():
+    final_message = AIMessage(content="durable final answer")
+    agent = _FakeStreamAgent([], 0)
+
+    answer, truncated, reason = _run_agent_with_turn_limit(
+        agent,
+        [final_message],
+        max_turns=5,
+        thread={"configurable": {"thread_id": "run-1"}},
+        turn_baseline_ai=0,
+        event_baseline_ai=1,
+        resume_from_checkpoint=True,
+    )
+
+    assert agent.input is None
+    assert answer == "durable final answer"
+    assert truncated is False
+    assert reason is None
+
+
+def test_resume_resets_uncheckpointed_stream_before_replay(
+    monkeypatch,
+    tmp_path,
+):
+    output = []
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 0}
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def restore_runtime_state(self, *_args):
+            pass
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=[],
+        mcp_configs=[],
+        skill_paths=[],
+        mcp_config_path=tmp_path / "mcp.json",
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+        summary_trigger_tokens=0,
+    )
+    state = ResumeState(
+        messages=(AIMessage(content="durable final answer"),),
+        route_decision={},
+        history_assistant_turns=0,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_resume_state",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_agent_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_agent_with_turn_limit",
+        lambda *_args, **_kwargs: ("durable final answer", False, None),
+    )
+
+    result = agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000019",
+            "resume": True,
+            "task": "knowledge_qa",
+            "question": "Question",
+            "agent_model_ref": "model-ref",
+        },
+        emit_output=lambda content, reset=False: output.append(
+            (content, reset)
+        ),
+    )
+
+    assert result["answer"] == "durable final answer"
+    assert output[0] == ("", True)
 
 
 def test_build_initial_messages_prepends_and_filters_history():
@@ -162,6 +538,47 @@ def test_historical_assistant_content_is_not_current_tool_evidence():
     assert middleware.successful_capabilities == set()
     assert outcome == "blocked"
     assert termination_detail["reason"] == "evidence_unavailable"
+
+
+def test_capability_boundary_state_round_trips_for_resume():
+    original = agent_runtime.CapabilityBoundaryMiddleware(
+        required_capabilities=["skill"]
+    )
+    original.initial_plan_exists = True
+    original.success_count = 1
+    original.successful_capabilities = {"skill"}
+    original.successful_evidence = [
+        {
+            "capability": "skill",
+            "tool": "run_skill_artifact",
+            "source": "skill:income",
+            "request_sha256": "1" * 64,
+        }
+    ]
+    original.failure_counts[("run_skill", "tool", "digest")] = 1
+    original.capability_failure_counts["skill"] = 1
+
+    restored = agent_runtime.CapabilityBoundaryMiddleware(
+        required_capabilities=["skill"]
+    )
+    restored.restore_state(original.export_state())
+
+    outcome, detail = _finalize_runtime_outcome(
+        capability_middleware=restored,
+        evidence_requirement="tool_result",
+        required_capabilities=["skill"],
+        truncated=False,
+        stop_reason=None,
+    )
+
+    assert restored.initial_plan_exists is True
+    assert restored.failure_counts[
+        ("run_skill", "tool", "digest")
+    ] == 1
+    assert restored.capability_failure_counts["skill"] == 1
+    assert restored.successful_evidence == original.successful_evidence
+    assert outcome == "completed"
+    assert detail == {}
 
 
 def test_model_event_records_cache_reasoning_and_latency():
@@ -788,6 +1205,108 @@ def test_direct_answer_does_not_recover_a_completed_explanation():
     assert model.calls == 1
 
 
+def test_direct_answer_persists_resume_state_before_model_call(
+    monkeypatch,
+    tmp_path,
+):
+    actions = []
+
+    class Model:
+        stop_reason = None
+        token_usage = {}
+        calls = 0
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def invoke(self, _messages, **_kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(
+                    content=(
+                        '{"intent":"informational","complexity":"simple",'
+                        '"route":"direct_answer",'
+                        '"required_capabilities":[],'
+                        '"evidence_requirement":"none"}'
+                    )
+                )
+            actions.append("model")
+            return SimpleNamespace(content="直接回答")
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=[],
+        mcp_configs=[],
+        skill_paths=[],
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_apply_offload_thresholds",
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda _workspace: actions.append("saver") or object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_resume_metadata",
+        lambda *_args, **_kwargs: actions.append("metadata"),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_initial_checkpoint",
+        lambda *_args, **_kwargs: actions.append("checkpoint"),
+    )
+
+    result = agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000018",
+            "task": "general_chat",
+            "question": "解释订单",
+            "agent_model_ref": "model-ref",
+        }
+    )
+
+    assert result["answer"] == "直接回答"
+    assert actions == ["saver", "metadata", "checkpoint", "model"]
+
+
 def test_unmatched_capability_returns_before_any_tool_call(monkeypatch):
     tool_calls = {"count": 0}
 
@@ -922,6 +1441,7 @@ def test_successful_skill_evidence_preserves_the_final_answer(
         mcp_config_path=tmp_path / "mcp.json",
     )
     config = SimpleNamespace(
+        workspace_path=str(tmp_path),
         ai_gateway_url="http://gateway/ai/",
         token="token",
         request_timeout_s=30,
@@ -987,6 +1507,13 @@ def test_successful_skill_evidence_preserves_the_final_answer(
         "create_deep_agent",
         lambda **_kwargs: object(),
     )
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("read-only checkpoint directory")
+        ),
+    )
 
     def run_agent(*_args, **_kwargs):
         captured["boundary"].success_count = 2
@@ -1008,6 +1535,7 @@ def test_successful_skill_evidence_preserves_the_final_answer(
                 "request_sha256": "2" * 64,
             },
         ]
+        captured["boundary"]._notify_state_change()
         return "已生成并交付订单流程图。", True, "token_budget_wrapup"
 
     monkeypatch.setattr(
@@ -2160,6 +2688,33 @@ def test_non_idempotent_write_does_not_receive_transient_retry():
     assert middleware.blocked_tools == {"mcp__orders__create"}
 
 
+def test_model_supplied_idempotency_key_does_not_enable_write_retry():
+    middleware = agent_runtime.CapabilityBoundaryMiddleware()
+    request = SimpleNamespace(
+        tool=SimpleNamespace(
+            name="mcp__orders__create",
+            metadata={"operation": "write", "idempotent": False},
+        ),
+        tool_call={
+            "name": "mcp__orders__create",
+            "id": "call-1",
+            "args": {"amount": 100, "idempotency_key": "model-value"},
+        },
+    )
+
+    middleware.wrap_tool_call(
+        request,
+        lambda _request: ToolMessage(
+            content='{"ok":false,"error":"TIMEOUT"}',
+            name="mcp__orders__create",
+            tool_call_id="call-1",
+            status="error",
+        ),
+    )
+
+    assert middleware.blocked_tools == {"mcp__orders__create"}
+
+
 def test_alternative_capability_recovery_is_counted_without_arguments():
     events = []
     middleware = agent_runtime.CapabilityBoundaryMiddleware(
@@ -2881,6 +3436,93 @@ def test_turn_limit_excludes_historical_assistant_turns():
     assert termination_reason == "turn_limit"
     # stops at the 3rd NEW turn; without baseline it would stop at the 2nd
     assert "answer 3" in answer
+
+
+def test_resume_keeps_consumed_turns_in_original_run_budget():
+    checkpoint_messages = [
+        _Msg("human", "q1"),
+        _Msg("ai", "history answer"),
+        _Msg("human", "q2"),
+        _Msg("ai", "run answer 1"),
+        _Msg("ai", "run answer 2"),
+    ]
+    agent = _FakeStreamAgent(checkpoint_messages, new_ai_turns=5)
+
+    answer, truncated, termination_reason = _run_agent_with_turn_limit(
+        agent,
+        [],
+        max_turns=4,
+        turn_baseline_ai=1,
+        event_baseline_ai=3,
+        resume_from_checkpoint=True,
+    )
+
+    assert truncated is True
+    assert termination_reason == "turn_limit"
+    assert "answer 2" in answer
+    assert agent.input is None
+
+
+def test_resume_does_not_reemit_checkpointed_tool_events():
+    checkpoint_message = _Msg(
+        "ai",
+        tool_calls=[
+            {
+                "id": "checkpoint-plan",
+                "name": "write_todos",
+                "args": {
+                    "todos": [
+                        {"content": "Inspect", "status": "in_progress"},
+                        {"content": "Finish", "status": "pending"},
+                    ]
+                },
+            }
+        ],
+    )
+    resumed_message = _Msg(
+        "ai",
+        content="done",
+        tool_calls=[
+            {
+                "id": "resumed-plan",
+                "name": "write_todos",
+                "args": {
+                    "todos": [
+                        {"content": "Inspect", "status": "completed"},
+                        {"content": "Finish", "status": "in_progress"},
+                    ]
+                },
+            }
+        ],
+    )
+
+    class Agent:
+        def stream(self, inp, stream_mode=None, config=None):
+            del stream_mode, config
+            assert inp is None
+            yield {"messages": [checkpoint_message]}
+            yield {"messages": [checkpoint_message, resumed_message]}
+
+    events = []
+    _run_agent_with_turn_limit(
+        Agent(),
+        [checkpoint_message],
+        max_turns=5,
+        turn_baseline_ai=0,
+        event_baseline_ai=1,
+        resume_from_checkpoint=True,
+        emit_event=lambda name, detail: events.append((name, detail)),
+    )
+
+    plan_events = [
+        detail for name, detail in events if name == "workflow.plan.updated"
+    ]
+    assert len(plan_events) == 1
+    assert plan_events[0]["payload"]["revision"] == 2
+    assert plan_events[0]["payload"]["steps"] == [
+        {"id": "step-1", "title": "Inspect", "status": "completed"},
+        {"id": "step-2", "title": "Finish", "status": "in_progress"},
+    ]
 
 
 def test_turn_limit_no_history_runs_to_completion():

--- a/lensnode/tests/test_main_tls.py
+++ b/lensnode/tests/test_main_tls.py
@@ -87,8 +87,8 @@ def test_runtime_cleanup_loop_repeats_until_stopped(monkeypatch):
         async def no_wait(_delay):
             return None
 
-        def cleanup(workspace_path):
-            calls.append(workspace_path)
+        def cleanup(workspace_path, max_age_s):
+            calls.append((workspace_path, max_age_s))
             if len(calls) == 2:
                 client.stopping.set()
 
@@ -97,12 +97,19 @@ def test_runtime_cleanup_loop_repeats_until_stopped(monkeypatch):
             "lensnode.main.cleanup_stale_runtime_resources",
             cleanup,
         )
+        monkeypatch.setattr(
+            "lensnode.main.cleanup_expired_checkpoints",
+            lambda *_args: None,
+        )
 
         await client._runtime_cleanup_loop()
 
     asyncio.run(exercise())
 
-    assert calls == ["/test-workspace", "/test-workspace"]
+    assert calls == [
+        ("/test-workspace", 24 * 60 * 60),
+        ("/test-workspace", 24 * 60 * 60),
+    ]
 
 
 def test_run_forever_starts_runtime_cleanup(monkeypatch):

--- a/lensnode/tests/test_outbox.py
+++ b/lensnode/tests/test_outbox.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from unittest.mock import patch
 
 from lensnode.main import LensNodeClient
 
@@ -179,7 +180,8 @@ def test_reconnect_hello_claims_buffered_terminal_run_before_flush():
 
         ws = FakeWebSocket()
         client.websocket = ws
-        await client._send_hello()
+        with patch("lensnode.main.get_checkpoint_saver"):
+            await client._send_hello()
 
         loop_task = asyncio.create_task(client._send_loop(ws))
         await _wait_until(lambda: len(ws.sent) == 4)
@@ -194,6 +196,7 @@ def test_reconnect_hello_claims_buffered_terminal_run_before_flush():
             "running-run",
         ]
         assert frames[0]["labels"]["run_document_attachments"] is True
+        assert frames[0]["labels"]["run_checkpoint_resume"] is True
         assert [frame["type"] for frame in frames[1:]] == [
             "run_output",
             "run_output",
@@ -201,3 +204,117 @@ def test_reconnect_hello_claims_buffered_terminal_run_before_flush():
         ]
 
     asyncio.run(exercise())
+
+
+def test_hello_does_not_advertise_resume_when_checkpointing_is_disabled(
+    monkeypatch,
+):
+    async def exercise():
+        client = _make_client()
+        client.websocket = FakeWebSocket()
+
+        await client._send_hello()
+
+        frame = json.loads(client.websocket.sent[0])
+        assert frame["labels"]["run_checkpoint_resume"] is False
+
+    monkeypatch.setenv("LENSNODE_CHECKPOINT_ENABLED", "0")
+    asyncio.run(exercise())
+
+
+def test_hello_does_not_advertise_unusable_checkpoint_storage():
+    async def exercise():
+        client = _make_client()
+        client.websocket = FakeWebSocket()
+
+        with patch(
+            "lensnode.main.get_checkpoint_saver",
+            side_effect=OSError("read only"),
+        ):
+            await client._send_hello()
+
+        frame = json.loads(client.websocket.sent[0])
+        assert frame["labels"]["run_checkpoint_resume"] is False
+
+    asyncio.run(exercise())
+
+
+def test_run_done_ack_cleans_checkpoint_and_runtime_resources():
+    async def exercise():
+        client = _make_client()
+        await client._handle_message(
+            json.dumps(
+                {
+                    "type": "run_done_ack",
+                    "run_uuid": "completed-run",
+                }
+            )
+        )
+
+    with (
+        patch("lensnode.main.cleanup_run_checkpoint") as checkpoint_cleanup,
+        patch(
+            "lensnode.main.cleanup_run_runtime_resources"
+        ) as runtime_cleanup,
+    ):
+        asyncio.run(exercise())
+
+    checkpoint_cleanup.assert_called_once_with(
+        "completed-run",
+        "/missing-test-workspace",
+    )
+    runtime_cleanup.assert_called_once_with(
+        "/missing-test-workspace",
+        "completed-run",
+    )
+
+
+def test_run_done_ack_waits_for_timed_out_worker_before_cleanup():
+    async def exercise(checkpoint_cleanup, runtime_cleanup):
+        client = _make_client()
+        worker_release = asyncio.Event()
+
+        async def worker():
+            await worker_release.wait()
+
+        worker_task = asyncio.create_task(worker())
+        client.executor._pending_workers = {"timed-out-run": worker_task}
+        await client._handle_message(
+            json.dumps(
+                {
+                    "type": "run_done_ack",
+                    "run_uuid": "timed-out-run",
+                }
+            )
+        )
+
+        checkpoint_cleanup.assert_not_called()
+        runtime_cleanup.assert_not_called()
+
+        worker_release.set()
+        await _wait_until(lambda: checkpoint_cleanup.called)
+
+    with (
+        patch("lensnode.main.cleanup_run_checkpoint") as checkpoint_cleanup,
+        patch(
+            "lensnode.main.cleanup_run_runtime_resources"
+        ) as runtime_cleanup,
+        patch(
+            "lensnode.executor.cleanup_run_checkpoint",
+            checkpoint_cleanup,
+        ),
+        patch(
+            "lensnode.executor.cleanup_run_runtime_resources",
+            runtime_cleanup,
+        ),
+    ):
+        asyncio.run(exercise(checkpoint_cleanup, runtime_cleanup))
+
+    checkpoint_cleanup.assert_called_once_with(
+        "timed-out-run",
+        "/missing-test-workspace",
+    )
+    runtime_cleanup.assert_called_once_with(
+        "/missing-test-workspace",
+        "timed-out-run",
+    )

--- a/lensnode/tests/test_subject_documents.py
+++ b/lensnode/tests/test_subject_documents.py
@@ -12,6 +12,7 @@ from lensnode import runtime_resources
 from lensnode.agent_runtime import _knowledge_system_prompt
 from lensnode.gateway_model import RunCancelledError
 from lensnode.runtime_resources import (
+    cleanup_run_runtime_resources,
     cleanup_runtime_resources,
     cleanup_stale_runtime_resources,
     prepare_runtime_resources,
@@ -279,6 +280,44 @@ def test_cleanup_stale_runtime_resources_keeps_recent_runs(tmp_path):
     assert removed == 1
     assert not stale.exists()
     assert recent.exists()
+
+
+def test_cleanup_run_runtime_resources_rejects_parent_traversal(tmp_path):
+    runs_root = tmp_path / ".sourcelens" / "runtime" / "runs"
+    victim = tmp_path / ".sourcelens" / "victim"
+    victim.mkdir(parents=True)
+    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    runs_root.mkdir(parents=True)
+
+    removed = cleanup_run_runtime_resources(
+        tmp_path,
+        "../../../victim",
+    )
+
+    assert removed is False
+    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_prepare_runtime_resources_rejects_parent_traversal(tmp_path):
+    command = _command(b"content")
+    command["run_uuid"] = "../../../victim"
+
+    with pytest.raises(ValueError, match="Invalid Run identifier"):
+        prepare_runtime_resources(_config(tmp_path), command)
+
+
+def test_cleanup_run_runtime_resources_removes_safe_run_directory(tmp_path):
+    run_uuid = "00000000-0000-0000-0000-000000000013"
+    run_root = (
+        tmp_path / ".sourcelens" / "runtime" / "runs" / run_uuid
+    )
+    run_root.mkdir(parents=True)
+    (run_root / "temporary.txt").write_text("remove", encoding="utf-8")
+
+    removed = cleanup_run_runtime_resources(tmp_path, run_uuid)
+
+    assert removed is True
+    assert not run_root.exists()
 
 
 def test_knowledge_prompt_separates_subject_from_reference_material():

--- a/lensnode/tests/test_workspace.py
+++ b/lensnode/tests/test_workspace.py
@@ -300,6 +300,58 @@ def test_scope_include_hidden_applies_to_all_discovery_modes(tmp_path):
     assert str(hidden_file) in glob_files(target_dirs, "**/*")
 
 
+def test_include_hidden_never_exposes_internal_run_data(tmp_path):
+    root = tmp_path / "ws"
+    hidden = root / ".codex"
+    checkpoints = root / ".checkpoints"
+    other_run = (
+        root
+        / ".sourcelens"
+        / "runtime"
+        / "runs"
+        / "other-run"
+        / "subject-documents"
+    )
+    hidden.mkdir(parents=True)
+    checkpoints.mkdir()
+    other_run.mkdir(parents=True)
+    allowed_file = hidden / "instructions.md"
+    checkpoint_file = checkpoints / "messages.txt"
+    other_run_file = other_run / "private.txt"
+    allowed_file.write_text("shared marker\n", encoding="utf-8")
+    checkpoint_file.write_text("shared marker\n", encoding="utf-8")
+    other_run_file.write_text("shared marker\n", encoding="utf-8")
+    target_dirs = [
+        {
+            "path": str(root),
+            "retrieval_scope": {"include_hidden": True},
+        }
+    ]
+
+    result = search_workspace(target_dirs, "shared marker")
+    found = glob_files(target_dirs, "**/*")
+    tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {"target_dirs": target_dirs, "settings": {}}
+        )
+    }
+    checkpoint_read = json.loads(
+        tools["read_workspace_file"].invoke({"path": str(checkpoint_file)})
+    )
+    other_run_read = json.loads(
+        tools["read_workspace_file"].invoke({"path": str(other_run_file)})
+    )
+
+    assert [item["path"] for item in result["matches"]] == [
+        str(allowed_file)
+    ]
+    assert str(checkpoint_file) not in found
+    assert str(other_run_file) not in found
+    assert checkpoint_read["error"] == "PATH_NOT_ALLOWED"
+    assert other_run_read["error"] == "PATH_NOT_ALLOWED"
+
+
 def test_directory_scope_overrides_assistant_hidden_policy(tmp_path):
     root = tmp_path / "ws"
     hidden = root / ".claude"


### PR DESCRIPTION
### **User description**
## Summary

- Park active runs behind a bounded `resume_by` deadline after a confirmed capable LensNode loss.
- Redispatch the same run UUID on reconnect while preserving original timeout and concurrency accounting.
- Keep legacy-node failure behavior, expire unrecoverable runs safely, and acknowledge terminal delivery before node cleanup.
- Expose the waiting-for-resume state through the API/SSE contract and localized Chat progress.

Part 2 of #240. Depends on #241 and should merge after it.

Closes #240

## Test plan

- [x] Backend checkpoint-resume regression set (40 passed)
- [x] Affected Chat/frontend unit tests (35 passed)
- [x] Frontend production build
- [x] ESLint for `Chat.vue`
- [x] Django system check
- [x] `makemigrations --check --dry-run`
- [x] `git diff --check`

## Known baseline failures

- Full frontend unit suite: 178 passed, 3 failed. The same three failures reproduce unchanged on `origin/main`: app locale parity (10 existing registration keys missing in English) and two Run Observation diagnosis assertions.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Persist agent messages, route decisions, guardrail state in SQLite checkpoints

- Resume with original timeout/turn budgets, suppress replay of checkpointed events

- Fail closed for missing checkpoints, unsafe writes, ephemeral session values

- Backend marks runs awaiting resume, re-dispatches on node reconnect


___

### Diagram Walkthrough


```mermaid
flowchart LR
  run_start["Run start"] --> checkpoint_persist["Persist checkpoint (SQLite)"]
  checkpoint_persist --> resume["Resume from checkpoint"]
  resume --> check_safety["Reject unsafe replay"]
  check_safety --> execute["Execute/resume agent"]
  execute --> checkpoint_update["Update checkpoint state"]
  checkpoint_update --> terminal["Terminal"]
  terminal --> cleanup["Ack & cleanup checkpoint"]
  run_start -.-> TTL_cleanup["TTL garbage collection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>checkpoint.py</strong><dd><code>Durable checkpoint persistence and resume logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-cdb179ce3164e8be5da01cce6a4d5881a0a220426fa6c2379471b8961cc2b5e1">+535/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Integrate checkpoint loading, saving, and resume safety</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+470/-36</a></td>

</tr>

<tr>
  <td><strong>executor.py</strong><dd><code>Track pending workers, defer cleanup, compute remaining timeout</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-09da87f66493ac6ca403c68c259713dfe47d390711eb1ae828c477954e2a79d5">+156/-16</a></td>

</tr>

<tr>
  <td><strong>gateway_model.py</strong><dd><code>Support runtime state restoration on resume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+152/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Integrate checkpoint lifecycle (startup, shutdown, cleanup)</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+102/-6</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspace.py</strong><dd><code>Exclude checkpoint and run runtime paths from workspace search</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-d710eb194a4daf8bf6178ae498494331d37629a86d7629780a486e5fcd8d5b20">+29/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Add run runtime directory cleanup and path validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+42/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_tools.py</strong><dd><code>Add on_runtime_evidence callback for checkpoint persistence</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Backend orchestration: mark runs awaiting resume, re-dispatch</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+398/-28</a></td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Add tasks for expire awaiting run and retry resume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+170/-13</a></td>

</tr>

<tr>
  <td><strong>consumers.py</strong><dd><code>Handle resume acknowledgement and busy draining responses</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add resume_by field to Run model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Expose resume_by in API serializers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0038_run_awaiting_resume.py</strong><dd><code>Migration for resume_by field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-2c1fa47c606da6140a2fd8001173f509806678b34fa697ee0b5b29acbb9c1735">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_checkpoint.py</strong><dd><code>Tests for checkpoint lifecycle, safety, and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-89287018d0a7e449f5e18f9478d6d9221233d63bcf09c9df738b0b1944d0c64e">+555/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Tests for resume path validation and state round-trips</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+827/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Tests for executor timeout and cleanup behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+227/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_gateway_model.py</strong><dd><code>Tests for gateway model runtime state export/restore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_run_lifecycle.py</strong><dd><code>Tests for resume lifecycle, deadline, and re-dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+458/-11</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add dependency on langgraph sqlite checkpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-0c1753523f3d947030264901da252eaeb9441e74e2dab26b09fe1aa7a6c2e78e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>test_api.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_disconnect_grace.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-4c30be79cc6bcad79aee8f4292034bf60ba45e1b95a1733ec8540c16b032949a">+60/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_document_attachments.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-abb5e8fe2ed314bd844c7f25d56c651e637f0a72584e61b2d938b0018f41a437">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sessions.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-5271360df826bc1230406d5a73425315af7aafd55724812d08e243956049a6ed">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_drain.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-7a8e3a7bc0056f4c38c6864bfb2918f40a1fd9f2f2b24467cf560ba1d845434c">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_main_tls.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-bc99d96e237833f5aeb490bb1f7fa15fd7719bb19a09c919215612bbc0676cd3">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_outbox.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-9d6e64d043d821dfbf8ad1c7d7c50ff84addf81e821efd9502c496855a7f9026">+118/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_subject_documents.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-13e8a99ae6db55f17067bd5a4af36980fafd91af472f30a2e605c5decb52172b">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_workspace.py</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/242/files#diff-024a4c4c32ac005dc254516b204d735def18a042cf823c5fc1d0b4d45dc9295e">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

