### PR TITLE
Recover interrupted agent streams from checkpoints

### DIFF
--- a/lensnode/lensnode/agent_runtime/execution.py
+++ b/lensnode/lensnode/agent_runtime/execution.py
@@ -5,7 +5,7 @@ import logging
 from langchain_core.messages import HumanMessage
 
 from ..agent_tools import SELF_REPORTING_TOOLS
-from ..gateway_model import RunCancelledError
+from ..gateway_model import GatewayStreamError, RunCancelledError
 from .messages import (
     extract_final_message as _extract_final_message,
     normalize_plan_steps as _normalize_plan_steps,
@@ -38,6 +38,8 @@ def _run_agent_with_turn_limit(
     token_budget_wrapup_event=None,
     on_checkpoint_state=None,
     input_checkpoint_seeded=False,
+    stream_recovery_attempts=0,
+    on_stream_recovery=None,
 ):
     """Stream agent events and stop after max_turns NEW AI turns.
 
@@ -61,6 +63,11 @@ def _run_agent_with_turn_limit(
     Returns (answer, truncated, termination_reason). ``truncated`` is true
     when the agent was stopped before it finished naturally, and the reason
     preserves the gate that requested wrap-up.
+
+    A gateway stream failure may resume from the latest graph checkpoint
+    when a thread and a positive recovery budget are supplied. Seen events
+    and turn accounting remain in memory so checkpoint replay is not exposed
+    as duplicate progress.
     """
 
     last_state = {"messages": messages} if resume_from_checkpoint else None
@@ -87,13 +94,13 @@ def _run_agent_with_turn_limit(
         graph_input = {"messages": []}
     else:
         graph_input = {"messages": messages}
-    for state in agent.stream(
+    for state in _stream_agent_states_with_recovery(
+        agent,
         graph_input,
-        stream_mode="values",
-        config={
-            "recursion_limit": 500,
-            **(thread or {}),
-        },
+        thread,
+        stream_recovery_attempts,
+        emit_event,
+        on_stream_recovery,
     ):
         if cancel_event is not None and cancel_event.is_set():
             raise RunCancelledError(
@@ -223,6 +230,57 @@ def _run_agent_with_turn_limit(
         }:
             termination_reason = model_reason
     return answer, truncated, termination_reason
+
+
+def _stream_agent_states_with_recovery(
+    agent,
+    graph_input,
+    thread,
+    recovery_attempts,
+    emit_event,
+    on_recovery,
+):
+    """Resume a failed gateway stream from the latest graph checkpoint."""
+
+    remaining_attempts = max(0, recovery_attempts)
+    max_attempts = remaining_attempts
+    attempt = 0
+
+    while True:
+        try:
+            yield from agent.stream(
+                graph_input,
+                stream_mode="values",
+                config={
+                    "recursion_limit": 500,
+                    **(thread or {}),
+                },
+            )
+            return
+        except GatewayStreamError as exc:
+            if not thread or remaining_attempts <= 0:
+                raise
+            attempt += 1
+            remaining_attempts -= 1
+            LOGGER.warning(
+                "Agent gateway stream failed; resuming checkpoint "
+                "(attempt %s/%s, code=%s)",
+                attempt,
+                max_attempts,
+                exc.code,
+            )
+            if on_recovery is not None:
+                on_recovery()
+            if emit_event is not None:
+                emit_event(
+                    "deepagents.stream.recovering",
+                    {
+                        "attempt": attempt,
+                        "max_attempts": max_attempts,
+                        "code": exc.code,
+                    },
+                )
+            graph_input = None
 
 
 def _strip_dangling_tool_call(messages):

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -781,6 +781,12 @@ class LensDeepAgentRuntime:
                     persist_execution_state if checkpoint_ready else None
                 ),
                 input_checkpoint_seeded=initial_checkpoint_seeded,
+                stream_recovery_attempts=1 if checkpoint_ready else 0,
+                on_stream_recovery=(
+                    (lambda: emit_output("", reset=True))
+                    if emit_output is not None
+                    else None
+                ),
             )
             if truncated:
                 emit_agent_event(

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -24,6 +24,7 @@ from lensnode.agent_runtime import (
     _synthesize_wrapup_answer,
 )
 from lensnode.checkpoint import CheckpointResumeError, ResumeState
+from lensnode.gateway_model import GatewayStreamError
 
 
 class _Msg:
@@ -1761,6 +1762,7 @@ def test_successful_skill_evidence_preserves_the_final_answer(
     )
 
     def run_agent(*_args, **_kwargs):
+        captured["run_options"] = _kwargs
         captured["boundary"].success_count = 2
         captured["boundary"].successful_capabilities = {
             "artifact_delivery",
@@ -1802,6 +1804,7 @@ def test_successful_skill_evidence_preserves_the_final_answer(
     assert result["answer"] == "已生成并交付订单流程图。"
     assert result["outcome"] == "completed"
     assert result["termination_detail"] == {}
+    assert captured["run_options"]["stream_recovery_attempts"] == 0
 
 
 def test_delivered_artifact_completes_after_token_budget_wrapup():
@@ -1948,6 +1951,8 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
         assert options["token_budget_wrapup_event"] is None
         assert "capability_stop_event" not in options
         assert options["input_checkpoint_seeded"] is True
+        assert options["stream_recovery_attempts"] == 1
+        assert options["on_stream_recovery"] is None
     assert checkpoint_actions == [
         "saver",
         "metadata",
@@ -3827,6 +3832,138 @@ def test_resume_does_not_reemit_checkpointed_tool_events():
     assert plan_events[0]["payload"]["steps"] == [
         {"id": "step-1", "title": "Inspect", "status": "completed"},
         {"id": "step-2", "title": "Finish", "status": "in_progress"},
+    ]
+
+
+def test_stream_error_recovers_from_checkpoint_without_duplicate_events():
+    checkpoint_message = _Msg(
+        "ai",
+        tool_calls=[
+            {
+                "id": "lookup-1",
+                "name": "lookup",
+                "args": {"query": "evidence"},
+            }
+        ],
+    )
+    final_message = _Msg("ai", content="recovered answer")
+
+    class Agent:
+        def __init__(self):
+            self.inputs = []
+
+        def stream(self, inp, stream_mode=None, config=None):
+            del stream_mode, config
+            self.inputs.append(inp)
+            if len(self.inputs) == 1:
+                yield {"messages": [checkpoint_message]}
+                raise GatewayStreamError(
+                    "MODEL_STREAM_ERROR",
+                    "stream ended before completion",
+                )
+            assert inp is None
+            yield {"messages": [checkpoint_message, final_message]}
+
+    agent = Agent()
+    events = []
+    output_resets = []
+
+    answer, truncated, termination_reason = _run_agent_with_turn_limit(
+        agent,
+        [{"role": "user", "content": "question"}],
+        max_turns=5,
+        thread={"configurable": {"thread_id": "run-1"}},
+        emit_event=lambda name, detail: events.append((name, detail)),
+        stream_recovery_attempts=1,
+        on_stream_recovery=lambda: output_resets.append(True),
+    )
+
+    assert answer == "recovered answer"
+    assert truncated is False
+    assert termination_reason is None
+    assert agent.inputs == [
+        {"messages": [{"role": "user", "content": "question"}]},
+        None,
+    ]
+    assert output_resets == [True]
+    assert [name for name, _detail in events].count(
+        "deepagents.stream.recovering"
+    ) == 1
+    assert [name for name, _detail in events].count(
+        "tool.lookup.invoke"
+    ) == 1
+    assert [name for name, _detail in events].count("llm.response") == 2
+
+
+@pytest.mark.parametrize(
+    ("thread", "stream_recovery_attempts"),
+    [
+        (None, 1),
+        ({"configurable": {"thread_id": "run-1"}}, 0),
+    ],
+)
+def test_stream_error_is_not_recovered_without_checkpoint_or_budget(
+    thread,
+    stream_recovery_attempts,
+):
+    error = GatewayStreamError(
+        "MODEL_STREAM_ERROR",
+        "stream ended before completion",
+    )
+
+    class Agent:
+        call_count = 0
+
+        def stream(self, inp, stream_mode=None, config=None):
+            del inp, stream_mode, config
+            self.call_count += 1
+            raise error
+
+    agent = Agent()
+
+    with pytest.raises(GatewayStreamError) as raised:
+        _run_agent_with_turn_limit(
+            agent,
+            [{"role": "user", "content": "question"}],
+            max_turns=5,
+            thread=thread,
+            stream_recovery_attempts=stream_recovery_attempts,
+        )
+
+    assert raised.value is error
+    assert agent.call_count == 1
+
+
+def test_stream_error_stops_after_recovery_budget_is_exhausted():
+    errors = [
+        GatewayStreamError("MODEL_STREAM_ERROR", "first failure"),
+        GatewayStreamError("MODEL_STREAM_ERROR", "second failure"),
+    ]
+
+    class Agent:
+        def __init__(self):
+            self.inputs = []
+
+        def stream(self, inp, stream_mode=None, config=None):
+            del stream_mode, config
+            self.inputs.append(inp)
+            raise errors[len(self.inputs) - 1]
+
+    agent = Agent()
+
+    with pytest.raises(GatewayStreamError) as raised:
+        _run_agent_with_turn_limit(
+            agent,
+            [{"role": "user", "content": "question"}],
+            max_turns=5,
+            thread={"configurable": {"thread_id": "run-1"}},
+            stream_recovery_attempts=1,
+        )
+
+    assert raised.value is errors[1]
+    assert agent.inputs == [
+        {"messages": [{"role": "user", "content": "question"}]},
+        None,
     ]
 
 

--- a/release-notes/275.yaml
+++ b/release-notes/275.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Improved long-running answer reliability by resuming interrupted model
+  streams from saved progress.
+zh-CN: >-
+  提升长时间回答的可靠性，在模型流意外中断时从已保存进度继续执行。


### PR DESCRIPTION
### **User description**
## Summary

- resume one interrupted gateway stream from the latest graph checkpoint
- preserve turn accounting and event de-duplication across checkpoint replay
- reset uncommitted visible output and emit a structured recovery event
- keep recovery bounded and re-raise errors when recovery is unavailable or exhausted

Closes #275

Related to #267. This PR does not close the remaining length-cap, frontend,
delivery-gate, or end-to-end scope tracked there.

## Test plan

- [x] LensNode test suite: 401 passed
- [x] Git diff whitespace validation


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Resume interrupted gateway streams from graph checkpoint with bounded retry.

- Preserve turn accounting and deduplicate events across checkpoint replay.

- Reset uncommitted visible output and emit structured recovery event.

- Re-raise errors when no checkpoint or recovery budget is exhausted.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Request"] --> B["Agent Stream"]
  B --> C{"Checkpoint Ready?"}
  C -- "Yes" --> D["Stream Running"]
  D --> E{"GatewayStreamError?"}
  E -- "Yes" --> F["Recover from Checkpoint"]
  F --> D
  E -- "No" --> G["Stream Completed"]
  C -- "No" --> H["Error Raised"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution.py</strong><dd><code>Add stream recovery logic and parameter wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/execution.py

<ul><li>Added <code>_stream_agent_states_with_recovery()</code> generator for <br>checkpoint-based recovery.<br> <li> Modified <code>_run_agent_with_turn_limit()</code> to accept <br><code>stream_recovery_attempts</code> and <code>on_stream_recovery</code>.<br> <li> Replaced direct <code>agent.stream()</code> with recovery wrapper when applicable.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/277/files#diff-fe9857808d8cf47bd0a22c9aa697d985122c3e48e6bfb036d9783c735d31a6e3">+65/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Enable recovery for checkpoint‑ready runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Pass <code>stream_recovery_attempts=1</code> when checkpoint is ready.<br> <li> Provide <code>on_stream_recovery</code> callback to reset output.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/277/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Add tests for stream recovery scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_history.py

<ul><li>Test successful recovery from checkpoint without duplicate events.<br> <li> Test no recovery when thread or budget is missing.<br> <li> Test recovery exhaustion after budget depleted.<br> <li> Assert <code>stream_recovery_attempts</code> and <code>on_stream_recovery</code> in existing <br>tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/277/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+137/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>275.yaml</strong><dd><code>Release note for stream recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/275.yaml

- Added user-facing release note for stream recovery improvement.


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/277/files#diff-3bb9bfc4a6f7b03948ee1af1421a4f2df67e4d09e7f5e98cdcf2cf8a8cd3d81e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

