### PR TITLE
Prevent unsafe LensNode resume for unadmitted runs

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -10,6 +10,8 @@ from django.utils import timezone
 from .lensnode_auth import hash_lensnode_token
 from .models import LensNode, Run
 from .services import (
+    acknowledge_run_admitted,
+    acknowledge_run_checkpoint_ready,
     append_lensnode_output,
     finish_lensnode_run,
     lensnode_group_name,
@@ -78,6 +80,10 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             await self._handle_node_draining(content)
         elif frame_type == "run_event":
             await self._handle_run_event(content)
+        elif frame_type == "run_admitted":
+            await self._handle_run_admitted(content)
+        elif frame_type == "run_checkpoint_ready":
+            await self._handle_run_checkpoint_ready(content)
         elif frame_type == "run_output":
             await self._handle_run_output(content)
         elif frame_type == "run_done":
@@ -291,6 +297,32 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             run_uuid,
             content.get("step_type") or "retrieval",
             content.get("status") or "running",
+        )
+
+    async def _handle_run_admitted(self, content):
+        """Persist a LensNode admission acknowledgement for one dispatch."""
+
+        run_uuid = self._parse_uuid(content.get("run_uuid"))
+        if run_uuid is None:
+            await self._send_bad_frame("run_uuid is invalid")
+            return
+        await database_sync_to_async(acknowledge_run_admitted)(
+            run_uuid,
+            content.get("dispatch_id"),
+            self.lensnode.uuid,
+        )
+
+    async def _handle_run_checkpoint_ready(self, content):
+        """Persist durable checkpoint readiness for one dispatch."""
+
+        run_uuid = self._parse_uuid(content.get("run_uuid"))
+        if run_uuid is None:
+            await self._send_bad_frame("run_uuid is invalid")
+            return
+        await database_sync_to_async(acknowledge_run_checkpoint_ready)(
+            run_uuid,
+            content.get("dispatch_id"),
+            self.lensnode.uuid,
         )
 
     async def _handle_run_output(self, content):

--- a/backend/lens/execution.py
+++ b/backend/lens/execution.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from contextlib import contextmanager
 
 from django.db import transaction
@@ -132,15 +133,25 @@ def _lensnode_dispatch(state):
         execution.save(update_fields=["loaded_skills"])
         validate_run_dispatch(run)
         execution.status = RunExecution.Status.DISPATCHED
-        execution.started_at = timezone.now()
-        execution.save(update_fields=["status", "started_at"])
+        execution.started_at = execution.started_at or timezone.now()
+        execution.dispatch_id = uuid.uuid4()
+        execution.admitted_at = None
+        execution.checkpoint_ready_at = None
+        execution.save(
+            update_fields=[
+                "status",
+                "started_at",
+                "dispatch_id",
+                "admitted_at",
+                "checkpoint_ready_at",
+            ]
+        )
         dispatch_run_to_lensnode(
             run,
             question,
             subject_documents=subject_documents,
+            dispatch_id=execution.dispatch_id,
         )
-        execution.status = RunExecution.Status.RUNNING
-        execution.save(update_fields=["status"])
         step.detail = {
             "lensnode_uuid": str(run.lensnode.uuid),
             "task": execution.task,

--- a/backend/lens/migrations/0039_runexecution_admission_state.py
+++ b/backend/lens/migrations/0039_runexecution_admission_state.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0038_run_awaiting_resume"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="runexecution",
+            name="dispatch_id",
+            field=models.UUIDField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name="runexecution",
+            name="admitted_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="runexecution",
+            name="checkpoint_ready_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -862,6 +862,9 @@ class RunExecution(models.Model):
         default=None,
     )
     run_timeout_s = models.PositiveIntegerField(null=True, default=None)
+    dispatch_id = models.UUIDField(null=True, blank=True, editable=False)
+    admitted_at = models.DateTimeField(null=True, blank=True)
+    checkpoint_ready_at = models.DateTimeField(null=True, blank=True)
     token_budget_profile = models.CharField(
         max_length=16,
         choices=Assistant.TokenBudgetProfile.choices,

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import math
+import uuid
 from datetime import timedelta
 from time import sleep
 
@@ -62,6 +63,7 @@ BUSY_RETRY_WINDOW_S = 120
 DOCUMENT_ATTACHMENT_CAPABILITY = "run_document_attachments"
 RUN_CHECKPOINT_RESUME_CAPABILITY = "run_checkpoint_resume"
 RUN_CHECKPOINT_TTL_HOURS_CAPABILITY = "run_checkpoint_ttl_hours"
+RUN_ADMISSION_CHECKPOINT_CAPABILITY = "run_admission_checkpoint_v1"
 
 HISTORY_MAX_PAIRS = 5
 HISTORY_MAX_MESSAGE_CHARS = 2000
@@ -360,35 +362,6 @@ def resume_awaiting_runs_for_lensnode(
         str(run_uuid) for run_uuid in reported_active_run_uuids or ()
     }
     lensnode = LensNode.objects.filter(uuid=lensnode_uuid).first()
-    if not supports_run_checkpoint_resume(lensnode):
-        now = timezone.now()
-        unsupported = Run.objects.filter(
-            lensnode=lensnode,
-            status__in=[Run.Status.RUNNING, Run.Status.STREAMING],
-            resume_by__isnull=False,
-        ).exclude(uuid__in=reported_active)
-        run_ids = list(unsupported.values_list("id", flat=True))
-        unsupported.update(
-            status=Run.Status.FAILED,
-            error="LENSNODE_RESUME_UNSUPPORTED",
-            resume_by=None,
-            finished_at=now,
-            updated_at=now,
-        )
-        if run_ids:
-            fail_running_steps_for_runs(run_ids)
-            RunExecution.objects.filter(
-                run_id__in=run_ids,
-                status__in=[
-                    RunExecution.Status.QUEUED,
-                    RunExecution.Status.DISPATCHED,
-                    RunExecution.Status.RUNNING,
-                ],
-            ).update(
-                status=RunExecution.Status.FAILED,
-                finished_at=now,
-            )
-        return 0
 
     report_at = lensnode.updated_at
     awaiting_status = Q(status=Run.Status.RUNNING) | Q(
@@ -407,7 +380,7 @@ def resume_awaiting_runs_for_lensnode(
         .filter(awaiting_status)
         .values_list("id", flat=True)
     )
-    resumed = 0
+    recovered = 0
     for run_id in run_ids:
         try:
             with transaction.atomic():
@@ -441,6 +414,100 @@ def resume_awaiting_runs_for_lensnode(
                 ):
                     continue
                 now = timezone.now()
+                execution = (
+                    RunExecution.objects.select_for_update()
+                    .filter(run=run)
+                    .first()
+                )
+                if execution is None:
+                    continue
+                if execution.status in [
+                    RunExecution.Status.QUEUED,
+                    RunExecution.Status.DISPATCHED,
+                ]:
+                    run.status = Run.Status.QUEUED
+                    run.resume_by = None
+                    run.last_activity_at = now
+                    run.error = ""
+                    run.outcome = ""
+                    run.termination_detail = {}
+                    run.save(
+                        update_fields=[
+                            "status",
+                            "resume_by",
+                            "last_activity_at",
+                            "error",
+                            "outcome",
+                            "termination_detail",
+                            "updated_at",
+                        ]
+                    )
+                    execution.status = RunExecution.Status.QUEUED
+                    execution.dispatch_id = None
+                    execution.admitted_at = None
+                    execution.checkpoint_ready_at = None
+                    execution.save(
+                        update_fields=[
+                            "status",
+                            "dispatch_id",
+                            "admitted_at",
+                            "checkpoint_ready_at",
+                        ]
+                    )
+                    expected_document_count = get_run_document_expectation(
+                        run.uuid
+                    )
+                    transaction.on_commit(
+                        lambda run_uuid=run.uuid, count=(
+                            expected_document_count
+                            if expected_document_count is not None
+                            else -1
+                        ): _enqueue_answer_run(run_uuid, count)
+                    )
+                    logger.warning(
+                        "never-admitted run requeued run_uuid=%s "
+                        "lensnode_uuid=%s",
+                        run.uuid,
+                        lensnode_uuid,
+                    )
+                    recovered += 1
+                    continue
+                if execution.status != RunExecution.Status.RUNNING:
+                    continue
+                recovery_error = None
+                if not supports_run_checkpoint_resume(lensnode):
+                    recovery_error = "LENSNODE_RESUME_UNSUPPORTED"
+                elif (
+                    supports_run_admission_checkpoint(lensnode)
+                    and execution.checkpoint_ready_at is None
+                ):
+                    recovery_error = "LENSNODE_CHECKPOINT_NOT_READY"
+                if recovery_error:
+                    run.status = Run.Status.FAILED
+                    run.error = recovery_error
+                    run.resume_by = None
+                    run.finished_at = now
+                    run.save(
+                        update_fields=[
+                            "status",
+                            "error",
+                            "resume_by",
+                            "finished_at",
+                            "updated_at",
+                        ]
+                    )
+                    execution.status = RunExecution.Status.FAILED
+                    execution.finished_at = now
+                    execution.save(update_fields=["status", "finished_at"])
+                    fail_running_steps_for_runs([run.id])
+                    logger.error(
+                        "run resume rejected run_uuid=%s lensnode_uuid=%s "
+                        "reason=%s",
+                        run.uuid,
+                        lensnode_uuid,
+                        recovery_error,
+                    )
+                    continue
                 run.status = Run.Status.STREAMING
                 run.last_activity_at = now
                 run.save(
@@ -450,13 +517,13 @@ def resume_awaiting_runs_for_lensnode(
                         "updated_at",
                     ]
                 )
-                if hasattr(run, "execution"):
-                    run.execution.status = RunExecution.Status.RUNNING
-                    run.execution.save(update_fields=["status"])
+                execution.dispatch_id = uuid.uuid4()
+                execution.save(update_fields=["dispatch_id"])
                 dispatch_run_to_lensnode(
                     run,
                     run.input_message.content,
                     resume=True,
+                    dispatch_id=execution.dispatch_id,
                 )
         except Exception:
             logger.exception(
@@ -465,10 +532,14 @@ def resume_awaiting_runs_for_lensnode(
             )
             continue
         logger.info(
-            "run %s: resumed on lensnode %s", run.uuid, lensnode_uuid
+            "run resume attempted run_uuid=%s lensnode_uuid=%s "
+            "dispatch_id=%s",
+            run.uuid,
+            lensnode_uuid,
+            execution.dispatch_id,
         )
-        resumed += 1
-    return resumed
+        recovered += 1
+    return recovered
 
 
 def fail_running_steps_for_runs(run_ids):
@@ -765,6 +836,16 @@ def supports_run_checkpoint_resume(lensnode):
     return bool(
         isinstance(labels, dict)
         and labels.get(RUN_CHECKPOINT_RESUME_CAPABILITY) is True
+    )
+
+
+def supports_run_admission_checkpoint(lensnode):
+    """Return whether a LensNode acknowledges admission and checkpoints."""
+
+    labels = lensnode.labels if lensnode else {}
+    return bool(
+        isinstance(labels, dict)
+        and labels.get(RUN_ADMISSION_CHECKPOINT_CAPABILITY) is True
     )
 
 
@@ -1454,6 +1535,7 @@ def dispatch_run_to_lensnode(
     rewritten_question,
     subject_documents=None,
     resume=False,
+    dispatch_id=None,
 ):
     """Send a run_start command to the connected LensNode.
 
@@ -1519,6 +1601,7 @@ def dispatch_run_to_lensnode(
             "payload": {
                 "type": "run_start",
                 "run_uuid": str(run.uuid),
+                "dispatch_id": str(dispatch_id) if dispatch_id else None,
                 "task": execution.task,
                 "question": rewritten_question,
                 "answer_language": answer_language,
@@ -1559,6 +1642,12 @@ def dispatch_run_to_lensnode(
                 "settings": runtime_settings,
             },
         },
+    )
+    logger.info(
+        "run command published run_uuid=%s dispatch_id=%s resume=%s",
+        run.uuid,
+        dispatch_id,
+        resume,
     )
 
 
@@ -1678,6 +1767,117 @@ def append_lensnode_output(
     return run
 
 
+def _parse_dispatch_id(dispatch_id):
+    """Return a UUID for a protocol dispatch identifier or None."""
+
+    try:
+        return uuid.UUID(str(dispatch_id))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+@transaction.atomic
+def _acknowledge_run_protocol_state(
+    run_uuid,
+    dispatch_id,
+    lensnode_uuid,
+    *,
+    checkpoint_ready,
+):
+    """Persist a current dispatch acknowledgement and reject stale frames."""
+
+    parsed_dispatch_id = _parse_dispatch_id(dispatch_id)
+    if parsed_dispatch_id is None:
+        logger.warning(
+            "run acknowledgement ignored reason=invalid_dispatch_id "
+            "run_uuid=%s lensnode_uuid=%s",
+            run_uuid,
+            lensnode_uuid,
+        )
+        return False
+    run = (
+        Run.objects.select_for_update()
+        .filter(
+            uuid=run_uuid,
+            lensnode__uuid=lensnode_uuid,
+        )
+        .first()
+    )
+    execution = (
+        RunExecution.objects.select_for_update().filter(run=run).first()
+        if run is not None
+        else None
+    )
+    if execution is None or execution.dispatch_id != parsed_dispatch_id:
+        logger.warning(
+            "stale dispatch acknowledgement ignored run_uuid=%s "
+            "dispatch_id=%s lensnode_uuid=%s",
+            run_uuid,
+            parsed_dispatch_id,
+            lensnode_uuid,
+        )
+        return False
+    if run.status in TERMINAL_RUN_STATUSES:
+        logger.warning(
+            "late dispatch acknowledgement ignored run_uuid=%s "
+            "dispatch_id=%s status=%s",
+            run_uuid,
+            parsed_dispatch_id,
+            run.status,
+        )
+        return False
+
+    now = timezone.now()
+    update_fields = []
+    if execution.status == RunExecution.Status.DISPATCHED:
+        execution.status = RunExecution.Status.RUNNING
+        update_fields.append("status")
+    if execution.admitted_at is None:
+        execution.admitted_at = now
+        update_fields.append("admitted_at")
+    if checkpoint_ready and execution.checkpoint_ready_at is None:
+        execution.checkpoint_ready_at = now
+        update_fields.append("checkpoint_ready_at")
+    if update_fields:
+        execution.save(update_fields=update_fields)
+    if run.resume_by is not None:
+        Run.objects.filter(pk=run.pk).update(
+            resume_by=None,
+            updated_at=now,
+        )
+    logger.info(
+        "run %s run_uuid=%s dispatch_id=%s lensnode_uuid=%s",
+        "checkpoint ready" if checkpoint_ready else "admitted",
+        run_uuid,
+        parsed_dispatch_id,
+        lensnode_uuid,
+    )
+    return True
+
+
+def acknowledge_run_admitted(run_uuid, dispatch_id, lensnode_uuid):
+    """Record that the current dispatch was accepted by its LensNode."""
+
+    return _acknowledge_run_protocol_state(
+        run_uuid,
+        dispatch_id,
+        lensnode_uuid,
+        checkpoint_ready=False,
+    )
+
+
+def acknowledge_run_checkpoint_ready(run_uuid, dispatch_id, lensnode_uuid):
+    """Record that the current dispatch has a durable initial checkpoint."""
+
+    return _acknowledge_run_protocol_state(
+        run_uuid,
+        dispatch_id,
+        lensnode_uuid,
+        checkpoint_ready=True,
+    )
+
+
+@transaction.atomic
 def record_lensnode_run_event(run_uuid, step_type, status, detail):
     """Persist a structured LensNode event into a RunStep row.
 
@@ -1687,7 +1887,7 @@ def record_lensnode_run_event(run_uuid, step_type, status, detail):
     makes orphan-thread activity observable.
     """
 
-    run = Run.objects.get(uuid=run_uuid)
+    run = Run.objects.select_for_update().get(uuid=run_uuid)
     if run.status in TERMINAL_RUN_STATUSES:
         logger.warning(
             "run %s: dropping late %s event (run already %s)",
@@ -1696,6 +1896,26 @@ def record_lensnode_run_event(run_uuid, step_type, status, detail):
             run.status,
         )
         return None
+    if status == RunStep.Status.RUNNING:
+        execution = (
+            RunExecution.objects.select_for_update()
+            .filter(run=run)
+            .first()
+        )
+    else:
+        execution = None
+    if (
+        execution is not None
+        and execution.status == RunExecution.Status.DISPATCHED
+    ):
+        execution.status = RunExecution.Status.RUNNING
+        execution.admitted_at = execution.admitted_at or timezone.now()
+        execution.save(update_fields=["status", "admitted_at"])
+        logger.info(
+            "run admitted by first event run_uuid=%s dispatch_id=%s",
+            run_uuid,
+            execution.dispatch_id,
+        )
     if run.resume_by is not None and status == RunStep.Status.RUNNING:
         Run.objects.filter(pk=run.pk, resume_by__isnull=False).update(
             resume_by=None

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -26,7 +26,14 @@ from lens.document_attachments import (
 )
 from lens.execution import execute_answer_run
 from lens.lensnode_auth import issue_lensnode_token
-from lens.models import Assistant, LensNode, MessageAttachment, Run, Session
+from lens.models import (
+    Assistant,
+    LensNode,
+    MessageAttachment,
+    Run,
+    RunExecution,
+    Session,
+)
 from lens.serializers import AssistantSerializer, MessageSerializer
 from lens.services import (
     LensNodeDispatchError,
@@ -651,6 +658,11 @@ class DocumentAttachmentTests(TestCase):
 
         rewrite_query.assert_not_called()
         self.assertEqual(dispatch.call_args.args[1], "请分析所附文档")
+        run.execution.refresh_from_db()
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.DISPATCHED,
+        )
 
     def test_english_document_only_run_uses_english_prompt(self):
         self.user.profile.language = "en-US"

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -17,6 +17,8 @@ from lens.models import (
     Session,
 )
 from lens.services import (
+    acknowledge_run_admitted,
+    acknowledge_run_checkpoint_ready,
     create_execution_run,
     finish_lensnode_run,
     mark_active_runs_awaiting_resume,
@@ -80,6 +82,13 @@ class RunLifecycleTests(TestCase):
         run.refresh_from_db()
         return run
 
+    def _mark_execution_running(self, run):
+        """Mark a fixture as admitted by its LensNode."""
+
+        run.execution.status = RunExecution.Status.RUNNING
+        run.execution.admitted_at = timezone.now()
+        run.execution.save(update_fields=["status", "admitted_at"])
+
     def test_touch_run_activity_throttles(self):
         run = self._run(
             Run.Status.STREAMING,
@@ -127,6 +136,173 @@ class RunLifecycleTests(TestCase):
 
         self.assertIsNotNone(step)
         self.assertEqual(run.steps.count(), 1)
+
+    def test_first_running_event_marks_dispatched_execution_admitted(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.save(update_fields=["status"])
+
+        record_lensnode_run_event(
+            run.uuid,
+            "retrieval",
+            "running",
+            {"message": "accepted"},
+        )
+
+        run.execution.refresh_from_db()
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.RUNNING,
+        )
+        self.assertIsNotNone(run.execution.admitted_at)
+
+    def test_stale_dispatch_acknowledgements_are_ignored(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        current_dispatch_id = uuid.uuid4()
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.dispatch_id = current_dispatch_id
+        run.execution.save(update_fields=["status", "dispatch_id"])
+
+        admitted = acknowledge_run_admitted(
+            run.uuid,
+            uuid.uuid4(),
+            self.lensnode.uuid,
+        )
+        checkpoint_ready = acknowledge_run_checkpoint_ready(
+            run.uuid,
+            uuid.uuid4(),
+            self.lensnode.uuid,
+        )
+
+        run.execution.refresh_from_db()
+        self.assertFalse(admitted)
+        self.assertFalse(checkpoint_ready)
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.DISPATCHED,
+        )
+        self.assertIsNone(run.execution.admitted_at)
+        self.assertIsNone(run.execution.checkpoint_ready_at)
+
+    def test_consumer_routes_admission_protocol_frames(self):
+        consumer = LensNodeConsumer()
+        consumer._handle_run_admitted = AsyncMock()
+        consumer._handle_run_checkpoint_ready = AsyncMock()
+        admitted_frame = {
+            "type": "run_admitted",
+            "run_uuid": str(uuid.uuid4()),
+            "dispatch_id": str(uuid.uuid4()),
+        }
+        checkpoint_frame = {
+            "type": "run_checkpoint_ready",
+            "run_uuid": str(uuid.uuid4()),
+            "dispatch_id": str(uuid.uuid4()),
+        }
+
+        async_to_sync(consumer.receive_json)(admitted_frame)
+        async_to_sync(consumer.receive_json)(checkpoint_frame)
+
+        consumer._handle_run_admitted.assert_awaited_once_with(
+            admitted_frame
+        )
+        consumer._handle_run_checkpoint_ready.assert_awaited_once_with(
+            checkpoint_frame
+        )
+
+    def test_current_dispatch_acknowledgements_are_idempotent(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        dispatch_id = uuid.uuid4()
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.dispatch_id = dispatch_id
+        run.execution.save(update_fields=["status", "dispatch_id"])
+
+        self.assertTrue(
+            acknowledge_run_admitted(
+                run.uuid,
+                dispatch_id,
+                self.lensnode.uuid,
+            )
+        )
+        self.assertTrue(
+            acknowledge_run_checkpoint_ready(
+                run.uuid,
+                dispatch_id,
+                self.lensnode.uuid,
+            )
+        )
+        run.execution.refresh_from_db()
+        admitted_at = run.execution.admitted_at
+        checkpoint_ready_at = run.execution.checkpoint_ready_at
+
+        self.assertTrue(
+            acknowledge_run_admitted(
+                run.uuid,
+                dispatch_id,
+                self.lensnode.uuid,
+            )
+        )
+        self.assertTrue(
+            acknowledge_run_checkpoint_ready(
+                run.uuid,
+                dispatch_id,
+                self.lensnode.uuid,
+            )
+        )
+
+        run.execution.refresh_from_db()
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.RUNNING,
+        )
+        self.assertEqual(run.execution.admitted_at, admitted_at)
+        self.assertEqual(
+            run.execution.checkpoint_ready_at,
+            checkpoint_ready_at,
+        )
+
+    def test_dispatch_acknowledgement_from_wrong_lensnode_is_ignored(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        dispatch_id = uuid.uuid4()
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.dispatch_id = dispatch_id
+        run.execution.save(update_fields=["status", "dispatch_id"])
+        other_lensnode = LensNode.objects.create(
+            name="Other LensNode",
+            status=LensNode.Status.ONLINE,
+            enrollment_status=LensNode.EnrollmentStatus.APPROVED,
+            workspace_path="/other-workspace",
+        )
+
+        acknowledged = acknowledge_run_checkpoint_ready(
+            run.uuid,
+            dispatch_id,
+            other_lensnode.uuid,
+        )
+
+        run.execution.refresh_from_db()
+        self.assertFalse(acknowledged)
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.DISPATCHED,
+        )
+        self.assertIsNone(run.execution.admitted_at)
+        self.assertIsNone(run.execution.checkpoint_ready_at)
 
     def test_first_resume_event_acknowledges_node_admission(self):
         run = self._run(
@@ -309,6 +485,7 @@ class RunLifecycleTests(TestCase):
         )
         self.lensnode.status = LensNode.Status.OFFLINE
         self.lensnode.save(update_fields=["status"])
+        self._mark_execution_running(run)
 
         confirm_reconcile_orphan(str(run.uuid))
 
@@ -328,6 +505,7 @@ class RunLifecycleTests(TestCase):
             sequence=1,
             status=RunStep.Status.RUNNING,
         )
+        self._mark_execution_running(run)
 
         confirm_reconcile_orphan(str(run.uuid))
 
@@ -389,6 +567,7 @@ class RunLifecycleTests(TestCase):
         )
         run.resume_by = timezone.now() + timedelta(hours=1)
         run.save(update_fields=["resume_by"])
+        self._mark_execution_running(run)
 
         with patch(
             "lens.services.dispatch_run_to_lensnode"
@@ -405,6 +584,111 @@ class RunLifecycleTests(TestCase):
         self.assertEqual(kwargs["resume"], True)
         self.assertEqual(run.status, Run.Status.STREAMING)
         self.assertIsNotNone(run.resume_by)
+
+    def test_never_admitted_run_is_requeued_through_normal_dispatch_once(self):
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.dispatch_id = uuid.uuid4()
+        run.execution.save(update_fields=["status", "dispatch_id"])
+
+        with (
+            patch(
+                "lens.services.get_run_document_expectation",
+                return_value=2,
+            ),
+            patch("lens.tasks.enqueue_answer_run_task") as enqueue,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            first = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+            second = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertEqual((first, second), (1, 0))
+        self.assertEqual(run.status, Run.Status.QUEUED)
+        self.assertIsNone(run.resume_by)
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.QUEUED,
+        )
+        self.assertIsNone(run.execution.dispatch_id)
+        enqueue.assert_called_once_with(run.uuid, 2)
+
+    def test_admitted_run_without_checkpoint_readiness_fails_closed(self):
+        self.lensnode.labels["run_admission_checkpoint_v1"] = True
+        self.lensnode.save(update_fields=["labels"])
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        run.execution.status = RunExecution.Status.RUNNING
+        run.execution.dispatch_id = uuid.uuid4()
+        run.execution.admitted_at = timezone.now()
+        run.execution.save(
+            update_fields=["status", "dispatch_id", "admitted_at"]
+        )
+
+        with patch("lens.services.dispatch_run_to_lensnode") as dispatch:
+            count = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertEqual(count, 0)
+        self.assertEqual(run.status, Run.Status.FAILED)
+        self.assertEqual(run.error, "LENSNODE_CHECKPOINT_NOT_READY")
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.FAILED,
+        )
+        dispatch.assert_not_called()
+
+    def test_checkpoint_ready_run_resumes_with_fresh_dispatch_id(self):
+        self.lensnode.labels["run_admission_checkpoint_v1"] = True
+        self.lensnode.save(update_fields=["labels"])
+        run = self._run(
+            Run.Status.RUNNING,
+            timedelta(minutes=5),
+            timedelta(minutes=5),
+        )
+        old_dispatch_id = uuid.uuid4()
+        ready_at = timezone.now() - timedelta(minutes=1)
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        run.execution.status = RunExecution.Status.RUNNING
+        run.execution.dispatch_id = old_dispatch_id
+        run.execution.admitted_at = ready_at
+        run.execution.checkpoint_ready_at = ready_at
+        run.execution.save(
+            update_fields=[
+                "status",
+                "dispatch_id",
+                "admitted_at",
+                "checkpoint_ready_at",
+            ]
+        )
+
+        with patch(
+            "lens.services.dispatch_run_to_lensnode"
+        ) as dispatch:
+            count = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
+
+        run.execution.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertNotEqual(run.execution.dispatch_id, old_dispatch_id)
+        self.assertEqual(
+            dispatch.call_args.kwargs["dispatch_id"],
+            run.execution.dispatch_id,
+        )
+        self.assertTrue(dispatch.call_args.kwargs["resume"])
 
     def test_resume_skips_run_reported_active_by_reconnected_node(self):
         run = self._run(
@@ -437,6 +721,7 @@ class RunLifecycleTests(TestCase):
         )
         run.resume_by = timezone.now() + timedelta(hours=1)
         run.save(update_fields=["resume_by"])
+        self._mark_execution_running(run)
         nested_counts = []
 
         def dispatch_once(*args, **kwargs):
@@ -466,6 +751,7 @@ class RunLifecycleTests(TestCase):
         )
         run.resume_by = timezone.now() + timedelta(hours=1)
         run.save(update_fields=["resume_by"])
+        self._mark_execution_running(run)
         LensNode.objects.filter(pk=self.lensnode.pk).update(
             updated_at=timezone.now()
         )
@@ -486,6 +772,7 @@ class RunLifecycleTests(TestCase):
             timedelta(minutes=5),
             timedelta(minutes=5),
         )
+        self._mark_execution_running(run)
 
         with patch(
             "lens.services.dispatch_run_to_lensnode"
@@ -505,6 +792,7 @@ class RunLifecycleTests(TestCase):
         )
         run.resume_by = timezone.now() + timedelta(hours=1)
         run.save(update_fields=["resume_by"])
+        self._mark_execution_running(run)
 
         with patch(
             "lens.services.dispatch_run_to_lensnode",
@@ -526,6 +814,7 @@ class RunLifecycleTests(TestCase):
         )
         run.resume_by = timezone.now() + timedelta(hours=1)
         run.save(update_fields=["resume_by"])
+        self._mark_execution_running(run)
         self.lensnode.labels = {}
         self.lensnode.save(update_fields=["labels"])
 

--- a/lensnode/lensnode/agent_runtime.py
+++ b/lensnode/lensnode/agent_runtime.py
@@ -1286,6 +1286,7 @@ class LensDeepAgentRuntime:
         on_activity=None,
         cancel_event=None,
         wrapup_event=None,
+        on_checkpoint_ready=None,
     ):
         """Execute a run_start command with create_deep_agent."""
 
@@ -1297,6 +1298,7 @@ class LensDeepAgentRuntime:
             on_activity,
             cancel_event,
             wrapup_event,
+            on_checkpoint_ready,
         )
 
     def _answer_sync(
@@ -1307,6 +1309,7 @@ class LensDeepAgentRuntime:
         on_activity=None,
         cancel_event=None,
         wrapup_event=None,
+        on_checkpoint_ready=None,
     ):
         """Synchronous Deep Agents invocation run in a worker thread."""
 
@@ -1409,6 +1412,17 @@ class LensDeepAgentRuntime:
             checkpoint_ready = resume_state is not None
             initial_checkpoint_seeded = False
             resume_from_graph_checkpoint = resume_state is not None
+            checkpoint_ready_notified = False
+
+            def notify_checkpoint_ready():
+                nonlocal checkpoint_ready_notified
+                if checkpoint_ready_notified or on_checkpoint_ready is None:
+                    return
+                on_checkpoint_ready()
+                checkpoint_ready_notified = True
+
+            if checkpoint_ready:
+                notify_checkpoint_ready()
             if (
                 runtime_mode.execution_gates
                 and resume_state is not None
@@ -1555,6 +1569,7 @@ class LensDeepAgentRuntime:
                             )
                             checkpoint_ready = True
                             initial_checkpoint_seeded = True
+                            notify_checkpoint_ready()
                         except Exception:
                             LOGGER.exception(
                                 "Failed to enable route checkpoint"
@@ -1814,7 +1829,14 @@ class LensDeepAgentRuntime:
                                 history_assistant_turns
                             ),
                         )
+                        save_initial_checkpoint(
+                            run_uuid,
+                            self.config.workspace_path,
+                            initial_messages,
+                        )
                         checkpoint_ready = True
+                        initial_checkpoint_seeded = True
+                        notify_checkpoint_ready()
                     except Exception:
                         kwargs.pop("checkpointer", None)
                         LOGGER.exception(

--- a/lensnode/lensnode/executor.py
+++ b/lensnode/lensnode/executor.py
@@ -398,6 +398,18 @@ class LensNodeExecutor:
                     }
                 )
 
+            def emit_checkpoint_ready():
+                dispatch_id = command.get("dispatch_id")
+                if not dispatch_id or cancel_event.is_set():
+                    return
+                emit(
+                    {
+                        "type": "run_checkpoint_ready",
+                        "run_uuid": run_uuid,
+                        "dispatch_id": str(dispatch_id),
+                    }
+                )
+
             # Inactivity watchdog on TRANSPORT activity, not user-visible
             # output: any gateway SSE event (heartbeats, reasoning and
             # tool-call tokens) refreshes the clock via on_activity, so a
@@ -407,15 +419,19 @@ class LensNodeExecutor:
             # Cancelling the asyncio task cannot stop the agent worker
             # thread, so cancel_event tells the thread to unwind at its
             # next chunk or model-call boundary and mutes its late emits.
-            answer_task = asyncio.create_task(
-                self.agent.answer(
-                    command,
-                    emit_progress=emit_progress,
-                    emit_output=emit_output,
-                    on_activity=touch_activity,
-                    cancel_event=cancel_event,
-                    wrapup_event=wrapup_event,
+            answer_options = {
+                "emit_progress": emit_progress,
+                "emit_output": emit_output,
+                "on_activity": touch_activity,
+                "cancel_event": cancel_event,
+                "wrapup_event": wrapup_event,
+            }
+            if command.get("dispatch_id"):
+                answer_options["on_checkpoint_ready"] = (
+                    emit_checkpoint_ready
                 )
+            answer_task = asyncio.create_task(
+                self.agent.answer(command, **answer_options)
             )
 
             def stop_answer_task():

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -521,6 +521,13 @@ class LensNodeClient:
             await self._send_busy(run_uuid, "LENSNODE_DRAINING")
             return
         if run_uuid in self.running_tasks:
+            if message.get("dispatch_id"):
+                self._send_run_admitted(run_uuid, message["dispatch_id"])
+                LOGGER.info(
+                    "Acknowledged duplicate delivery for active run %s.",
+                    run_uuid,
+                )
+                return
             if message.get("resume"):
                 LOGGER.info(
                     "Ignored duplicate resume for active run %s.",
@@ -548,7 +555,20 @@ class LensNodeClient:
         )
         self.running_commands[run_uuid] = message
         self.running_tasks[run_uuid] = task
+        if message.get("dispatch_id"):
+            self._send_run_admitted(run_uuid, message["dispatch_id"])
         task.add_done_callback(lambda item: self._consume_task_exception(item))
+
+    def _send_run_admitted(self, run_uuid, dispatch_id):
+        """Acknowledge one accepted dispatch without exposing its payload."""
+
+        self._enqueue(
+            {
+                "type": "run_admitted",
+                "run_uuid": run_uuid,
+                "dispatch_id": str(dispatch_id),
+            }
+        )
 
     async def _handle_list_dirs(self, message):
         """List immediate subdirectories for requested paths and reply."""
@@ -922,6 +942,7 @@ class LensNodeClient:
                         "mode": "local",
                         "run_document_attachments": True,
                         "run_checkpoint_resume": checkpoint_resume_ready,
+                        "run_admission_checkpoint_v1": True,
                         "run_checkpoint_ttl_hours": checkpoint_ttl_hours(),
                     },
                 },

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -262,6 +262,105 @@ def test_duplicate_resume_for_active_run_is_idempotent():
     asyncio.run(exercise())
 
 
+def test_run_admission_echoes_dispatch_id_and_duplicate_is_idempotent():
+    async def exercise():
+        config = type(
+            "Config",
+            (),
+            {
+                "name": "test-node",
+                "request_timeout_s": 240,
+                "max_concurrent_runs": 1,
+            },
+        )()
+        client = LensNodeClient(config)
+        executor = BlockingExecutor()
+        client.executor = executor
+        run_uuid = "00000000-0000-0000-0000-000000000018"
+        dispatch_id = "00000000-0000-0000-0000-000000000019"
+        duplicate_dispatch_id = "00000000-0000-0000-0000-000000000022"
+        message = {
+            "type": "run_start",
+            "run_uuid": run_uuid,
+            "dispatch_id": dispatch_id,
+            "task": "knowledge_qa",
+            "target_dirs": [],
+        }
+
+        await client._handle_message(json.dumps(message))
+        await asyncio.wait_for(executor.started.wait(), timeout=1)
+        await client._handle_message(
+            json.dumps(
+                {
+                    **message,
+                    "dispatch_id": duplicate_dispatch_id,
+                    "resume": True,
+                }
+            )
+        )
+
+        admissions = [
+            frame
+            for frame in client._outbox
+            if frame.get("type") == "run_admitted"
+        ]
+        assert admissions == [
+            {
+                "type": "run_admitted",
+                "run_uuid": run_uuid,
+                "dispatch_id": dispatch_id,
+            },
+            {
+                "type": "run_admitted",
+                "run_uuid": run_uuid,
+                "dispatch_id": duplicate_dispatch_id,
+            },
+        ]
+        assert not any(
+            frame.get("error") == "LENSNODE_RUN_ACTIVE"
+            for frame in client._outbox
+        )
+        client.running_tasks[run_uuid].cancel()
+        await asyncio.gather(
+            client.running_tasks[run_uuid],
+            return_exceptions=True,
+        )
+
+    asyncio.run(exercise())
+
+
+def test_executor_emits_checkpoint_ready_for_current_dispatch():
+    class CheckpointAwareAgent(FakeAgent):
+        async def answer(self, command, on_checkpoint_ready=None, **kwargs):
+            if on_checkpoint_ready is not None:
+                on_checkpoint_ready()
+            return await super().answer(command, **kwargs)
+
+    executor = LensNodeExecutor.__new__(LensNodeExecutor)
+    executor.agent = CheckpointAwareAgent()
+    events = []
+    run_uuid = "00000000-0000-0000-0000-000000000020"
+    dispatch_id = "00000000-0000-0000-0000-000000000021"
+
+    asyncio.run(
+        executor.execute(
+            {
+                "run_uuid": run_uuid,
+                "dispatch_id": dispatch_id,
+                "task": "knowledge_qa",
+                "target_dirs": [],
+            },
+            events.append,
+        )
+    )
+
+    assert {
+        "type": "run_checkpoint_ready",
+        "run_uuid": run_uuid,
+        "dispatch_id": dispatch_id,
+    } in events
+
+
 def test_control_plane_cancel_cleans_idle_checkpoint_and_runtime_files():
     async def exercise():
         config = type(

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -1821,6 +1821,7 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
 ):
     model_options = []
     run_options = []
+    checkpoint_actions = []
 
     class Model:
         stop_reason = None
@@ -1837,6 +1838,7 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
         mcp_config_path=tmp_path / "mcp.json",
     )
     config = SimpleNamespace(
+        workspace_path=str(tmp_path),
         ai_gateway_url="http://gateway/ai/",
         token="token",
         request_timeout_s=30,
@@ -1880,6 +1882,22 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
         "create_deep_agent",
         lambda **_kwargs: object(),
     )
+    monkeypatch.setattr(agent_runtime, "checkpoint_enabled", lambda: True)
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda _workspace: checkpoint_actions.append("saver") or object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_resume_metadata",
+        lambda *_args, **_kwargs: checkpoint_actions.append("metadata"),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_initial_checkpoint",
+        lambda *_args, **_kwargs: checkpoint_actions.append("checkpoint"),
+    )
 
     def run_agent(*_args, **options):
         run_options.append(options)
@@ -1902,6 +1920,9 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
                 "agent_model_ref": "model-ref",
             },
             wrapup_event=wrapup_event,
+            on_checkpoint_ready=lambda task=task: checkpoint_actions.append(
+                ("ready", task)
+            ),
         )
 
         assert result["answer"] == "legacy answer"
@@ -1916,6 +1937,17 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
         assert options["wrapup_event"] is None
         assert options["token_budget_wrapup_event"] is None
         assert "capability_stop_event" not in options
+        assert options["input_checkpoint_seeded"] is True
+    assert checkpoint_actions == [
+        "saver",
+        "metadata",
+        "checkpoint",
+        ("ready", "knowledge_qa"),
+        "saver",
+        "metadata",
+        "checkpoint",
+        ("ready", "code_analysis"),
+    ]
 
 
 def test_unverified_answer_distinguishes_unavailable_from_execution_failure():

--- a/lensnode/tests/test_outbox.py
+++ b/lensnode/tests/test_outbox.py
@@ -197,6 +197,9 @@ def test_reconnect_hello_claims_buffered_terminal_run_before_flush():
         ]
         assert frames[0]["labels"]["run_document_attachments"] is True
         assert frames[0]["labels"]["run_checkpoint_resume"] is True
+        assert (
+            frames[0]["labels"]["run_admission_checkpoint_v1"] is True
+        )
         assert [frame["type"] for frame in frames[1:]] == [
             "run_output",
             "run_output",


### PR DESCRIPTION
### **User description**
## Summary

- Keep each Run execution in `DISPATCHED` until the LensNode explicitly admits the current dispatch, and track checkpoint readiness independently.
- Requeue never-admitted Runs through the existing fresh-dispatch workflow while allowing resume only after a durable checkpoint acknowledgement.
- Add stale-acknowledgement and duplicate-delivery safeguards, an additive migration, and regression coverage across backend and LensNode recovery paths.

Closes #245

## Test plan

- [x] Backend focused admission and recovery tests (42 passed)
- [x] Remaining backend `lens.tests` PostgreSQL regression suite (402 passed)
- [x] Full LensNode test suite (388 passed)
- [x] LensNode core test suite (172 passed)
- [x] Django system and migration checks
- [x] MCP integration tests
- [x] `git diff --check`


___

### **PR Type**
Bug fix


___

### **Description**
- Track admission and checkpoint readiness explicitly

- Requeue never-admitted runs via fresh dispatch

- Add protocol frames for admission and checkpoint

- Add migration and regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Run dispatched"] --> B["Node admits (run_admitted)"]
  B --> C["Checkpoint ready (run_checkpoint_ready)"]
  C --> D["Running (resume allowed)"]
  A -- "never admitted" --> E["Requeue fresh dispatch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>consumers.py</strong><dd><code>Add handlers for run_admitted and run_checkpoint_ready frames</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0039_runexecution_admission_state.py</strong><dd><code>Add migration for admission state fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-655d08404a07dd2b3428d7f554481552a54b873f553e300e1e003c6c8e1c5312">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add admission state fields to RunExecution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_runtime.py</strong><dd><code>Add checkpoint readiness callback to agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-614f56ab3aba4569d04062b0394a01e86cd44767f6dc48d5c14684c69517b4f9">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>executor.py</strong><dd><code>Emit checkpoint_ready frame from executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-09da87f66493ac6ca403c68c259713dfe47d390711eb1ae828c477954e2a79d5">+24/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Add admission acknowledgement and duplicate handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>execution.py</strong><dd><code>Track dispatch admission state explicitly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-7cef6eaf866533349878e22f422222cf01e55ed2affb461d5b362c0a4aa9f6b6">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Implement admission-aware recovery logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+257/-37</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_document_attachments.py</strong><dd><code>Verify document-only run stays dispatched</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-abb5e8fe2ed314bd844c7f25d56c651e637f0a72584e61b2d938b0018f41a437">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_run_lifecycle.py</strong><dd><code>Add admission and recovery tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+289/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Test admission and checkpoint readiness frames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Verify checkpoint actions in legacy modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_outbox.py</strong><dd><code>Verify admission label in hello frame</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/252/files#diff-9d6e64d043d821dfbf8ad1c7d7c50ff84addf81e821efd9502c496855a7f9026">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

