### PR TITLE
Fix user settings language selection

### DIFF
--- a/frontend/src/components/settings/UserSettingsModal.vue
+++ b/frontend/src/components/settings/UserSettingsModal.vue
@@ -184,7 +184,7 @@
                   <BaseSelect
                     id="ui-language"
                     :model-value="locale"
-                    @change="selectLanguage($event.target.value)"
+                    @update:model-value="selectLanguage"
                   >
                     <option
                       v-for="lang in languages"

--- a/frontend/src/pages/lens/DataSourceFormDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceFormDrawer.vue
@@ -113,7 +113,7 @@
             <div class="flex gap-2">
               <BaseSelect
                 :model-value="form.credential_uuid"
-                @change="handleCredentialChange"
+                @update:model-value="handleCredentialChange"
               >
                 <option value="">
                   {{ t('lensAdmin.datasourceWizard.selectCredential') }}
@@ -201,7 +201,7 @@
             <div class="flex gap-2">
               <BaseSelect
                 :model-value="form.credential_uuid"
-                @change="handleCredentialChange"
+                @update:model-value="handleCredentialChange"
               >
                 <option value="">
                   {{ t('lensAdmin.datasourceWizard.selectFeishuCredential') }}
@@ -1890,8 +1890,7 @@ function testConnectionIfVisible() {
   }
 }
 
-async function handleCredentialChange(event) {
-  const nextUuid = event.target.value
+async function handleCredentialChange(nextUuid) {
   const previousUuid =
     acceptedCredentialUuid.value || props.form.credential_uuid
   if (nextUuid === props.form.credential_uuid) {
@@ -1903,7 +1902,6 @@ async function handleCredentialChange(event) {
     )
     if (!confirmed) {
       props.form.credential_uuid = previousUuid
-      event.target.value = previousUuid
       return
     }
   }

--- a/frontend/tests/answerLanguageSettings.test.js
+++ b/frontend/tests/answerLanguageSettings.test.js
@@ -6,19 +6,49 @@ const source = (path) =>
   readFile(new URL(`../src/${path}`, import.meta.url), 'utf8')
 
 test('one language setting controls both UI and AI output', async () => {
-  const [component, switcher, userStore, languages] = await Promise.all([
-    source('components/settings/UserSettingsModal.vue'),
-    source('components/ui/LanguageSwitcher.vue'),
-    source('store/user.js'),
-    source('utils/languages.js')
-  ])
+  const [component, switcher, userStore, preferencesStore, languages] =
+    await Promise.all([
+      source('components/settings/UserSettingsModal.vue'),
+      source('components/ui/LanguageSwitcher.vue'),
+      source('store/user.js'),
+      source('store/preferences.js'),
+      source('utils/languages.js')
+    ])
 
   assert.match(component, /id="ui-language"/)
+  assert.match(component, /@update:model-value="selectLanguage"/)
+  assert.doesNotMatch(component, /@change="selectLanguage/)
   assert.doesNotMatch(component, /id="answer-language"/)
   assert.doesNotMatch(component, /getAnswerLanguageOptions/)
   assert.match(component, /userStore\.updateLanguage\(language\)/)
   assert.match(switcher, /userStore\.updateLanguage\(language\)/)
   assert.match(userStore, /profile_language: language/)
   assert.match(userStore, /preferencesStore\.setLanguage/)
+  assert.match(
+    preferencesStore,
+    /i18n\.global\.locale\.value = normalizedLanguage/
+  )
+  assert.match(
+    preferencesStore,
+    /document\.documentElement\.lang = normalizedLanguage/
+  )
+  assert.match(
+    preferencesStore,
+    /localStorage\.setItem\('userLanguage', normalizedLanguage\)/
+  )
   assert.doesNotMatch(languages, /ANSWER_LANGUAGES/)
+})
+
+test('controlled credential selects consume value updates directly', async () => {
+  const component = await source('pages/lens/DataSourceFormDrawer.vue')
+  const valueBindings = component.match(/:model-value="form\.credential_uuid"/g)
+  const updateBindings = component.match(
+    /@update:model-value="handleCredentialChange"/g
+  )
+
+  assert.equal(valueBindings?.length, 2)
+  assert.equal(updateBindings?.length, 2)
+  assert.doesNotMatch(component, /@change="handleCredentialChange"/)
+  assert.match(component, /handleCredentialChange\(nextUuid\)/)
+  assert.doesNotMatch(component, /handleCredentialChange\(event\)/)
 })

--- a/release-notes/268.yaml
+++ b/release-notes/268.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Fixed language selection in User Settings so interface changes persist.
+zh-CN: 修复用户设置中的语言选择，使界面语言切换能够正确保存。


### PR DESCRIPTION
### **User description**
## Summary

- consume BaseSelect value updates directly in User Settings
- migrate the remaining controlled credential selectors to the same value update contract
- add regression coverage for language persistence and controlled selector bindings

## Testing

- node --test tests/answerLanguageSettings.test.js tests/baseSelect.test.js
- prettier --check tests/answerLanguageSettings.test.js src/components/settings/UserSettingsModal.vue
- npm run build
- manually verified mouse and keyboard language selection in the shared runtime

Fixes #268


___

### **PR Type**
Bug fix


___

### **Description**
- Fix language selection in User Settings by consuming BaseSelect value updates directly

- Migrate credential selectors in DataSourceFormDrawer to the same value update contract

- Add regression coverage for language persistence and controlled selector bindings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UserSettingsModal["UserSettingsModal.vue"]
  BaseSelect["BaseSelect (ui-language)"]
  selectLanguage["selectLanguage()"]
  UserSettingsModal -- "@update:model-value" --> BaseSelect
  BaseSelect -- "value (language)" --> selectLanguage
  selectLanguage --> i18n["i18n locale"]
  selectLanguage --> localStorage["localStorage.userLanguage"]
  selectLanguage --> docLang["document.documentElement.lang"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserSettingsModal.vue</strong><dd><code>Fix language selector event binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/settings/UserSettingsModal.vue

<ul><li>Changed event handler from @change to @update:model-value for language <br>selector<br> <li> Removed reliance on synthetic change event target value</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/271/files#diff-aa6410cf6949d28f892578c56dc32520cf22ed90043fa5a4d5c266acc570041b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataSourceFormDrawer.vue</strong><dd><code>Migrate credential selectors to value update contract</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/DataSourceFormDrawer.vue

<ul><li>Changed event handler from @change to @update:model-value for <br>credential selectors<br> <li> Updated handleCredentialChange function to accept value directly <br>instead of event object<br> <li> Removed manual reset of event.target.value in confirmation cancel path</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/271/files#diff-0b2ea6040d7c458a234eb3d290500ddb300a087019b6b58d947883cda373ec42">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>answerLanguageSettings.test.js</strong><dd><code>Add regression tests for selector value updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/answerLanguageSettings.test.js

<ul><li>Added test for controlled language selector using @update:model-value<br> <li> Added test for controlled credential selects using @update:model-value<br> <li> Verified persistence and event handling patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/271/files#diff-d1ca409ea030a54a9615ae4fc2164f77004e8c2f3424c1b6adb6b4b52295718d">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>268.yaml</strong><dd><code>Add release note for language selection fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/268.yaml

<ul><li>Added release note for the language selection fix in English and <br>Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/271/files#diff-86aecd53829d618a66ef5e6ca0adaf5640ce02437d1c49c05fec344f84ae867a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

