### PR TITLE
fix(lens): reject oversized image attachments

### DIFF
--- a/backend/lens/attachments.py
+++ b/backend/lens/attachments.py
@@ -16,6 +16,8 @@ from .session_lifecycle import lock_active_session
 ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
 ATTACHMENT_MAX_PER_MESSAGE = 4
 ATTACHMENT_MAX_DIMENSION = 1600
+ATTACHMENT_MAX_PIXELS = 5_000_000
+ATTACHMENT_MAX_ASPECT_RATIO = 3
 _IMAGE_FORMAT_MAP = {
     "PNG": ("PNG", "image/png", "png"),
     "JPEG": ("JPEG", "image/jpeg", "jpg"),
@@ -63,7 +65,8 @@ def store_message_attachment(session, user, uploaded_file):
 
     try:
         image = Image.open(uploaded_file)
-        image.load()
+    except Image.DecompressionBombError:
+        raise AttachmentError("ATTACHMENT_DIMENSIONS_TOO_LARGE")
     except (UnidentifiedImageError, OSError):
         raise AttachmentError("ATTACHMENT_UNSUPPORTED_TYPE")
 
@@ -72,6 +75,19 @@ def store_message_attachment(session, user, uploaded_file):
         (None, None, None),
     )
     if out_format is None:
+        raise AttachmentError("ATTACHMENT_UNSUPPORTED_TYPE")
+
+    width, height = image.size
+    if width * height > ATTACHMENT_MAX_PIXELS:
+        raise AttachmentError("ATTACHMENT_DIMENSIONS_TOO_LARGE")
+    if max(width, height) > min(width, height) * ATTACHMENT_MAX_ASPECT_RATIO:
+        raise AttachmentError("ATTACHMENT_ASPECT_UNSUPPORTED")
+
+    try:
+        image.load()
+    except Image.DecompressionBombError:
+        raise AttachmentError("ATTACHMENT_DIMENSIONS_TOO_LARGE")
+    except OSError:
         raise AttachmentError("ATTACHMENT_UNSUPPORTED_TYPE")
 
     image = _downscale_image(image, ATTACHMENT_MAX_DIMENSION)

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -20,6 +20,8 @@ from lens.models import (
 )
 from lens.serializers import RunCreateSerializer
 from lens.attachments import (
+    ATTACHMENT_MAX_ASPECT_RATIO,
+    ATTACHMENT_MAX_PIXELS,
     AttachmentError,
     bind_attachments_to_message,
     store_message_attachment,
@@ -90,6 +92,49 @@ class AttachmentServiceTests(TestCase):
         )
         with self.assertRaises(AttachmentError):
             store_message_attachment(self.session, self.user, bad)
+
+    def test_store_rejects_extreme_aspect_ratio(self):
+        with self.assertRaisesRegex(
+            AttachmentError,
+            "ATTACHMENT_ASPECT_UNSUPPORTED",
+        ):
+            store_message_attachment(
+                self.session,
+                self.user,
+                _png_upload(size=(3001, 1000)),
+            )
+
+        self.assertEqual(MessageAttachment.objects.count(), 0)
+
+    def test_store_rejects_excessive_pixel_count(self):
+        with self.assertRaisesRegex(
+            AttachmentError,
+            "ATTACHMENT_DIMENSIONS_TOO_LARGE",
+        ):
+            store_message_attachment(
+                self.session,
+                self.user,
+                _png_upload(size=(2501, 2000)),
+            )
+
+        self.assertEqual(MessageAttachment.objects.count(), 0)
+
+    def test_store_accepts_dimension_boundaries(self):
+        aspect_boundary = store_message_attachment(
+            self.session,
+            self.user,
+            _png_upload(
+                size=(int(1000 * ATTACHMENT_MAX_ASPECT_RATIO), 1000)
+            ),
+        )
+        pixel_boundary = store_message_attachment(
+            self.session,
+            self.user,
+            _png_upload(size=(2500, ATTACHMENT_MAX_PIXELS // 2500)),
+        )
+
+        self.assertIsNotNone(aspect_boundary.pk)
+        self.assertIsNotNone(pixel_boundary.pk)
 
     def test_bind_links_in_order_and_ignores_foreign(self):
         first = store_message_attachment(
@@ -462,3 +507,23 @@ class AttachmentEndpointTests(TestCase):
             format="multipart",
         )
         self.assertEqual(resp.status_code, 400)
+
+    def test_upload_rejects_unsupported_image_dimensions(self):
+        self.client.force_authenticate(self.user)
+        cases = (
+            ((3001, 1000), "ATTACHMENT_ASPECT_UNSUPPORTED"),
+            ((2501, 2000), "ATTACHMENT_DIMENSIONS_TOO_LARGE"),
+        )
+
+        for size, error_code in cases:
+            with self.subTest(error_code=error_code):
+                response = self.client.post(
+                    f"/api/lens/sessions/{self.session.uuid}/attachments/",
+                    {"file": _png_upload(size=size)},
+                    format="multipart",
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertIn(error_code.encode(), response.content)
+
+        self.assertEqual(MessageAttachment.objects.count(), 0)

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -234,6 +234,8 @@
       "attachFile": "Upload image or document",
       "removeAttachment": "Remove attachment",
       "imageTooLarge": "Image is too large; max 10MB each.",
+      "imageDimensionsTooLarge": "Image resolution is too high. Crop or resize it to about one page and try again.",
+      "imageAspectUnsupported": "Image is too long. Crop it to about one page and try again.",
       "documentTooLarge": "Document is too large; max 25MB each.",
       "attachmentUnsupported": "Only PNG, JPEG, WebP, GIF, PDF, DOCX, PPTX and XLSX files are supported.",
       "attachmentTooMany": "Up to {max} attachments per message.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -234,6 +234,8 @@
       "attachFile": "上传图片或文档",
       "removeAttachment": "移除附件",
       "imageTooLarge": "图片过大，单张不超过 10MB。",
+      "imageDimensionsTooLarge": "图片分辨率过高，请缩小或裁剪为大约一页后重试。",
+      "imageAspectUnsupported": "图片过长，请裁剪为大约一页后重试。",
       "documentTooLarge": "文档过大，单个不超过 25MB。",
       "attachmentUnsupported": "仅支持 PNG、JPEG、WebP、GIF、PDF、DOCX、PPTX 和 XLSX 文件。",
       "attachmentTooMany": "每条消息最多上传 {max} 个附件。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1462,8 +1462,11 @@ import {
 import { prepareRunSubmission } from '@/pages/lens/chatSubmission'
 import {
   ATTACHMENT_ACCEPT,
+  attachmentUploadError,
   hasAttachmentErrorCode,
   MAX_ATTACHMENTS,
+  readImageDimensions,
+  validateImageDimensions,
   validateAttachment
 } from '@/pages/lens/chatAttachments'
 import {
@@ -2774,6 +2777,19 @@ async function addAttachment(file) {
     )
     return
   }
+  if (validation.kind === 'image') {
+    try {
+      const { width, height } = await readImageDimensions(file)
+      const dimensionError = validateImageDimensions(width, height)
+      if (dimensionError) {
+        showError(t(`lens.chat.${dimensionError}`))
+        return
+      }
+    } catch {
+      showError(t('lens.chat.attachmentUploadFailed'))
+      return
+    }
+  }
   const sessionUuid = selectedSessionUuid.value
   if (!sessionUuid) return
   const item = {
@@ -2802,9 +2818,9 @@ async function addAttachment(file) {
     }
     item.status = 'done'
     attachments.value = [...attachments.value]
-  } catch {
+  } catch (error) {
     removeAttachment(item)
-    showError(t('lens.chat.attachmentUploadFailed'))
+    showError(t(`lens.chat.${attachmentUploadError(error)}`))
   }
 }
 

--- a/frontend/src/pages/lens/chatAttachments.js
+++ b/frontend/src/pages/lens/chatAttachments.js
@@ -1,5 +1,7 @@
 export const MAX_ATTACHMENTS = 4
 export const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+export const MAX_IMAGE_PIXELS = 5_000_000
+export const MAX_IMAGE_ASPECT_RATIO = 3
 export const MAX_DOCUMENT_BYTES = 25 * 1024 * 1024
 export const IMAGE_MIME = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
 export const DOCUMENT_EXTENSIONS = ['.pdf', '.docx', '.pptx', '.xlsx']
@@ -45,6 +47,35 @@ export function validateAttachment(file, options) {
   return { kind, error: '' }
 }
 
+export function validateImageDimensions(width, height) {
+  if (width * height > MAX_IMAGE_PIXELS) {
+    return 'imageDimensionsTooLarge'
+  }
+  if (
+    Math.max(width, height) >
+    Math.min(width, height) * MAX_IMAGE_ASPECT_RATIO
+  ) {
+    return 'imageAspectUnsupported'
+  }
+  return ''
+}
+
+export function readImageDimensions(file) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const image = new Image()
+    image.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve({ width: image.naturalWidth, height: image.naturalHeight })
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('IMAGE_DIMENSIONS_UNAVAILABLE'))
+    }
+    image.src = url
+  })
+}
+
 export function hasAttachmentErrorCode(error, code) {
   const pending = [error?.response?.data]
   while (pending.length) {
@@ -59,4 +90,14 @@ export function hasAttachmentErrorCode(error, code) {
     }
   }
   return false
+}
+
+export function attachmentUploadError(error) {
+  if (hasAttachmentErrorCode(error, 'ATTACHMENT_DIMENSIONS_TOO_LARGE')) {
+    return 'imageDimensionsTooLarge'
+  }
+  if (hasAttachmentErrorCode(error, 'ATTACHMENT_ASPECT_UNSUPPORTED')) {
+    return 'imageAspectUnsupported'
+  }
+  return 'attachmentUploadFailed'
 }

--- a/frontend/tests/chatAttachments.test.js
+++ b/frontend/tests/chatAttachments.test.js
@@ -3,8 +3,12 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import {
+  attachmentUploadError,
   classifyAttachment,
   hasAttachmentErrorCode,
+  MAX_IMAGE_ASPECT_RATIO,
+  MAX_IMAGE_PIXELS,
+  validateImageDimensions,
   validateAttachment
 } from '../src/pages/lens/chatAttachments.js'
 
@@ -60,6 +64,47 @@ test('enforces type, capability, size and shared count limits', () => {
     ).error,
     'attachmentTooMany'
   )
+})
+
+test('enforces image pixel and aspect-ratio boundaries', () => {
+  assert.equal(validateImageDimensions(2500, MAX_IMAGE_PIXELS / 2500), '')
+  assert.equal(validateImageDimensions(1000 * MAX_IMAGE_ASPECT_RATIO, 1000), '')
+  assert.equal(validateImageDimensions(2501, 2000), 'imageDimensionsTooLarge')
+  assert.equal(
+    validateImageDimensions(1000, 1000 * MAX_IMAGE_ASPECT_RATIO + 1),
+    'imageAspectUnsupported'
+  )
+})
+
+test('maps backend dimension errors to actionable upload messages', () => {
+  const apiError = (code) => ({ response: { data: { errors: [code] } } })
+
+  assert.equal(
+    attachmentUploadError(apiError('ATTACHMENT_DIMENSIONS_TOO_LARGE')),
+    'imageDimensionsTooLarge'
+  )
+  assert.equal(
+    attachmentUploadError(apiError('ATTACHMENT_ASPECT_UNSUPPORTED')),
+    'imageAspectUnsupported'
+  )
+  assert.equal(
+    attachmentUploadError(new Error('network')),
+    'attachmentUploadFailed'
+  )
+})
+
+test('checks browser image dimensions before uploading', async () => {
+  const source = await readFile(
+    new URL('../src/pages/lens/Chat.vue', import.meta.url),
+    'utf8'
+  )
+  const dimensionCheck = source.indexOf('await readImageDimensions(file)')
+  const uploadStart = source.indexOf(
+    'const result = await uploadAttachment(sessionUuid, file)'
+  )
+
+  assert.notEqual(dimensionCheck, -1)
+  assert.ok(dimensionCheck < uploadStart)
 })
 
 test('preserves uploaded document metadata in optimistic messages', async () => {


### PR DESCRIPTION
### **User description**
## Summary

- reject image attachments above 5 megapixels or a 3:1 aspect ratio before full decoding
- mirror the authoritative limits in the chat client for immediate feedback
- surface actionable localized messages for dimension and aspect-ratio errors
- preserve the existing 10 MB limit and 1600 px normalization for accepted images

## Testing

- `python manage.py test lens.tests.test_attachments` (18 passed)
- focused image boundary and API tests (4 passed)
- `node --test frontend/tests/chatAttachments.test.js` (10 passed)
- ESLint and Prettier checks for changed frontend files
- `npm run build`
- ego-browser baseline reproduced the issue at `http://localhost:8000`; post-fix manual verification was blocked by an unrelated shared-runtime overlay conflict

Closes #149


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add backend dimension and aspect ratio validation

- Add client-side image dimension check

- Surface actionable error messages for users

- Add tests for image boundary cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Image upload] --> B[Frontend: validate dimensions]
  B -->|pass| C[Backend: validate dimensions]
  B -->|fail| D[Reject early]
  C -->|pass| E[Downscale & store]
  C -->|fail| F[Return error code]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>attachments.py</strong><dd><code>Add pixel and aspect ratio validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-97384f8eadbdf1361ec654c54ed29161ee0b55ff909be3cb9fb09cfce32b046f">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Add client-side dimension check before upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatAttachments.js</strong><dd><code>Add dimension validation and error mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-70e3a7166d2d7b8efedc022929f0ccb60464c1b27c1a550654b2f7a2813ad08f">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_attachments.py</strong><dd><code>Add tests for image dimension boundaries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatAttachments.test.js</strong><dd><code>Add tests for validation and error mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-da5b4010f4857150843a8fe2dac7eca09695469117a5a90518f9c46fc8a65843">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add error messages for dimension rejections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese error messages for dimension rejections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/248/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

