### PR TITLE
Update agentcore-metering for deterministic retries

### DIFF
--- a/release-notes/269.yaml
+++ b/release-notes/269.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Improved answer reliability by retrying temporary model-service failures
+  before returning an error.
+zh-CN: >-
+  提升回答可靠性，在模型服务临时失败时先自动重试，再决定是否返回错误。


### PR DESCRIPTION
### **User description**
## Summary

- Update `agentcore-metering` from `1b53c77` to upstream merge commit `daad811`.
- Adopt deterministic per-call LiteLLM retries for transient provider failures.
- Add a bilingual user release note for improved answer reliability.

Closes #269
Related to #265

Upstream implementation: cloud2ai/agentcore-metering#13 and cloud2ai/agentcore-metering#14.
Pre-existing upstream test debt: cloud2ai/agentcore-metering#15.

## Review notes

- The retry loop classifies 408, 429, provider 5xx, timeouts, and eligible connection failures as transient.
- Each attempt disables nested LiteLLM and provider-SDK retries.
- Backoff and retries share one bounded request timeout.
- Streaming retries stop after the first caller-visible reasoning or content chunk, preventing replayed output.
- No fallback-model selection, SourceLens error-code mapping, or whole-Run retry is included.

## Test plan

- [x] Retry-specific upstream tests: 10 passed on Python 3.11.
- [x] Release-note tooling tests: 6 passed.
- [x] PR release-note validation: 1 fragment validated.
- [x] `git diff --check` passed.
- [x] Baseline comparison confirmed no new affected-suite failures.

## Baseline comparison

The same isolated Python 3.11 command was run against both gitlinks:

| Submodule commit | Collected | Passed | Failed |
| --- | ---: | ---: | ---: |
| `1b53c77` | 50 | 30 | 20 |
| `daad811` | 72 | 52 | 20 |

The 20 failures are pre-existing test-debt issues and are unchanged by this update. They are tracked in cloud2ai/agentcore-metering#15. The new deterministic retry tests pass 10/10.


___

### **PR Type**
Bug fix


___

### **Description**
- Update agentcore-metering submodule to daad811

- Add bilingual release note for retry improvement


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agentcore-metering</strong><dd><code>Update agentcore-metering submodule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/agentcore/agentcore-metering

Updated git submodule from 1b53c77 to daad811 to adopt deterministic <br>per-call LiteLLM retries for transient provider failures.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/270/files#diff-6526bad06cb84f460e39dbe67971544b06e0e7b4cd6e09b06e22aed0987b9982">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>269.yaml</strong><dd><code>Add release note for retry fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/269.yaml

Added bilingual user-facing release note for improved answer <br>reliability with retries.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/270/files#diff-cbe3866c2b7f0ab4bef8c76a6d2b2eb91d98cd7491911c4ce2b210d7c6942c89">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

