### PR TITLE
Show models actually used in the Run overview

### DIFF
--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -342,6 +342,7 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(detail["total_tokens"], 350)
         self.assertEqual(detail["cached_tokens"], 240)
         self.assertEqual(detail["reasoning_tokens"], 15)
+        self.assertEqual(detail["models_used"], ["deepseek-v4-flash"])
         self.assertEqual(len(detail["model_calls"]), 2)
         self.assertFalse(detail["model_calls"][0]["is_subagent"])
         self.assertTrue(detail["model_calls"][1]["is_subagent"])

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -210,6 +210,11 @@ def _admin_run_model_usage(run):
         return None
     return {
         "llm_calls": len(calls),
+        "models_used": list(
+            dict.fromkeys(
+                item["model"] for item in calls if item["model"]
+            )
+        ),
         "subagent_model_calls": sum(
             1 for item in calls if item["is_subagent"]
         ),
@@ -446,6 +451,7 @@ def _admin_run_detail(run):
             "cached_tokens": 0,
             "reasoning_tokens": 0,
             "subagent_model_calls": 0,
+            "models_used": [],
             "model_calls": [],
         })
     return row

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -48,6 +48,7 @@
     "tabFiles": "Files",
     "overviewSummary": "Run overview",
     "overviewExecution": "Execution configuration",
+    "modelsUsed": "Models used",
     "overviewTiming": "Timing",
     "overviewResources": "Runtime resources",
     "noFiles": "No generated files",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -48,6 +48,7 @@
     "tabFiles": "生成文件",
     "overviewSummary": "运行概览",
     "overviewExecution": "执行配置",
+    "modelsUsed": "执行模型",
     "overviewTiming": "时间信息",
     "overviewResources": "运行资源",
     "noFiles": "没有生成文件",

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -692,6 +692,17 @@
                     </div>
                     <div>
                       <dt class="overview-label">
+                        {{ t('lensRuns.modelsUsed') }}
+                      </dt>
+                      <dd
+                        data-testid="run-models-used"
+                        class="overview-value break-all"
+                      >
+                        {{ detail.models_used?.join(', ') || '-' }}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt class="overview-label">
                         {{ t('lensAdmin.fields.agentRounds') }}
                       </dt>
                       <dd class="mt-1">

--- a/frontend/tests/runObservation.test.js
+++ b/frontend/tests/runObservation.test.js
@@ -51,6 +51,14 @@ test('run overview groups related fields and localizes analysis depth', async ()
   assert.doesNotMatch(contents, /· \{\{ detail\.agent_rounds \}\}/)
 })
 
+test('run overview shows the models actually used by the run', async () => {
+  const contents = await source()
+
+  assert.match(contents, /data-testid="run-models-used"/)
+  assert.match(contents, /lensRuns\.modelsUsed/)
+  assert.match(contents, /detail\.models_used/)
+})
+
 test('run overview separates executor status from business outcome', async () => {
   const contents = await source()
 


### PR DESCRIPTION
### **User description**
## Summary

- derive a stable, deduplicated model list from Run-scoped `LLMUsage` records
- show the models actually used in the localized admin Run overview
- cover the API field and frontend presentation with focused regression tests

Closes #250

## Test plan

- [x] `python manage.py test lens.tests.test_attachments.AttachmentServiceTests.test_admin_run_detail_uses_metered_calls_including_subagents --noinput`
- [x] `node --test --test-name-pattern='run overview shows the models actually used by the run' tests/runObservation.test.js`
- [x] `npx eslint src/admin/pages/lens/RunObservation.vue tests/runObservation.test.js`
- [x] `git diff origin/main...HEAD --check`

## Known baseline

- The complete `runObservation.test.js` run remains at 6/8 because two diagnosis-action assertions already fail on `origin/main`; the new model-display test passes.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Derive model list from LLMUsage records in admin run API.

- Display models used in frontend admin Run overview.

- Add translations for English and Chinese locales.

- Add regression tests for backend and frontend.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  B[Backend: admin_runs.py] -- "derives models_used" --> A[API response]
  A -- "includes models_used" --> F[Frontend: RunObservation.vue]
  F -- "renders with locales" --> U[User sees models used]
  T[Tests] -- "verify field and display" --> B & F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attachments.py</strong><dd><code>Assert models_used in backend test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_attachments.py

- Added assertion for `models_used` field in admin run detail test.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runObservation.test.js</strong><dd><code>Test models used display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/runObservation.test.js

<ul><li>Added test verifying presence of models used data-testid, locale key, <br>and Vue binding.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-969f2ecc66245d2d96ef61f330f9a8efd1ab220f5df212fd63404018230f1673">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin_runs.py</strong><dd><code>Derive models_used from LLMUsage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/views/admin_runs.py

<ul><li>Added <code>models_used</code> key to admin run model usage response.<br> <li> Provided default empty list when no model usage exists.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RunObservation.vue</strong><dd><code>Display models used in overview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/pages/lens/RunObservation.vue

<ul><li>Added a new row in the overview grid for models used.<br> <li> Uses localised label and <code>detail.models_used</code> joined by comma.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English locale key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/en.json

- Added "Models used" translation key for English.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese locale key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/zh-CN.json

- Added "执行模型" translation key for Chinese.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/251/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

