### PR TITLE
Fix stale answer completion title during active runs

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2921,11 +2921,10 @@ async function selectSession(session, updateRoute = true) {
   }
   await nextTick(scrollToBottom)
   if (!isCurrentLoad()) return
-  await maybeResumeActiveRun(session.uuid, isCurrentLoad)
-  if (!isCurrentLoad()) return
   if (clearUnreadSession(window.localStorage, session.uuid)) {
     refreshUnreadSessions()
   }
+  await maybeResumeActiveRun(session.uuid, isCurrentLoad)
 }
 
 // If the session has a run still in progress (e.g. the user navigated away

--- a/frontend/src/utils/answerCompletionNotifications.js
+++ b/frontend/src/utils/answerCompletionNotifications.js
@@ -41,7 +41,7 @@ export function answerCompletionTitle({
   completionLabel,
   hasUnread
 }) {
-  return hasUnread ? `🔔 ${completionLabel} · ${baseTitle}` : baseTitle
+  return hasUnread ? `${completionLabel} · ${baseTitle}` : baseTitle
 }
 
 export function shouldReviewUnreadSession({

--- a/frontend/tests/answerCompletionNotifications.test.js
+++ b/frontend/tests/answerCompletionNotifications.test.js
@@ -70,14 +70,14 @@ function createNotificationApi(permission = 'granted', requested = permission) {
   return NotificationApi
 }
 
-test('uses a bell instead of an unread count in the browser title', () => {
+test('uses a completion label without an unread count in the browser title', () => {
   assert.equal(
     answerCompletionTitle({
       baseTitle: 'SourceLens',
       completionLabel: 'Answer completed',
       hasUnread: true
     }),
-    '🔔 Answer completed · SourceLens'
+    'Answer completed · SourceLens'
   )
   assert.equal(
     answerCompletionTitle({

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -20,6 +20,24 @@ test('reveals loaded chat before waiting for active run recovery', async () => {
   assert.ok(chatRevealed < resumeActiveRun)
 })
 
+test('reviews a selected unread chat before active run recovery', async () => {
+  const source = await chatSource()
+  const selectSession = source.indexOf('async function selectSession(')
+  const resumeActiveRun = source.indexOf(
+    'await maybeResumeActiveRun(session.uuid, isCurrentLoad)',
+    selectSession
+  )
+  const clearUnread = source.indexOf(
+    'clearUnreadSession(window.localStorage, session.uuid)',
+    selectSession
+  )
+
+  assert.notEqual(selectSession, -1)
+  assert.notEqual(resumeActiveRun, -1)
+  assert.notEqual(clearUnread, -1)
+  assert.ok(clearUnread < resumeActiveRun)
+})
+
 test('guards restored run state with the current session load', async () => {
   const source = await chatSource()
 

--- a/release-notes/278.yaml
+++ b/release-notes/278.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed a stale answer-completion browser title when reopening a conversation
+  that is still running.
+zh-CN: >-
+  修复重新打开仍在运行的会话后，浏览器标题仍显示“回答已完成”的问题。


### PR DESCRIPTION
### **User description**
## Summary
- Clear the selected conversation unread marker before awaiting active Run SSE recovery.
- Restore the base browser title immediately while preserving active progress and stop controls.
- Remove the bell emoji from the completion title and add ordering regression coverage.

Closes #278

## Test plan
- [x] `node --test tests/chatBootstrap.test.js tests/answerCompletionNotifications.test.js tests/sessionActivity.test.js` (26/26)
- [x] Targeted ESLint for the four changed files
- [x] `npm run build`
- [x] ego-browser task space 23: verified the plain completion title clears immediately while the Run remains active

## Known baseline failures
- `npm run test:unit`: 228/231 pass; the existing app locale parity failure and two Run Observation source-contract failures are unrelated to this change.


___

### **PR Type**
Bug fix


___

### **Description**
- Reorder selectSession to clear unread before active run recovery

- Remove bell emoji from answer completion title

- Add regression test for unread ordering

- Add release note for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["selectSession()"] --> B["clearUnreadSession()"]
  B --> C["maybeResumeActiveRun()"]
  C --> D["Browser title updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Reorder unread clear before run recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Moved <code>clearUnreadSession</code> call before <code>maybeResumeActiveRun</code> in <br><code>selectSession</code><br> <li> Ensures browser title reflects unread state before run recovery begins</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/280/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>answerCompletionNotifications.js</strong><dd><code>Remove bell emoji from completion title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/answerCompletionNotifications.js

<ul><li>Removed <code>🔔</code> bell emoji from the title when <code>hasUnread</code> is true<br> <li> Title now shows plain completion label without unread glyph</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/280/files#diff-9bb037824c83eaf62241e46228e0e3b9815f220ad3d4c109d8e0f9958652d7c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>answerCompletionNotifications.test.js</strong><dd><code>Update test for plain completion title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/answerCompletionNotifications.test.js

<ul><li>Updated test description and assertion to reflect no bell emoji<br> <li> Verifies title uses plain completion label</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/280/files#diff-6fea43041bf4dc70b7e1b3b66493067d8bab264bc218cdf8fd03ff3f7ddb2461">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add regression test for unread ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Added test to verify <code>clearUnreadSession</code> is called before <br><code>maybeResumeActiveRun</code> in <code>selectSession</code><br> <li> Ensures ordering regression coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/280/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>278.yaml</strong><dd><code>Add release note for title fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/278.yaml

<ul><li>Added English and Chinese release note for the fix<br> <li> Describes stale answer-completion title fix</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/280/files#diff-e01d84d6cd91c7fd559bc39ca1c924d37610f881463cc4a39515e53326eb3795">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

