### PR TITLE
Add localized in-product release notes

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -15,6 +15,9 @@ concurrency:
   group: sourcelens-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ${{ vars.REGISTRY }}
   SSH_HOST: ${{ vars.SOURCELENS_SSH_HOST }}
@@ -27,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      release_date: ${{ steps.version.outputs.release_date }}
+      release_date: ${{ steps.release.outputs.release_date }}
       ref: ${{ steps.version.outputs.ref }}
     steps:
       - name: Resolve version
@@ -55,10 +58,59 @@ jobs:
             VERSION="${GITHUB_SHA}"
             REF="${GITHUB_SHA}"
           fi
-          RELEASE_DATE="$(date -u +'%Y/%m/%d')"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install release-note tooling dependency
+        run: python -m pip install 'PyYAML==6.0.3'
+
+      - name: Generate deterministic release notes
+        id: release
+        shell: bash
+        env:
+          RELEASE_REF: ${{ steps.version.outputs.ref }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          release_date="$(
+            git for-each-ref \
+              --format='%(taggerdate:format:%Y/%m/%d)' \
+              "refs/tags/${RELEASE_REF}"
+          )"
+          if [ -z "${release_date}" ]; then
+            release_date="$(
+              git show -s \
+                --format='%cd' \
+                --date='format:%Y/%m/%d' \
+                "${RELEASE_REF}^{commit}"
+            )"
+          fi
+          python scripts/release_notes.py build \
+            --tag "${RELEASE_REF}" \
+            --version "${RELEASE_VERSION}" \
+            --release-date "${release_date}" \
+            --manifest release-artifacts/release-notes.json \
+            --body release-artifacts/release-notes.md
+          echo "release_date=${release_date}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release-note artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ steps.version.outputs.version }}
+          path: release-artifacts/
+          if-no-files-found: error
+          retention-days: 7
 
   build-images:
     runs-on: ubuntu-latest
@@ -86,6 +138,31 @@ jobs:
           # agentcore-* are public submodules; recurse so the backend image
           # build has their source (the default token fetches public repos).
           submodules: recursive
+          ref: ${{ needs.prepare-version.outputs.ref }}
+
+      - name: Download release-note artifacts
+        if: ${{ matrix.image_name == 'sourcelens-frontend' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes-${{ needs.prepare-version.outputs.version }}
+          path: release-artifacts
+
+      - name: Embed and verify frontend release notes
+        if: ${{ matrix.image_name == 'sourcelens-frontend' }}
+        shell: bash
+        env:
+          RELEASE_DATE: ${{ needs.prepare-version.outputs.release_date }}
+          RELEASE_VERSION: ${{ needs.prepare-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cp \
+            release-artifacts/release-notes.json \
+            frontend/src/generated/release-notes.json
+          jq -e \
+            --arg version "${RELEASE_VERSION}" \
+            --arg release_date "${RELEASE_DATE}" \
+            '.version == $version and .releaseDate == $release_date' \
+            frontend/src/generated/release-notes.json
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -122,6 +199,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-version
+      - build-images
+    if: ${{ startsWith(needs.prepare-version.outputs.ref, 'v') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Download release-note artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: >-
+            release-notes-${{ needs.prepare-version.outputs.version }}
+          path: release-artifacts
+
+      - name: Create or update GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_REF: ${{ needs.prepare-version.outputs.ref }}
+          RELEASE_VERSION: ${{ needs.prepare-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_REF}" >/dev/null 2>&1; then
+            gh release edit "${RELEASE_REF}" \
+              --title "SourceLens ${RELEASE_VERSION}" \
+              --notes-file release-artifacts/release-notes.md
+          else
+            gh release create "${RELEASE_REF}" \
+              --verify-tag \
+              --title "SourceLens ${RELEASE_VERSION}" \
+              --notes-file release-artifacts/release-notes.md
+          fi
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,58 @@
+name: Release Notes
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-notes-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout pull request history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install release-note tooling dependency
+        run: python -m pip install 'PyYAML==6.0.3'
+
+      - name: Test release-note tooling
+        run: python -m unittest scripts.test_release_notes
+
+      - name: Validate pull request release-note decision
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKIP_RELEASE_NOTE: >-
+            ${{ contains(github.event.pull_request.labels.*.name,
+            'skip-release-note') }}
+        run: |
+          set -euo pipefail
+          args=(
+            --base "${BASE_SHA}"
+            --head "${HEAD_SHA}"
+          )
+          if [ "${SKIP_RELEASE_NOTE}" = "true" ]; then
+            args+=(--skip-release-note)
+          fi
+          python scripts/release_notes.py validate-pr "${args[@]}"

--- a/frontend/src/admin/layout/AdminHeader.vue
+++ b/frontend/src/admin/layout/AdminHeader.vue
@@ -135,6 +135,14 @@
                       />
                     </svg>
                     <span>{{ t('common.settings') }}</span>
+                    <span
+                      v-if="uiStore.hasUnreadReleaseNotes"
+                      class="ml-auto h-2 w-2 shrink-0 rounded-full bg-brand-500"
+                    >
+                      <span class="sr-only">
+                        {{ t('settings.modal.releaseNotesUnread') }}
+                      </span>
+                    </span>
                   </button>
                 </div>
                 <div class="border-t border-line px-4 py-2 min-[430px]:hidden">

--- a/frontend/src/components/layout/SidebarQuickMenu.vue
+++ b/frontend/src/components/layout/SidebarQuickMenu.vue
@@ -80,6 +80,14 @@
           </div>
           <button type="button" class="quick-menu-link" @click="openSettings">
             <span class="truncate">{{ t('common.settings') }}</span>
+            <span
+              v-if="uiStore.hasUnreadReleaseNotes"
+              class="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary-500"
+            >
+              <span class="sr-only">
+                {{ t('settings.modal.releaseNotesUnread') }}
+              </span>
+            </span>
           </button>
           <button type="button" class="quick-menu-link" @click="handleLogout">
             <span class="truncate">{{ t('common.logout') }}</span>

--- a/frontend/src/components/lens/UserDock.vue
+++ b/frontend/src/components/lens/UserDock.vue
@@ -96,6 +96,14 @@
           <button type="button" class="dock-link" @click="openSettings">
             <Settings :size="18" :stroke-width="2" aria-hidden="true" />
             <span class="truncate">{{ t('common.settings') }}</span>
+            <span
+              v-if="uiStore.hasUnreadReleaseNotes"
+              class="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary-500"
+            >
+              <span class="sr-only">
+                {{ t('settings.modal.releaseNotesUnread') }}
+              </span>
+            </span>
           </button>
           <button type="button" class="dock-link" @click="handleLogout">
             <LogOut :size="18" :stroke-width="2" aria-hidden="true" />

--- a/frontend/src/components/settings/ReleaseNotesSettings.vue
+++ b/frontend/src/components/settings/ReleaseNotesSettings.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="space-y-5">
+    <div
+      class="flex flex-wrap items-start justify-between gap-4 rounded-xl border border-line bg-gray-50 px-4 py-3"
+    >
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+          {{ t('settings.releaseNotes.currentVersion') }}
+        </p>
+        <p class="mt-1 text-lg font-semibold text-gray-900">
+          SourceLens {{ manifest.version }}
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+          {{ t('settings.releaseNotes.releaseDate') }}
+        </p>
+        <p class="mt-1 text-sm font-medium text-gray-800">
+          {{ manifest.releaseDate || '—' }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="groups.length" class="space-y-5">
+      <section
+        v-for="group in groups"
+        :key="group.type"
+        :aria-labelledby="`release-notes-${group.type}`"
+      >
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <h3
+            :id="`release-notes-${group.type}`"
+            class="inline-flex rounded-md px-2 py-1 text-xs font-semibold"
+            :class="categoryStyles[group.type].badge"
+          >
+            {{ t(`settings.releaseNotes.categories.${group.type}`) }}
+          </h3>
+          <span class="text-xs text-gray-400">
+            {{
+              t('settings.releaseNotes.entryCount', {
+                count: group.entries.length
+              })
+            }}
+          </span>
+        </div>
+        <ul class="space-y-2">
+          <li
+            v-for="(entry, index) in group.entries"
+            :key="`${group.type}-${entry.audience}-${index}`"
+            class="border-l-2 bg-white py-2 pl-3 pr-2 text-sm leading-6 text-gray-700"
+            :class="categoryStyles[group.type].border"
+          >
+            <span class="sr-only">
+              {{ t(`settings.releaseNotes.categories.${group.type}`) }}:
+            </span>
+            <span
+              v-if="entry.audience === 'admin'"
+              class="mr-2 inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600"
+            >
+              {{ t('settings.releaseNotes.adminOnly') }}
+            </span>
+            {{ entry.text }}
+          </li>
+        </ul>
+      </section>
+    </div>
+
+    <p
+      v-else
+      class="rounded-xl border border-dashed border-line px-4 py-8 text-center text-sm text-gray-500"
+    >
+      {{ t('settings.releaseNotes.empty') }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import manifest from '@/generated/release-notes.json'
+import { useUserStore } from '@/store/user'
+import { selectLocalizedReleaseNotes } from '@/utils/releaseNotes'
+
+const { locale, t } = useI18n()
+const userStore = useUserStore()
+const isAdmin = computed(() => userStore.userHasFeature('admin_console'))
+
+const categoryStyles = {
+  feature: {
+    badge: 'bg-emerald-50 text-emerald-700',
+    border: 'border-emerald-300'
+  },
+  improvement: {
+    badge: 'bg-blue-50 text-blue-700',
+    border: 'border-blue-300'
+  },
+  fix: {
+    badge: 'bg-amber-50 text-amber-700',
+    border: 'border-amber-300'
+  }
+}
+
+const groups = computed(() =>
+  selectLocalizedReleaseNotes(manifest, locale.value, isAdmin.value)
+)
+</script>

--- a/frontend/src/components/settings/UserSettingsModal.vue
+++ b/frontend/src/components/settings/UserSettingsModal.vue
@@ -28,9 +28,9 @@
         >
           <!-- Left nav -->
           <nav
-            class="flex w-44 shrink-0 flex-col border-r border-line bg-gray-50 py-3"
+            class="flex w-14 shrink-0 flex-col border-r border-line bg-gray-50 py-3 sm:w-44"
           >
-            <div class="px-3 pb-2 pt-1">
+            <div class="hidden px-3 pb-2 pt-1 sm:block">
               <div
                 class="text-xs font-semibold uppercase tracking-wide text-gray-400"
               >
@@ -43,7 +43,8 @@
                 v-for="section in sections"
                 :key="section.key"
                 type="button"
-                class="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors"
+                class="flex w-full items-center justify-center gap-2.5 rounded-lg px-2 py-2 text-left text-sm transition-colors sm:justify-start sm:px-3"
+                :aria-label="section.label"
                 :class="
                   activeSection === section.key
                     ? 'bg-white font-medium text-gray-900 shadow-sm'
@@ -52,14 +53,28 @@
                 @click="activeSection = section.key"
               >
                 <component :is="section.icon" class="h-4 w-4 shrink-0" />
-                {{ section.label }}
+                <span class="hidden min-w-0 flex-1 truncate sm:block">
+                  {{ section.label }}
+                </span>
+                <span
+                  v-if="
+                    section.key === 'release-notes' &&
+                    uiStore.hasUnreadReleaseNotes
+                  "
+                  class="h-2 w-2 shrink-0 rounded-full bg-primary-500"
+                >
+                  <span class="sr-only">
+                    {{ t('settings.modal.releaseNotesUnread') }}
+                  </span>
+                </span>
               </button>
             </div>
 
             <div class="border-t border-line px-2 pt-2">
               <button
                 type="button"
-                class="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600"
+                class="flex w-full items-center justify-center gap-2.5 rounded-lg px-2 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 sm:justify-start sm:px-3"
+                :aria-label="t('common.logout')"
                 @click="handleLogout"
               >
                 <svg
@@ -82,7 +97,7 @@
                   />
                   <line x1="21" y1="12" x2="9" y2="12" stroke-linecap="round" />
                 </svg>
-                {{ t('common.logout') }}
+                <span class="hidden sm:block">{{ t('common.logout') }}</span>
               </button>
             </div>
           </nav>
@@ -90,7 +105,7 @@
           <!-- Right content -->
           <div class="flex min-w-0 flex-1 flex-col">
             <header
-              class="flex items-center justify-between border-b border-line px-5 py-4"
+              class="flex items-center justify-between border-b border-line px-4 py-4 sm:px-5"
             >
               <h2 class="text-base font-semibold text-gray-900">
                 {{ sections.find((s) => s.key === activeSection)?.label }}
@@ -118,7 +133,7 @@
               </button>
             </header>
 
-            <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+            <div class="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-5">
               <!-- Profile section -->
               <div v-if="activeSection === 'profile'" class="space-y-5">
                 <div class="flex items-center gap-4">
@@ -203,6 +218,8 @@
                 v-if="activeSection === 'notifications'"
               />
 
+              <ReleaseNotesSettings v-if="activeSection === 'release-notes'" />
+
               <PasswordChangeSettings v-if="activeSection === 'security'" />
             </div>
           </div>
@@ -218,6 +235,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import AnswerNotificationSettings from '@/components/settings/AnswerNotificationSettings.vue'
 import PasswordChangeSettings from '@/components/settings/PasswordChangeSettings.vue'
+import ReleaseNotesSettings from '@/components/settings/ReleaseNotesSettings.vue'
 import BaseSelect from '@/components/ui/BaseSelect.vue'
 import { getPasswordManagementText } from '@/locales/passwordManagement'
 import { getUiLanguageOptions } from '@/utils/languages'
@@ -246,12 +264,20 @@ const GlobeIcon = {
 const BellIcon = {
   template: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9" stroke-linecap="round" stroke-linejoin="round"/><path d="M10 21h4" stroke-linecap="round"/></svg>`
 }
+const ReleaseNotesIcon = {
+  template: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 4h14v16H5z"/><path d="M8 8h8M8 12h8M8 16h5" stroke-linecap="round"/></svg>`
+}
 const LockIcon = {
   template: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="10" width="14" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3" stroke-linecap="round"/></svg>`
 }
 
 const sections = computed(() => [
   { key: 'profile', label: t('settings.modal.title'), icon: UserIcon },
+  {
+    key: 'release-notes',
+    label: t('settings.modal.releaseNotes'),
+    icon: ReleaseNotesIcon
+  },
   { key: 'language', label: t('settings.modal.language'), icon: GlobeIcon },
   {
     key: 'notifications',
@@ -311,6 +337,16 @@ watch(
     if (show) activeSection.value = uiStore.settingsTab || 'profile'
     if (typeof document !== 'undefined')
       document.body.style.overflow = show ? 'hidden' : ''
+  },
+  { immediate: true }
+)
+
+watch(
+  [() => props.show, activeSection],
+  ([show, section]) => {
+    if (show && section === 'release-notes') {
+      uiStore.markReleaseNotesViewed()
+    }
   },
   { immediate: true }
 )

--- a/frontend/src/generated/release-notes.json
+++ b/frontend/src/generated/release-notes.json
@@ -1,0 +1,9 @@
+{
+  "version": "dev",
+  "releaseDate": "",
+  "categories": {
+    "feature": [],
+    "improvement": [],
+    "fix": []
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -564,6 +564,8 @@
       "user": "User",
       "language": "Language",
       "languageDesc": "Used for the interface and AI-generated content",
+      "releaseNotes": "What's New",
+      "releaseNotesUnread": "New release notes are available",
       "notifications": "Notifications",
       "notificationsDesc": "Choose how SourceLens tells you when a long-running answer is ready.",
       "completionIndicator": "Answer completion reminders",
@@ -582,6 +584,18 @@
       "assistantFallback": "Current assistant",
       "noteTitle": "Note",
       "noteBody": "More settings will be folded into this panel later. For now, it keeps only the most commonly used account information and language selection."
+    },
+    "releaseNotes": {
+      "currentVersion": "Current version",
+      "releaseDate": "Release date",
+      "entryCount": "{count} change(s)",
+      "adminOnly": "Administrators",
+      "empty": "No user-facing changes were included in this release.",
+      "categories": {
+        "feature": "Features",
+        "improvement": "Improvements",
+        "fix": "Fixes"
+      }
     },
     "preferences": {
       "title": "Global Language & Timezone",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -574,6 +574,8 @@
       "user": "普通用户",
       "language": "语言",
       "languageDesc": "用于界面显示和 AI 生成内容",
+      "releaseNotes": "更新日志",
+      "releaseNotesUnread": "有新的更新日志",
       "notifications": "通知",
       "notificationsDesc": "选择长时间运行的回答完成后，SourceLens 提醒你的方式。",
       "completionIndicator": "回答完成提醒",
@@ -592,6 +594,18 @@
       "assistantFallback": "当前助手",
       "noteTitle": "说明",
       "noteBody": "后续更多设置项会继续收拢到这里，当前只保留最常用的账户信息和语言选择。"
+    },
+    "releaseNotes": {
+      "currentVersion": "当前版本",
+      "releaseDate": "发布日期",
+      "entryCount": "{count} 项变更",
+      "adminOnly": "仅管理员",
+      "empty": "此版本没有面向用户的变更。",
+      "categories": {
+        "feature": "新功能",
+        "improvement": "改进",
+        "fix": "问题修复"
+      }
     },
     "preferences": {
       "title": "全局语言与时区",

--- a/frontend/src/store/ui.js
+++ b/frontend/src/store/ui.js
@@ -1,10 +1,46 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+
+import releaseNotesManifest from '@/generated/release-notes.json'
+import { useUserStore } from '@/store/user'
+import {
+  getReleaseNotesStorageKey,
+  hasReleaseNotesForAudience,
+  isReleaseNotesVersionUnread,
+  markReleaseNotesViewed as persistReleaseNotesViewed
+} from '@/utils/releaseNotes'
+
+function readViewedReleaseNotesVersion(isAdmin) {
+  if (typeof window === 'undefined') return ''
+  return window.localStorage.getItem(getReleaseNotesStorageKey(isAdmin)) || ''
+}
 
 export const useUiStore = defineStore('ui', () => {
   const adminSidebarScrollTop = ref(0)
   const settingsOpen = ref(false)
   const settingsTab = ref('profile')
+  const userStore = useUserStore()
+  const releaseNotesVersion = releaseNotesManifest.version || 'dev'
+  const isAdmin = computed(() => userStore.userHasFeature('admin_console'))
+  const viewedUserReleaseNotesVersion = ref(
+    readViewedReleaseNotesVersion(false)
+  )
+  const viewedAdminReleaseNotesVersion = ref(
+    readViewedReleaseNotesVersion(true)
+  )
+  const viewedReleaseNotesVersion = computed(() =>
+    isAdmin.value
+      ? viewedAdminReleaseNotesVersion.value
+      : viewedUserReleaseNotesVersion.value
+  )
+  const hasUnreadReleaseNotes = computed(
+    () =>
+      hasReleaseNotesForAudience(releaseNotesManifest, isAdmin.value) &&
+      isReleaseNotesVersionUnread(
+        releaseNotesVersion,
+        viewedReleaseNotesVersion.value
+      )
+  )
 
   const openSettings = (tab = 'profile') => {
     settingsTab.value = tab
@@ -15,8 +51,18 @@ export const useUiStore = defineStore('ui', () => {
     settingsOpen.value = false
   }
 
+  const markReleaseNotesViewed = () => {
+    persistReleaseNotesViewed(releaseNotesVersion, undefined, isAdmin.value)
+    const viewedVersion = isAdmin.value
+      ? viewedAdminReleaseNotesVersion
+      : viewedUserReleaseNotesVersion
+    viewedVersion.value = releaseNotesVersion
+  }
+
   return {
     adminSidebarScrollTop,
+    hasUnreadReleaseNotes,
+    markReleaseNotesViewed,
     settingsOpen,
     settingsTab,
     openSettings,

--- a/frontend/src/utils/releaseNotes.js
+++ b/frontend/src/utils/releaseNotes.js
@@ -1,0 +1,70 @@
+export const RELEASE_NOTES_STORAGE_KEY =
+  'sourcelens.releaseNotes.lastViewedVersion'
+
+const CATEGORY_ORDER = ['feature', 'improvement', 'fix']
+
+function browserStorage() {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+function isEntryVisible(entry, isAdmin) {
+  return entry?.audience === 'user' || (isAdmin && entry?.audience === 'admin')
+}
+
+export function getReleaseNotesStorageKey(isAdmin = false) {
+  const audience = isAdmin ? 'admin' : 'user'
+  return `${RELEASE_NOTES_STORAGE_KEY}.${audience}`
+}
+
+export function selectLocalizedReleaseNotes(manifest, locale, isAdmin = false) {
+  const language = locale === 'zh-CN' ? 'zh-CN' : 'en'
+  const categories = manifest?.categories || {}
+
+  return CATEGORY_ORDER.map((type) => {
+    const entries = Array.isArray(categories[type]) ? categories[type] : []
+    return {
+      type,
+      entries: entries
+        .filter((entry) => isEntryVisible(entry, isAdmin))
+        .map((entry) => ({
+          audience: entry.audience,
+          text: entry?.[language] || entry?.en || ''
+        }))
+        .filter((entry) => entry.text)
+    }
+  }).filter((group) => group.entries.length > 0)
+}
+
+export function hasReleaseNotesForAudience(manifest, isAdmin = false) {
+  const categories = manifest?.categories || {}
+  return CATEGORY_ORDER.some((type) => {
+    const entries = Array.isArray(categories[type]) ? categories[type] : []
+    return entries.some((entry) => isEntryVisible(entry, isAdmin))
+  })
+}
+
+export function hasUnreadReleaseNotes(
+  version,
+  storage = browserStorage(),
+  isAdmin = false
+) {
+  if (!storage) return false
+  return isReleaseNotesVersionUnread(
+    version,
+    storage.getItem(getReleaseNotesStorageKey(isAdmin))
+  )
+}
+
+export function isReleaseNotesVersionUnread(version, viewedVersion) {
+  if (!version || version === 'dev') return false
+  return viewedVersion !== version
+}
+
+export function markReleaseNotesViewed(
+  version,
+  storage = browserStorage(),
+  isAdmin = false
+) {
+  if (!version || version === 'dev' || !storage) return
+  storage.setItem(getReleaseNotesStorageKey(isAdmin), version)
+}

--- a/frontend/tests/releaseNotes.test.js
+++ b/frontend/tests/releaseNotes.test.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  hasReleaseNotesForAudience,
+  hasUnreadReleaseNotes,
+  markReleaseNotesViewed,
+  selectLocalizedReleaseNotes
+} from '../src/utils/releaseNotes.js'
+
+const manifest = {
+  version: '1.2.0',
+  releaseDate: '2026/08/03',
+  categories: {
+    feature: [
+      {
+        audience: 'user',
+        en: 'Added release notes.',
+        'zh-CN': '\u65b0\u589e\u66f4\u65b0\u65e5\u5fd7\u3002'
+      },
+      {
+        audience: 'admin',
+        en: 'Added an administrator control.',
+        'zh-CN': '\u65b0\u589e\u7ba1\u7406\u5458\u63a7\u5236\u9879\u3002'
+      }
+    ],
+    improvement: [
+      {
+        audience: 'user',
+        en: 'Improved fallback behavior.'
+      }
+    ],
+    fix: []
+  }
+}
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial))
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null
+    },
+    setItem(key, value) {
+      values.set(key, String(value))
+    }
+  }
+}
+
+test('selects the current locale with an English per-entry fallback', () => {
+  const groups = selectLocalizedReleaseNotes(manifest, 'zh-CN')
+
+  assert.deepEqual(groups, [
+    {
+      type: 'feature',
+      entries: [
+        {
+          audience: 'user',
+          text: '\u65b0\u589e\u66f4\u65b0\u65e5\u5fd7\u3002'
+        }
+      ]
+    },
+    {
+      type: 'improvement',
+      entries: [
+        {
+          audience: 'user',
+          text: 'Improved fallback behavior.'
+        }
+      ]
+    }
+  ])
+})
+
+test('falls back to English for unsupported locales', () => {
+  const groups = selectLocalizedReleaseNotes(manifest, 'fr')
+
+  assert.equal(groups[0].entries[0].text, 'Added release notes.')
+})
+
+test('includes administrator entries only for administrators', () => {
+  const userGroups = selectLocalizedReleaseNotes(manifest, 'en')
+  const adminGroups = selectLocalizedReleaseNotes(manifest, 'en', true)
+
+  assert.deepEqual(userGroups[0].entries, [
+    { audience: 'user', text: 'Added release notes.' }
+  ])
+  assert.deepEqual(adminGroups[0].entries, [
+    { audience: 'user', text: 'Added release notes.' },
+    { audience: 'admin', text: 'Added an administrator control.' }
+  ])
+})
+
+test('reports whether the current audience has visible release notes', () => {
+  const adminOnlyManifest = {
+    categories: {
+      feature: [{ audience: 'admin', en: 'Admin only.' }]
+    }
+  }
+
+  assert.equal(hasReleaseNotesForAudience(adminOnlyManifest), false)
+  assert.equal(hasReleaseNotesForAudience(adminOnlyManifest, true), true)
+})
+
+test('marks viewed versions independently for users and administrators', () => {
+  const storage = memoryStorage()
+
+  assert.equal(hasUnreadReleaseNotes('1.2.0', storage), true)
+  markReleaseNotesViewed('1.2.0', storage)
+  assert.equal(hasUnreadReleaseNotes('1.2.0', storage), false)
+  assert.equal(hasUnreadReleaseNotes('1.1.0', storage), true)
+  assert.equal(hasUnreadReleaseNotes('1.2.0', storage, true), true)
+  markReleaseNotesViewed('1.2.0', storage, true)
+  assert.equal(hasUnreadReleaseNotes('1.2.0', storage, true), false)
+})
+
+test('does not show an unread indicator for local development builds', () => {
+  assert.equal(hasUnreadReleaseNotes('dev', memoryStorage()), false)
+  assert.equal(hasUnreadReleaseNotes('', memoryStorage()), false)
+})
+
+test('settings integrates the release-note view and unread indicator', async () => {
+  const source = (path) =>
+    readFile(new URL(`../src/${path}`, import.meta.url), 'utf8')
+  const [modal, releaseNotesSettings, dock, store] = await Promise.all([
+    source('components/settings/UserSettingsModal.vue'),
+    source('components/settings/ReleaseNotesSettings.vue'),
+    source('components/lens/UserDock.vue'),
+    source('store/ui.js')
+  ])
+
+  assert.match(modal, /ReleaseNotesSettings/)
+  assert.match(modal, /activeSection === 'release-notes'/)
+  assert.match(modal, /markReleaseNotesViewed/)
+  assert.match(releaseNotesSettings, /userHasFeature\('admin_console'\)/)
+  assert.match(releaseNotesSettings, /isAdmin\.value/)
+  assert.match(releaseNotesSettings, /settings\.releaseNotes\.adminOnly/)
+  assert.match(dock, /hasUnreadReleaseNotes/)
+  assert.match(store, /release-notes\.json/)
+  assert.match(store, /getReleaseNotesStorageKey/)
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-django>=4.5.2",
+    "PyYAML>=6.0,<7.0",
     "black>=22.0.0",
     "flake8>=6.0.0",
     "isort>=5.12.0",

--- a/release-notes/221.yaml
+++ b/release-notes/221.yaml
@@ -1,0 +1,4 @@
+type: feature
+audience: user
+en: Added localized in-product release notes for the running SourceLens version.
+zh-CN: 新增当前 SourceLens 版本的本地化应用内更新日志。

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,30 @@
+# Release-note fragments
+
+Every pull request must either add a user-facing release-note fragment here or
+carry the `skip-release-note` label.
+
+Use the issue or pull-request number as the filename when possible:
+
+```yaml
+type: feature
+audience: user
+en: Added email and verification-code sign-in.
+zh-CN: 新增邮箱和验证码登录方式。
+```
+
+Supported types are `feature`, `improvement`, and `fix`. Both translations are
+required. Set `audience` to `user` for changes relevant to every user, or
+`admin` for administrator-only product changes. Administrators see both
+audiences in the application; other users see only `user` entries.
+
+Audience filtering is presentation targeting, not a confidentiality boundary.
+All fragments are embedded in the frontend image and included in the public
+GitHub Release, so keep each entry concise, user-facing, and free of customer
+data, credentials, infrastructure details, or unnecessary security details.
+
+Use `skip-release-note` only when a change has no user-visible product impact,
+such as tests, refactoring, CI maintenance, or internal documentation.
+
+Tag builds collect only fragments added after the previous `v*` tag. They
+generate the English GitHub Release body and embed the bilingual manifest in
+the frontend image.

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Validate and aggregate localized SourceLens release notes."""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+import yaml
+
+CATEGORY_ORDER = ("feature", "improvement", "fix")
+AUDIENCE_ORDER = ("user", "admin")
+CATEGORY_HEADINGS = {
+    "feature": "Features",
+    "improvement": "Improvements",
+    "fix": "Fixes",
+}
+FRAGMENT_FIELDS = {"type", "audience", "en", "zh-CN"}
+FRAGMENT_DIRECTORY = "release-notes"
+MAX_FRAGMENT_BYTES = 16 * 1024
+MAX_ENTRY_CHARACTERS = 1000
+
+ReleaseFragment = TypedDict(
+    "ReleaseFragment",
+    {"type": str, "audience": str, "en": str, "zh-CN": str},
+)
+LocalizedEntry = TypedDict(
+    "LocalizedEntry",
+    {"audience": str, "en": str, "zh-CN": str},
+)
+
+
+class ReleaseManifest(TypedDict):
+    """Build-time release-note manifest consumed by the frontend."""
+
+    version: str
+    releaseDate: str
+    categories: dict[str, list[LocalizedEntry]]
+
+
+class ReleaseNoteError(ValueError):
+    """Raised when release-note content or Git history is invalid."""
+
+
+def parse_fragment(path: str | Path) -> ReleaseFragment:
+    """Load and validate one release-note fragment from disk."""
+
+    fragment_path = Path(path)
+    try:
+        size = fragment_path.stat().st_size
+    except OSError as exc:
+        raise ReleaseNoteError(
+            f"unable to read {fragment_path}: {exc}"
+        ) from exc
+    if size > MAX_FRAGMENT_BYTES:
+        raise ReleaseNoteError(
+            f"{fragment_path} exceeds {MAX_FRAGMENT_BYTES} bytes"
+        )
+    try:
+        content = fragment_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ReleaseNoteError(
+            f"unable to read {fragment_path}: {exc}"
+        ) from exc
+    return parse_fragment_content(content, str(fragment_path))
+
+
+def parse_fragment_content(content: str, source: str) -> ReleaseFragment:
+    """Parse and validate a release-note YAML document."""
+
+    if len(content.encode("utf-8")) > MAX_FRAGMENT_BYTES:
+        raise ReleaseNoteError(f"{source} exceeds {MAX_FRAGMENT_BYTES} bytes")
+    try:
+        payload = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise ReleaseNoteError(f"invalid YAML in {source}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ReleaseNoteError(f"{source} must contain a YAML mapping")
+    if any(not isinstance(field, str) for field in payload):
+        raise ReleaseNoteError(f"{source} field names must be strings")
+
+    fields = set(payload)
+    missing = sorted(FRAGMENT_FIELDS - fields)
+    if missing:
+        raise ReleaseNoteError(
+            f"{source} missing required fields: {', '.join(missing)}"
+        )
+    unknown = sorted(fields - FRAGMENT_FIELDS)
+    if unknown:
+        raise ReleaseNoteError(
+            f"{source} contains unknown fields: {', '.join(unknown)}"
+        )
+
+    note_type = payload["type"]
+    if note_type not in CATEGORY_ORDER:
+        supported = ", ".join(CATEGORY_ORDER)
+        raise ReleaseNoteError(
+            f"{source} has unsupported type {note_type!r}; use {supported}"
+        )
+
+    audience = payload["audience"]
+    if audience not in AUDIENCE_ORDER:
+        supported = ", ".join(AUDIENCE_ORDER)
+        raise ReleaseNoteError(
+            f"{source} has unsupported audience {audience!r}; "
+            f"use {supported}"
+        )
+
+    fragment: ReleaseFragment = {
+        "type": note_type,
+        "audience": audience,
+        "en": "",
+        "zh-CN": "",
+    }
+    for language in ("en", "zh-CN"):
+        text = payload[language]
+        if not isinstance(text, str) or not text.strip():
+            raise ReleaseNoteError(
+                f"{source} field {language} must be a non-empty string"
+            )
+        normalized = " ".join(text.split())
+        if len(normalized) > MAX_ENTRY_CHARACTERS:
+            raise ReleaseNoteError(
+                f"{source} field {language} exceeds "
+                f"{MAX_ENTRY_CHARACTERS} characters"
+            )
+        fragment[language] = normalized
+    return fragment
+
+
+def build_manifest(
+    repo: str | Path,
+    tag: str,
+    version: str,
+    release_date: str,
+) -> ReleaseManifest:
+    """Build the deterministic manifest for one version tag."""
+
+    repository = Path(repo)
+    _ensure_ref(repository, tag)
+    previous_tag = find_previous_tag(repository, tag)
+    paths = collect_fragment_paths(repository, previous_tag, tag)
+    categories: dict[str, list[LocalizedEntry]] = {
+        category: [] for category in CATEGORY_ORDER
+    }
+
+    for path in paths:
+        content = _read_fragment_at_ref(repository, tag, path)
+        fragment = parse_fragment_content(content, path)
+        categories[fragment["type"]].append(
+            {
+                "audience": fragment["audience"],
+                "en": fragment["en"],
+                "zh-CN": fragment["zh-CN"],
+            }
+        )
+
+    return {
+        "version": version,
+        "releaseDate": release_date,
+        "categories": categories,
+    }
+
+
+def find_previous_tag(repo: str | Path, tag: str) -> str | None:
+    """Return the highest prior version tag reachable from ``tag``."""
+
+    current_commit = _git(repo, "rev-parse", f"{tag}^{{commit}}").strip()
+    tags = _git(
+        repo,
+        "tag",
+        "--merged",
+        current_commit,
+        "--sort=-version:refname",
+        "--list",
+        "v*",
+    ).splitlines()
+    for candidate in tags:
+        if candidate != tag:
+            return candidate
+    return None
+
+
+def collect_fragment_paths(
+    repo: str | Path,
+    start_ref: str | None,
+    end_ref: str,
+) -> list[str]:
+    """List fragments added after ``start_ref`` in deterministic order."""
+
+    if start_ref:
+        output = _git(
+            repo,
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            f"{start_ref}..{end_ref}",
+            "--",
+            FRAGMENT_DIRECTORY,
+        )
+    else:
+        output = _git(
+            repo,
+            "ls-tree",
+            "-r",
+            "--name-only",
+            end_ref,
+            "--",
+            FRAGMENT_DIRECTORY,
+        )
+    return sorted(
+        path
+        for path in output.splitlines()
+        if Path(path).suffix in {".yaml", ".yml"}
+    )
+
+
+def validate_pr(
+    repo: str | Path,
+    base_ref: str,
+    head_ref: str,
+    skip: bool,
+) -> list[str]:
+    """Require and validate new fragments, or accept an explicit opt-out."""
+
+    repository = Path(repo)
+    _ensure_ref(repository, base_ref)
+    _ensure_ref(repository, head_ref)
+    output = _git(
+        repository,
+        "diff",
+        "--diff-filter=A",
+        "--name-only",
+        f"{base_ref}...{head_ref}",
+        "--",
+        FRAGMENT_DIRECTORY,
+    )
+    paths = sorted(
+        path
+        for path in output.splitlines()
+        if Path(path).suffix in {".yaml", ".yml"}
+    )
+
+    if not paths and not skip:
+        raise ReleaseNoteError(
+            "add a release-note fragment or apply the "
+            "skip-release-note label"
+        )
+
+    for path in paths:
+        content = _read_fragment_at_ref(repository, head_ref, path)
+        parse_fragment_content(content, path)
+    return paths
+
+
+def render_release_body(manifest: ReleaseManifest) -> str:
+    """Render the English GitHub Release body for a manifest."""
+
+    lines = [
+        f"# SourceLens {manifest['version']}",
+        "",
+        f"Released {manifest['releaseDate']}.",
+    ]
+    has_entries = False
+    for category in CATEGORY_ORDER:
+        entries = manifest["categories"].get(category, [])
+        if not entries:
+            continue
+        has_entries = True
+        lines.extend(["", f"## {CATEGORY_HEADINGS[category]}", ""])
+        for entry in entries:
+            prefix = (
+                "**Administrators:** " if entry["audience"] == "admin" else ""
+            )
+            lines.append(f"- {prefix}{entry['en']}")
+
+    if not has_entries:
+        lines.extend(
+            ["", "No user-facing changes were included in this release."]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(
+    manifest: ReleaseManifest,
+    manifest_path: str | Path,
+    body_path: str | Path,
+) -> None:
+    """Write the JSON manifest and English release body."""
+
+    output_manifest = Path(manifest_path)
+    output_body = Path(body_path)
+    output_manifest.parent.mkdir(parents=True, exist_ok=True)
+    output_body.parent.mkdir(parents=True, exist_ok=True)
+    output_manifest.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    output_body.write_text(
+        render_release_body(manifest),
+        encoding="utf-8",
+    )
+
+
+def _read_fragment_at_ref(repo: str | Path, ref: str, path: str) -> str:
+    """Read a size-bounded fragment from one Git ref."""
+
+    object_name = f"{ref}:{path}"
+    size_text = _git(repo, "cat-file", "-s", object_name).strip()
+    try:
+        size = int(size_text)
+    except ValueError as exc:
+        raise ReleaseNoteError(
+            f"unable to determine fragment size for {path}"
+        ) from exc
+    if size > MAX_FRAGMENT_BYTES:
+        raise ReleaseNoteError(f"{path} exceeds {MAX_FRAGMENT_BYTES} bytes")
+    return _git(repo, "show", object_name)
+
+
+def _ensure_ref(repo: str | Path, ref: str) -> None:
+    try:
+        _git(repo, "rev-parse", "--verify", f"{ref}^{{commit}}")
+    except ReleaseNoteError as exc:
+        raise ReleaseNoteError(f"Git ref does not exist: {ref}") from exc
+
+
+def _git(repo: str | Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ReleaseNoteError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the release-note command-line parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser(
+        "validate-pr",
+        help="Validate the release-note decision for a pull request",
+    )
+    validate.add_argument("--repo", default=".")
+    validate.add_argument("--base", required=True)
+    validate.add_argument("--head", required=True)
+    validate.add_argument("--skip-release-note", action="store_true")
+
+    build = subparsers.add_parser(
+        "build",
+        help="Aggregate the release-note manifest for a version tag",
+    )
+    build.add_argument("--repo", default=".")
+    build.add_argument("--tag", required=True)
+    build.add_argument("--version", required=True)
+    build.add_argument("--release-date", required=True)
+    build.add_argument("--manifest", required=True)
+    build.add_argument("--body", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release-note command-line interface."""
+
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "validate-pr":
+            paths = validate_pr(
+                repo=args.repo,
+                base_ref=args.base,
+                head_ref=args.head,
+                skip=args.skip_release_note,
+            )
+            if paths:
+                print(f"Validated {len(paths)} release-note fragment(s).")
+            else:
+                print("Validated skip-release-note decision.")
+            return 0
+
+        manifest = build_manifest(
+            repo=Path(args.repo),
+            tag=args.tag,
+            version=args.version,
+            release_date=args.release_date,
+        )
+        write_artifacts(manifest, args.manifest, args.body)
+        count = sum(
+            len(entries) for entries in manifest["categories"].values()
+        )
+        print(f"Generated release notes with {count} fragment(s).")
+        return 0
+    except ReleaseNoteError as exc:
+        print(f"release-note error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -1,0 +1,279 @@
+"""Tests for the release-note build tooling."""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from scripts.release_notes import (
+    ReleaseNoteError,
+    build_manifest,
+    parse_fragment,
+    render_release_body,
+    validate_pr,
+)
+
+
+class ReleaseNotesTestCase(unittest.TestCase):
+    """Exercise fragment validation and Git range aggregation."""
+
+    def test_parse_fragment_requires_supported_type_and_translations(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            valid = root / "valid.yaml"
+            valid.write_text(
+                "type: feature\n"
+                "audience: user\n"
+                "en: Added localized release notes.\n"
+                "zh-CN: "
+                "\u65b0\u589e\u672c\u5730\u5316\u66f4\u65b0"
+                "\u65e5\u5fd7\u3002\n",
+                encoding="utf-8",
+            )
+            missing_translation = root / "missing.yaml"
+            missing_translation.write_text(
+                "type: fix\n" "audience: user\n" "en: Fixed the issue.\n",
+                encoding="utf-8",
+            )
+            invalid_type = root / "invalid.yaml"
+            invalid_type.write_text(
+                "type: security\n"
+                "audience: user\n"
+                "en: Hardened access.\n"
+                "zh-CN: \u52a0\u5f3a\u8bbf\u95ee\u63a7\u5236\u3002\n",
+                encoding="utf-8",
+            )
+            invalid_audience = root / "invalid-audience.yaml"
+            invalid_audience.write_text(
+                "type: improvement\n"
+                "audience: operator\n"
+                "en: Improved administration.\n"
+                "zh-CN: \u6539\u8fdb\u7ba1\u7406\u4f53\u9a8c\u3002\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                parse_fragment(valid),
+                {
+                    "type": "feature",
+                    "audience": "user",
+                    "en": "Added localized release notes.",
+                    "zh-CN": (
+                        "\u65b0\u589e\u672c\u5730\u5316\u66f4\u65b0"
+                        "\u65e5\u5fd7\u3002"
+                    ),
+                },
+            )
+            with self.assertRaisesRegex(
+                ReleaseNoteError,
+                "missing required fields: zh-CN",
+            ):
+                parse_fragment(missing_translation)
+            with self.assertRaisesRegex(
+                ReleaseNoteError,
+                "unsupported type",
+            ):
+                parse_fragment(invalid_type)
+            with self.assertRaisesRegex(
+                ReleaseNoteError,
+                "unsupported audience",
+            ):
+                parse_fragment(invalid_audience)
+
+    def test_parse_fragment_rejects_oversized_user_facing_text(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fragment = Path(directory) / "oversized.yaml"
+            fragment.write_text(
+                "type: feature\n"
+                "audience: user\n"
+                f"en: {'x' * 1001}\n"
+                "zh-CN: \u65b0\u529f\u80fd\u3002\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ReleaseNoteError,
+                "field en exceeds 1000 characters",
+            ):
+                parse_fragment(fragment)
+
+    def test_build_manifest_collects_only_new_fragments_since_previous_tag(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            self._git(repo, "init", "-b", "main")
+            self._git(repo, "config", "user.name", "Test User")
+            self._git(repo, "config", "user.email", "test@example.com")
+
+            notes = repo / "release-notes"
+            notes.mkdir()
+            old_fragment = notes / "100.yaml"
+            old_fragment.write_text(
+                "type: fix\n"
+                "audience: user\n"
+                "en: Fixed the old issue.\n"
+                "zh-CN: \u4fee\u590d\u65e7\u95ee\u9898\u3002\n",
+                encoding="utf-8",
+            )
+            self._commit_all(repo, "First release")
+            self._git(repo, "tag", "v1.0.0")
+
+            old_fragment.write_text(
+                "type: fix\n"
+                "audience: user\n"
+                "en: Edited historical text.\n"
+                "zh-CN: \u7f16\u8f91\u5386\u53f2\u6587\u672c\u3002\n",
+                encoding="utf-8",
+            )
+            (notes / "200.yaml").write_text(
+                "type: improvement\n"
+                "audience: admin\n"
+                "en: Improved release visibility.\n"
+                "zh-CN: "
+                "\u6539\u8fdb\u7248\u672c\u53d8\u66f4"
+                "\u53ef\u89c1\u6027\u3002\n",
+                encoding="utf-8",
+            )
+            self._commit_all(repo, "Second release")
+            self._git(repo, "tag", "v1.1.0")
+
+            manifest = build_manifest(
+                repo=repo,
+                tag="v1.1.0",
+                version="1.1.0",
+                release_date="2026/08/03",
+            )
+
+            self.assertEqual(manifest["version"], "1.1.0")
+            self.assertEqual(manifest["releaseDate"], "2026/08/03")
+            self.assertEqual(manifest["categories"]["feature"], [])
+            self.assertEqual(manifest["categories"]["fix"], [])
+            self.assertEqual(
+                manifest["categories"]["improvement"],
+                [
+                    {
+                        "audience": "admin",
+                        "en": "Improved release visibility.",
+                        "zh-CN": (
+                            "\u6539\u8fdb\u7248\u672c\u53d8\u66f4"
+                            "\u53ef\u89c1\u6027\u3002"
+                        ),
+                    }
+                ],
+            )
+
+    def test_release_body_uses_only_english_user_facing_text(
+        self,
+    ) -> None:
+        manifest = {
+            "version": "1.1.0",
+            "releaseDate": "2026/08/03",
+            "categories": {
+                "feature": [
+                    {
+                        "audience": "user",
+                        "en": "Added in-product release notes.",
+                        "zh-CN": (
+                            "\u65b0\u589e\u5e94\u7528\u5185\u66f4\u65b0"
+                            "\u65e5\u5fd7\u3002"
+                        ),
+                    }
+                ],
+                "improvement": [],
+                "fix": [
+                    {
+                        "audience": "admin",
+                        "en": "Fixed an administrator workflow.",
+                        "zh-CN": (
+                            "\u4fee\u590d\u7ba1\u7406\u5458"
+                            "\u5de5\u4f5c\u6d41\u7a0b\u3002"
+                        ),
+                    }
+                ],
+            },
+        }
+
+        body = render_release_body(manifest)
+
+        self.assertIn("## Features", body)
+        self.assertIn("Added in-product release notes.", body)
+        self.assertNotIn(
+            "\u65b0\u589e\u5e94\u7528\u5185\u66f4\u65b0\u65e5\u5fd7",
+            body,
+        )
+        self.assertIn("## Fixes", body)
+        self.assertIn(
+            "- **Administrators:** Fixed an administrator workflow.",
+            body,
+        )
+
+    def test_pr_requires_new_fragment_or_explicit_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            self._git(repo, "init", "-b", "main")
+            self._git(repo, "config", "user.name", "Test User")
+            self._git(repo, "config", "user.email", "test@example.com")
+            (repo / "README.md").write_text("initial\n", encoding="utf-8")
+            self._commit_all(repo, "Base")
+            base = self._git(repo, "rev-parse", "HEAD").stdout.strip()
+
+            (repo / "README.md").write_text("changed\n", encoding="utf-8")
+            self._commit_all(repo, "Head")
+            head = self._git(repo, "rev-parse", "HEAD").stdout.strip()
+
+            with self.assertRaisesRegex(
+                ReleaseNoteError,
+                "add a release-note fragment",
+            ):
+                validate_pr(repo, base, head, skip=False)
+            self.assertEqual(validate_pr(repo, base, head, skip=True), [])
+
+    def test_release_workflow_gives_github_cli_repository_context(
+        self,
+    ) -> None:
+        workflow_path = (
+            Path(__file__).resolve().parents[1]
+            / ".github"
+            / "workflows"
+            / "build_and_deploy.yml"
+        )
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        publish_steps = workflow["jobs"]["publish-release"]["steps"]
+        release_step = next(
+            step
+            for step in publish_steps
+            if step.get("name") == "Create or update GitHub Release"
+        )
+
+        self.assertEqual(
+            release_step["env"].get("GH_REPO"),
+            "${{ github.repository }}",
+        )
+
+    def _commit_all(self, repo: Path, message: str) -> None:
+        self._git(repo, "add", ".")
+        self._git(repo, "commit", "-m", message)
+
+    def _git(
+        self,
+        repo: Path,
+        *args: str,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
## Summary
- collect typed, audience-aware release-note fragments with required English and Simplified Chinese content
- generate deterministic tag manifests, publish English GitHub Release notes, and embed the matching manifest in the frontend image
- add a localized What's New view with administrator targeting, English fallback, and per-audience unread state

Closes #221

## Test plan
- [x] `python -m unittest scripts.test_release_notes` (6 tests, Python 3.12)
- [x] release-note PR validation against `origin/main`
- [x] `node --test tests/releaseNotes.test.js` (7 tests)
- [x] targeted ESLint, Black, isort, workflow YAML parsing, and `git diff --check`
- [x] `npm run build`
- [x] ego-browser task spaces 127 and 130: English and Chinese notes, current-version/unread behavior, 320 px layout, and user/admin audience filtering


___

### **PR Type**
Enhancement


___

### **Description**
- Add release-note fragment validation and aggregation tooling.

- Embed localized manifest in frontend builds.

- Add What's New view with unread indicator and audience filtering.

- Add CI workflows for PR validation and tag publishing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["PR Fragment"] --> Validate["validate-pr workflow"]
  Validate --> TagBuild["Tag Build (build_and_deploy)"]
  TagBuild --> Manifest["release-notes.json embedded"]
  Manifest --> Frontend["Frontend image build"]
  Frontend --> Display["What's New view"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>release_notes.py</strong><dd><code>Aggregate and validate release-note fragments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-a48d3ad4b76d29211660dccd798dc7ffc5035912eb7178f4728a89bc9c74b875">+409/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AdminHeader.vue</strong><dd><code>Add unread indicator dot to settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-72b027d627396e485c9cc13fc1b63078364fa57d249b1af9b940fef26d8e5334">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarQuickMenu.vue</strong><dd><code>Add unread indicator to quick menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-a9643e06699a868da4933fb08db868d59085202793f8cd19ef5664d3885c6af5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserDock.vue</strong><dd><code>Add unread indicator to user dock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-3af2b7b57c4fd4db8ba89ac090e204a86783c9801d13d30ff6cb164a5612a512">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReleaseNotesSettings.vue</strong><dd><code>New component for displaying release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-6daf4ab7971ff7db721014cca79cbfd486164840868cd6cfd0290d5b8b2ec452">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserSettingsModal.vue</strong><dd><code>Integrate release notes section and unread indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-aa6410cf6949d28f892578c56dc32520cf22ed90043fa5a4d5c266acc570041b">+44/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ui.js</strong><dd><code>Add release notes state and unread logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-2b1e00d550e83d55acf19427728fa2c6ad81d9feceb6b1b79f4bcbb608944243">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>releaseNotes.js</strong><dd><code>Utility functions for release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-0755a36cc42b175b090a514081da9f339f234d2c3a1fbd1764d3a6bf814f4002">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English i18n keys for release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese i18n keys for release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_release_notes.py</strong><dd><code>Unit tests for release-note tooling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-b5e60cb67dc1adda2d480943c5eb880774608cfb4dfad74c1b553cc0326e5b8d">+279/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>releaseNotes.test.js</strong><dd><code>Unit tests for release notes utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-682b44509c0593d4d27e4fbf44777979bf53c7585ee457b97c518338d4c8ba7e">+141/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>build_and_deploy.yml</strong><dd><code>Add release note generation and publish job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-8812abff9ed11e2e98d5066031a3181c6d44b28aea00f0d369532d5cb254650f">+116/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>release_notes.yml</strong><dd><code>New workflow for PR release-note validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-940d91b1f30a248f045914b0bf13b7088d8dcc7e200c3b288e797680bedab73c">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release-notes.json</strong><dd><code>Placeholder release-note manifest for dev</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-e534c7f518116f93594833404a7c5fedcc0ac0b0259f4e221149e9a5d3a8cce1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add PyYAML dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>221.yaml</strong><dd><code>Sample fragment for this PR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-bb1160716c4acd8c4d33b1b62a5b1d2fcfc6ce42a1abdfdb70b8c41e181a9a35">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Documentation for release-note fragments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/258/files#diff-59dc1c38fc0c20bd8a3e887f6ad443dab6264d015c428b83a710c4d20d54ed30">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

