### PR TITLE
Fix session deletion with run diagnostics

### DIFF
--- a/backend/lens/tests/test_session_management.py
+++ b/backend/lens/tests/test_session_management.py
@@ -7,7 +7,15 @@ from django.test import TestCase
 from PIL import Image
 from rest_framework.test import APIClient
 
-from lens.models import Assistant, LensNode, Run, Session, SharedQA
+from lens.models import (
+    Assistant,
+    LensNode,
+    Run,
+    RunDiagnostic,
+    RunDiagnosticEvidence,
+    Session,
+    SharedQA,
+)
 from lens.services import create_execution_run
 
 
@@ -194,6 +202,37 @@ class SessionManagementTests(TestCase):
 
         self.assertTrue(rows[str(self.first.uuid)]["has_shareable_answer"])
         self.assertFalse(rows[str(self.second.uuid)]["has_shareable_answer"])
+
+    def test_delete_session_with_run_diagnostic_history(self):
+        run = create_execution_run(
+            self.first,
+            "Diagnosed question",
+            enqueue=False,
+            user=self.user,
+        )
+        evidence = RunDiagnosticEvidence.objects.create(
+            run=run,
+            payload={"events": []},
+        )
+        diagnostic = RunDiagnostic.objects.create(
+            run=run,
+            evidence=evidence,
+            requested_by=self.user,
+        )
+
+        response = self.client.delete(
+            f"/api/lens/sessions/{self.first.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Session.objects.filter(pk=self.first.pk).exists())
+        self.assertFalse(Run.objects.filter(pk=run.pk).exists())
+        self.assertFalse(
+            RunDiagnostic.objects.filter(pk=diagnostic.pk).exists()
+        )
+        self.assertFalse(
+            RunDiagnosticEvidence.objects.filter(pk=evidence.pk).exists()
+        )
 
     def test_other_users_cannot_manage_sessions_they_do_not_own(self):
         self.client.force_authenticate(self.other)

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -41,6 +41,7 @@ from lens.models import (
     Message,
     MessageAttachment,
     Run,
+    RunDiagnostic,
     RunExecution,
     RunOutputFile,
     Session,
@@ -192,18 +193,19 @@ class SessionViewSet(BaseAuthenticatedViewSet):
         return Response(serializer.data)
 
     def perform_destroy(self, instance):
-        """Delete runs first to avoid PROTECT conflict on Run.input_message.
+        """Delete protected dependents in dependency order.
 
-        Django 5.1's deletion collector checks PROTECT constraints during
-        the collection phase. It processes Message.session (CASCADE) before
-        Run.session (CASCADE), so Run.input_message (PROTECT) blocks Message
-        deletion before Run is added to the deletion set. Deleting Runs
-        explicitly first removes the PROTECT reference.
+        Django's deletion collector checks PROTECT constraints while it
+        collects related objects. Delete diagnostics before their evidence
+        cascades from Run, then delete Runs before Messages cascade from the
+        Session.
         """
         session_uuid = instance.uuid
         user_id = instance.user_id
-        instance.run_set.all().delete()
-        instance.delete()
+        with transaction.atomic():
+            RunDiagnostic.objects.filter(run__session=instance).delete()
+            instance.run_set.all().delete()
+            instance.delete()
         try:
             delete_session_document_attachments(
                 session_uuid,

--- a/release-notes/274.yaml
+++ b/release-notes/274.yaml
@@ -1,0 +1,5 @@
+type: fix
+audience: user
+en: >-
+  Fixed session deletion when a session contains runs with diagnostic history.
+zh-CN: 修复会话包含运行诊断记录时无法删除的问题。


### PR DESCRIPTION
### **User description**
## Summary
- delete run diagnostics before their protected evidence is collected during session deletion
- keep diagnostic, run, and session deletion in one database transaction
- add regression coverage for sessions whose runs have diagnostic history

Closes #274

## Test plan
- [x] `python manage.py test --keepdb lens.tests.test_session_management lens.tests.test_run_diagnostics` (30 tests)


___

### **PR Type**
Bug fix


___

### **Description**
- Delete run diagnostics before runs to avoid PROTECT constraint.

- Keep deletion atomic within a single transaction.

- Add regression test for sessions with diagnostic history.

- Add release note for the fix.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Session deletion starts] --> B[Delete RunDiagnostic]
  B --> C[Delete Run]
  C --> D[Delete Message via cascade]
  D --> E[Delete Session]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_session_management.py</strong><dd><code>Add regression test for session deletion with diagnostics</code></dd></summary>
<hr>

backend/lens/tests/test_session_management.py

<ul><li>Added test <code>test_delete_session_with_run_diagnostic_history</code>.<br> <li> Creates a run with diagnostic evidence and verifies session deletion <br>removes all related objects.<br> <li> Imports <code>RunDiagnostic</code> and <code>RunDiagnosticEvidence</code> models.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/276/files#diff-388fe1a422b63d03d261be45bec2e25e874834faa7f3bd702680421e62a35171">+40/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Delete diagnostics before runs in session deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/views/sessions.py

<ul><li>Modified <code>perform_destroy</code> to delete <code>RunDiagnostic</code> objects before <br>deleting runs.<br> <li> Wrapped deletions in <code>transaction.atomic()</code> to ensure atomicity.<br> <li> Updated comment to reflect new dependency order.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/276/files#diff-5271360df826bc1230406d5a73425315af7aafd55724812d08e243956049a6ed">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>274.yaml</strong><dd><code>Add release note for session deletion fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/274.yaml

<ul><li>Added release note entry for the fix.<br> <li> Includes both English and Chinese descriptions.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/276/files#diff-d7c37333772a214f9ef6e1f75d45e378ccbecc973909743b0d0eb4784fcd47f7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

