### PR TITLE
Polish BaseSelect interactions and add regression coverage

### DIFF
--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -392,6 +392,35 @@ class AttachmentServiceTests(TestCase):
         self.assertFalse(detail["model_calls"][0]["is_subagent"])
         self.assertTrue(detail["model_calls"][1]["is_subagent"])
 
+    def test_admin_run_detail_deduplicates_models_in_call_order(self):
+        from lens.views.admin_runs import _admin_run_detail
+
+        run = create_execution_run(
+            session=self.session,
+            question="q",
+            enqueue=False,
+        )
+        for model in (
+            "deepseek-v4-flash",
+            "qwen3-coder-plus",
+            "deepseek-v4-flash",
+        ):
+            LLMUsage.objects.create(
+                user=self.user,
+                model=model,
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+                metadata={"run_uuid": str(run.uuid)},
+            )
+
+        detail = _admin_run_detail(run)
+
+        self.assertEqual(
+            detail["models_used"],
+            ["deepseek-v4-flash", "qwen3-coder-plus"],
+        )
+
     def test_analyze_multimodal_intent_passthrough_without_model(self):
         self.assistant.multimodal_model_ref = None
         self.assistant.save(update_fields=["multimodal_model_ref"])

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -272,6 +272,36 @@ class RunLifecycleTests(TestCase):
             checkpoint_ready_at,
         )
 
+    def test_checkpoint_ready_before_admission_records_both_states(self):
+        run = self._run(
+            Run.Status.STREAMING,
+            timedelta(seconds=10),
+            timedelta(seconds=10),
+        )
+        dispatch_id = uuid.uuid4()
+        run.resume_by = timezone.now() + timedelta(hours=1)
+        run.save(update_fields=["resume_by"])
+        run.execution.status = RunExecution.Status.DISPATCHED
+        run.execution.dispatch_id = dispatch_id
+        run.execution.save(update_fields=["status", "dispatch_id"])
+
+        acknowledged = acknowledge_run_checkpoint_ready(
+            run.uuid,
+            dispatch_id,
+            self.lensnode.uuid,
+        )
+
+        run.refresh_from_db()
+        run.execution.refresh_from_db()
+        self.assertTrue(acknowledged)
+        self.assertEqual(
+            run.execution.status,
+            RunExecution.Status.RUNNING,
+        )
+        self.assertIsNotNone(run.execution.admitted_at)
+        self.assertIsNotNone(run.execution.checkpoint_ready_at)
+        self.assertIsNone(run.resume_by)
+
     def test_dispatch_acknowledgement_from_wrong_lensnode_is_ignored(self):
         run = self._run(
             Run.Status.STREAMING,

--- a/frontend/src/components/ui/BaseSelect.vue
+++ b/frontend/src/components/ui/BaseSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="rootClasses">
+  <div ref="rootRef" :class="rootClasses">
     <label
       v-if="label"
       :for="selectId"
@@ -10,36 +10,67 @@
     </label>
 
     <div class="relative">
+      <button
+        :id="selectId"
+        ref="triggerRef"
+        type="button"
+        role="combobox"
+        aria-haspopup="listbox"
+        :aria-activedescendant="activeOptionId"
+        :aria-controls="listboxId"
+        :aria-describedby="describedBy"
+        :aria-expanded="isOpen"
+        :aria-invalid="isInvalid ? 'true' : attrs['aria-invalid']"
+        :aria-label="attrs['aria-label']"
+        :aria-labelledby="attrs['aria-labelledby']"
+        :aria-required="required ? 'true' : undefined"
+        :disabled="disabled"
+        :title="attrs.title"
+        :class="selectClasses"
+        @blur="$emit('blur', $event)"
+        @click="toggleMenu"
+        @focus="$emit('focus', $event)"
+        @keydown="handleTriggerKeydown"
+      >
+        <span class="min-w-0 flex-1 truncate">
+          {{ selectedOption?.label || '' }}
+        </span>
+
+        <svg
+          aria-hidden="true"
+          :class="[
+            'pointer-events-none absolute right-3 top-1/2 h-4 w-4',
+            '-translate-y-1/2 transition-transform duration-150',
+            isOpen ? 'rotate-180' : '',
+            disabled ? 'text-ink-300' : 'text-ink-500'
+          ]"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m8 10 4 4 4-4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+
       <select
         v-model="selectedValue"
         v-bind="selectAttrs"
+        ref="nativeSelectRef"
+        aria-hidden="true"
+        class="hidden"
+        tabindex="-1"
         :disabled="disabled"
         :required="required"
-        :class="selectClasses"
         @change="handleChange"
-        @focus="$emit('focus', $event)"
-        @blur="$emit('blur', $event)"
+        @invalid="handleInvalid"
       >
         <slot />
       </select>
-
-      <svg
-        aria-hidden="true"
-        :class="[
-          'pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2',
-          disabled ? 'text-ink-300' : 'text-ink-500'
-        ]"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="m8 10 4 4 4-4"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-        />
-      </svg>
     </div>
 
     <p v-if="error" :id="errorId" class="text-sm text-danger-700">
@@ -49,13 +80,72 @@
     <p v-else-if="help" :id="helpId" class="text-sm text-ink-500">
       {{ help }}
     </p>
+
+    <Teleport to="body">
+      <ul
+        v-if="isOpen"
+        :id="listboxId"
+        ref="menuRef"
+        role="listbox"
+        tabindex="-1"
+        :aria-labelledby="attrs['aria-labelledby'] || selectId"
+        :style="menuStyle"
+        class="fixed z-[120] overflow-y-auto rounded-lg border border-line bg-surface p-1 shadow-lg ring-1 ring-black/5"
+        @mousedown.prevent
+      >
+        <li
+          v-for="(option, index) in optionItems"
+          :id="optionId(index)"
+          :key="option.key"
+          role="option"
+          :aria-disabled="option.disabled ? 'true' : undefined"
+          :aria-selected="isSelected(option)"
+          :class="optionClasses(option, index)"
+          @click="selectOption(option, index)"
+          @mouseenter="activateOption(option, index)"
+        >
+          <span class="min-w-0 flex-1 break-words">
+            {{ option.label }}
+          </span>
+
+          <svg
+            v-if="isSelected(option)"
+            aria-hidden="true"
+            class="h-4 w-4 shrink-0 text-primary-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m5 12 4 4L19 6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </li>
+      </ul>
+    </Teleport>
   </div>
 </template>
 
 <script setup>
-import { computed, ref, useAttrs } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  useAttrs,
+  useSlots,
+  watch
+} from 'vue'
 
-import { applyModelModifiers } from './baseSelect'
+import {
+  applyModelModifiers,
+  extractSelectOptions,
+  findNextEnabledOption,
+  findTypeaheadOption
+} from './baseSelect'
 
 defineOptions({ inheritAttrs: false })
 
@@ -113,12 +203,38 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'change', 'focus', 'blur'])
 const attrs = useAttrs()
+const slots = useSlots()
+const rootRef = ref(null)
+const triggerRef = ref(null)
+const nativeSelectRef = ref(null)
+const menuRef = ref(null)
+const isOpen = ref(false)
+const activeIndex = ref(-1)
+const menuStyle = ref({})
 const generatedId = ref(`select-${Math.random().toString(36).substring(2, 11)}`)
+let typeaheadQuery = ''
+let typeaheadTimer
 
 const selectId = computed(() => attrs.id || generatedId.value)
+const nativeSelectId = computed(() => `${selectId.value}-native`)
+const listboxId = computed(() => `${selectId.value}-listbox`)
 const errorId = computed(() => `${selectId.value}-error`)
 const helpId = computed(() => `${selectId.value}-help`)
 const isInvalid = computed(() => props.invalid || Boolean(props.error))
+const optionItems = computed(() =>
+  extractSelectOptions(slots.default?.() || [])
+)
+const selectedIndex = computed(() =>
+  optionItems.value.findIndex((option) => isSelected(option))
+)
+const selectedOption = computed(() =>
+  selectedIndex.value >= 0 ? optionItems.value[selectedIndex.value] : null
+)
+const activeOptionId = computed(() =>
+  isOpen.value && activeIndex.value >= 0
+    ? optionId(activeIndex.value)
+    : undefined
+)
 const describedBy = computed(() => {
   let feedbackId = ''
   if (props.error) feedbackId = errorId.value
@@ -134,14 +250,15 @@ const selectAttrs = computed(() => {
   const forwardedAttrs = { ...attrs }
   delete forwardedAttrs.class
   delete forwardedAttrs.id
+  delete forwardedAttrs.title
   delete forwardedAttrs['aria-describedby']
   delete forwardedAttrs['aria-invalid']
+  delete forwardedAttrs['aria-label']
+  delete forwardedAttrs['aria-labelledby']
 
   return {
     ...forwardedAttrs,
-    id: selectId.value,
-    'aria-describedby': describedBy.value,
-    'aria-invalid': isInvalid.value ? 'true' : attrs['aria-invalid']
+    id: nativeSelectId.value
   }
 })
 
@@ -165,10 +282,18 @@ const selectClasses = computed(() => {
     lg: 'px-4 py-3 pr-12 text-base'
   }
   const variantClasses = {
-    default:
-      'rounded-lg border bg-surface text-ink-900 shadow-sm transition-colors hover:border-ink-300 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 disabled:bg-surface-sunken disabled:text-ink-400 disabled:opacity-50',
-    unstyled:
-      'border-0 bg-transparent text-ink-900 shadow-none focus:outline-none focus:ring-0 disabled:text-ink-400 disabled:opacity-50'
+    default: [
+      'rounded-lg border bg-surface text-ink-900 shadow-sm',
+      'transition-colors hover:border-ink-300',
+      'focus:border-primary-500 focus:outline-none focus:ring-2',
+      'focus:ring-primary-500/20 disabled:bg-surface-sunken',
+      'disabled:text-ink-400 disabled:opacity-50'
+    ].join(' '),
+    unstyled: [
+      'border-0 bg-transparent text-ink-900 shadow-none',
+      'focus:outline-none focus:ring-0',
+      'disabled:text-ink-400 disabled:opacity-50'
+    ].join(' ')
   }
   const invalidClasses = isInvalid.value
     ? 'border-danger-600 focus:border-danger-600 focus:ring-danger-600/20'
@@ -179,7 +304,8 @@ const selectClasses = computed(() => {
       : sizeClasses[props.size]
 
   return [
-    'block w-full appearance-none disabled:cursor-not-allowed',
+    'relative flex w-full appearance-none items-center text-left',
+    'disabled:cursor-not-allowed',
     spacingClasses,
     variantClasses[props.variant],
     props.variant === 'default' ? invalidClasses : '',
@@ -189,7 +315,271 @@ const selectClasses = computed(() => {
     .join(' ')
 })
 
+const optionSizeClasses = computed(() => {
+  const sizeClasses = {
+    sm: 'px-2 py-1.5 text-xs',
+    md: 'px-3 py-2 text-sm',
+    lg: 'px-4 py-2.5 text-base'
+  }
+  return sizeClasses[props.size]
+})
+
+function isSelected(option) {
+  return Object.is(option.value, props.modelValue)
+}
+
+function optionId(index) {
+  return `${listboxId.value}-option-${index}`
+}
+
+function optionClasses(option, index) {
+  return [
+    'relative flex select-none items-center gap-2 rounded-md outline-none',
+    optionSizeClasses.value,
+    props.mobileTouch ? 'min-h-11 md:min-h-0' : '',
+    option.disabled
+      ? 'cursor-not-allowed text-ink-400 opacity-60'
+      : 'cursor-pointer text-ink-800',
+    !option.disabled && activeIndex.value === index
+      ? 'bg-primary-50 text-primary-700'
+      : '',
+    !option.disabled && activeIndex.value !== index
+      ? 'hover:bg-surface-sunken'
+      : '',
+    isSelected(option) ? 'font-medium' : ''
+  ]
+}
+
+function activateOption(option, index) {
+  if (!option.disabled) activeIndex.value = index
+}
+
+function toggleMenu() {
+  if (isOpen.value) closeMenu()
+  else openMenu(1)
+}
+
+function openMenu(direction) {
+  if (props.disabled || !optionItems.value.length) return
+
+  isOpen.value = true
+  if (selectedIndex.value >= 0) {
+    activeIndex.value = selectedIndex.value
+  } else {
+    const startIndex = direction < 0 ? 0 : -1
+    activeIndex.value = findNextEnabledOption(
+      optionItems.value,
+      startIndex,
+      direction
+    )
+  }
+
+  nextTick(() => {
+    updateMenuPosition()
+    scrollActiveOptionIntoView()
+  })
+}
+
+function closeMenu() {
+  isOpen.value = false
+  activeIndex.value = -1
+  clearTypeahead()
+}
+
+function moveActiveOption(direction) {
+  const nextIndex = findNextEnabledOption(
+    optionItems.value,
+    activeIndex.value,
+    direction
+  )
+  if (nextIndex < 0) return
+
+  activeIndex.value = nextIndex
+  nextTick(scrollActiveOptionIntoView)
+}
+
+function selectOption(option, index) {
+  if (option.disabled) return
+
+  activeIndex.value = index
+  const changed = !isSelected(option)
+  if (changed) selectedValue.value = option.value
+  closeMenu()
+
+  if (changed) {
+    nextTick(() => {
+      const event = new Event('change', { bubbles: true })
+      Object.defineProperty(event, 'target', {
+        configurable: true,
+        value: nativeSelectRef.value
+      })
+      handleChange(event)
+    })
+  }
+}
+
+function handleTriggerKeydown(event) {
+  if (props.disabled) return
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    const direction = event.key === 'ArrowDown' ? 1 : -1
+    if (!isOpen.value) openMenu(direction)
+    else moveActiveOption(direction)
+    return
+  }
+
+  if (event.key === 'Home' || event.key === 'End') {
+    event.preventDefault()
+    if (!isOpen.value) openMenu(event.key === 'Home' ? 1 : -1)
+    const startIndex = event.key === 'Home' ? -1 : 0
+    const direction = event.key === 'Home' ? 1 : -1
+    activeIndex.value = findNextEnabledOption(
+      optionItems.value,
+      startIndex,
+      direction
+    )
+    nextTick(scrollActiveOptionIntoView)
+    return
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    if (!isOpen.value) openMenu(1)
+    else if (activeIndex.value >= 0) {
+      selectOption(optionItems.value[activeIndex.value], activeIndex.value)
+    }
+    return
+  }
+
+  if (event.key === 'Escape' && isOpen.value) {
+    event.preventDefault()
+    closeMenu()
+    return
+  }
+
+  if (event.key === 'Tab') {
+    closeMenu()
+    return
+  }
+
+  if (
+    event.key.length === 1 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey
+  ) {
+    handleTypeahead(event.key)
+  }
+}
+
+function handleTypeahead(character) {
+  typeaheadQuery += character.toLocaleLowerCase()
+  window.clearTimeout(typeaheadTimer)
+  typeaheadTimer = window.setTimeout(clearTypeahead, 500)
+
+  const startIndex = isOpen.value ? activeIndex.value : selectedIndex.value
+  const matchingIndex = findTypeaheadOption(
+    optionItems.value,
+    typeaheadQuery,
+    startIndex
+  )
+  if (matchingIndex < 0) return
+
+  if (isOpen.value) {
+    activeIndex.value = matchingIndex
+    nextTick(scrollActiveOptionIntoView)
+  } else {
+    selectOption(optionItems.value[matchingIndex], matchingIndex)
+  }
+}
+
+function clearTypeahead() {
+  typeaheadQuery = ''
+  window.clearTimeout(typeaheadTimer)
+  typeaheadTimer = undefined
+}
+
+function scrollActiveOptionIntoView() {
+  if (!menuRef.value || activeIndex.value < 0) return
+  const option = document.getElementById(optionId(activeIndex.value))
+  option?.scrollIntoView({ block: 'nearest' })
+}
+
+function updateMenuPosition() {
+  const trigger = triggerRef.value
+  if (!trigger) return
+
+  const rect = trigger.getBoundingClientRect()
+  const viewportMargin = 8
+  const menuGap = 4
+  const maximumHeight = 256
+  const availableBelow = window.innerHeight - rect.bottom - menuGap
+  const availableAbove = rect.top - menuGap
+  const opensAbove = availableBelow < 160 && availableAbove > availableBelow
+  const availableHeight = opensAbove ? availableAbove : availableBelow
+  const width = Math.min(rect.width, window.innerWidth - viewportMargin * 2)
+  const left = Math.max(
+    viewportMargin,
+    Math.min(rect.left, window.innerWidth - width - viewportMargin)
+  )
+
+  menuStyle.value = {
+    bottom: opensAbove
+      ? `${window.innerHeight - rect.top + menuGap}px`
+      : 'auto',
+    left: `${left}px`,
+    maxHeight: `${Math.max(96, Math.min(maximumHeight, availableHeight))}px`,
+    top: opensAbove ? 'auto' : `${rect.bottom + menuGap}px`,
+    width: `${width}px`
+  }
+}
+
+function handleOutsidePointer(event) {
+  if (
+    rootRef.value?.contains(event.target) ||
+    menuRef.value?.contains(event.target)
+  ) {
+    return
+  }
+  closeMenu()
+}
+
+function handleInvalid(event) {
+  event.preventDefault()
+  triggerRef.value?.focus()
+}
+
 function handleChange(event) {
   emit('change', event)
 }
+
+function addOpenListeners() {
+  document.addEventListener('pointerdown', handleOutsidePointer)
+  window.addEventListener('resize', updateMenuPosition)
+  window.addEventListener('scroll', updateMenuPosition, true)
+}
+
+function removeOpenListeners() {
+  document.removeEventListener('pointerdown', handleOutsidePointer)
+  window.removeEventListener('resize', updateMenuPosition)
+  window.removeEventListener('scroll', updateMenuPosition, true)
+}
+
+watch(isOpen, (open) => {
+  if (open) addOpenListeners()
+  else removeOpenListeners()
+})
+
+watch(
+  () => props.disabled,
+  (disabled) => {
+    if (disabled) closeMenu()
+  }
+)
+
+onBeforeUnmount(() => {
+  removeOpenListeners()
+  clearTypeahead()
+})
 </script>

--- a/frontend/src/components/ui/baseSelect.js
+++ b/frontend/src/components/ui/baseSelect.js
@@ -4,3 +4,77 @@ export function applyModelModifiers(value, modifiers = {}) {
   const numberValue = Number.parseFloat(value)
   return Number.isNaN(numberValue) ? value : numberValue
 }
+
+function optionText(children) {
+  if (children === null || children === undefined) return ''
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children)
+  }
+  if (Array.isArray(children)) {
+    return children.map((child) => optionText(child)).join('')
+  }
+  if (typeof children === 'object') return optionText(children.children)
+  return ''
+}
+
+export function extractSelectOptions(nodes) {
+  const options = []
+
+  function visit(children) {
+    for (const node of children || []) {
+      if (node?.type === 'option') {
+        const label = optionText(node.children).trim()
+        const hasValue = Object.prototype.hasOwnProperty.call(
+          node.props || {},
+          'value'
+        )
+        options.push({
+          key: node.key ?? `option-${options.length}`,
+          label,
+          value: hasValue ? node.props.value : label,
+          disabled:
+            node.props?.disabled !== undefined && node.props.disabled !== false
+        })
+      } else if (Array.isArray(node?.children)) {
+        visit(node.children)
+      }
+    }
+  }
+
+  visit(nodes)
+  return options
+}
+
+export function findNextEnabledOption(options, currentIndex, direction) {
+  if (!options.length) return -1
+
+  const step = direction < 0 ? -1 : 1
+  let index = currentIndex
+
+  for (let offset = 0; offset < options.length; offset += 1) {
+    index = (index + step + options.length) % options.length
+    if (!options[index]?.disabled) return index
+  }
+
+  return -1
+}
+
+export function findTypeaheadOption(options, query, currentIndex = -1) {
+  const normalizedQuery = String(query || '')
+    .trim()
+    .toLocaleLowerCase()
+  if (!normalizedQuery || !options.length) return -1
+
+  for (let offset = 1; offset <= options.length; offset += 1) {
+    const index = (currentIndex + offset + options.length) % options.length
+    const option = options[index]
+    if (
+      !option?.disabled &&
+      String(option.label).toLocaleLowerCase().startsWith(normalizedQuery)
+    ) {
+      return index
+    }
+  }
+
+  return -1
+}

--- a/frontend/tests/baseSelect.test.js
+++ b/frontend/tests/baseSelect.test.js
@@ -4,7 +4,12 @@ import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { applyModelModifiers } from '../src/components/ui/baseSelect.js'
+import {
+  applyModelModifiers,
+  extractSelectOptions,
+  findNextEnabledOption,
+  findTypeaheadOption
+} from '../src/components/ui/baseSelect.js'
 
 const source = (relativePath) =>
   readFile(new URL(`../src/${relativePath}`, import.meta.url), 'utf8')
@@ -37,10 +42,57 @@ test('BaseSelect exposes the native select contract and visual variants', async 
   assert.match(component, /'blur'/)
 })
 
+test('BaseSelect owns a themed listbox instead of the browser popup', async () => {
+  const component = await source('components/ui/BaseSelect.vue')
+
+  assert.match(component, /role="combobox"/)
+  assert.match(component, /aria-activedescendant/)
+  assert.match(component, /@keydown="handleTriggerKeydown"/)
+  assert.match(component, /<Teleport to="body">/)
+  assert.match(component, /role="listbox"/)
+  assert.match(component, /role="option"/)
+  assert.match(component, /bg-surface/)
+  assert.match(component, /shadow-lg/)
+})
+
+test('BaseSelect removes the listbox immediately when it closes', async () => {
+  const component = await source('components/ui/BaseSelect.vue')
+
+  assert.doesNotMatch(component, /<Transition/)
+  assert.match(component, /<ul\s+v-if="isOpen"/)
+})
+
 test('BaseSelect preserves values received from bound native options', () => {
   const objectValue = { id: 'model-a' }
 
   assert.equal(applyModelModifiers(objectValue), objectValue)
+})
+
+test('BaseSelect derives labels and values from nested option nodes', () => {
+  const objectValue = { id: 'model-a' }
+  const options = extractSelectOptions([
+    { type: 'option', props: { value: '' }, children: 'All models' },
+    {
+      type: Symbol('fragment'),
+      children: [
+        {
+          type: 'option',
+          props: { value: objectValue, disabled: true },
+          children: [{ children: 'Model A' }]
+        }
+      ]
+    }
+  ])
+
+  assert.deepEqual(options, [
+    { key: 'option-0', label: 'All models', value: '', disabled: false },
+    {
+      key: 'option-1',
+      label: 'Model A',
+      value: objectValue,
+      disabled: true
+    }
+  ])
 })
 
 test('BaseSelect applies the number model modifier to native string values', () => {
@@ -50,6 +102,31 @@ test('BaseSelect applies the number model modifier to native string values', () 
     'not-a-number'
   )
   assert.equal(applyModelModifiers('20'), '20')
+})
+
+test('BaseSelect keyboard navigation skips disabled options and wraps', () => {
+  const options = [
+    { label: 'All', disabled: false },
+    { label: 'Queued', disabled: true },
+    { label: 'Done', disabled: false }
+  ]
+
+  assert.equal(findNextEnabledOption(options, 0, 1), 2)
+  assert.equal(findNextEnabledOption(options, 2, 1), 0)
+  assert.equal(findNextEnabledOption(options, 0, -1), 2)
+})
+
+test('BaseSelect typeahead starts after the active option', () => {
+  const options = [
+    { label: 'All status', disabled: false },
+    { label: 'Done', disabled: false },
+    { label: 'Disabled', disabled: true },
+    { label: 'Draft', disabled: false }
+  ]
+
+  assert.equal(findTypeaheadOption(options, 'd', 0), 1)
+  assert.equal(findTypeaheadOption(options, 'd', 1), 3)
+  assert.equal(findTypeaheadOption(options, 'z', 0), -1)
 })
 
 test('all production selects use BaseSelect while prototypes stay native', async () => {

--- a/frontend/tests/chatAttachments.test.js
+++ b/frontend/tests/chatAttachments.test.js
@@ -8,6 +8,7 @@ import {
   hasAttachmentErrorCode,
   MAX_IMAGE_ASPECT_RATIO,
   MAX_IMAGE_PIXELS,
+  readImageDimensions,
   validateImageDimensions,
   validateAttachment
 } from '../src/pages/lens/chatAttachments.js'
@@ -105,6 +106,59 @@ test('checks browser image dimensions before uploading', async () => {
 
   assert.notEqual(dimensionCheck, -1)
   assert.ok(dimensionCheck < uploadStart)
+})
+
+test('releases the browser image URL after reading dimensions', async (t) => {
+  const originalImage = globalThis.Image
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  const revoked = []
+
+  t.after(() => {
+    globalThis.Image = originalImage
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+  URL.createObjectURL = () => 'blob:dimensions-success'
+  URL.revokeObjectURL = (url) => revoked.push(url)
+  globalThis.Image = class {
+    set src(_value) {
+      this.naturalWidth = 1200
+      this.naturalHeight = 800
+      queueMicrotask(() => this.onload())
+    }
+  }
+
+  const dimensions = await readImageDimensions({ name: 'screen.png' })
+
+  assert.deepEqual(dimensions, { width: 1200, height: 800 })
+  assert.deepEqual(revoked, ['blob:dimensions-success'])
+})
+
+test('releases the browser image URL when dimensions fail', async (t) => {
+  const originalImage = globalThis.Image
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  const revoked = []
+
+  t.after(() => {
+    globalThis.Image = originalImage
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+  URL.createObjectURL = () => 'blob:dimensions-error'
+  URL.revokeObjectURL = (url) => revoked.push(url)
+  globalThis.Image = class {
+    set src(_value) {
+      queueMicrotask(() => this.onerror())
+    }
+  }
+
+  await assert.rejects(
+    readImageDimensions({ name: 'broken.png' }),
+    /IMAGE_DIMENSIONS_UNAVAILABLE/
+  )
+  assert.deepEqual(revoked, ['blob:dimensions-error'])
 })
 
 test('preserves uploaded document metadata in optimistic messages', async () => {


### PR DESCRIPTION
### **User description**
## Summary

- Render BaseSelect options in a themed, accessible teleported listbox while preserving the native form contract.
- Add keyboard navigation, typeahead, disabled-option handling, viewport-aware positioning, and reliable menu cleanup.
- Add regression coverage for checkpoint-ready admission, model ordering, and browser image URL cleanup.

Closes #254

## Test plan

- [x] Focused Django tests: 2 passed.
- [x] Focused frontend tests: 21 passed.
- [x] ESLint passed for all affected frontend files.
- [x] Production frontend build passed.
- [x] `git diff --check` passed.
- [x] ego-browser task space 136: verified the admin History select menu, option selection/reset, keyboard navigation, Escape and outside-click closure, and 390px viewport containment.
- [x] Full frontend unit suite executed: 196/199 passed; the 3 existing failures are the app locale parity check and 2 stale Run Observation source assertions, all outside this diff.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace native select with themed accessible listbox

- Add keyboard navigation, typeahead, viewport-aware positioning

- Add regression tests for Run admission, model ordering, image URL cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BaseSelect.vue"] --> B["Custom Accessible Listbox"]
  B --> C["Keyboard Navigation, Typeahead, Positioning"]
  D["baseSelect.js"] --> B
  E["Frontend Tests"] --> B
  F["Backend Tests"] --> G["Run Admission & Model Order"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attachments.py</strong><dd><code>Add model deduplication order test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_attachments.py

<ul><li>Added test for model deduplication preserving call order in admin run <br>detail</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_run_lifecycle.py</strong><dd><code>Add checkpoint-ready admission test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_run_lifecycle.py

<ul><li>Added test for checkpoint-ready before admission recording both states</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>baseSelect.test.js</strong><dd><code>Add BaseSelect interaction tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/baseSelect.test.js

<ul><li>Added tests for listbox existence, keyboard navigation, typeahead, and <br>option extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-6a265551b0887078932fa492dd02cb9f97c2df43f78703cc6c88d068d1b27873">+78/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatAttachments.test.js</strong><dd><code>Add image URL cleanup tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatAttachments.test.js

<ul><li>Added tests for browser image URL release on successful and failed <br>dimension reads</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-da5b4010f4857150843a8fe2dac7eca09695469117a5a90518f9c46fc8a65843">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseSelect.vue</strong><dd><code>Implement custom themed listbox</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/BaseSelect.vue

<ul><li>Replaced native select with themed accessible listbox<br> <li> Added keyboard navigation, typeahead, viewport-aware positioning<br> <li> Added aria attributes and event handling</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-4177eda97a5d6c29bb073653137833de16ec48a50175575548028eb1039007a9">+422/-32</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>baseSelect.js</strong><dd><code>Add select option utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/baseSelect.js

<ul><li>Added utility functions: extractSelectOptions, findNextEnabledOption, <br>findTypeaheadOption</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/255/files#diff-691902095d54a562198466e0ede4b4aa06cf1e45a6814ede1651e9f753737e59">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

