### PR TITLE
Add MCP environment bindings and improve Assistant configuration

### DIFF
--- a/backend/lens/environment_variables.py
+++ b/backend/lens/environment_variables.py
@@ -5,7 +5,60 @@ from rest_framework import serializers
 
 
 ENVIRONMENT_KEY_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+ENVIRONMENT_REFERENCE_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
 ALLOWED_SKILL_API_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+
+def environment_references(value):
+    """Return environment variable names referenced by nested values."""
+
+    if isinstance(value, dict):
+        references = set()
+        for item in value.values():
+            references.update(environment_references(item))
+        return references
+    if isinstance(value, list):
+        references = set()
+        for item in value:
+            references.update(environment_references(item))
+        return references
+    if not isinstance(value, str):
+        return set()
+    return set(ENVIRONMENT_REFERENCE_RE.findall(value))
+
+
+def declared_environment_references(value, declarations):
+    """Return references backed by MCP environment declarations."""
+
+    declared_names = {
+        item.get("name")
+        for item in declarations or []
+        if isinstance(item, dict) and item.get("name")
+    }
+    return environment_references(value) & declared_names
+
+
+def expand_environment_references(value, environment):
+    """Expand available environment references in nested runtime values."""
+
+    if isinstance(value, dict):
+        return {
+            key: expand_environment_references(item, environment)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            expand_environment_references(item, environment)
+            for item in value
+        ]
+    if not isinstance(value, str):
+        return value
+    return ENVIRONMENT_REFERENCE_RE.sub(
+        lambda match: str(
+            environment.get(match.group(1), match.group(0))
+        ),
+        value,
+    )
 
 
 def validate_environment_schema(value):

--- a/backend/lens/migrations/0040_mcp_environment_bindings.py
+++ b/backend/lens/migrations/0040_mcp_environment_bindings.py
@@ -1,0 +1,27 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0039_runexecution_admission_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mcpserver",
+            name="environment",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name="assistantmcp",
+            name="environment_variable_set",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="mcp_bindings",
+                to="lens.environmentvariableset",
+            ),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -299,7 +299,7 @@ class Skill(TimestampedUUIDModel):
 
 
 class EnvironmentVariableSet(TimestampedUUIDModel):
-    """Reusable encrypted environment values for Skill bindings."""
+    """Reusable encrypted environment values for Skill and MCP bindings."""
 
     name = models.CharField(max_length=160, unique=True)
     description = models.TextField(blank=True, default="")
@@ -354,6 +354,7 @@ class MCPServer(TimestampedUUIDModel):
     transport = models.CharField(max_length=16, choices=Transport.choices)
     endpoint = models.CharField(max_length=500, blank=True, default="")
     config = models.JSONField(default=dict, blank=True)
+    environment = models.JSONField(default=list, blank=True)
     version = models.CharField(max_length=64, blank=True, default="1")
     enabled = models.BooleanField(default=True)
 
@@ -546,6 +547,13 @@ class AssistantMCP(models.Model):
         related_name="mcp_bindings",
     )
     mcp = models.ForeignKey(MCPServer, on_delete=models.PROTECT)
+    environment_variable_set = models.ForeignKey(
+        EnvironmentVariableSet,
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="mcp_bindings",
+    )
     enabled = models.BooleanField(default=True)
     load_config = models.JSONField(default=dict, blank=True)
 

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import PurePosixPath
 from urllib import parse
 
@@ -22,6 +23,8 @@ from .datasource_services import (
     validate_datasource_lensnode,
 )
 from .environment_variables import (
+    declared_environment_references,
+    environment_references,
     missing_required_environment_values,
     validate_environment_schema,
     validate_environment_values,
@@ -394,6 +397,12 @@ class McpBindingsField(serializers.Field):
                 and declaration.get("required")
                 and declaration.get("name")
             }
+            required_names.update(
+                declared_environment_references(
+                    {"endpoint": mcp.endpoint, "config": mcp.config},
+                    declarations,
+                )
+            )
             missing = sorted(
                 name
                 for name in required_names
@@ -1970,11 +1979,13 @@ class EnvironmentVariableSetSerializer(serializers.ModelSerializer):
 class MCPServerSerializer(serializers.ModelSerializer):
     """MCP server serializer."""
 
+    environment_references = serializers.SerializerMethodField()
     secret_mask = "********"
-    sensitive_key_fragments = {
+    sensitive_key_names = {
         "apikey",
         "authorization",
         "credential",
+        "credentials",
         "password",
         "passwd",
         "privatekey",
@@ -1991,6 +2002,7 @@ class MCPServerSerializer(serializers.ModelSerializer):
             "endpoint",
             "config",
             "environment",
+            "environment_references",
             "version",
             "enabled",
             "created_at",
@@ -2012,15 +2024,70 @@ class MCPServerSerializer(serializers.ModelSerializer):
 
         return validate_environment_schema(value)
 
-    def update(self, instance, validated_data):
-        """Preserve masked or blank sensitive values during edits."""
+    def get_environment_references(self, instance):
+        """Return referenced variable names without exposing configuration."""
 
-        if "config" in validated_data:
-            validated_data["config"] = self._merge_sensitive_values(
-                validated_data["config"],
-                instance.config or {},
+        return sorted(
+            declared_environment_references(
+                {"endpoint": instance.endpoint, "config": instance.config},
+                instance.environment,
             )
-        return super().update(instance, validated_data)
+        )
+
+    def validate(self, attrs):
+        """Require every MCP environment reference to be declared."""
+
+        attrs = super().validate(attrs)
+        if "config" in attrs:
+            attrs["config"] = self._merge_sensitive_values(
+                attrs["config"],
+                getattr(self.instance, "config", {}) or {},
+            )
+        endpoint = attrs.get(
+            "endpoint",
+            getattr(self.instance, "endpoint", ""),
+        )
+        config = attrs.get(
+            "config",
+            getattr(self.instance, "config", {}),
+        )
+        environment = attrs.get(
+            "environment",
+            getattr(self.instance, "environment", []),
+        )
+        declared = {
+            item["name"]
+            for item in environment or []
+            if isinstance(item, dict) and item.get("name")
+        }
+        references = environment_references(
+            {"endpoint": endpoint, "config": config}
+        )
+        existing_references = environment_references(
+            {
+                "endpoint": getattr(self.instance, "endpoint", ""),
+                "config": getattr(self.instance, "config", {}) or {},
+            }
+        )
+        existing_declared = {
+            item.get("name")
+            for item in getattr(self.instance, "environment", []) or []
+            if isinstance(item, dict) and item.get("name")
+        }
+        legacy_references = existing_references - existing_declared
+        undeclared = sorted(
+            references - declared - legacy_references
+        )
+        if undeclared:
+            raise serializers.ValidationError(
+                {
+                    "environment": (
+                        "Declare every referenced MCP environment variable: "
+                        f"{', '.join(undeclared)}."
+                    )
+                }
+            )
+        return attrs
 
     def to_representation(self, instance):
         """Mask sensitive MCP configuration values in every response."""
@@ -2040,10 +2107,36 @@ class MCPServerSerializer(serializers.ModelSerializer):
     @classmethod
     def _is_sensitive_key(cls, key):
         normalized = cls._normalize_key(key)
-        return any(
-            fragment in normalized
-            for fragment in cls.sensitive_key_fragments
+        if normalized in cls.sensitive_key_names:
+            return True
+        segmented_key = re.sub(
+            r"([a-z0-9])([A-Z])",
+            r"\1_\2",
+            str(key or ""),
         )
+        segments = [
+            segment.lower()
+            for segment in re.findall(r"[A-Za-z0-9]+", segmented_key)
+        ]
+        if any(
+            segment
+            in {
+                "authorization",
+                "credential",
+                "credentials",
+                "password",
+                "passwd",
+                "secret",
+            }
+            for segment in segments
+        ):
+            return True
+        if any(
+            pair in {("api", "key"), ("private", "key")}
+            for pair in zip(segments, segments[1:])
+        ):
+            return True
+        return bool(segments and segments[-1] == "token")
 
     @classmethod
     def _mask_sensitive_values(cls, value):
@@ -2080,6 +2173,14 @@ class MCPServerSerializer(serializers.ModelSerializer):
                 else None
             )
             if (
+                value == cls.secret_mask
+                and existing_value in (None, "")
+            ):
+                raise serializers.ValidationError(
+                    "Masked sensitive values require an existing value. "
+                    "Provide the new sensitive value."
+                )
+            if (
                 cls._is_sensitive_key(key)
                 and value in (None, "", cls.secret_mask)
                 and existing_value not in (None, "")
@@ -2094,21 +2195,119 @@ class MCPServerSerializer(serializers.ModelSerializer):
                 existing_items = (
                     existing_value if isinstance(existing_value, list) else []
                 )
-                merged[existing_key] = [
-                    cls._merge_sensitive_values(
-                        item,
-                        existing_items[index]
-                        if index < len(existing_items)
-                        and isinstance(existing_items[index], dict)
-                        else {},
+                if (
+                    cls._contains_sensitive_placeholder(
+                        value,
+                        existing_items,
                     )
-                    if isinstance(item, dict)
-                    else item
-                    for index, item in enumerate(value)
-                ]
+                    and not cls._masked_list_matches(value, existing_items)
+                ):
+                    raise serializers.ValidationError(
+                        "Lists containing masked sensitive values cannot be "
+                        "reordered or structurally edited. Provide every "
+                        "sensitive value to replace the list."
+                    )
+                merged[existing_key] = cls._merge_sensitive_list(
+                    value,
+                    existing_items,
+                )
             else:
                 merged[existing_key] = value
         return merged
+
+    @classmethod
+    def _merge_sensitive_list(cls, incoming, existing):
+        merged = []
+        for index, item in enumerate(incoming):
+            existing_item = existing[index] if index < len(existing) else None
+            if isinstance(item, dict):
+                merged.append(
+                    cls._merge_sensitive_values(
+                        item,
+                        existing_item
+                        if isinstance(existing_item, dict)
+                        else {},
+                    )
+                )
+            elif isinstance(item, list):
+                merged.append(
+                    cls._merge_sensitive_list(
+                        item,
+                        existing_item
+                        if isinstance(existing_item, list)
+                        else [],
+                    )
+                )
+            else:
+                merged.append(item)
+        return merged
+
+    @classmethod
+    def _contains_sensitive_placeholder(cls, value, existing=None):
+        if isinstance(value, dict):
+            existing_items = existing if isinstance(existing, dict) else {}
+            for key, item in value.items():
+                existing_key = key
+                if key not in existing_items:
+                    normalized_key = cls._normalize_key(key)
+                    existing_key = next(
+                        (
+                            candidate
+                            for candidate in existing_items
+                            if cls._normalize_key(candidate) == normalized_key
+                        ),
+                        key,
+                    )
+                existing_item = existing_items.get(existing_key)
+                if (
+                    cls._is_sensitive_key(key)
+                    and item in (None, "", cls.secret_mask)
+                    and existing_item not in (None, "")
+                ):
+                    return True
+                if cls._contains_sensitive_placeholder(item, existing_item):
+                    return True
+            return False
+        if isinstance(value, list):
+            existing_items = existing if isinstance(existing, list) else []
+            return any(
+                cls._contains_sensitive_placeholder(
+                    item,
+                    existing_items[index]
+                    if index < len(existing_items)
+                    else None,
+                )
+                for index, item in enumerate(value)
+            )
+        return False
+
+    @classmethod
+    def _masked_list_matches(cls, incoming, existing):
+        if isinstance(incoming, dict):
+            if (
+                not isinstance(existing, dict)
+                or incoming.keys() != existing.keys()
+            ):
+                return False
+            return all(
+                (
+                    cls._is_sensitive_key(key)
+                    and item in (None, "", cls.secret_mask)
+                    and existing[key] not in (None, "")
+                )
+                or cls._masked_list_matches(item, existing[key])
+                for key, item in incoming.items()
+            )
+        if isinstance(incoming, list):
+            return (
+                isinstance(existing, list)
+                and len(incoming) == len(existing)
+                and all(
+                    cls._masked_list_matches(item, existing[index])
+                    for index, item in enumerate(incoming)
+                )
+            )
+        return incoming == existing
 
 
 class GlobalSettingSerializer(serializers.ModelSerializer):

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -321,13 +321,25 @@ class McpBindingsField(serializers.Field):
     """Read/write field for assistant MCP bindings."""
 
     def to_representation(self, bindings):
-        bindings = bindings.select_related("mcp").all()
+        bindings = bindings.select_related(
+            "mcp", "environment_variable_set"
+        ).all()
         return [
             {
                 "mcp_uuid": str(binding.mcp.uuid),
                 "mcp_name": binding.mcp.name,
                 "enabled": binding.enabled,
                 "load_config": binding.load_config,
+                "environment_variable_set_uuid": (
+                    str(binding.environment_variable_set.uuid)
+                    if binding.environment_variable_set
+                    else None
+                ),
+                "environment_variable_set_name": (
+                    binding.environment_variable_set.name
+                    if binding.environment_variable_set
+                    else ""
+                ),
             }
             for binding in bindings
         ]
@@ -342,11 +354,73 @@ class McpBindingsField(serializers.Field):
                 raise serializers.ValidationError("Each binding must be an object.")
             if "mcp_uuid" not in item:
                 raise serializers.ValidationError("Missing mcp_uuid in binding.")
+            mcp = MCPServer.objects.filter(uuid=item["mcp_uuid"]).first()
+            if mcp is None:
+                raise serializers.ValidationError("MCP server does not exist.")
+            variable_set_uuid = item.get("environment_variable_set_uuid")
+            variable_set = None
+            if variable_set_uuid:
+                variable_set = EnvironmentVariableSet.objects.filter(
+                    uuid=variable_set_uuid,
+                    enabled=True,
+                ).first()
+                if variable_set is None:
+                    raise serializers.ValidationError(
+                        "The selected environment variable set is unavailable."
+                    )
+            environment_values = validate_environment_values(
+                item.get("environment_values")
+            )
+            declarations = mcp.environment or []
+            declared_names = {
+                declaration.get("name")
+                for declaration in declarations
+                if isinstance(declaration, dict)
+            }
+            unknown_names = sorted(set(environment_values) - declared_names)
+            if unknown_names:
+                raise serializers.ValidationError(
+                    "Environment values must be declared by the MCP server: "
+                    f'{", ".join(unknown_names)}.'
+                )
+            effective_values = (
+                variable_set.get_values() if variable_set is not None else {}
+            )
+            effective_values.update(environment_values)
+            required_names = {
+                declaration.get("name")
+                for declaration in declarations
+                if isinstance(declaration, dict)
+                and declaration.get("required")
+                and declaration.get("name")
+            }
+            missing = sorted(
+                name
+                for name in required_names
+                if not str(effective_values.get(name) or "")
+            )
+            enabled = item.get("enabled", True)
+            if enabled and missing:
+                raise serializers.ValidationError(
+                    "Add values for the required environment variables for "
+                    f'"{mcp.name}": {", ".join(missing)}.'
+                )
+            variable_set_name = str(
+                item.get("environment_variable_set_name") or ""
+            ).strip()
+            if len(variable_set_name) > 160:
+                raise serializers.ValidationError(
+                    "The environment variable set name must be 160 "
+                    "characters or fewer."
+                )
             validated.append(
                 {
                     "mcp_uuid": item["mcp_uuid"],
-                    "enabled": item.get("enabled", True),
+                    "enabled": enabled,
                     "load_config": item.get("load_config", {}),
+                    "environment_variable_set": variable_set,
+                    "environment_variable_set_name": variable_set_name,
+                    "environment_values": environment_values,
                 }
             )
         return validated
@@ -555,10 +629,16 @@ class AssistantSerializer(serializers.ModelSerializer):
         skill_bindings = validated_data.pop("skill_bindings", None)
         mcp_bindings = validated_data.pop("mcp_bindings", None)
 
-        if skill_bindings is not None:
+        binding_groups = [
+            bindings
+            for bindings in (skill_bindings, mcp_bindings)
+            if bindings is not None
+        ]
+        if binding_groups:
             variable_set_ids = {
                 binding["environment_variable_set"].pk
-                for binding in skill_bindings
+                for bindings in binding_groups
+                for binding in bindings
                 if binding.get("environment_variable_set") is not None
                 and binding.get("environment_values")
             }
@@ -569,12 +649,18 @@ class AssistantSerializer(serializers.ModelSerializer):
                 if variable_set_ids
                 else {}
             )
-            for binding in skill_bindings:
-                variable_set = binding.get("environment_variable_set")
-                if variable_set is not None:
-                    binding["environment_variable_set"] = (
-                        locked_variable_sets.get(variable_set.pk, variable_set)
-                    )
+            for bindings in binding_groups:
+                for binding in bindings:
+                    variable_set = binding.get("environment_variable_set")
+                    if variable_set is not None:
+                        binding["environment_variable_set"] = (
+                            locked_variable_sets.get(
+                                variable_set.pk,
+                                variable_set,
+                            )
+                        )
+
+        if skill_bindings is not None:
             assistant.skill_bindings.all().delete()
             for binding in skill_bindings:
                 skill = Skill.objects.get(uuid=binding["skill_uuid"])
@@ -595,14 +681,20 @@ class AssistantSerializer(serializers.ModelSerializer):
             assistant.mcp_bindings.all().delete()
             for binding in mcp_bindings:
                 mcp = MCPServer.objects.get(uuid=binding["mcp_uuid"])
+                variable_set = self._sync_environment_variable_set(
+                    assistant,
+                    mcp,
+                    binding,
+                )
                 AssistantMCP.objects.create(
                     assistant=assistant,
                     mcp=mcp,
+                    environment_variable_set=variable_set,
                     enabled=binding.get("enabled", True),
                     load_config=binding.get("load_config", {}),
                 )
 
-    def _sync_environment_variable_set(self, assistant, skill, binding):
+    def _sync_environment_variable_set(self, assistant, resource, binding):
         """Apply inline values without mutating another Assistant's set."""
 
         variable_set = binding.get("environment_variable_set")
@@ -612,13 +704,17 @@ class AssistantSerializer(serializers.ModelSerializer):
 
         merged_values = variable_set.get_values() if variable_set else {}
         merged_values.update(values)
-        if variable_set and not variable_set.skill_bindings.exists():
+        if (
+            variable_set
+            and not variable_set.skill_bindings.exists()
+            and not variable_set.mcp_bindings.exists()
+        ):
             variable_set.set_values(merged_values)
             variable_set.save(update_fields=["encrypted_values", "updated_at"])
             return variable_set
 
         requested_name = binding.get("environment_variable_set_name") or ""
-        base_name = requested_name or f"{assistant.name} · {skill.name}"
+        base_name = requested_name or f"{assistant.name} · {resource.name}"
         description = variable_set.description if variable_set else ""
         variable_set = EnvironmentVariableSet(
             name=self._next_environment_variable_set_name(base_name),
@@ -1790,6 +1886,7 @@ class EnvironmentVariableSetSerializer(serializers.ModelSerializer):
 
     values = serializers.JSONField(write_only=True, required=False)
     keys = serializers.ListField(read_only=True)
+    usages = serializers.SerializerMethodField()
 
     class Meta:
         model = EnvironmentVariableSet
@@ -1799,11 +1896,50 @@ class EnvironmentVariableSetSerializer(serializers.ModelSerializer):
             "description",
             "values",
             "keys",
+            "usages",
             "enabled",
             "created_at",
             "updated_at",
         ]
-        read_only_fields = ["uuid", "keys", "created_at", "updated_at"]
+        read_only_fields = [
+            "uuid",
+            "keys",
+            "usages",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_usages(self, variable_set):
+        """Return secret-safe Skill and MCP binding references."""
+
+        usages = [
+            {
+                "type": "skill",
+                "resource_uuid": str(binding.skill.uuid),
+                "resource_name": binding.skill.name,
+                "assistant_uuid": str(binding.assistant.uuid),
+                "assistant_name": binding.assistant.name,
+            }
+            for binding in variable_set.skill_bindings.all()
+        ]
+        usages.extend(
+            {
+                "type": "mcp",
+                "resource_uuid": str(binding.mcp.uuid),
+                "resource_name": binding.mcp.name,
+                "assistant_uuid": str(binding.assistant.uuid),
+                "assistant_name": binding.assistant.name,
+            }
+            for binding in variable_set.mcp_bindings.all()
+        )
+        return sorted(
+            usages,
+            key=lambda item: (
+                item["type"],
+                item["resource_name"].casefold(),
+                item["assistant_name"].casefold(),
+            ),
+        )
 
     def validate_values(self, value):
         """Validate environment variable names and scalar values."""
@@ -1834,6 +1970,18 @@ class EnvironmentVariableSetSerializer(serializers.ModelSerializer):
 class MCPServerSerializer(serializers.ModelSerializer):
     """MCP server serializer."""
 
+    secret_mask = "********"
+    sensitive_key_fragments = {
+        "apikey",
+        "authorization",
+        "credential",
+        "password",
+        "passwd",
+        "privatekey",
+        "secret",
+        "token",
+    }
+
     class Meta:
         model = MCPServer
         fields = [
@@ -1842,12 +1990,125 @@ class MCPServerSerializer(serializers.ModelSerializer):
             "transport",
             "endpoint",
             "config",
+            "environment",
             "version",
             "enabled",
             "created_at",
             "updated_at",
         ]
         read_only_fields = ["uuid", "created_at", "updated_at"]
+
+    def validate_config(self, value):
+        """Require MCP configuration to remain a key-value object."""
+
+        if not isinstance(value, dict):
+            raise serializers.ValidationError(
+                "MCP configuration must be an object."
+            )
+        return value
+
+    def validate_environment(self, value):
+        """Validate MCP environment declarations like Skill declarations."""
+
+        return validate_environment_schema(value)
+
+    def update(self, instance, validated_data):
+        """Preserve masked or blank sensitive values during edits."""
+
+        if "config" in validated_data:
+            validated_data["config"] = self._merge_sensitive_values(
+                validated_data["config"],
+                instance.config or {},
+            )
+        return super().update(instance, validated_data)
+
+    def to_representation(self, instance):
+        """Mask sensitive MCP configuration values in every response."""
+
+        payload = super().to_representation(instance)
+        payload["config"] = self._mask_sensitive_values(instance.config or {})
+        return payload
+
+    @classmethod
+    def _normalize_key(cls, key):
+        return "".join(
+            character.lower()
+            for character in str(key or "")
+            if character.isalnum()
+        )
+
+    @classmethod
+    def _is_sensitive_key(cls, key):
+        normalized = cls._normalize_key(key)
+        return any(
+            fragment in normalized
+            for fragment in cls.sensitive_key_fragments
+        )
+
+    @classmethod
+    def _mask_sensitive_values(cls, value):
+        if isinstance(value, dict):
+            masked = {}
+            for key, item in value.items():
+                if cls._is_sensitive_key(key) and item not in (None, ""):
+                    masked[key] = cls.secret_mask
+                else:
+                    masked[key] = cls._mask_sensitive_values(item)
+            return masked
+        if isinstance(value, list):
+            return [cls._mask_sensitive_values(item) for item in value]
+        return value
+
+    @classmethod
+    def _merge_sensitive_values(cls, incoming, existing):
+        merged = {}
+        for key, value in incoming.items():
+            existing_key = key
+            if isinstance(existing, dict) and key not in existing:
+                normalized_key = cls._normalize_key(key)
+                existing_key = next(
+                    (
+                        candidate
+                        for candidate in existing
+                        if cls._normalize_key(candidate) == normalized_key
+                    ),
+                    key,
+                )
+            existing_value = (
+                existing.get(existing_key)
+                if isinstance(existing, dict)
+                else None
+            )
+            if (
+                cls._is_sensitive_key(key)
+                and value in (None, "", cls.secret_mask)
+                and existing_value not in (None, "")
+            ):
+                merged[existing_key] = existing_value
+            elif isinstance(value, dict):
+                merged[existing_key] = cls._merge_sensitive_values(
+                    value,
+                    existing_value if isinstance(existing_value, dict) else {},
+                )
+            elif isinstance(value, list):
+                existing_items = (
+                    existing_value if isinstance(existing_value, list) else []
+                )
+                merged[existing_key] = [
+                    cls._merge_sensitive_values(
+                        item,
+                        existing_items[index]
+                        if index < len(existing_items)
+                        and isinstance(existing_items[index], dict)
+                        else {},
+                    )
+                    if isinstance(item, dict)
+                    else item
+                    for index, item in enumerate(value)
+                ]
+            else:
+                merged[existing_key] = value
+        return merged
 
 
 class GlobalSettingSerializer(serializers.ModelSerializer):

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -966,9 +966,9 @@ def build_loaded_mcps(assistant):
     """Snapshot active MCP bindings for LensNode dispatch."""
 
     loaded = []
-    for binding in assistant.mcp_bindings.select_related("mcp").filter(
-        enabled=True
-    ):
+    for binding in assistant.mcp_bindings.select_related(
+        "mcp", "environment_variable_set"
+    ).filter(enabled=True):
         loaded.append(
             {
                 "mcp_uuid": str(binding.mcp.uuid),
@@ -979,12 +979,19 @@ def build_loaded_mcps(assistant):
                         "transport": binding.mcp.transport,
                         "endpoint": binding.mcp.endpoint,
                         "config": binding.mcp.config,
+                        "environment": binding.mcp.environment,
                     }
                 ),
                 "transport": binding.mcp.transport,
                 "endpoint": binding.mcp.endpoint,
                 "config": binding.mcp.config,
                 "load_config": binding.load_config,
+                "environment_schema": binding.mcp.environment,
+                "environment_variable_set_uuid": (
+                    str(binding.environment_variable_set.uuid)
+                    if binding.environment_variable_set
+                    else None
+                ),
             }
         )
     return loaded
@@ -1024,6 +1031,35 @@ def resolve_loaded_skill_environment(loaded_skills):
         }
         runtime_skills.append(runtime_skill)
     return runtime_skills
+
+
+def resolve_loaded_mcp_environment(loaded_mcps):
+    """Add decrypted per-MCP values to an ephemeral runtime payload."""
+
+    runtime_mcps = []
+    for mcp in loaded_mcps or []:
+        runtime_mcp = dict(mcp)
+        variable_set_uuid = mcp.get("environment_variable_set_uuid")
+        variable_set = None
+        if variable_set_uuid:
+            variable_set = EnvironmentVariableSet.objects.filter(
+                uuid=variable_set_uuid,
+                enabled=True,
+            ).first()
+        values = variable_set.get_values() if variable_set else {}
+        declarations = mcp.get("environment_schema") or []
+        declared_names = {
+            item.get("name")
+            for item in declarations
+            if isinstance(item, dict) and item.get("name")
+        }
+        runtime_mcp["environment"] = {
+            name: str(values[name])
+            for name in declared_names
+            if name in values
+        }
+        runtime_mcps.append(runtime_mcp)
+    return runtime_mcps
 
 
 def task_names(lensnode):
@@ -1070,6 +1106,7 @@ def validate_run_dispatch(run):
         raise LensNodeDispatchError("LENSNODE_TASK_UNAVAILABLE")
 
     runtime_skills = resolve_loaded_skill_environment(execution.loaded_skills)
+    runtime_mcps = resolve_loaded_mcp_environment(execution.loaded_mcps)
     if execution.task == "general_chat":
         if not runtime_skills:
             raise LensNodeDispatchError("GENERAL_CHAT_SKILL_REQUIRED")
@@ -1091,6 +1128,19 @@ def validate_run_dispatch(run):
         values = skill.get("environment") or {}
         if any(not str(values.get(name) or "") for name in required):
             raise LensNodeDispatchError("SKILL_ENVIRONMENT_REQUIRED")
+
+    for mcp in runtime_mcps:
+        declarations = mcp.get("environment_schema") or []
+        required = {
+            item["name"]
+            for item in declarations
+            if isinstance(item, dict)
+            and item.get("required")
+            and item.get("name")
+        }
+        values = mcp.get("environment") or {}
+        if any(not str(values.get(name) or "") for name in required):
+            raise LensNodeDispatchError("MCP_ENVIRONMENT_REQUIRED")
 
 
 TOKEN_BUDGET_PROFILES = {
@@ -1616,7 +1666,9 @@ def dispatch_run_to_lensnode(
                 "loaded_skills": resolve_loaded_skill_environment(
                     execution.loaded_skills
                 ),
-                "loaded_mcps": execution.loaded_mcps,
+                "loaded_mcps": resolve_loaded_mcp_environment(
+                    execution.loaded_mcps
+                ),
                 "agent_model_ref": (
                     model_refs.get("agent")
                     or str(run.session.assistant.agent_model_ref or "")

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -28,6 +28,10 @@ from .document_attachments import (
     get_run_document_expectation,
     set_run_document_expectation,
 )
+from .environment_variables import (
+    declared_environment_references,
+    expand_environment_references,
+)
 from .llm import run_completion, run_completion_multimodal
 from .models import (
     Assistant,
@@ -1058,6 +1062,25 @@ def resolve_loaded_mcp_environment(loaded_mcps):
             for name in declared_names
             if name in values
         }
+        references = declared_environment_references(
+            {
+                "endpoint": mcp.get("endpoint"),
+                "config": mcp.get("config") or {},
+            },
+            declarations,
+        )
+        runtime_mcp["endpoint"] = expand_environment_references(
+            mcp.get("endpoint"),
+            runtime_mcp["environment"],
+        )
+        runtime_mcp["config"] = expand_environment_references(
+            mcp.get("config") or {},
+            runtime_mcp["environment"],
+        )
+        runtime_mcp["environment_resolved"] = all(
+            str(runtime_mcp["environment"].get(name) or "")
+            for name in references
+        )
         runtime_mcps.append(runtime_mcp)
     return runtime_mcps
 
@@ -1129,7 +1152,11 @@ def validate_run_dispatch(run):
         if any(not str(values.get(name) or "") for name in required):
             raise LensNodeDispatchError("SKILL_ENVIRONMENT_REQUIRED")
 
-    for mcp in runtime_mcps:
+    for mcp, snapshot_mcp in zip(
+        runtime_mcps,
+        execution.loaded_mcps or [],
+        strict=True,
+    ):
         declarations = mcp.get("environment_schema") or []
         required = {
             item["name"]
@@ -1139,7 +1166,17 @@ def validate_run_dispatch(run):
             and item.get("name")
         }
         values = mcp.get("environment") or {}
-        if any(not str(values.get(name) or "") for name in required):
+        referenced = declared_environment_references(
+            {
+                "endpoint": snapshot_mcp.get("endpoint"),
+                "config": snapshot_mcp.get("config") or {},
+            },
+            declarations,
+        )
+        if any(
+            not str(values.get(name) or "")
+            for name in required | referenced
+        ):
             raise LensNodeDispatchError("MCP_ENVIRONMENT_REQUIRED")
 
 

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -337,6 +337,188 @@ class LensApiTests(TestCase):
         self.assertEqual(response.data["config"]["api_key"], "********")
         self.assertNotIn("mcp-secret", str(response.data))
 
+    def test_mcp_api_preserves_non_secret_token_settings(self):
+        self.mcp.config = {
+            "github_token": "secret",
+            "max_tokens": 100,
+            "token_limit": 200,
+            "tokenizer": "cl100k_base",
+        }
+        self.mcp.save(update_fields=["config"])
+
+        response = self.client.get(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["config"]["github_token"], "********")
+        self.assertEqual(response.data["config"]["max_tokens"], 100)
+        self.assertEqual(response.data["config"]["token_limit"], 200)
+        self.assertEqual(response.data["config"]["tokenizer"], "cl100k_base")
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": response.data["config"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.mcp.refresh_from_db()
+        self.assertEqual(
+            self.mcp.config,
+            {
+                "github_token": "secret",
+                "max_tokens": 100,
+                "token_limit": 200,
+                "tokenizer": "cl100k_base",
+            },
+        )
+
+    def test_mcp_api_allows_blank_sensitive_fields_in_lists(self):
+        config = {"profiles": [{"name": "local", "token": ""}]}
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": config},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["config"], config)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config, config)
+
+    def test_mcp_api_protects_masked_list_item_identity(self):
+        self.mcp.config = {
+            "region": "us-east-1",
+            "profiles": [
+                {"name": "production", "token": "production-secret"},
+                {"name": "staging", "token": "staging-secret"},
+            ]
+        }
+        self.mcp.save(update_fields=["config"])
+
+        detail = self.client.get(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/"
+        )
+        unchanged = detail.data["config"]
+        unchanged["region"] = "eu-west-1"
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": unchanged},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config["region"], "eu-west-1")
+        self.assertEqual(
+            [item["token"] for item in self.mcp.config["profiles"]],
+            ["production-secret", "staging-secret"],
+        )
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {
+                "config": {
+                    "profiles": [
+                        {"name": "staging", "token": "********"},
+                        {"name": "production", "token": "********"},
+                    ]
+                }
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mcp.refresh_from_db()
+        self.assertEqual(
+            self.mcp.config["profiles"],
+            [
+                {"name": "production", "token": "production-secret"},
+                {"name": "staging", "token": "staging-secret"},
+            ],
+        )
+
+        self.mcp.config = {
+            "profiles": [
+                {"name": "production", "api_key": "production-secret"},
+                {"name": "staging", "api_key": "staging-secret"},
+            ]
+        }
+        self.mcp.save(update_fields=["config"])
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {
+                "config": {
+                    "profiles": [
+                        {"name": "staging", "api-key": "********"},
+                        {
+                            "name": "production",
+                            "api-key": "********",
+                        },
+                    ]
+                }
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mcp.refresh_from_db()
+        self.assertEqual(
+            self.mcp.config["profiles"],
+            [
+                {"name": "production", "api_key": "production-secret"},
+                {"name": "staging", "api_key": "staging-secret"},
+            ],
+        )
+
+    def test_mcp_api_preserves_masked_secrets_in_nested_lists(self):
+        self.mcp.config = {
+            "groups": [[{"name": "production", "token": "secret"}]]
+        }
+        self.mcp.save(update_fields=["config"])
+
+        detail = self.client.get(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/"
+        )
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": detail.data["config"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.mcp.refresh_from_db()
+        self.assertEqual(
+            self.mcp.config,
+            {"groups": [[{"name": "production", "token": "secret"}]]},
+        )
+
+    def test_mcp_api_rejects_mask_for_renamed_sensitive_key(self):
+        self.mcp.config = {"api_key": "secret"}
+        self.mcp.save(update_fields=["config"])
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": {"access_token": "********"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config, {"api_key": "secret"})
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"config": {"auth": "********"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config, {"api_key": "secret"})
+
     def test_mcp_api_accepts_environment_declarations(self):
         environment = [
             {
@@ -358,7 +540,109 @@ class LensApiTests(TestCase):
         self.assertEqual(self.mcp.environment, environment)
         self.assertEqual(response.data["environment"], environment)
 
+    def test_mcp_api_rejects_undeclared_environment_references(self):
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {
+                "endpoint": "https://${MCP_HOST}/api",
+                "environment": [],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("MCP_HOST", str(response.data))
+
+    def test_mcp_api_preserves_legacy_literal_environment_references(self):
+        self.mcp.endpoint = "https://mcp.example.com/${API_VERSION}"
+        self.mcp.config = {"template": "${LITERAL}"}
+        self.mcp.save(update_fields=["endpoint", "config"])
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"name": "Legacy Template MCP"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["environment_references"], [])
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(session, "Use legacy MCP", enqueue=False)
+
+        validate_run_dispatch(run)
+        runtime = resolve_loaded_mcp_environment(run.execution.loaded_mcps)
+
+        self.assertEqual(
+            runtime[0]["endpoint"],
+            "https://mcp.example.com/${API_VERSION}",
+        )
+        self.assertEqual(runtime[0]["config"], {"template": "${LITERAL}"})
+        self.assertTrue(runtime[0]["environment_resolved"])
+
+    def test_mcp_api_validates_references_after_restoring_secrets(self):
+        self.mcp.config = {"api_token": "${MCP_TOKEN}"}
+        self.mcp.environment = [
+            {
+                "name": "MCP_TOKEN",
+                "required": False,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["config", "environment"])
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {
+                "config": {"api_token": "********"},
+                "environment": [],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("MCP_TOKEN", str(response.data))
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config, {"api_token": "${MCP_TOKEN}"})
+        self.assertEqual(len(self.mcp.environment), 1)
+
+    def test_mcp_api_exposes_secret_safe_environment_references(self):
+        self.mcp.config = {
+            "headers": {"Authorization": "Bearer ${MCP_TOKEN}"}
+        }
+        self.mcp.environment = [
+            {
+                "name": "MCP_TOKEN",
+                "required": False,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["config", "environment"])
+
+        response = self.client.get(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(
+            response.data["config"]["headers"]["Authorization"],
+            "********",
+        )
+        self.assertEqual(
+            response.data["environment_references"],
+            ["MCP_TOKEN"],
+        )
+
     def test_assistant_mcp_resolves_environment_without_leaking(self):
+        self.mcp.config = {
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"}
+        }
         self.mcp.environment = [
             {
                 "name": "GITHUB_TOKEN",
@@ -367,7 +651,7 @@ class LensApiTests(TestCase):
                 "secret": True,
             }
         ]
-        self.mcp.save(update_fields=["environment"])
+        self.mcp.save(update_fields=["config", "environment"])
 
         response = self.client.patch(
             f"/api/lens/assistants/{self.assistant.uuid}/",
@@ -404,6 +688,69 @@ class LensApiTests(TestCase):
             runtime[0]["environment"],
             {"GITHUB_TOKEN": "runtime-secret"},
         )
+        self.assertEqual(
+            runtime[0]["config"]["headers"]["Authorization"],
+            "Bearer runtime-secret",
+        )
+        self.assertTrue(runtime[0]["environment_resolved"])
+
+    def test_dispatch_preserves_references_inside_mcp_environment_values(self):
+        self.mcp.config = {
+            "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"}
+        }
+        self.mcp.environment = [
+            {
+                "name": "GITHUB_TOKEN",
+                "required": True,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["config", "environment"])
+        variable_set = EnvironmentVariableSet.objects.create(
+            name="GitHub token with literal reference"
+        )
+        variable_set.set_values(
+            {"GITHUB_TOKEN": "runtime-${HOME}-secret"}
+        )
+        variable_set.save(update_fields=["encrypted_values"])
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+            environment_variable_set=variable_set,
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(session, "Search GitHub", enqueue=False)
+
+        validate_run_dispatch(run)
+        runtime = resolve_loaded_mcp_environment(run.execution.loaded_mcps)
+
+        self.assertEqual(
+            runtime[0]["config"]["headers"]["Authorization"],
+            "Bearer runtime-${HOME}-secret",
+        )
+
+    def test_assistant_requires_referenced_optional_mcp_environment(self):
+        self.mcp.endpoint = "https://${MCP_TOKEN}/api"
+        self.mcp.environment = [
+            {
+                "name": "MCP_TOKEN",
+                "required": False,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["endpoint", "environment"])
+
+        response = self.client.patch(
+            f"/api/lens/assistants/{self.assistant.uuid}/",
+            {"mcp_bindings": [{"mcp_uuid": str(self.mcp.uuid)}]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("MCP_TOKEN", str(response.data))
 
     def test_environment_variable_set_lists_skill_and_mcp_usages(self):
         variable_set = EnvironmentVariableSet.objects.create(
@@ -1991,6 +2338,36 @@ class LensApiTests(TestCase):
             str(context.exception),
             "MCP_ENVIRONMENT_REQUIRED",
         )
+
+    def test_dispatch_requires_optional_mcp_environment_when_referenced(self):
+        self.mcp.endpoint = "https://${MCP_TOKEN}/api"
+        self.mcp.environment = [
+            {
+                "name": "MCP_TOKEN",
+                "required": False,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["endpoint", "environment"])
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(session, "Search API", enqueue=False)
+
+        with self.assertRaises(LensNodeDispatchError) as context:
+            validate_run_dispatch(run)
+
+        self.assertEqual(
+            str(context.exception),
+            "MCP_ENVIRONMENT_REQUIRED",
+        )
+        runtime = resolve_loaded_mcp_environment(run.execution.loaded_mcps)
+        self.assertFalse(runtime[0]["environment_resolved"])
 
     def test_dispatch_rejects_run_queued_before_assistant_was_archived(self):
         session = Session.objects.create(

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -39,6 +39,7 @@ from lens.lensnode_auth import hash_lensnode_token
 from lens.models import (
     Assistant,
     AssistantAccess,
+    AssistantMCP,
     AssistantSkill,
     DataSource,
     DataSourceCredential,
@@ -62,8 +63,10 @@ from lens.serializers import (
 )
 from lens.services import (
     LensNodeDispatchError,
+    build_loaded_mcps,
     build_loaded_skills,
     create_execution_run,
+    resolve_loaded_mcp_environment,
     resolve_loaded_skill_environment,
     validate_run_dispatch,
 )
@@ -279,6 +282,176 @@ class LensApiTests(TestCase):
             transport="url",
             endpoint="https://mcp.example.com/github",
         )
+
+    def test_mcp_api_masks_sensitive_config_and_preserves_masked_updates(self):
+        self.mcp.config = {
+            "api_key": "mcp-secret-key",
+            "region": "us-east-1",
+            "headers": {
+                "Authorization": "Bearer mcp-secret-token",
+                "X-Client": "sourcelens",
+            },
+        }
+        self.mcp.save(update_fields=["config"])
+
+        response = self.client.get(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["config"]["api_key"], "********")
+        self.assertEqual(
+            response.data["config"]["headers"]["Authorization"],
+            "********",
+        )
+        self.assertEqual(response.data["config"]["region"], "us-east-1")
+        self.assertNotIn("mcp-secret", str(response.data))
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {
+                "config": {
+                    "api_key": "",
+                    "region": "eu-west-1",
+                    "headers": {
+                        "Authorization": "********",
+                        "X-Client": "updated-client",
+                    },
+                }
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.config["api_key"], "mcp-secret-key")
+        self.assertEqual(
+            self.mcp.config["headers"]["Authorization"],
+            "Bearer mcp-secret-token",
+        )
+        self.assertEqual(self.mcp.config["region"], "eu-west-1")
+        self.assertEqual(
+            self.mcp.config["headers"]["X-Client"],
+            "updated-client",
+        )
+        self.assertEqual(response.data["config"]["api_key"], "********")
+        self.assertNotIn("mcp-secret", str(response.data))
+
+    def test_mcp_api_accepts_environment_declarations(self):
+        environment = [
+            {
+                "name": "GITHUB_TOKEN",
+                "description": "GitHub access token",
+                "required": True,
+                "secret": True,
+            }
+        ]
+
+        response = self.client.patch(
+            f"/api/lens/admin/mcp-servers/{self.mcp.uuid}/",
+            {"environment": environment},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.mcp.refresh_from_db()
+        self.assertEqual(self.mcp.environment, environment)
+        self.assertEqual(response.data["environment"], environment)
+
+    def test_assistant_mcp_resolves_environment_without_leaking(self):
+        self.mcp.environment = [
+            {
+                "name": "GITHUB_TOKEN",
+                "description": "GitHub access token",
+                "required": True,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["environment"])
+
+        response = self.client.patch(
+            f"/api/lens/assistants/{self.assistant.uuid}/",
+            {
+                "mcp_bindings": [
+                    {
+                        "mcp_uuid": str(self.mcp.uuid),
+                        "environment_variable_set_name": "GitHub MCP",
+                        "environment_values": [
+                            {
+                                "key": "GITHUB_TOKEN",
+                                "value": "runtime-secret",
+                            }
+                        ],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertNotIn("runtime-secret", str(response.data))
+        binding = self.assistant.mcp_bindings.get(mcp=self.mcp)
+        self.assertEqual(
+            binding.environment_variable_set.get_values(),
+            {"GITHUB_TOKEN": "runtime-secret"},
+        )
+
+        loaded = build_loaded_mcps(self.assistant)
+        runtime = resolve_loaded_mcp_environment(loaded)
+
+        self.assertNotIn("runtime-secret", str(loaded))
+        self.assertEqual(
+            runtime[0]["environment"],
+            {"GITHUB_TOKEN": "runtime-secret"},
+        )
+
+    def test_environment_variable_set_lists_skill_and_mcp_usages(self):
+        variable_set = EnvironmentVariableSet.objects.create(
+            name="Shared Integration Credentials"
+        )
+        variable_set.set_values({"TOKEN": "secret-value"})
+        variable_set.save(update_fields=["encrypted_values"])
+        AssistantSkill.objects.create(
+            assistant=self.assistant,
+            skill=self.skill,
+            environment_variable_set=variable_set,
+        )
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+            environment_variable_set=variable_set,
+        )
+
+        response = self.client.get(
+            "/api/lens/admin/environment-variable-sets/"
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        row = next(
+            item
+            for item in response.data["results"]
+            if item["uuid"] == str(variable_set.uuid)
+        )
+        self.assertEqual(
+            row["usages"],
+            [
+                {
+                    "type": "mcp",
+                    "resource_uuid": str(self.mcp.uuid),
+                    "resource_name": self.mcp.name,
+                    "assistant_uuid": str(self.assistant.uuid),
+                    "assistant_name": self.assistant.name,
+                },
+                {
+                    "type": "skill",
+                    "resource_uuid": str(self.skill.uuid),
+                    "resource_name": self.skill.name,
+                    "assistant_uuid": str(self.assistant.uuid),
+                    "assistant_name": self.assistant.name,
+                },
+            ],
+        )
+        self.assertNotIn("secret-value", str(response.data))
 
     def test_assistant_create_saves_lensnode_and_bindings(self):
         payload = {
@@ -1791,6 +1964,33 @@ class LensApiTests(TestCase):
             build_loaded_skills(self.assistant)
         )
         self.assertEqual(runtime[0]["environment"], {})
+
+    def test_dispatch_rejects_missing_mcp_environment(self):
+        self.mcp.environment = [
+            {
+                "name": "GITHUB_TOKEN",
+                "required": True,
+                "secret": True,
+            }
+        ]
+        self.mcp.save(update_fields=["environment"])
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+        )
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(session, "Search GitHub", enqueue=False)
+
+        with self.assertRaises(LensNodeDispatchError) as context:
+            validate_run_dispatch(run)
+
+        self.assertEqual(
+            str(context.exception),
+            "MCP_ENVIRONMENT_REQUIRED",
+        )
 
     def test_dispatch_rejects_run_queued_before_assistant_was_archived(self):
         session = Session.objects.create(

--- a/backend/lens/views/environment_variables.py
+++ b/backend/lens/views/environment_variables.py
@@ -9,9 +9,14 @@ from .base import BaseAdminViewSet
 
 
 class EnvironmentVariableSetViewSet(BaseAdminViewSet):
-    """Admin-only CRUD for encrypted Skill environment values."""
+    """Admin-only CRUD for encrypted Skill and MCP environment values."""
 
-    queryset = EnvironmentVariableSet.objects.all()
+    queryset = EnvironmentVariableSet.objects.prefetch_related(
+        "skill_bindings__skill",
+        "skill_bindings__assistant",
+        "mcp_bindings__mcp",
+        "mcp_bindings__assistant",
+    )
     serializer_class = EnvironmentVariableSetSerializer
 
     def destroy(self, request, *args, **kwargs):

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -823,6 +823,12 @@
         "action": "Create Setting"
       }
     },
+    "mcp": {
+      "secretConfigured": "Configured",
+      "sensitiveConfigHint": "Password, secret, token, API key, authorization, credential, and private-key values are masked. Leave a masked value unchanged to keep it, enter a new value to replace it, or remove the row to clear it.",
+      "environmentVariablesHelp": "List the variables this MCP Server needs. You'll provide their values when adding the MCP Server to an Assistant.",
+      "environmentPlaceholderHint": "Reference a declared variable in the endpoint or Config with {placeholder}. SourceLens expands it only in the private per-Run MCP configuration."
+    },
     "skills": {
       "beautify": "Beautify",
       "beautifyHint": "Polish or generate the SKILL.md with the configured generator model",
@@ -919,6 +925,10 @@
     "environmentVariables": {
       "empty": "No variable sets yet.",
       "keys": "Variables",
+      "usages": "Referenced by",
+      "skillUsage": "Skill",
+      "mcpUsage": "MCP",
+      "assistantUsage": "Assistant: {name}",
       "values": "Environment variables",
       "value": "Value",
       "addValue": "Add variable",
@@ -1514,6 +1524,12 @@
       "skillsSection": "Skills",
       "skillsSectionRequired": "Skills *",
       "generalChatSkillsHint": "Select at least one Skill. General Chat runs from bound Skill instructions, bundled scripts, and declared executable Artifacts.",
+      "searchSkills": "Search Skills",
+      "skillSearchResults": "Showing {count} of {total} Skills",
+      "noMatchingSkills": "No Skills match your search",
+      "environmentSection": "Environment variables",
+      "environmentSectionHint": "These values apply only to this Skill. Configure every required variable before continuing.",
+      "environmentRequired": "Required",
       "environmentConfiguration": "Environment variables",
       "environmentConfigurationHint": "This Skill needs {count} environment variables. Choose an existing variable set or create a new one.",
       "selectEnvironmentSet": "Choose a variable set",
@@ -1522,6 +1538,8 @@
       "environmentConfigured": "Saved",
       "environmentMissing": "Not set",
       "mcpSection": "MCP Servers",
+      "mcpEnvironmentSectionHint": "These values apply only to this MCP Server. Configure every required variable before continuing.",
+      "mcpEnvironmentConfigurationHint": "This MCP Server needs {count} environment variables. Choose an existing variable set or create a new one.",
       "noSkills": "No Skills available — create one in the Skill Library first",
       "noMcp": "No MCP Servers available — create one in the MCP Server Library first",
       "visibilityHint": "Admins can always access every assistant."

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -823,6 +823,12 @@
         "action": "新建配置"
       }
     },
+    "mcp": {
+      "secretConfigured": "已配置",
+      "sensitiveConfigHint": "密码、Secret、Token、API Key、Authorization、Credential 和私钥配置会以掩码显示。保留掩码表示不修改，输入新值表示覆盖，删除该行表示清除。",
+      "environmentVariablesHelp": "添加此 MCP Server 运行所需的变量；将 MCP Server 绑定到 Assistant 时再填写变量值。",
+      "environmentPlaceholderHint": "可在 Endpoint 或 Config 中使用 {placeholder} 引用已声明变量；SourceLens 只会在每次 Run 的私有 MCP 配置中解析。"
+    },
     "skills": {
       "beautify": "一键美化",
       "beautifyHint": "使用已配置的 Skill 生成模型润色 / 生成 SKILL.md 内容",
@@ -919,6 +925,10 @@
     "environmentVariables": {
       "empty": "暂无环境变量配置集。",
       "keys": "变量 Key",
+      "usages": "引用方",
+      "skillUsage": "Skill",
+      "mcpUsage": "MCP",
+      "assistantUsage": "Assistant：{name}",
       "values": "变量值",
       "value": "变量值",
       "addValue": "＋ 添加变量",
@@ -1514,6 +1524,12 @@
       "skillsSection": "Skills",
       "skillsSectionRequired": "Skills *",
       "generalChatSkillsHint": "请至少选择一个 Skill。通用对话会根据绑定 Skill 的指令、包内脚本和声明的可执行 Artifact 运行。",
+      "searchSkills": "搜索 Skills",
+      "skillSearchResults": "显示 {count} / {total} 个 Skills",
+      "noMatchingSkills": "没有匹配的 Skills",
+      "environmentSection": "环境变量",
+      "environmentSectionHint": "这些配置仅对当前 Skill 生效；继续前需配置全部必填变量。",
+      "environmentRequired": "必填",
       "environmentConfiguration": "环境配置",
       "environmentConfigurationHint": "该 Skill 声明了 {count} 个环境变量。请选择已有配置集，或在这里新建。",
       "selectEnvironmentSet": "请选择配置集",
@@ -1522,6 +1538,8 @@
       "environmentConfigured": "已保存",
       "environmentMissing": "未配置",
       "mcpSection": "MCP Servers",
+      "mcpEnvironmentSectionHint": "这些配置仅对当前 MCP Server 生效；继续前需配置全部必填变量。",
+      "mcpEnvironmentConfigurationHint": "该 MCP Server 声明了 {count} 个环境变量。请选择已有配置集，或在这里新建。",
       "noSkills": "暂无可用 Skill，请先在 Skill 资源库中创建",
       "noMcp": "暂无可用 MCP Server，请先在 MCP Server 资源库中创建",
       "visibilityHint": "管理员始终可访问全部助手。"

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -325,10 +325,12 @@ export async function deleteCredential(uuid) {
 }
 
 export async function listEnvironmentVariableSets() {
-  const response = await api.get('/lens/admin/environment-variable-sets/', {
-    params: { page_size: 10000 }
+  return collectPaginatedResults(async (page) => {
+    const response = await api.get('/lens/admin/environment-variable-sets/', {
+      params: { page_size: 1000, page }
+    })
+    return unwrapResponse(response)
   })
-  return unwrapList(unwrapResponse(response))
 }
 
 export async function createEnvironmentVariableSet(payload) {
@@ -392,8 +394,12 @@ export async function cancelDataSourceSync(uuid) {
 }
 
 export async function listSkills() {
-  const response = await api.get('/lens/admin/skills/')
-  return unwrapList(unwrapResponse(response))
+  return collectPaginatedResults(async (page) => {
+    const response = await api.get('/lens/admin/skills/', {
+      params: { page_size: 1000, page }
+    })
+    return unwrapResponse(response)
+  })
 }
 
 export async function createSkill(payload) {
@@ -476,8 +482,12 @@ export async function beautifySkill(payload) {
 }
 
 export async function listMcpServers() {
-  const response = await api.get('/lens/admin/mcp-servers/')
-  return unwrapList(unwrapResponse(response))
+  return collectPaginatedResults(async (page) => {
+    const response = await api.get('/lens/admin/mcp-servers/', {
+      params: { page_size: 1000, page }
+    })
+    return unwrapResponse(response)
+  })
 }
 
 export async function createMcpServer(payload) {

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -312,156 +312,210 @@
         <p v-if="isGeneralChatTask" class="mb-2 text-xs text-ink-500">
           {{ t('lensAdmin.wizard.generalChatSkillsHint') }}
         </p>
-        <div
-          v-if="selectableSkills.length"
-          class="space-y-2 rounded-md border border-line bg-surface-sunken p-2"
-        >
-          <template v-for="skill in selectableSkills" :key="skill.uuid">
-            <label
-              class="group flex cursor-pointer items-start gap-3 rounded-md border bg-surface px-3 py-2.5 transition-colors hover:border-primary-200 hover:bg-primary-50/40"
+        <div v-if="selectableSkills.length" class="space-y-2">
+          <div class="relative">
+            <Search
+              :size="16"
+              class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-400"
+              aria-hidden="true"
+            />
+            <input
+              v-model="skillSearch"
+              class="form-input skill-search-input"
+              type="search"
+              :placeholder="t('lensAdmin.wizard.searchSkills')"
+              :aria-label="t('lensAdmin.wizard.searchSkills')"
+              autocomplete="off"
+            />
+          </div>
+          <p class="text-xs text-ink-500" aria-live="polite">
+            {{
+              t('lensAdmin.wizard.skillSearchResults', {
+                count: filteredSelectableSkills.length,
+                total: selectableSkills.length
+              })
+            }}
+          </p>
+          <div
+            v-if="filteredSelectableSkills.length"
+            class="max-h-96 space-y-2 overflow-y-auto rounded-md border border-line bg-surface-sunken p-2"
+            data-testid="assistant-skill-options"
+          >
+            <div
+              v-for="skill in filteredSelectableSkills"
+              :key="skill.uuid"
+              data-testid="assistant-skill-option"
+              class="overflow-hidden rounded-md border bg-surface transition-colors"
               :class="
                 isSkillSelected(skill.uuid)
-                  ? 'border-primary-300 bg-primary-50'
-                  : 'border-line'
+                  ? 'border-primary-300 bg-primary-50/60'
+                  : 'border-line hover:border-primary-200'
               "
             >
-              <input
-                type="checkbox"
-                :value="skill.uuid"
-                v-model="form.skill_uuids"
-                class="sr-only"
-              />
-              <span
-                class="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border transition-colors"
-                :class="
-                  isSkillSelected(skill.uuid)
-                    ? 'border-primary-600 bg-primary-600 text-white'
-                    : 'border-line bg-surface text-transparent group-hover:border-primary-300'
-                "
+              <label
+                class="group flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
               >
-                <svg
-                  class="h-3.5 w-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                <input
+                  type="checkbox"
+                  :value="skill.uuid"
+                  v-model="form.skill_uuids"
+                  class="sr-only"
+                />
+                <span
+                  class="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border transition-colors"
+                  :class="
+                    isSkillSelected(skill.uuid)
+                      ? 'border-primary-600 bg-primary-600 text-white'
+                      : 'border-line bg-surface text-transparent group-hover:border-primary-300'
+                  "
                 >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="3"
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </span>
-              <div class="min-w-0 flex-1 space-y-1">
-                <div class="flex min-w-0 items-start justify-between gap-2">
-                  <div
-                    class="min-w-0 truncate text-sm font-semibold text-ink-900"
+                  <svg
+                    class="h-3.5 w-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
                   >
-                    {{ skill.name }}
-                  </div>
-                  <StatusBadge
-                    :status="skill.enabled ? 'enabled' : 'disabled'"
-                  />
-                </div>
-                <div class="truncate font-mono text-xs text-ink-400">
-                  {{ skill.slug }}
-                </div>
-                <p
-                  v-if="skillDescription(skill)"
-                  class="line-clamp-2 text-xs leading-5 text-ink-500"
-                >
-                  {{ skillDescription(skill) }}
-                </p>
-              </div>
-            </label>
-            <div
-              v-if="
-                isSkillSelected(skill.uuid) && skillEnvironment(skill).length
-              "
-              class="-mt-2 space-y-3 rounded-b-md border border-t-0 border-primary-300 bg-surface px-3 py-3"
-            >
-              <div>
-                <div class="text-sm font-medium text-ink-700">
-                  {{ t('lensAdmin.wizard.environmentConfiguration') }}
-                  <span
-                    v-if="hasRequiredEnvironment(skill)"
-                    class="text-danger-600"
-                    >*</span
-                  >
-                </div>
-                <p class="mt-1 text-xs leading-5 text-ink-500">
-                  {{
-                    t('lensAdmin.wizard.environmentConfigurationHint', {
-                      count: skillEnvironment(skill).length
-                    })
-                  }}
-                </p>
-              </div>
-              <BaseSelect
-                v-model="form.skill_environment_set_uuids[skill.uuid]"
-                :aria-label="t('lensAdmin.wizard.selectEnvironmentSet')"
-              >
-                <option value="">
-                  {{ t('lensAdmin.wizard.selectEnvironmentSet') }}
-                </option>
-                <option value="__new__">
-                  {{ t('lensAdmin.wizard.createEnvironmentSet') }}
-                </option>
-                <option
-                  v-for="variableSet in enabledEnvironmentVariableSets"
-                  :key="variableSet.uuid"
-                  :value="variableSet.uuid"
-                >
-                  {{ variableSet.name }}
-                </option>
-              </BaseSelect>
-              <input
-                v-if="
-                  form.skill_environment_set_uuids[skill.uuid] === '__new__'
-                "
-                v-model="environmentDraft(skill.uuid).name"
-                class="form-input"
-                type="text"
-                :placeholder="t('lensAdmin.wizard.environmentSetName')"
-                :aria-label="t('lensAdmin.wizard.environmentSetName')"
-                maxlength="160"
-                autocomplete="off"
-              />
-              <div
-                class="space-y-3 rounded-md border border-line bg-surface-sunken p-3"
-              >
-                <div
-                  v-for="item in skillEnvironment(skill)"
-                  :key="item.name"
-                  class="space-y-1.5"
-                >
-                  <div class="flex items-center justify-between gap-3">
-                    <label class="font-mono text-xs font-medium text-ink-700">
-                      {{ item.name
-                      }}<span v-if="item.required" class="text-danger-600">
-                        *</span
-                      >
-                    </label>
-                    <span
-                      v-if="environmentItemSaved(skill, item)"
-                      class="text-xs text-success-700"
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="3"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                </span>
+                <div class="min-w-0 flex-1 space-y-1">
+                  <div class="flex min-w-0 items-start justify-between gap-2">
+                    <div
+                      class="min-w-0 truncate text-sm font-semibold text-ink-900"
                     >
-                      {{ t('lensAdmin.wizard.environmentConfigured') }}
+                      {{ skill.name }}
+                    </div>
+                    <StatusBadge
+                      :status="skill.enabled ? 'enabled' : 'disabled'"
+                    />
+                  </div>
+                  <div class="truncate font-mono text-xs text-ink-400">
+                    {{ skill.slug }}
+                  </div>
+                  <p
+                    v-if="skillDescription(skill)"
+                    class="line-clamp-2 text-xs leading-5 text-ink-500"
+                  >
+                    {{ skillDescription(skill) }}
+                  </p>
+                </div>
+              </label>
+              <div
+                v-if="
+                  isSkillSelected(skill.uuid) && skillEnvironment(skill).length
+                "
+                class="px-3 pb-3"
+                data-testid="assistant-skill-environments"
+              >
+                <div class="ml-8 border-l border-primary-200 pl-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <h3 class="text-xs font-semibold text-ink-700">
+                      {{ t('lensAdmin.wizard.environmentSection') }}
+                    </h3>
+                    <span
+                      v-if="hasRequiredEnvironment(skill)"
+                      class="flex-shrink-0 text-[11px] font-medium text-danger-600"
+                    >
+                      {{ t('lensAdmin.wizard.environmentRequired') }}
                     </span>
                   </div>
-                  <input
-                    v-model="environmentDraft(skill.uuid).values[item.name]"
-                    class="form-input font-mono"
-                    :type="item.secret ? 'password' : 'text'"
-                    :placeholder="environmentInputPlaceholder(item)"
-                    :aria-label="item.name"
-                    autocomplete="off"
-                  />
+                  <p class="mt-1 text-[11px] leading-4 text-ink-500">
+                    {{ t('lensAdmin.wizard.environmentSectionHint') }}
+                  </p>
+                  <div class="mt-2 space-y-2.5">
+                    <p class="text-[11px] leading-4 text-ink-500">
+                      {{
+                        t('lensAdmin.wizard.environmentConfigurationHint', {
+                          count: skillEnvironment(skill).length
+                        })
+                      }}
+                    </p>
+                    <BaseSelect
+                      v-model="form.skill_environment_set_uuids[skill.uuid]"
+                      class="text-xs"
+                      :aria-label="t('lensAdmin.wizard.selectEnvironmentSet')"
+                    >
+                      <option value="">
+                        {{ t('lensAdmin.wizard.selectEnvironmentSet') }}
+                      </option>
+                      <option value="__new__">
+                        {{ t('lensAdmin.wizard.createEnvironmentSet') }}
+                      </option>
+                      <option
+                        v-for="variableSet in enabledEnvironmentVariableSets"
+                        :key="variableSet.uuid"
+                        :value="variableSet.uuid"
+                      >
+                        {{ variableSet.name }}
+                      </option>
+                    </BaseSelect>
+                    <input
+                      v-if="
+                        form.skill_environment_set_uuids[skill.uuid] ===
+                        '__new__'
+                      "
+                      v-model="environmentDraft(skill.uuid).name"
+                      class="form-input skill-environment-input"
+                      type="text"
+                      :placeholder="t('lensAdmin.wizard.environmentSetName')"
+                      :aria-label="t('lensAdmin.wizard.environmentSetName')"
+                      maxlength="160"
+                      autocomplete="off"
+                    />
+                    <div class="space-y-2.5 rounded-md bg-surface-sunken p-2.5">
+                      <div
+                        v-for="item in skillEnvironment(skill)"
+                        :key="item.name"
+                        class="space-y-1"
+                      >
+                        <div class="flex items-center justify-between gap-3">
+                          <label
+                            class="font-mono text-[11px] font-medium text-ink-700"
+                          >
+                            {{ item.name
+                            }}<span
+                              v-if="item.required"
+                              class="text-danger-600"
+                            >
+                              *</span
+                            >
+                          </label>
+                          <span
+                            v-if="environmentItemSaved(skill, item)"
+                            class="text-[11px] text-success-700"
+                          >
+                            {{ t('lensAdmin.wizard.environmentConfigured') }}
+                          </span>
+                        </div>
+                        <input
+                          v-model="
+                            environmentDraft(skill.uuid).values[item.name]
+                          "
+                          class="form-input skill-environment-input font-mono"
+                          :type="item.secret ? 'password' : 'text'"
+                          :placeholder="environmentInputPlaceholder(item)"
+                          :aria-label="item.name"
+                          autocomplete="off"
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </template>
+          </div>
+          <div
+            v-else
+            class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
+            role="status"
+          >
+            {{ t('lensAdmin.wizard.noMatchingSkills') }}
+          </div>
         </div>
         <div
           v-else
@@ -476,27 +530,134 @@
         </div>
         <div
           v-if="mcps.length"
-          class="space-y-1 rounded-md border border-line bg-surface-sunken p-2"
+          class="space-y-2 rounded-md border border-line bg-surface-sunken p-2"
         >
-          <label
+          <div
             v-for="mcp in mcps"
             :key="mcp.uuid"
-            class="flex cursor-pointer items-center gap-3 rounded px-2 py-2 transition-colors hover:bg-surface"
+            class="overflow-hidden rounded-md border bg-surface transition-colors"
+            :class="
+              isMcpSelected(mcp.uuid)
+                ? 'border-primary-300 bg-primary-50/60'
+                : 'border-line hover:border-primary-200'
+            "
           >
-            <input
-              type="checkbox"
-              :value="mcp.uuid"
-              v-model="form.mcp_uuids"
-              class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
-            />
-            <div class="min-w-0 flex-1">
-              <div class="text-sm font-medium text-ink-900">{{ mcp.name }}</div>
-              <div class="text-xs text-ink-400">
-                {{ mcp.transport }} · {{ mcp.endpoint || emptyValue }}
+            <label
+              class="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
+            >
+              <input
+                type="checkbox"
+                :value="mcp.uuid"
+                v-model="form.mcp_uuids"
+                class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
+              />
+              <div class="min-w-0 flex-1">
+                <div class="text-sm font-medium text-ink-900">
+                  {{ mcp.name }}
+                </div>
+                <div class="truncate text-xs text-ink-400">
+                  {{ mcp.transport }} · {{ mcp.endpoint || emptyValue }}
+                </div>
+              </div>
+              <StatusBadge :status="mcp.enabled ? 'enabled' : 'disabled'" />
+            </label>
+            <div
+              v-if="isMcpSelected(mcp.uuid) && mcpEnvironment(mcp).length"
+              class="px-3 pb-3"
+              data-testid="assistant-mcp-environments"
+            >
+              <div class="ml-7 border-l border-primary-200 pl-3">
+                <div class="flex items-center justify-between gap-3">
+                  <h3 class="text-xs font-semibold text-ink-700">
+                    {{ t('lensAdmin.wizard.environmentSection') }}
+                  </h3>
+                  <span
+                    v-if="hasRequiredMcpEnvironment(mcp)"
+                    class="flex-shrink-0 text-[11px] font-medium text-danger-600"
+                  >
+                    {{ t('lensAdmin.wizard.environmentRequired') }}
+                  </span>
+                </div>
+                <p class="mt-1 text-[11px] leading-4 text-ink-500">
+                  {{ t('lensAdmin.wizard.mcpEnvironmentSectionHint') }}
+                </p>
+                <div class="mt-2 space-y-2.5">
+                  <p class="text-[11px] leading-4 text-ink-500">
+                    {{
+                      t('lensAdmin.wizard.mcpEnvironmentConfigurationHint', {
+                        count: mcpEnvironment(mcp).length
+                      })
+                    }}
+                  </p>
+                  <BaseSelect
+                    v-model="form.mcp_environment_set_uuids[mcp.uuid]"
+                    class="text-xs"
+                    :aria-label="t('lensAdmin.wizard.selectEnvironmentSet')"
+                  >
+                    <option value="">
+                      {{ t('lensAdmin.wizard.selectEnvironmentSet') }}
+                    </option>
+                    <option value="__new__">
+                      {{ t('lensAdmin.wizard.createEnvironmentSet') }}
+                    </option>
+                    <option
+                      v-for="variableSet in enabledEnvironmentVariableSets"
+                      :key="variableSet.uuid"
+                      :value="variableSet.uuid"
+                    >
+                      {{ variableSet.name }}
+                    </option>
+                  </BaseSelect>
+                  <input
+                    v-if="
+                      form.mcp_environment_set_uuids[mcp.uuid] === '__new__'
+                    "
+                    v-model="mcpEnvironmentDraft(mcp.uuid).name"
+                    class="form-input skill-environment-input"
+                    type="text"
+                    :placeholder="t('lensAdmin.wizard.environmentSetName')"
+                    :aria-label="t('lensAdmin.wizard.environmentSetName')"
+                    maxlength="160"
+                    autocomplete="off"
+                  />
+                  <div class="space-y-2.5 rounded-md bg-surface-sunken p-2.5">
+                    <div
+                      v-for="item in mcpEnvironment(mcp)"
+                      :key="item.name"
+                      class="space-y-1"
+                    >
+                      <div class="flex items-center justify-between gap-3">
+                        <label
+                          class="font-mono text-[11px] font-medium text-ink-700"
+                        >
+                          {{ item.name
+                          }}<span v-if="item.required" class="text-danger-600">
+                            *</span
+                          >
+                        </label>
+                        <span
+                          v-if="mcpEnvironmentItemSaved(mcp, item)"
+                          class="text-[11px] text-success-700"
+                        >
+                          {{ t('lensAdmin.wizard.environmentConfigured') }}
+                        </span>
+                      </div>
+                      <input
+                        v-model="
+                          mcpEnvironmentDraft(mcp.uuid).values[item.name]
+                        "
+                        class="form-input skill-environment-input font-mono"
+                        :type="item.secret ? 'password' : 'text'"
+                        :placeholder="environmentInputPlaceholder(item)"
+                        :aria-label="item.name"
+                        autocomplete="off"
+                      />
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-            <StatusBadge :status="mcp.enabled ? 'enabled' : 'disabled'" />
-          </label>
+          </div>
         </div>
         <div
           v-else
@@ -799,6 +960,7 @@
 import {
   Globe as GlobeIcon,
   Lock as LockIcon,
+  Search,
   User as UserIcon,
   Users as UsersIcon
 } from '@lucide/vue'
@@ -821,6 +983,7 @@ import {
   assignmentFirstOptions,
   createLatestRequestRunner
 } from './assistantAccessSelectors'
+import { filterSelectableSkills, skillDescription } from './assistantSkills'
 
 const props = defineProps({
   show: Boolean,
@@ -862,6 +1025,7 @@ const userOptions = ref(new Map())
 const userLoading = ref(false)
 const userFailed = ref(false)
 const userSearch = ref('')
+const skillSearch = ref('')
 const groupRequest = createLatestRequestRunner()
 const userRequest = createLatestRequestRunner()
 let groupSearchTimer = null
@@ -875,6 +1039,7 @@ watch(
   (show) => {
     if (show) {
       wizardStep.value = 1
+      skillSearch.value = ''
       initializeAccessSelectors()
     } else {
       resetPendingAccessRequests()
@@ -1030,7 +1195,11 @@ const canProceedWizard = computed(() => {
   if (wizardStep.value === 3) {
     const hasRequiredSkill =
       !isGeneralChatTask.value || (props.form.skill_uuids || []).length > 0
-    return hasRequiredSkill && selectedSkillEnvironmentsConfigured()
+    return (
+      hasRequiredSkill &&
+      selectedSkillEnvironmentsConfigured() &&
+      selectedMcpEnvironmentsConfigured()
+    )
   }
   return true
 })
@@ -1265,13 +1434,11 @@ function maybeLoadMoreUsers(event) {
 }
 
 const selectableSkills = computed(() =>
-  props.skills.filter(
-    (skill) =>
-      !(
-        typeof skill.slug === 'string' &&
-        skill.slug.endsWith('-workspace-guide')
-      )
-  )
+  filterSelectableSkills(props.skills, '')
+)
+
+const filteredSelectableSkills = computed(() =>
+  filterSelectableSkills(props.skills, skillSearch.value)
 )
 
 const enabledEnvironmentVariableSets = computed(() =>
@@ -1280,17 +1447,6 @@ const enabledEnvironmentVariableSets = computed(() =>
 
 function isSkillSelected(uuid) {
   return (props.form.skill_uuids || []).includes(uuid)
-}
-
-function skillDescription(skill) {
-  const definition = skill?.definition || {}
-  return (
-    skill?.description ||
-    definition.description ||
-    definition.summary ||
-    skill?.package_manifest?.description ||
-    ''
-  )
 }
 
 function skillEnvironment(skill) {
@@ -1348,6 +1504,62 @@ function selectedSkillEnvironmentsConfigured() {
     }
     if (!required.length) return true
     return required.every((item) => environmentItemConfigured(skill, item))
+  })
+}
+
+function isMcpSelected(uuid) {
+  return (props.form.mcp_uuids || []).includes(uuid)
+}
+
+function mcpEnvironment(mcp) {
+  return Array.isArray(mcp?.environment) ? mcp.environment : []
+}
+
+function hasRequiredMcpEnvironment(mcp) {
+  return mcpEnvironment(mcp).some((item) => item.required)
+}
+
+function mcpEnvironmentDraft(mcpUuid) {
+  props.form.mcp_environment_drafts ||= {}
+  props.form.mcp_environment_drafts[mcpUuid] ||= {
+    name: '',
+    values: {}
+  }
+  return props.form.mcp_environment_drafts[mcpUuid]
+}
+
+function selectedMcpEnvironmentSet(mcpUuid) {
+  const selectedUuid = props.form.mcp_environment_set_uuids?.[mcpUuid]
+  return props.environmentVariableSets.find(
+    (variableSet) => variableSet.uuid === selectedUuid
+  )
+}
+
+function mcpEnvironmentItemSaved(mcp, item) {
+  return (selectedMcpEnvironmentSet(mcp.uuid)?.keys || []).includes(item.name)
+}
+
+function mcpEnvironmentItemConfigured(mcp, item) {
+  const draftValue = mcpEnvironmentDraft(mcp.uuid).values[item.name]
+  return !!String(draftValue || '').trim() || mcpEnvironmentItemSaved(mcp, item)
+}
+
+function selectedMcpEnvironmentsConfigured() {
+  return (props.form.mcp_uuids || []).every((mcpUuid) => {
+    const mcp = props.mcps.find((item) => item.uuid === mcpUuid)
+    if (!mcp) return true
+    const required = mcpEnvironment(mcp).filter((item) => item.required)
+    const selectedUuid = props.form.mcp_environment_set_uuids?.[mcpUuid] || ''
+    const draft = mcpEnvironmentDraft(mcpUuid)
+    const hasEnteredValue = Object.values(draft.values || {}).some((value) =>
+      String(value ?? '').trim()
+    )
+    if (!selectedUuid && (required.length || hasEnteredValue)) return false
+    if (selectedUuid === '__new__' && !String(draft.name || '').trim()) {
+      return false
+    }
+    if (!required.length) return true
+    return required.every((item) => mcpEnvironmentItemConfigured(mcp, item))
   })
 }
 
@@ -1415,5 +1627,13 @@ function ensureSelectedTask() {
 <style scoped>
 .form-input {
   @apply w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20;
+}
+
+.skill-search-input {
+  @apply pl-9;
+}
+
+.skill-environment-input {
+  @apply py-1.5 text-xs;
 }
 </style>

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -631,7 +631,10 @@
                           class="font-mono text-[11px] font-medium text-ink-700"
                         >
                           {{ item.name
-                          }}<span v-if="item.required" class="text-danger-600">
+                          }}<span
+                            v-if="isMcpEnvironmentRequired(mcp, item)"
+                            class="text-danger-600"
+                          >
                             *</span
                           >
                         </label>
@@ -983,6 +986,7 @@ import {
   assignmentFirstOptions,
   createLatestRequestRunner
 } from './assistantAccessSelectors'
+import { mcpRequiredEnvironmentNames } from './assistantEnvironment'
 import { filterSelectableSkills, skillDescription } from './assistantSkills'
 
 const props = defineProps({
@@ -1516,7 +1520,11 @@ function mcpEnvironment(mcp) {
 }
 
 function hasRequiredMcpEnvironment(mcp) {
-  return mcpEnvironment(mcp).some((item) => item.required)
+  return mcpRequiredEnvironmentNames(mcp).length > 0
+}
+
+function isMcpEnvironmentRequired(mcp, item) {
+  return mcpRequiredEnvironmentNames(mcp).includes(item.name)
 }
 
 function mcpEnvironmentDraft(mcpUuid) {
@@ -1548,7 +1556,10 @@ function selectedMcpEnvironmentsConfigured() {
   return (props.form.mcp_uuids || []).every((mcpUuid) => {
     const mcp = props.mcps.find((item) => item.uuid === mcpUuid)
     if (!mcp) return true
-    const required = mcpEnvironment(mcp).filter((item) => item.required)
+    const requiredNames = new Set(mcpRequiredEnvironmentNames(mcp))
+    const required = mcpEnvironment(mcp).filter((item) =>
+      requiredNames.has(item.name)
+    )
     const selectedUuid = props.form.mcp_environment_set_uuids?.[mcpUuid] || ''
     const draft = mcpEnvironmentDraft(mcpUuid)
     const hasEnteredValue = Object.values(draft.values || {}).some((value) =>

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -341,7 +341,10 @@ import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 import AssistantDetailDrawer from './AssistantDetailDrawer.vue'
 import AssistantFormDrawer from './AssistantFormDrawerDirectEnvironment.vue'
-import { buildSkillEnvironmentBinding } from './assistantEnvironment'
+import {
+  buildMcpEnvironmentBinding,
+  buildSkillEnvironmentBinding
+} from './assistantEnvironment'
 import {
   EMPTY_VALUE as emptyValue,
   formatAssistantType,
@@ -572,6 +575,8 @@ function defaultForm() {
     skill_environment_set_uuids: {},
     skill_environment_drafts: {},
     mcp_uuids: [],
+    mcp_environment_set_uuids: {},
+    mcp_environment_drafts: {},
     visibility: 'private',
     access_group_ids: [],
     access_user_ids: [],
@@ -641,6 +646,15 @@ function formFromRow(row) {
     mcp_uuids: (row.mcp_bindings || [])
       .map((b) => b.mcp_server?.uuid || b.mcp_uuid)
       .filter(Boolean),
+    mcp_environment_set_uuids: Object.fromEntries(
+      (row.mcp_bindings || [])
+        .filter((binding) => binding.environment_variable_set_uuid)
+        .map((binding) => [
+          binding.mcp_uuid,
+          binding.environment_variable_set_uuid
+        ])
+    ),
+    mcp_environment_drafts: {},
     visibility: row.visibility || 'public',
     access_group_ids: (row.access_grants || [])
       .filter((g) => g.type === 'group')
@@ -714,9 +728,17 @@ function buildPayload() {
         form.value.skill_environment_drafts?.[uuid]
       )
     }),
-    mcp_bindings: (form.value.mcp_uuids || []).map((uuid) => ({
-      mcp_uuid: uuid
-    })),
+    mcp_bindings: (form.value.mcp_uuids || []).map((uuid) => {
+      const mcp = mcps.value.find((item) => item.uuid === uuid) || {
+        uuid,
+        environment: []
+      }
+      return buildMcpEnvironmentBinding(
+        mcp,
+        form.value.mcp_environment_set_uuids?.[uuid],
+        form.value.mcp_environment_drafts?.[uuid]
+      )
+    }),
     visibility: form.value.visibility || 'public',
     access_grants: buildAccessGrants(),
     status: form.value.status || 'active'

--- a/frontend/src/pages/lens/EnvironmentVariables.vue
+++ b/frontend/src/pages/lens/EnvironmentVariables.vue
@@ -34,6 +34,9 @@
                 <th class="px-5 py-3">
                   {{ t('lensAdmin.environmentVariables.keys') }}
                 </th>
+                <th class="px-5 py-3">
+                  {{ t('lensAdmin.environmentVariables.usages') }}
+                </th>
                 <th class="px-5 py-3">{{ t('lensAdmin.fields.status') }}</th>
                 <th class="px-5 py-3 text-right">{{ t('common.actions') }}</th>
               </tr>
@@ -52,6 +55,27 @@
                 </td>
                 <td class="px-5 py-4 font-mono text-xs text-ink-600">
                   {{ (row.keys || []).join(', ') || '—' }}
+                </td>
+                <td class="px-5 py-4">
+                  <div v-if="row.usages?.length" class="flex flex-wrap gap-1.5">
+                    <span
+                      v-for="usage in row.usages"
+                      :key="usageKey(usage)"
+                      class="inline-flex max-w-72 items-center gap-1 rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-600"
+                      :title="usageTitle(usage)"
+                    >
+                      <span class="font-medium text-ink-700">
+                        {{ usageTypeLabel(usage.type) }}
+                      </span>
+                      <span aria-hidden="true">·</span>
+                      <span class="truncate">{{ usage.resource_name }}</span>
+                      <span aria-hidden="true">·</span>
+                      <span class="truncate text-ink-400">
+                        {{ usage.assistant_name }}
+                      </span>
+                    </span>
+                  </div>
+                  <span v-else class="text-xs text-ink-400">—</span>
                 </td>
                 <td class="px-5 py-4">
                   <StatusBadge :status="row.enabled ? 'enabled' : 'disabled'" />
@@ -257,6 +281,23 @@ function addValue() {
 
 function removeValue(index) {
   form.value.values.splice(index, 1)
+}
+
+function usageTypeLabel(type) {
+  return type === 'mcp'
+    ? t('lensAdmin.environmentVariables.mcpUsage')
+    : t('lensAdmin.environmentVariables.skillUsage')
+}
+
+function usageKey(usage) {
+  return `${usage.type}:${usage.resource_uuid}:${usage.assistant_uuid}`
+}
+
+function usageTitle(usage) {
+  return `${usageTypeLabel(usage.type)} · ${usage.resource_name} · ${t(
+    'lensAdmin.environmentVariables.assistantUsage',
+    { name: usage.assistant_name }
+  )}`
 }
 
 function payload() {

--- a/frontend/src/pages/lens/Mcp.vue
+++ b/frontend/src/pages/lens/Mcp.vue
@@ -127,8 +127,24 @@
               v-model="form.config_rows"
               :key-label="t('lensAdmin.fields.configKey')"
               :value-label="t('lensAdmin.fields.configValue')"
+              :mask-sensitive-values="true"
+              :configured-label="t('lensAdmin.mcp.secretConfigured')"
             />
+            <p class="mt-2 text-xs leading-5 text-ink-500">
+              {{ t('lensAdmin.mcp.sensitiveConfigHint') }}
+            </p>
           </FormRow>
+          <SkillEnvironmentEditor
+            v-model="form.environment"
+            :help-text="t('lensAdmin.mcp.environmentVariablesHelp')"
+          />
+          <p class="text-xs leading-5 text-ink-500">
+            {{
+              t('lensAdmin.mcp.environmentPlaceholderHint', {
+                placeholder: '${VARIABLE_NAME}'
+              })
+            }}
+          </p>
           <BooleanRow v-model="form.enabled" />
 
           <p v-if="formError" class="text-sm text-danger-700">
@@ -174,12 +190,10 @@ import BooleanRow from './components/BooleanRow.vue'
 import FormRow from './components/FormRow.vue'
 import KeyValueEditor from './components/KeyValueEditor.vue'
 import RowActions from './components/RowActions.vue'
-import {
-  EMPTY_VALUE as emptyValue,
-  normalizeList,
-  objectToRows,
-  rowsToObject
-} from './adminHelpers'
+import SkillEnvironmentEditor from './components/SkillEnvironmentEditor.vue'
+import { EMPTY_VALUE as emptyValue, normalizeList } from './adminHelpers'
+import { mcpConfigToRows, mcpRowsToConfig } from './mcpConfig'
+import { buildSkillEnvironment, skillEnvironmentForm } from './skillEnvironment'
 
 const { t } = useI18n()
 const { showSuccess, showError } = useToast()
@@ -236,6 +250,7 @@ function defaultForm() {
     transport: 'url',
     endpoint: '',
     config_rows: [],
+    environment: [],
     enabled: true
   }
 }
@@ -246,7 +261,8 @@ function formFromRow(row) {
     name: row.name || '',
     transport: row.transport || 'url',
     endpoint: row.endpoint || '',
-    config_rows: objectToRows(row.config || {}),
+    config_rows: mcpConfigToRows(row.config || {}),
+    environment: skillEnvironmentForm(row.environment || []),
     enabled: row.enabled !== false
   }
 }
@@ -256,7 +272,8 @@ function buildPayload() {
     name: form.value.name,
     transport: form.value.transport,
     endpoint: form.value.endpoint,
-    config: rowsToObject(form.value.config_rows),
+    config: mcpRowsToConfig(form.value.config_rows),
+    environment: buildSkillEnvironment(form.value.environment),
     enabled: !!form.value.enabled
   }
 }

--- a/frontend/src/pages/lens/Mcp.vue
+++ b/frontend/src/pages/lens/Mcp.vue
@@ -192,8 +192,12 @@ import KeyValueEditor from './components/KeyValueEditor.vue'
 import RowActions from './components/RowActions.vue'
 import SkillEnvironmentEditor from './components/SkillEnvironmentEditor.vue'
 import { EMPTY_VALUE as emptyValue, normalizeList } from './adminHelpers'
-import { mcpConfigToRows, mcpRowsToConfig } from './mcpConfig'
-import { buildSkillEnvironment, skillEnvironmentForm } from './skillEnvironment'
+import {
+  buildMcpEnvironment,
+  mcpConfigToRows,
+  mcpEnvironmentForm,
+  mcpRowsToConfig
+} from './mcpConfig'
 
 const { t } = useI18n()
 const { showSuccess, showError } = useToast()
@@ -262,7 +266,7 @@ function formFromRow(row) {
     transport: row.transport || 'url',
     endpoint: row.endpoint || '',
     config_rows: mcpConfigToRows(row.config || {}),
-    environment: skillEnvironmentForm(row.environment || []),
+    environment: mcpEnvironmentForm(row.environment || []),
     enabled: row.enabled !== false
   }
 }
@@ -273,7 +277,7 @@ function buildPayload() {
     transport: form.value.transport,
     endpoint: form.value.endpoint,
     config: mcpRowsToConfig(form.value.config_rows),
-    environment: buildSkillEnvironment(form.value.environment),
+    environment: buildMcpEnvironment(form.value.environment),
     enabled: !!form.value.enabled
   }
 }

--- a/frontend/src/pages/lens/assistantEnvironment.js
+++ b/frontend/src/pages/lens/assistantEnvironment.js
@@ -29,3 +29,49 @@ export function buildSkillEnvironmentBinding(
   }
   return binding
 }
+
+export function buildMcpEnvironmentBinding(
+  mcp,
+  selectedEnvironmentSetUuid,
+  draft = {}
+) {
+  return buildEnvironmentBinding(
+    'mcp_uuid',
+    mcp.uuid,
+    mcp.environment,
+    selectedEnvironmentSetUuid,
+    draft
+  )
+}
+
+function buildEnvironmentBinding(
+  resourceKey,
+  resourceUuid,
+  declarations,
+  selectedEnvironmentSetUuid,
+  draft
+) {
+  const selectedUuid =
+    selectedEnvironmentSetUuid === '__new__'
+      ? null
+      : selectedEnvironmentSetUuid || null
+  const binding = {
+    [resourceKey]: resourceUuid,
+    environment_variable_set_uuid: selectedUuid
+  }
+  const declaredNames = new Set((declarations || []).map((item) => item.name))
+  const environmentValues = Object.entries(draft.values || {})
+    .filter(
+      ([name, value]) =>
+        declaredNames.has(name) && String(value ?? '').trim().length > 0
+    )
+    .map(([key, value]) => ({ key, value }))
+
+  if (selectedEnvironmentSetUuid === '__new__' && draft.name?.trim()) {
+    binding.environment_variable_set_name = draft.name.trim()
+  }
+  if (environmentValues.length) {
+    binding.environment_values = environmentValues
+  }
+  return binding
+}

--- a/frontend/src/pages/lens/assistantEnvironment.js
+++ b/frontend/src/pages/lens/assistantEnvironment.js
@@ -44,6 +44,33 @@ export function buildMcpEnvironmentBinding(
   )
 }
 
+export function mcpRequiredEnvironmentNames(mcp) {
+  const references = new Set(mcp?.environment_references || [])
+  environmentReferences({
+    endpoint: mcp?.endpoint,
+    config: mcp?.config
+  }).forEach((name) => references.add(name))
+  return (mcp?.environment || [])
+    .filter((item) => item.required || references.has(item.name))
+    .map((item) => item.name)
+}
+
+function environmentReferences(value) {
+  if (Array.isArray(value)) {
+    return value.reduce((references, item) => {
+      environmentReferences(item).forEach((name) => references.add(name))
+      return references
+    }, new Set())
+  }
+  if (value && typeof value === 'object') {
+    return environmentReferences(Object.values(value))
+  }
+  if (typeof value !== 'string') return new Set()
+  return new Set(
+    Array.from(value.matchAll(/\$\{([A-Z_][A-Z0-9_]*)\}/g), (match) => match[1])
+  )
+}
+
 function buildEnvironmentBinding(
   resourceKey,
   resourceUuid,

--- a/frontend/src/pages/lens/assistantSkills.js
+++ b/frontend/src/pages/lens/assistantSkills.js
@@ -1,0 +1,31 @@
+export function skillDescription(skill) {
+  const definition = skill?.definition || {}
+  return (
+    skill?.description ||
+    definition.description ||
+    definition.summary ||
+    skill?.package_manifest?.description ||
+    ''
+  )
+}
+
+export function filterSelectableSkills(skills, keyword) {
+  const query = String(keyword || '')
+    .trim()
+    .toLocaleLowerCase()
+  return (skills || []).filter((skill) => {
+    if (
+      typeof skill.slug === 'string' &&
+      skill.slug.endsWith('-workspace-guide')
+    ) {
+      return false
+    }
+    if (!query) return true
+
+    return [skill.name, skill.slug, skillDescription(skill)].some((value) =>
+      String(value || '')
+        .toLocaleLowerCase()
+        .includes(query)
+    )
+  })
+}

--- a/frontend/src/pages/lens/components/KeyValueEditor.vue
+++ b/frontend/src/pages/lens/components/KeyValueEditor.vue
@@ -11,12 +11,22 @@
         class="rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
         @input="updateRow(index, 'key', $event.target.value)"
       />
-      <input
-        :value="row.value"
-        :placeholder="valueLabel"
-        class="rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
-        @input="updateRow(index, 'value', $event.target.value)"
-      />
+      <div class="min-w-0">
+        <div
+          v-if="isMaskedSensitiveRow(row)"
+          class="mb-1 text-right text-[11px] font-medium text-success-700"
+        >
+          {{ configuredLabel }}
+        </div>
+        <input
+          :value="row.value"
+          :type="isSensitiveRow(row) ? 'password' : 'text'"
+          :autocomplete="isSensitiveRow(row) ? 'new-password' : 'off'"
+          :placeholder="valueLabel"
+          class="w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+          @input="updateRow(index, 'value', $event.target.value)"
+        />
+      </div>
       <BaseButton size="sm" variant="outline" @click="removeRow(index)">
         {{ t('lensAdmin.actions.removeRow') }}
       </BaseButton>
@@ -32,6 +42,8 @@ import { useI18n } from 'vue-i18n'
 
 import BaseButton from '@/components/ui/BaseButton.vue'
 
+import { isSensitiveMcpConfigKey, MCP_CONFIG_MASK } from '../mcpConfig'
+
 const props = defineProps({
   modelValue: {
     type: Array,
@@ -44,11 +56,31 @@ const props = defineProps({
   valueLabel: {
     type: String,
     required: true
+  },
+  maskSensitiveValues: {
+    type: Boolean,
+    default: false
+  },
+  configuredLabel: {
+    type: String,
+    default: ''
   }
 })
 const emit = defineEmits(['update:modelValue'])
 
 const { t } = useI18n()
+
+function isSensitiveRow(row) {
+  return props.maskSensitiveValues && isSensitiveMcpConfigKey(row.key)
+}
+
+function isMaskedSensitiveRow(row) {
+  return (
+    isSensitiveRow(row) &&
+    row.value === MCP_CONFIG_MASK &&
+    props.configuredLabel
+  )
+}
 
 function updateRow(index, field, value) {
   const rows = props.modelValue.map((item) => ({ ...item }))

--- a/frontend/src/pages/lens/components/SkillEnvironmentEditor.vue
+++ b/frontend/src/pages/lens/components/SkillEnvironmentEditor.vue
@@ -5,7 +5,7 @@
         class="flex items-center justify-between gap-3 border-b border-line bg-surface-sunken px-3 py-2.5"
       >
         <p class="text-sm leading-5 text-ink-600">
-          {{ t('lensAdmin.skills.environmentVariablesHelp') }}
+          {{ helpText || t('lensAdmin.skills.environmentVariablesHelp') }}
         </p>
         <BaseButton
           class="shrink-0"
@@ -66,6 +66,10 @@ import FormRow from './FormRow.vue'
 const { t } = useI18n()
 
 const props = defineProps({
+  helpText: {
+    type: String,
+    default: ''
+  },
   modelValue: {
     type: Array,
     default: () => []

--- a/frontend/src/pages/lens/mcpConfig.js
+++ b/frontend/src/pages/lens/mcpConfig.js
@@ -1,0 +1,50 @@
+export const MCP_CONFIG_MASK = '********'
+
+const SENSITIVE_KEY_FRAGMENTS = [
+  'apikey',
+  'authorization',
+  'credential',
+  'password',
+  'passwd',
+  'privatekey',
+  'secret',
+  'token'
+]
+
+export function isSensitiveMcpConfigKey(key) {
+  const normalized = String(key || '')
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) =>
+    normalized.includes(fragment)
+  )
+}
+
+export function mcpConfigToRows(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return []
+  }
+  return Object.entries(value).map(([key, rowValue]) => ({
+    key,
+    value: typeof rowValue === 'string' ? rowValue : JSON.stringify(rowValue),
+    serialized: typeof rowValue !== 'string'
+  }))
+}
+
+export function mcpRowsToConfig(rows) {
+  return (rows || []).reduce((output, row) => {
+    const key = String(row.key || '').trim()
+    if (!key) return output
+    const value = String(row.value || '').trim()
+    if (!row.serialized) {
+      output[key] = value
+      return output
+    }
+    try {
+      output[key] = JSON.parse(value)
+    } catch {
+      output[key] = value
+    }
+    return output
+  }, {})
+}

--- a/frontend/src/pages/lens/mcpConfig.js
+++ b/frontend/src/pages/lens/mcpConfig.js
@@ -1,23 +1,53 @@
+import {
+  buildSkillEnvironment,
+  skillEnvironmentForm
+} from './skillEnvironment.js'
+
 export const MCP_CONFIG_MASK = '********'
 
-const SENSITIVE_KEY_FRAGMENTS = [
+const SENSITIVE_KEY_NAMES = new Set([
   'apikey',
   'authorization',
   'credential',
+  'credentials',
   'password',
   'passwd',
   'privatekey',
   'secret',
   'token'
-]
+])
+
+const SENSITIVE_KEY_SEGMENTS = new Set([
+  'authorization',
+  'credential',
+  'credentials',
+  'password',
+  'passwd',
+  'secret'
+])
 
 export function isSensitiveMcpConfigKey(key) {
-  const normalized = String(key || '')
-    .toLocaleLowerCase()
-    .replace(/[^a-z0-9]/g, '')
-  return SENSITIVE_KEY_FRAGMENTS.some((fragment) =>
-    normalized.includes(fragment)
+  const rawKey = String(key || '')
+  const normalized = rawKey.toLocaleLowerCase().replace(/[^a-z0-9]/g, '')
+  if (SENSITIVE_KEY_NAMES.has(normalized)) return true
+
+  const segmentedKey = rawKey.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+  const segments = (segmentedKey.match(/[A-Za-z0-9]+/g) || []).map((segment) =>
+    segment.toLocaleLowerCase()
   )
+  if (segments.some((segment) => SENSITIVE_KEY_SEGMENTS.has(segment))) {
+    return true
+  }
+  if (
+    segments.some(
+      (segment, index) =>
+        (segment === 'api' || segment === 'private') &&
+        segments[index + 1] === 'key'
+    )
+  ) {
+    return true
+  }
+  return segments.at(-1) === 'token'
 }
 
 export function mcpConfigToRows(value) {
@@ -36,8 +66,12 @@ export function mcpRowsToConfig(rows) {
     const key = String(row.key || '').trim()
     if (!key) return output
     const value = String(row.value || '').trim()
-    if (!row.serialized) {
+    if (row.serialized === false) {
       output[key] = value
+      return output
+    }
+    if (row.serialized !== true) {
+      output[key] = parseJsonContainer(value)
       return output
     }
     try {
@@ -47,4 +81,28 @@ export function mcpRowsToConfig(rows) {
     }
     return output
   }, {})
+}
+
+function parseJsonContainer(value) {
+  if (!value.startsWith('{') && !value.startsWith('[')) return value
+  try {
+    const parsed = JSON.parse(value)
+    return parsed !== null && typeof parsed === 'object' ? parsed : value
+  } catch {
+    return value
+  }
+}
+
+export function mcpEnvironmentForm(declarations = []) {
+  return skillEnvironmentForm(declarations).map((item, index) => ({
+    ...item,
+    required: declarations[index]?.required !== false
+  }))
+}
+
+export function buildMcpEnvironment(items = []) {
+  return buildSkillEnvironment(items).map((item, index) => ({
+    ...item,
+    required: items[index]?.required !== false
+  }))
 }

--- a/frontend/tests/assistantEnvironment.test.js
+++ b/frontend/tests/assistantEnvironment.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildSkillEnvironmentBinding } from '../src/pages/lens/assistantEnvironment.js'
+import {
+  buildMcpEnvironmentBinding,
+  buildSkillEnvironmentBinding
+} from '../src/pages/lens/assistantEnvironment.js'
 
 const skill = {
   uuid: 'skill-uuid',
@@ -57,5 +60,29 @@ test('sends a named new set in the assistant payload', () => {
       { key: 'API_BASE_URL', value: 'https://jira.example.com' },
       { key: 'API_TOKEN', value: 'production-token' }
     ]
+  })
+})
+
+test('builds an MCP binding with only declared environment values', () => {
+  const binding = buildMcpEnvironmentBinding(
+    {
+      uuid: 'mcp-uuid',
+      environment: [{ name: 'GITHUB_TOKEN', required: true }]
+    },
+    '__new__',
+    {
+      name: 'GitHub MCP',
+      values: {
+        GITHUB_TOKEN: 'secret-token',
+        UNDECLARED: 'ignored'
+      }
+    }
+  )
+
+  assert.deepEqual(binding, {
+    mcp_uuid: 'mcp-uuid',
+    environment_variable_set_uuid: null,
+    environment_variable_set_name: 'GitHub MCP',
+    environment_values: [{ key: 'GITHUB_TOKEN', value: 'secret-token' }]
   })
 })

--- a/frontend/tests/assistantEnvironment.test.js
+++ b/frontend/tests/assistantEnvironment.test.js
@@ -3,7 +3,8 @@ import test from 'node:test'
 
 import {
   buildMcpEnvironmentBinding,
-  buildSkillEnvironmentBinding
+  buildSkillEnvironmentBinding,
+  mcpRequiredEnvironmentNames
 } from '../src/pages/lens/assistantEnvironment.js'
 
 const skill = {
@@ -85,4 +86,37 @@ test('builds an MCP binding with only declared environment values', () => {
     environment_variable_set_name: 'GitHub MCP',
     environment_values: [{ key: 'GITHUB_TOKEN', value: 'secret-token' }]
   })
+})
+
+test('treats referenced optional MCP variables as required', () => {
+  const required = mcpRequiredEnvironmentNames({
+    endpoint: 'https://${MCP_HOST}/api',
+    config: {
+      headers: [{ Authorization: 'Bearer ${MCP_TOKEN}' }],
+      literal: '${OPTIONAL_UNUSED}'
+    },
+    environment: [
+      { name: 'MCP_HOST', required: false },
+      { name: 'MCP_TOKEN', required: false },
+      { name: 'OPTIONAL_UNUSED', required: false },
+      { name: 'ALWAYS_REQUIRED', required: true }
+    ]
+  })
+
+  assert.deepEqual(required, [
+    'MCP_HOST',
+    'MCP_TOKEN',
+    'OPTIONAL_UNUSED',
+    'ALWAYS_REQUIRED'
+  ])
+})
+
+test('uses secret-safe MCP reference metadata when config is masked', () => {
+  const required = mcpRequiredEnvironmentNames({
+    config: { headers: { Authorization: '********' } },
+    environment_references: ['MCP_TOKEN'],
+    environment: [{ name: 'MCP_TOKEN', required: false }]
+  })
+
+  assert.deepEqual(required, ['MCP_TOKEN'])
 })

--- a/frontend/tests/assistantSkills.test.js
+++ b/frontend/tests/assistantSkills.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { filterSelectableSkills } from '../src/pages/lens/assistantSkills.js'
+
+const skills = [
+  {
+    uuid: 'jira',
+    name: 'Jira Issues',
+    slug: 'jira-issues',
+    definition: {
+      description: 'Search project tickets',
+      environment: [{ name: 'JIRA_TOKEN', required: true }]
+    }
+  },
+  {
+    uuid: 'github',
+    name: 'GitHub Pull Requests',
+    slug: 'github-prs',
+    package_manifest: { description: 'Review repository changes' }
+  },
+  {
+    uuid: 'guide',
+    name: 'Workspace Guide',
+    slug: 'project-workspace-guide'
+  }
+]
+
+test('returns every selectable Skill when the keyword is empty', () => {
+  const results = filterSelectableSkills(skills, '')
+
+  assert.deepEqual(
+    results.map((skill) => skill.uuid),
+    ['jira', 'github']
+  )
+})
+
+test('searches Skills by name, slug, and description without case sensitivity', () => {
+  assert.deepEqual(
+    filterSelectableSkills(skills, 'JIRA').map((skill) => skill.uuid),
+    ['jira']
+  )
+  assert.deepEqual(
+    filterSelectableSkills(skills, 'github-prs').map((skill) => skill.uuid),
+    ['github']
+  )
+  assert.deepEqual(
+    filterSelectableSkills(skills, 'repository changes').map(
+      (skill) => skill.uuid
+    ),
+    ['github']
+  )
+})
+
+test('preserves environment declarations on filtered Skills', () => {
+  const [result] = filterSelectableSkills(skills, 'tickets')
+
+  assert.deepEqual(result.definition.environment, [
+    { name: 'JIRA_TOKEN', required: true }
+  ])
+})

--- a/frontend/tests/mcpConfig.test.js
+++ b/frontend/tests/mcpConfig.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isSensitiveMcpConfigKey,
+  mcpConfigToRows,
+  mcpRowsToConfig,
+  MCP_CONFIG_MASK
+} from '../src/pages/lens/mcpConfig.js'
+
+test('detects MCP credential keys without masking ordinary config', () => {
+  for (const key of [
+    'password',
+    'client-secret',
+    'API_KEY',
+    'accessToken',
+    'Authorization',
+    'private_key',
+    'credential'
+  ]) {
+    assert.equal(isSensitiveMcpConfigKey(key), true, key)
+  }
+
+  for (const key of ['region', 'endpoint', 'timeout', 'transport']) {
+    assert.equal(isSensitiveMcpConfigKey(key), false, key)
+  }
+  assert.equal(MCP_CONFIG_MASK, '********')
+})
+
+test('preserves nested MCP config objects through the editor', () => {
+  const config = {
+    headers: {
+      Authorization: MCP_CONFIG_MASK,
+      'X-Client': 'sourcelens'
+    },
+    retries: 3
+  }
+
+  const rows = mcpConfigToRows(config)
+
+  assert.deepEqual(mcpRowsToConfig(rows), config)
+  assert.match(rows[0].value, /"Authorization":"\*{8}"/)
+})

--- a/frontend/tests/mcpConfig.test.js
+++ b/frontend/tests/mcpConfig.test.js
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  buildMcpEnvironment,
   isSensitiveMcpConfigKey,
   mcpConfigToRows,
+  mcpEnvironmentForm,
   mcpRowsToConfig,
   MCP_CONFIG_MASK
 } from '../src/pages/lens/mcpConfig.js'
@@ -21,7 +23,15 @@ test('detects MCP credential keys without masking ordinary config', () => {
     assert.equal(isSensitiveMcpConfigKey(key), true, key)
   }
 
-  for (const key of ['region', 'endpoint', 'timeout', 'transport']) {
+  for (const key of [
+    'region',
+    'endpoint',
+    'timeout',
+    'transport',
+    'max_tokens',
+    'token_limit',
+    'tokenizer'
+  ]) {
     assert.equal(isSensitiveMcpConfigKey(key), false, key)
   }
   assert.equal(MCP_CONFIG_MASK, '********')
@@ -40,4 +50,46 @@ test('preserves nested MCP config objects through the editor', () => {
 
   assert.deepEqual(mcpRowsToConfig(rows), config)
   assert.match(rows[0].value, /"Authorization":"\*{8}"/)
+})
+
+test('parses JSON containers entered in new MCP config rows', () => {
+  const config = mcpRowsToConfig([
+    {
+      key: 'headers',
+      value: '{"Authorization":"Bearer ${MCP_TOKEN}"}'
+    },
+    { key: 'scopes', value: '["issues:read","pulls:read"]' },
+    { key: 'timeout', value: '30' }
+  ])
+
+  assert.deepEqual(config.headers, {
+    Authorization: 'Bearer ${MCP_TOKEN}'
+  })
+  assert.deepEqual(config.scopes, ['issues:read', 'pulls:read'])
+  assert.equal(config.timeout, '30')
+})
+
+test('preserves existing JSON-looking string values', () => {
+  const config = {
+    template: '{"mode":"strict"}',
+    scopes: '["issues:read"]'
+  }
+
+  assert.deepEqual(mcpRowsToConfig(mcpConfigToRows(config)), config)
+})
+
+test('preserves optional MCP environment declarations', () => {
+  const declarations = [
+    {
+      name: 'MCP_TOKEN',
+      description: 'Optional access token',
+      required: false,
+      secret: true
+    }
+  ]
+
+  assert.deepEqual(
+    buildMcpEnvironment(mcpEnvironmentForm(declarations)),
+    declarations
+  )
 })

--- a/frontend/tests/paginationTruncation.test.js
+++ b/frontend/tests/paginationTruncation.test.js
@@ -5,7 +5,7 @@ import test from 'node:test'
 const readSource = (path) =>
   readFile(new URL(`../src/${path}`, import.meta.url), 'utf8')
 
-test('complete assistant and LensNode reads collect every API page', async () => {
+test('complete assistant resource reads collect every API page', async () => {
   const source = await readSource('api/lens.js')
   const assistants = source.slice(
     source.indexOf('export async function listAssistants'),
@@ -15,9 +15,24 @@ test('complete assistant and LensNode reads collect every API page', async () =>
     source.indexOf('export async function listLensNodes'),
     source.indexOf('export async function getAdminRuns')
   )
+  const skills = source.slice(
+    source.indexOf('export async function listSkills'),
+    source.indexOf('export async function createSkill')
+  )
+  const environmentSets = source.slice(
+    source.indexOf('export async function listEnvironmentVariableSets'),
+    source.indexOf('export async function createEnvironmentVariableSet')
+  )
+  const mcps = source.slice(
+    source.indexOf('export async function listMcpServers'),
+    source.indexOf('export async function createMcpServer')
+  )
 
   assert.match(assistants, /collectPaginatedResults/)
   assert.match(lensnodes, /collectPaginatedResults/)
+  assert.match(skills, /collectPaginatedResults/)
+  assert.match(environmentSets, /collectPaginatedResults/)
+  assert.match(mcps, /collectPaginatedResults/)
 })
 
 test('shared Q&A review uses backend pagination metadata', async () => {

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -63,8 +63,9 @@ test('task statistics request all users unless a user is selected', async () => 
 
 test('drawer leave transition completes when animations are suspended', async () => {
   const drawer = await source('components/ui/BaseDrawer.vue')
-  const { runDrawerTransition } =
-    await import('../src/components/ui/drawerTransition.js')
+  const { runDrawerTransition } = await import(
+    '../src/components/ui/drawerTransition.js'
+  )
 
   let cancelledAnimations = 0
   const suspendedAnimation = () => ({
@@ -98,8 +99,9 @@ test('drawer leave transition completes when animations are suspended', async ()
 })
 
 test('drawer skips visual transitions in a hidden document', async () => {
-  const { runDrawerTransition } =
-    await import('../src/components/ui/drawerTransition.js')
+  const { runDrawerTransition } = await import(
+    '../src/components/ui/drawerTransition.js'
+  )
   let animationCount = 0
   let completed = false
   const panel = {
@@ -137,4 +139,95 @@ test('assistant token budget offers an unlimited profile', async () => {
   assert.equal(chinese.lensAdmin.tokenBudget.unlimited, '无限制')
   assert.match(english.lensAdmin.tokenBudget.unlimitedHint, /token cap/i)
   assert.match(chinese.lensAdmin.tokenBudget.unlimitedHint, /Token 预算/)
+})
+
+test('assistant Skill picker supports search and environment configuration', async () => {
+  const [drawer, english, chinese] = await Promise.all([
+    source('pages/lens/AssistantFormDrawerDirectEnvironment.vue'),
+    source('admin/locales/en.json').then(JSON.parse),
+    source('admin/locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  assert.match(drawer, /v-model="skillSearch"/)
+  assert.match(drawer, /type="search"/)
+  assert.match(drawer, /class="form-input skill-search-input"/)
+  assert.match(drawer, /\.skill-search-input\s*{\s*@apply pl-9;/)
+  assert.match(drawer, /v-for="skill in filteredSelectableSkills"/)
+  assert.match(drawer, /filterSelectableSkills/)
+  assert.match(drawer, /data-testid="assistant-skill-option"/)
+  assert.match(
+    drawer,
+    /isSkillSelected\(skill\.uuid\)\s*&& skillEnvironment\(skill\)\.length/
+  )
+  assert.match(drawer, /data-testid="assistant-skill-environments"/)
+  assert.match(drawer, /class="ml-8 border-l border-primary-200 pl-3"/)
+  assert.doesNotMatch(drawer, /selectedSkillsWithEnvironment/)
+  assert.equal(english.lensAdmin.wizard.searchSkills, 'Search Skills')
+  assert.equal(chinese.lensAdmin.wizard.searchSkills, '搜索 Skills')
+  assert.match(english.lensAdmin.wizard.skillSearchResults, /showing/i)
+  assert.match(chinese.lensAdmin.wizard.skillSearchResults, /显示/)
+  assert.equal(
+    english.lensAdmin.wizard.environmentSection,
+    'Environment variables'
+  )
+  assert.equal(chinese.lensAdmin.wizard.environmentSection, '环境变量')
+  assert.match(english.lensAdmin.wizard.environmentSectionHint, /this Skill/i)
+  assert.match(chinese.lensAdmin.wizard.environmentSectionHint, /当前 Skill/)
+})
+
+test('MCP config masks credential values while preserving edit feedback', async () => {
+  const [page, editor, english, chinese] = await Promise.all([
+    source('pages/lens/Mcp.vue'),
+    source('pages/lens/components/KeyValueEditor.vue'),
+    source('admin/locales/en.json').then(JSON.parse),
+    source('admin/locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  assert.match(page, /:mask-sensitive-values="true"/)
+  assert.match(page, /lensAdmin\.mcp\.sensitiveConfigHint/)
+  assert.match(editor, /isSensitiveMcpConfigKey/)
+  assert.match(editor, /:type="isSensitiveRow\(row\) \? 'password' : 'text'"/)
+  assert.match(editor, /isMaskedSensitiveRow\(row\)/)
+  assert.match(english.lensAdmin.mcp.sensitiveConfigHint, /masked/i)
+  assert.match(chinese.lensAdmin.mcp.sensitiveConfigHint, /掩码/)
+})
+
+test('MCP declarations and assistant bindings configure environment variables nearby', async () => {
+  const [mcpPage, drawer, english, chinese] = await Promise.all([
+    source('pages/lens/Mcp.vue'),
+    source('pages/lens/AssistantFormDrawerDirectEnvironment.vue'),
+    source('admin/locales/en.json').then(JSON.parse),
+    source('admin/locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  assert.match(mcpPage, /v-model="form\.environment"/)
+  assert.match(mcpPage, /environment: buildSkillEnvironment/)
+  assert.match(mcpPage, /mcpConfigToRows/)
+  assert.match(mcpPage, /mcpRowsToConfig/)
+  assert.match(
+    drawer,
+    /isMcpSelected\(mcp\.uuid\)\s*&& mcpEnvironment\(mcp\)\.length/
+  )
+  assert.match(drawer, /data-testid="assistant-mcp-environments"/)
+  assert.match(drawer, /mcp_environment_set_uuids/)
+  assert.match(english.lensAdmin.wizard.mcpEnvironmentSectionHint, /MCP Server/)
+  assert.match(chinese.lensAdmin.wizard.mcpEnvironmentSectionHint, /MCP Server/)
+  assert.match(
+    chinese.lensAdmin.mcp.environmentPlaceholderHint,
+    /\{placeholder\}/
+  )
+})
+
+test('environment variable sets show their Skill and MCP references', async () => {
+  const [page, english, chinese] = await Promise.all([
+    source('pages/lens/EnvironmentVariables.vue'),
+    source('admin/locales/en.json').then(JSON.parse),
+    source('admin/locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  assert.match(page, /row\.usages\?\.length/)
+  assert.match(page, /usage\.resource_name/)
+  assert.match(page, /usage\.assistant_name/)
+  assert.equal(english.lensAdmin.environmentVariables.usages, 'Referenced by')
+  assert.equal(chinese.lensAdmin.environmentVariables.usages, '引用方')
 })

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -201,7 +201,7 @@ test('MCP declarations and assistant bindings configure environment variables ne
   ])
 
   assert.match(mcpPage, /v-model="form\.environment"/)
-  assert.match(mcpPage, /environment: buildSkillEnvironment/)
+  assert.match(mcpPage, /environment: buildMcpEnvironment/)
   assert.match(mcpPage, /mcpConfigToRows/)
   assert.match(mcpPage, /mcpRowsToConfig/)
   assert.match(
@@ -210,6 +210,7 @@ test('MCP declarations and assistant bindings configure environment variables ne
   )
   assert.match(drawer, /data-testid="assistant-mcp-environments"/)
   assert.match(drawer, /mcp_environment_set_uuids/)
+  assert.match(drawer, /mcpRequiredEnvironmentNames/)
   assert.match(english.lensAdmin.wizard.mcpEnvironmentSectionHint, /MCP Server/)
   assert.match(chinese.lensAdmin.wizard.mcpEnvironmentSectionHint, /MCP Server/)
   assert.match(

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -831,16 +831,29 @@ def _materialize_mcp(mcp_root, mcp):
     environment = mcp.get("environment") or {}
     if not isinstance(environment, dict):
         environment = {}
+    environment_resolution = mcp.get("environment_resolved")
+    environment_resolved = environment_resolution is True
+    require_all_environment = environment_resolution is False
     payload = {
         "name": mcp.get("mcp_name"),
         "transport": mcp.get("transport"),
-        "endpoint": _expand_mcp_environment(
-            mcp.get("endpoint"),
-            environment,
+        "endpoint": (
+            mcp.get("endpoint")
+            if environment_resolved
+            else _expand_mcp_environment(
+                mcp.get("endpoint"),
+                environment,
+                require_all=require_all_environment,
+            )
         ),
-        "config": _expand_mcp_environment(
-            mcp.get("config") or {},
-            environment,
+        "config": (
+            mcp.get("config") or {}
+            if environment_resolved
+            else _expand_mcp_environment(
+                mcp.get("config") or {},
+                environment,
+                require_all=require_all_environment,
+            )
         ),
         "load_config": mcp.get("load_config") or {},
     }
@@ -852,25 +865,40 @@ def _materialize_mcp(mcp_root, mcp):
     return payload
 
 
-def _expand_mcp_environment(value, environment):
+def _expand_mcp_environment(value, environment, *, require_all=True):
     """Expand declared ${NAME} references in an ephemeral MCP payload."""
 
     if isinstance(value, dict):
         return {
-            key: _expand_mcp_environment(item, environment)
+            key: _expand_mcp_environment(
+                item,
+                environment,
+                require_all=require_all,
+            )
             for key, item in value.items()
         }
     if isinstance(value, list):
         return [
-            _expand_mcp_environment(item, environment)
+            _expand_mcp_environment(
+                item,
+                environment,
+                require_all=require_all,
+            )
             for item in value
         ]
     if not isinstance(value, str):
         return value
+
+    def replace_reference(match):
+        name = match.group(1)
+        if name not in environment:
+            if require_all:
+                raise ValueError(f"Missing MCP environment variable: {name}")
+            return match.group(0)
+        return str(environment[name])
+
     return MCP_ENVIRONMENT_REFERENCE_PATTERN.sub(
-        lambda match: str(
-            environment.get(match.group(1), match.group(0))
-        ),
+        replace_reference,
         value,
     )
 

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -31,6 +31,9 @@ STALE_RUNTIME_MAX_AGE_S = 24 * 60 * 60
 RUNTIME_ACTIVITY_INTERVAL_S = 15
 RUNTIME_CONVERSION_POLL_S = 0.25
 RUN_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+MCP_ENVIRONMENT_REFERENCE_PATTERN = re.compile(
+    r"\$\{([A-Z_][A-Z0-9_]*)\}"
+)
 
 
 @dataclass(frozen=True)
@@ -825,11 +828,20 @@ def _materialize_mcp(mcp_root, mcp):
 
     runtime_dir = mcp_root / name
     runtime_dir.mkdir(parents=True, exist_ok=True)
+    environment = mcp.get("environment") or {}
+    if not isinstance(environment, dict):
+        environment = {}
     payload = {
         "name": mcp.get("mcp_name"),
         "transport": mcp.get("transport"),
-        "endpoint": mcp.get("endpoint"),
-        "config": mcp.get("config") or {},
+        "endpoint": _expand_mcp_environment(
+            mcp.get("endpoint"),
+            environment,
+        ),
+        "config": _expand_mcp_environment(
+            mcp.get("config") or {},
+            environment,
+        ),
         "load_config": mcp.get("load_config") or {},
     }
     _write_private_json(
@@ -838,6 +850,29 @@ def _materialize_mcp(mcp_root, mcp):
     )
     _write_json(runtime_dir / "metadata.json", _mcp_metadata(mcp))
     return payload
+
+
+def _expand_mcp_environment(value, environment):
+    """Expand declared ${NAME} references in an ephemeral MCP payload."""
+
+    if isinstance(value, dict):
+        return {
+            key: _expand_mcp_environment(item, environment)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _expand_mcp_environment(item, environment)
+            for item in value
+        ]
+    if not isinstance(value, str):
+        return value
+    return MCP_ENVIRONMENT_REFERENCE_PATTERN.sub(
+        lambda match: str(
+            environment.get(match.group(1), match.group(0))
+        ),
+        value,
+    )
 
 
 def _skill_markdown(skill):

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -860,6 +860,54 @@ def test_mcp_credentials_are_materialized_only_in_run_directory(tmp_path):
         cleanup_runtime_resources(resources)
 
 
+def test_mcp_environment_expands_runtime_placeholders_only(tmp_path):
+    config = type(
+        "Config",
+        (),
+        {
+            "workspace_path": str(tmp_path),
+        },
+    )()
+    secret = "runtime-environment-secret"
+    command = {
+        "run_uuid": "00000000-0000-0000-0000-000000000009",
+        "loaded_skills": [],
+        "loaded_mcps": [
+            {
+                "mcp_uuid": "22222222-2222-2222-2222-222222222223",
+                "mcp_name": "Environment API",
+                "content_hash": "sha256:environment",
+                "transport": "url",
+                "endpoint": "https://${MCP_HOST}/api",
+                "config": {
+                    "headers": {
+                        "Authorization": "Bearer ${MCP_TOKEN}",
+                    }
+                },
+                "environment": {
+                    "MCP_HOST": "mcp.example.com",
+                    "MCP_TOKEN": secret,
+                },
+                "load_config": {},
+            }
+        ],
+    }
+
+    resources = prepare_runtime_resources(config, command)
+
+    try:
+        runtime_mcp = resources.mcp_configs[0]
+        assert runtime_mcp["endpoint"] == "https://mcp.example.com/api"
+        assert runtime_mcp["config"]["headers"] == {
+            "Authorization": f"Bearer {secret}"
+        }
+        runtime_text = resources.mcp_config_path.read_text(encoding="utf-8")
+        assert secret not in runtime_text
+        assert "MCP_TOKEN" not in runtime_text
+    finally:
+        cleanup_runtime_resources(resources)
+
+
 def test_system_prompt_includes_context_skill_guidance():
     prompt = _system_prompt(
         {

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -6,13 +6,18 @@ import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 from lensnode.agent_runtime import _system_prompt
 from lensnode.agent_tools import _skill_script_environment, build_agent_tools
 from lensnode.executor import LensNodeExecutor, _remaining_run_timeout_seconds
 from lensnode.gateway_model import RunCancelledError
 from lensnode.main import LensNodeClient
-from lensnode.runtime_resources import cleanup_runtime_resources
-from lensnode.runtime_resources import prepare_runtime_resources
+from lensnode.runtime_resources import (
+    _expand_mcp_environment,
+    cleanup_runtime_resources,
+    prepare_runtime_resources,
+)
 
 
 class FakeAgent:
@@ -904,6 +909,99 @@ def test_mcp_environment_expands_runtime_placeholders_only(tmp_path):
         runtime_text = resources.mcp_config_path.read_text(encoding="utf-8")
         assert secret not in runtime_text
         assert "MCP_TOKEN" not in runtime_text
+    finally:
+        cleanup_runtime_resources(resources)
+
+
+def test_mcp_environment_rejects_unresolved_placeholders():
+    with pytest.raises(
+        ValueError,
+        match="Missing MCP environment variable: MCP_TOKEN",
+    ):
+        _expand_mcp_environment(
+            {
+                "headers": {
+                    "Authorization": "Bearer ${MCP_TOKEN}",
+                }
+            },
+            {},
+        )
+
+
+def test_mcp_environment_preserves_preexpanded_values(tmp_path):
+    config = type(
+        "Config",
+        (),
+        {
+            "workspace_path": str(tmp_path),
+        },
+    )()
+    secret = "runtime-${HOME}-secret"
+    command = {
+        "run_uuid": "00000000-0000-0000-0000-000000000010",
+        "loaded_skills": [],
+        "loaded_mcps": [
+            {
+                "mcp_uuid": "22222222-2222-2222-2222-222222222224",
+                "mcp_name": "Resolved Environment API",
+                "content_hash": "sha256:resolved-environment",
+                "transport": "url",
+                "endpoint": "https://mcp.example.com/api",
+                "config": {
+                    "headers": {
+                        "Authorization": f"Bearer {secret}",
+                    }
+                },
+                "environment": {"MCP_TOKEN": secret},
+                "environment_resolved": True,
+                "load_config": {},
+            }
+        ],
+    }
+
+    resources = prepare_runtime_resources(config, command)
+
+    try:
+        assert resources.mcp_configs[0]["config"]["headers"] == {
+            "Authorization": f"Bearer {secret}"
+        }
+    finally:
+        cleanup_runtime_resources(resources)
+
+
+def test_mcp_environment_preserves_legacy_placeholder_literals(tmp_path):
+    config = type(
+        "Config",
+        (),
+        {
+            "workspace_path": str(tmp_path),
+        },
+    )()
+    command = {
+        "run_uuid": "00000000-0000-0000-0000-000000000011",
+        "loaded_skills": [],
+        "loaded_mcps": [
+            {
+                "mcp_uuid": "22222222-2222-2222-2222-222222222225",
+                "mcp_name": "Legacy Placeholder API",
+                "content_hash": "sha256:legacy-placeholder",
+                "transport": "url",
+                "endpoint": "https://mcp.example.com/${API_VERSION}",
+                "config": {"template": "${LITERAL}"},
+                "load_config": {},
+            }
+        ],
+    }
+
+    resources = prepare_runtime_resources(config, command)
+
+    try:
+        assert resources.mcp_configs[0]["endpoint"] == (
+            "https://mcp.example.com/${API_VERSION}"
+        )
+        assert resources.mcp_configs[0]["config"] == {
+            "template": "${LITERAL}"
+        }
     finally:
         cleanup_runtime_resources(resources)
 

--- a/release-notes/261.yaml
+++ b/release-notes/261.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: admin
+en: Improved Assistant Skill and MCP configuration with complete resource loading, reusable environment bindings, and protected MCP credentials.
+zh-CN: 改进助手的 Skill 与 MCP 配置，支持完整资源加载、可复用环境变量绑定和 MCP 凭据保护。


### PR DESCRIPTION
### **User description**
## Summary

- Load every paginated Skill, MCP server, and environment variable set in Assistant configuration, with searchable Skill selection and colocated environment controls.
- Add per-Assistant MCP environment bindings, required-variable validation, secret-safe usage metadata, and protected MCP credential editing.
- Keep decrypted values out of run snapshots, resolve only declared values at dispatch, and expand `${NAME}` references in the LensNode private runtime configuration.
- Add bilingual administrator release notes and regression coverage across the backend, frontend, and LensNode.

## Review scope note

This is a cross-runtime vertical slice: the database migration, control-plane validation and snapshot format, LensNode consumer, and administrator UI must land together to avoid a partially supported MCP binding protocol. The change exceeds the preferred PR size threshold, so it should receive explicit maintainer acceptance of that review scope before merge.

## Test plan

- [x] Backend focused API and dispatch tests: 5 passed in the isolated development container.
- [x] LensNode executor tests: 24 passed.
- [x] Focused frontend unit tests: 22 passed.
- [x] Admin locale key parity passed.
- [x] Frontend production build passed.
- [x] ESLint passed for all changed Vue and JavaScript files.
- [x] Django migration consistency check reported no changes.
- [x] Release-note unit tests: 6 passed; PR fragment validation passed.

Known baseline: the full frontend unit suite reports 221/224 passing. The three failures are outside this diff: one app locale parity assertion for existing registration keys and two existing Run Observation source assertions.

Closes #261


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Paginated loading for Skills, MCP servers, and environment variable sets.

- MCP environment declarations with required-variable validation.

- Secret-safe masking and idempotent editing of MCP configuration.

- Environment variable set usage metadata for skill and MCP bindings.

- Runtime MCP environment expansion in LensNode.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Backend API] --> B[MCPServer serializer]
  B --> C[Mask sensitive config & validate environment]
  C --> D[Assistant binding with environment set]
  D --> E[Snapshot loaded MCPs]
  E --> F[Dispatch to LensNode]
  F --> G[Runtime expansion of ${NAME} references]
  G --> H[MCP execution]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add MCP API and dispatch tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+577/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Add LensNode MCP environment expansion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+148/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>regressionFixes.test.js</strong><dd><code>Add frontend regression tests for MCP and skill features</code>&nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-c6817d11aa2607c6dcdf8fef1d9bd8766a8fe8625f22ac8dbbf8d3181d0d1e06">+98/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Enhance serializers with MCP environment and secret handling</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+474/-14</a></td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add MCP environment resolution and dispatch validation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+93/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Add MCP runtime environment expansion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+65/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>environment_variables.py</strong><dd><code>Add environment reference extraction and expansion utilities</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-c7626bece1d8778387fcfd29a4d52c4f58044f40da18bfcd363a102b3fbeb6b6">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Extend models for MCP environment bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>environment_variables.py</strong><dd><code>Optimize environment variable set view for usages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-63bd86508e3229cda13e96e59583c14ca5dc767be0a9719070e1137903c9f5ed">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssistantFormDrawerDirectEnvironment.vue</strong><dd><code>Add searchable skills and MCP environment UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-1bbf22475c1d3e7a28848d3821a473ca289b3ce9c70ed901042e503be4fbc9ff">+394/-163</a></td>

</tr>

<tr>
  <td><strong>EnvironmentVariables.vue</strong><dd><code>Show environment variable set usage references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-93c362d6b5fa8972954c44d140b15162086df5a2b0cc8a01c2e293ec4e16bebd">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>KeyValueEditor.vue</strong><dd><code>Support sensitive value masking in key-value editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-83bd42d4f4e62cb0f3c6d1391a54a1bfd564e74c51fc15eebac9af8192979952">+38/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Mcp.vue</strong><dd><code>Add MCP environment declarations and config masking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-84a9cc053a9ae958bb1e7c02121ba71cebff1c73d291413cfbb6cf0cfc61212d">+28/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Assistants.vue</strong><dd><code>Include MCP environment bindings in assistant form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+26/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SkillEnvironmentEditor.vue</strong><dd><code>Make environment editor help text configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-afb5e7b017ab561bfd0ac0ff92847285c0257b3014de1b83b424eba6171b1d8b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add paginated loading for resource lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+17/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Database migrations</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0040_mcp_environment_bindings.py</strong><dd><code>Add MCP environment and binding migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-19185ea03effd219fb4f4cf021d59362ca81662f51e28015e755bd2d1b6850b2">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>en.json</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantEnvironment.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-494cfedcbd462ba89210acf6406b686fc11490756bda47ba870ce1b030868366">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantSkills.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-ad23f3df444617d390bf67c844f9b057fc5ef9752a57bfc7fde4d6d3df1262f7">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcpConfig.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-79c2447b4d07b181ebe577981271bc9ef52eef6598fb5e91871f88a509aa1350">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>assistantEnvironment.test.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-87260b91107db75d9e3bc816fccb323fa13eaff5de72f561eba91ba22137021d">+62/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantSkills.test.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-8abe9ddcac7fa90b00d74bb7ca9253592023a23912c5223bbdbcf7a9cff181c6">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcpConfig.test.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-a293a65a794c2c3cc6727ccdfd53abbb14cbbb9a2fe2c722e24ba61f03aa3f2c">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paginationTruncation.test.js</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-5ea11f42bc8491da3cb7b4f2ace3138e82663a4d0b0657ddbcad62e357cab120">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>261.yaml</strong></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/262/files#diff-72c155ed0b456337b9b31bd9cae870a611e58250bc0ddf6cd74aff93c5c4ad88">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

