### PR TITLE
Expose document preprocessing progress

### DIFF
--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -5,6 +5,7 @@ from datetime import datetime
 PUBLIC_EVENT_TYPES = {
     "artifact.created",
     "capability.blocked",
+    "document.progress",
     "execution.failed",
     "verification.failed",
     "phase.changed",
@@ -54,6 +55,13 @@ PUBLIC_STAGE_STATUSES = {
     "completed",
     "failed",
     "skipped",
+}
+
+PUBLIC_DOCUMENT_PROGRESS_STAGES = {
+    "downloading",
+    "extracting_text",
+    "recognizing_images",
+    "ready",
 }
 
 TOOL_ACTIVITY_STATUSES = {
@@ -412,6 +420,30 @@ def _sanitize_payload(event_type, payload):
     if event_type == "phase.changed":
         phase = payload.get("phase")
         return {"phase": phase} if phase in PUBLIC_PHASES else {}
+    if event_type == "document.progress":
+        stage = payload.get("stage")
+        if stage not in PUBLIC_DOCUMENT_PROGRESS_STAGES:
+            return {}
+        return {
+            "revision": _positive_int(payload.get("revision")),
+            "stage": stage,
+            "document_index": min(
+                _positive_int(payload.get("document_index")),
+                100,
+            ),
+            "document_total": min(
+                _positive_int(payload.get("document_total")),
+                100,
+            ),
+            "image_completed": min(
+                _positive_int(payload.get("image_completed")),
+                100,
+            ),
+            "image_total": min(
+                _positive_int(payload.get("image_total")),
+                100,
+            ),
+        }
     if event_type == "plan.updated":
         steps = []
         for item in (payload.get("steps") or [])[:12]:

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -1298,6 +1298,53 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(event["payload"], {})
         self.assertNotIn("secret-token", str(event))
 
+    def test_document_progress_event_exposes_only_bounded_counts(self):
+        event = sanitize_runtime_event(
+            {
+                "event_type": "document.progress",
+                "visibility": "user",
+                "payload": {
+                    "revision": "7",
+                    "stage": "recognizing_images",
+                    "document_index": 1,
+                    "document_total": 2,
+                    "image_completed": 3,
+                    "image_total": 5,
+                    "filename": "private-report.docx",
+                    "secret": "hidden",
+                },
+            }
+        )
+
+        self.assertEqual(event["event_type"], "document.progress")
+        self.assertEqual(
+            event["payload"],
+            {
+                "revision": 7,
+                "stage": "recognizing_images",
+                "document_index": 1,
+                "document_total": 2,
+                "image_completed": 3,
+                "image_total": 5,
+            },
+        )
+        self.assertNotIn("private-report.docx", str(event))
+        self.assertNotIn("hidden", str(event))
+
+    def test_document_progress_event_rejects_unknown_stage(self):
+        event = sanitize_runtime_event(
+            {
+                "event_type": "document.progress",
+                "visibility": "user",
+                "payload": {
+                    "revision": 1,
+                    "stage": "reading_private_content",
+                },
+            }
+        )
+
+        self.assertEqual(event["payload"], {})
+
     def test_order_query_activity_exposes_safe_real_parameters(self):
         event = sanitize_runtime_event(
             {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -296,6 +296,11 @@
         "stageEnded": "Ended {completed}/{total}",
         "activityProgress": "Recorded {count} activities",
         "activityCompleted": "Completed {count} activities",
+        "documentProgress": {
+          "downloading": "Downloading document {current}/{total}",
+          "extractingText": "Extracting document text {current}/{total}",
+          "recognizingImages": "Recognizing document images {completed}/{total}"
+        },
         "blockedTitle": "Capability unavailable",
         "executionFailedTitle": "Capability execution failed",
         "verificationFailedTitle": "Result verification incomplete",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -296,6 +296,11 @@
         "stageEnded": "已结束 {completed}/{total}",
         "activityProgress": "已记录 {count} 项活动",
         "activityCompleted": "已完成 {count} 项活动",
+        "documentProgress": {
+          "downloading": "正在下载文档 {current}/{total}",
+          "extractingText": "正在提取文档文本 {current}/{total}",
+          "recognizingImages": "正在识别文档图片 {completed}/{total}"
+        },
         "blockedTitle": "所需能力当前不可用",
         "executionFailedTitle": "能力执行失败",
         "verificationFailedTitle": "结果验证未完成",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1480,6 +1480,7 @@ import {
   createConversationAutoScroller,
   createRuntimeState,
   formatActivityProgressText,
+  formatDocumentProgressText,
   formatDuration,
   getMessageTimestamp,
   isActiveProgressAncestor,
@@ -2013,6 +2014,10 @@ const liveFinalAnswerProgressText = computed(() => {
   return t('lens.chat.runtime.planCompletedAnswering', progress)
 })
 
+const liveDocumentProgressText = computed(() =>
+  formatDocumentProgressText(runtimeState.value.documentProgress, t)
+)
+
 const liveStageProgressText = computed(() =>
   stageProgressText(runtimeState.value.stages)
 )
@@ -2032,6 +2037,7 @@ const liveProgressText = computed(() => {
   }
   return selectLiveProgressText({
     finalAnswerProgressText: liveFinalAnswerProgressText.value,
+    documentProgressText: liveDocumentProgressText.value,
     structuredProgressText: liveStructuredProgressText.value,
     planProgressText: livePlanProgressText.value,
     stageProgressText: runtimeState.value.route

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -7,6 +7,12 @@ const STAGE_STATUSES = new Set([
   'skipped'
 ])
 const ACTIVITY_STATUSES = new Set(['in_progress', 'completed', 'failed'])
+const DOCUMENT_PROGRESS_STAGES = new Set([
+  'downloading',
+  'extracting_text',
+  'recognizing_images',
+  'ready'
+])
 const STRUCTURED_ACTIVITY_KINDS = new Set([
   'query_orders',
   'get_order_detail',
@@ -70,6 +76,26 @@ export function formatActivityProgressText(
     text += ` · ${formatDuration(durationSeconds)}`
   }
   return text
+}
+
+export function formatDocumentProgressText(progress, translate) {
+  if (!progress || progress.stage === 'ready') return ''
+  if (progress.stage === 'recognizing_images') {
+    return translate('lens.chat.runtime.documentProgress.recognizingImages', {
+      completed: progress.imageCompleted,
+      total: progress.imageTotal
+    })
+  }
+  const keys = {
+    downloading: 'downloading',
+    extracting_text: 'extractingText'
+  }
+  const key = keys[progress.stage]
+  if (!key) return ''
+  return translate(`lens.chat.runtime.documentProgress.${key}`, {
+    current: progress.documentIndex,
+    total: progress.documentTotal
+  })
 }
 
 export function getMessageTimestamp(message) {
@@ -150,6 +176,8 @@ export function createRuntimeState() {
     complexity: null,
     evidenceRequirement: null,
     phase: null,
+    documentProgress: null,
+    documentProgressRevision: 0,
     plan: [],
     planRevision: 0,
     stages: [],
@@ -556,6 +584,7 @@ export function summarizeStageProgress(stages, { terminal = false } = {}) {
 
 export function selectLiveProgressText({
   finalAnswerProgressText,
+  documentProgressText,
   structuredProgressText,
   planProgressText,
   stageProgressText,
@@ -566,6 +595,7 @@ export function selectLiveProgressText({
 }) {
   return (
     finalAnswerProgressText ||
+    documentProgressText ||
     structuredProgressText ||
     planProgressText ||
     stageProgressText ||
@@ -798,6 +828,27 @@ export function applyRuntimeEvent(state, event) {
   }
   if (event.event_type === 'phase.changed') {
     return { ...current, phase: payload.phase || null }
+  }
+  if (event.event_type === 'document.progress') {
+    const revision = Math.max(Number(payload.revision || 0), 0)
+    if (
+      revision < current.documentProgressRevision ||
+      !DOCUMENT_PROGRESS_STAGES.has(payload.stage)
+    ) {
+      return current
+    }
+    return {
+      ...current,
+      documentProgressRevision: revision,
+      documentProgress: {
+        revision,
+        stage: payload.stage,
+        documentIndex: Math.max(Number(payload.document_index || 0), 0),
+        documentTotal: Math.max(Number(payload.document_total || 0), 0),
+        imageCompleted: Math.max(Number(payload.image_completed || 0), 0),
+        imageTotal: Math.max(Number(payload.image_total || 0), 0)
+      }
+    }
   }
   if (event.event_type === 'plan.updated') {
     const revision = Math.max(Number(payload.revision || 0), 0)

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -8,6 +8,7 @@ import {
   calculateRunElapsedSeconds,
   createConversationAutoScroller,
   createRuntimeState,
+  formatDocumentProgressText,
   formatActivityProgressText,
   getMessageTimestamp,
   isActiveProgressAncestor,
@@ -1334,6 +1335,56 @@ test('falls back through phase, activity and run status', () => {
   assert.equal(selectLiveProgressText({ fallbackText: 'Waiting' }), 'Waiting')
 })
 
+test('formats active document preparation without exposing document data', () => {
+  const translate = (key, values) => `${key}:${JSON.stringify(values)}`
+
+  assert.equal(
+    formatDocumentProgressText(
+      {
+        stage: 'downloading',
+        documentIndex: 1,
+        documentTotal: 2
+      },
+      translate
+    ),
+    'lens.chat.runtime.documentProgress.downloading:{"current":1,"total":2}'
+  )
+  assert.equal(
+    formatDocumentProgressText(
+      {
+        stage: 'recognizing_images',
+        imageCompleted: 3,
+        imageTotal: 5
+      },
+      translate
+    ),
+    'lens.chat.runtime.documentProgress.recognizingImages:{"completed":3,"total":5}'
+  )
+  assert.equal(
+    formatDocumentProgressText(
+      {
+        stage: 'extracting_text',
+        documentIndex: 2,
+        documentTotal: 2
+      },
+      translate
+    ),
+    'lens.chat.runtime.documentProgress.extractingText:{"current":2,"total":2}'
+  )
+  assert.equal(formatDocumentProgressText({ stage: 'ready' }, translate), '')
+})
+
+test('shows document preparation before generic run status', () => {
+  assert.equal(
+    selectLiveProgressText({
+      documentProgressText: 'Recognizing document images 3/5',
+      phaseText: 'Analyzing',
+      fallbackText: 'Generating'
+    }),
+    'Recognizing document images 3/5'
+  )
+})
+
 test('ignores stale plan revisions after reconnect', () => {
   let state = createRuntimeState()
   state = applyRuntimeEvent(state, {
@@ -1355,6 +1406,42 @@ test('ignores stale plan revisions after reconnect', () => {
 
   assert.equal(state.planRevision, 2)
   assert.equal(state.plan[0].title, 'New plan')
+})
+
+test('keeps the latest document progress after reconnect', () => {
+  let state = createRuntimeState()
+  state = applyRuntimeEvent(state, {
+    event_type: 'document.progress',
+    visibility: 'user',
+    payload: {
+      revision: 2,
+      stage: 'recognizing_images',
+      document_index: 1,
+      document_total: 1,
+      image_completed: 3,
+      image_total: 5
+    }
+  })
+  state = applyRuntimeEvent(state, {
+    event_type: 'document.progress',
+    visibility: 'user',
+    payload: {
+      revision: 1,
+      stage: 'extracting_text',
+      document_index: 1,
+      document_total: 1
+    }
+  })
+
+  assert.equal(state.documentProgressRevision, 2)
+  assert.deepEqual(state.documentProgress, {
+    revision: 2,
+    stage: 'recognizing_images',
+    documentIndex: 1,
+    documentTotal: 1,
+    imageCompleted: 3,
+    imageTotal: 5
+  })
 })
 
 test('reduces ordered direct-execution stages and ignores stale revisions', () => {

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -61,6 +61,18 @@ def _touch_runtime_activity(context):
         on_activity()
 
 
+def _emit_conversion_progress(context, detail):
+    """Send content-free conversion progress to the parent process."""
+
+    progress_queue = context.get("progress_queue")
+    if progress_queue is None:
+        return
+    try:
+        progress_queue.put(detail)
+    except (AttributeError, OSError, ValueError):
+        return
+
+
 class ConversionOutput:
     """One converter output."""
 
@@ -1121,6 +1133,17 @@ def convert_embedded_images(path, context):
     try:
         with zipfile.ZipFile(path) as archive:
             entries = embedded_image_entries(archive, prefix)
+            image_total = min(len(entries), max(max_images, 0))
+            if image_total:
+                _emit_conversion_progress(
+                    context,
+                    {
+                        "stage": "recognizing_images",
+                        "image_completed": 0,
+                        "image_total": image_total,
+                    },
+                )
+            image_completed = 0
             for index, name in enumerate(entries, start=1):
                 _check_runtime_cancelled(context)
                 _touch_runtime_activity(context)
@@ -1143,6 +1166,15 @@ def convert_embedded_images(path, context):
                     stats["images_duplicate"] = int(
                         stats.get("images_duplicate") or 0
                     ) + 1
+                    image_completed += 1
+                    _emit_conversion_progress(
+                        context,
+                        {
+                            "stage": "recognizing_images",
+                            "image_completed": image_completed,
+                            "image_total": image_total,
+                        },
+                    )
                     continue
                 seen.add(digest)
                 result = convert_one_embedded_image(
@@ -1156,6 +1188,15 @@ def convert_embedded_images(path, context):
                 merge_cost_stats(cost, result["cost"])
                 if result["description"]:
                     descriptions.append(result)
+                image_completed += 1
+                _emit_conversion_progress(
+                    context,
+                    {
+                        "stage": "recognizing_images",
+                        "image_completed": image_completed,
+                        "image_total": image_total,
+                    },
+                )
     except (OSError, zipfile.BadZipFile):
         return {"markdown": "", "stats": stats, "cost": cost}
 
@@ -1831,6 +1872,7 @@ def describe_image_bytes(image_bytes, mime_type, context):
         model_ref=model_ref,
         ai_gateway_url=gateway_url,
         token=token,
+        run_uuid=context.get("run_uuid"),
         tls_skip_verify=context.get("tls_skip_verify", False),
         tls_ca_file=context.get("tls_ca_file"),
         http_client=context.get("gateway_http_client"),

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -1384,6 +1384,7 @@ def describe_image_result(
     model_ref,
     ai_gateway_url,
     token,
+    run_uuid=None,
     tls_skip_verify=False,
     tls_ca_file=None,
     http_client=None,
@@ -1409,6 +1410,8 @@ def describe_image_result(
             }
         ],
     }
+    if run_uuid:
+        payload["run_uuid"] = str(run_uuid)
     with _http_client_context(
         http_client,
         timeout=120,

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -149,6 +149,7 @@ def prepare_runtime_resources(
             config,
             command,
             runtime_root,
+            emit_event=emit_event,
             cancel_event=cancel_event,
             on_activity=on_activity,
         )
@@ -269,6 +270,7 @@ def _materialize_subject_documents(
     config,
     command,
     runtime_root,
+    emit_event=None,
     cancel_event=None,
     on_activity=None,
 ):
@@ -287,7 +289,35 @@ def _materialize_subject_documents(
         1,
         int(command.get("run_timeout_s") or config.request_timeout_s),
     )
-    for document in documents:
+    progress_revision = 0
+
+    def emit_document_progress(stage, document_index, detail=None):
+        """Emit one replayable, content-free document progress event."""
+
+        nonlocal progress_revision
+        if emit_event is None:
+            return
+        progress_revision += 1
+        detail = detail or {}
+        emit_event(
+            "workflow.document.progress",
+            {
+                "event_type": "document.progress",
+                "visibility": "user",
+                "payload": {
+                    "revision": progress_revision,
+                    "stage": stage,
+                    "document_index": document_index,
+                    "document_total": len(documents),
+                    "image_completed": int(
+                        detail.get("image_completed") or 0
+                    ),
+                    "image_total": int(detail.get("image_total") or 0),
+                },
+            },
+        )
+
+    for document_index, document in enumerate(documents, start=1):
         _check_cancelled(cancel_event)
         attachment_uuid = str(document.get("uuid") or "").strip()
         original_name = Path(
@@ -309,6 +339,7 @@ def _materialize_subject_documents(
         extension = Path(filename).suffix.lower()
         if not attachment_uuid or extension not in RUN_DOCUMENT_EXTENSIONS:
             raise ValueError("Unsupported Run attachment metadata")
+        emit_document_progress("downloading", document_index)
         data = _download_run_attachment(
             config,
             run_uuid,
@@ -325,8 +356,10 @@ def _materialize_subject_documents(
 
         source_path = subject_dir / f"{prefix}{filename}"
         source_path.write_bytes(data)
+        emit_document_progress("extracting_text", document_index)
         context = {
             "source_type": "run_attachment",
+            "run_uuid": run_uuid,
             "target_path": str(subject_dir),
             "conversion": {
                 "document": True,
@@ -346,16 +379,30 @@ def _materialize_subject_documents(
             context,
             cancel_event=cancel_event,
             on_activity=on_activity,
+            on_progress=lambda detail: emit_document_progress(
+                detail.get("stage") or "extracting_text",
+                document_index,
+                detail,
+            ),
             deadline_at=conversion_deadline,
         )
+        emit_document_progress("ready", document_index)
     return subject_dir
 
 
-def _conversion_worker(target, path, item, context, result_queue):
+def _conversion_worker(
+    target,
+    path,
+    item,
+    context,
+    result_queue,
+    progress_queue,
+):
     """Convert one document and report a serialization-safe result."""
 
     try:
-        result = convert_one(target, path, item, context)
+        worker_context = {**context, "progress_queue": progress_queue}
+        result = convert_one(target, path, item, worker_context)
     except Exception as exc:
         result_queue.put(
             {
@@ -375,6 +422,7 @@ def _run_document_conversion(
     *,
     cancel_event,
     on_activity,
+    on_progress=None,
     deadline_at,
 ):
     """Run conversion in a child process bounded by cancellation and time."""
@@ -386,9 +434,17 @@ def _run_document_conversion(
 
     process_context = multiprocessing.get_context("spawn")
     result_queue = process_context.Queue(maxsize=1)
+    progress_queue = process_context.Queue(maxsize=128)
     process = process_context.Process(
         target=_conversion_worker,
-        args=(target, path, item, context, result_queue),
+        args=(
+            target,
+            path,
+            item,
+            context,
+            result_queue,
+            progress_queue,
+        ),
         name="document-attachment-conversion",
     )
     started = False
@@ -406,11 +462,13 @@ def _run_document_conversion(
             process.join(
                 timeout=min(RUNTIME_CONVERSION_POLL_S, remaining_s)
             )
+            _forward_conversion_progress(progress_queue, on_progress)
             now = time.monotonic()
             if now >= next_activity_at:
                 _touch_activity(on_activity)
                 next_activity_at = now + RUNTIME_ACTIVITY_INTERVAL_S
 
+        _forward_conversion_progress(progress_queue, on_progress)
         try:
             payload = result_queue.get(timeout=1)
         except queue.Empty as exc:
@@ -429,6 +487,20 @@ def _run_document_conversion(
             process.join(timeout=1)
         result_queue.close()
         result_queue.join_thread()
+        progress_queue.close()
+        progress_queue.join_thread()
+
+
+def _forward_conversion_progress(progress_queue, on_progress):
+    """Forward all available child progress messages to the Run emitter."""
+
+    while True:
+        try:
+            detail = progress_queue.get_nowait()
+        except queue.Empty:
+            return
+        if on_progress is not None and isinstance(detail, dict):
+            on_progress(detail)
 
 
 def _download_run_attachment(

--- a/lensnode/tests/test_document_convert.py
+++ b/lensnode/tests/test_document_convert.py
@@ -246,6 +246,7 @@ def test_post_process_document_recognizes_embedded_office_image(
         describe_image_bytes,
     )
 
+    progress = []
     summary = post_process_documents(
         {
             "datasource_uuid": "ds1",
@@ -260,6 +261,7 @@ def test_post_process_document_recognizes_embedded_office_image(
             },
             "ai_gateway_url": "http://gateway",
             "lensnode_token": "token",
+            "progress_queue": types.SimpleNamespace(put=progress.append),
         },
         SyncResult(items=[sync_item(doc)]),
     )
@@ -272,6 +274,18 @@ def test_post_process_document_recognizes_embedded_office_image(
     assert summary["embedded_images_total"] == 1
     assert summary["embedded_images_recognized"] == 1
     assert meta["conversion"]["stats"]["embedded_images_recognized"] == 1
+    assert progress == [
+        {
+            "stage": "recognizing_images",
+            "image_completed": 0,
+            "image_total": 1,
+        },
+        {
+            "stage": "recognizing_images",
+            "image_completed": 1,
+            "image_total": 1,
+        },
+    ]
 
 
 def test_post_process_pdf_recognizes_embedded_image(tmp_path, monkeypatch):

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -1130,8 +1130,10 @@ def test_legacy_tool_result_is_neutralized_without_recovery_metadata():
 
 def test_image_gateway_request_uses_configured_tls_context(monkeypatch):
     client_options = {}
+    captured = {}
 
     def handler(request):
+        captured["payload"] = json.loads(request.read())
         return httpx.Response(
             200,
             json={"message": {"content": "described"}},
@@ -1146,10 +1148,12 @@ def test_image_gateway_request_uses_configured_tls_context(monkeypatch):
         model_ref="vision-model",
         ai_gateway_url="https://gateway.example/ai/",
         token="token",
+        run_uuid="run-123",
         tls_skip_verify=True,
     )
 
     assert result["content"] == "described"
+    assert captured["payload"]["run_uuid"] == "run-123"
     assert client_options["verify"].verify_mode == ssl.CERT_NONE
 
 

--- a/lensnode/tests/test_subject_documents.py
+++ b/lensnode/tests/test_subject_documents.py
@@ -143,6 +143,7 @@ def test_prepare_materializes_converts_and_scopes_subject_document(
     assert calls[0][3]["conversion"]["document"] is True
     assert calls[0][3]["conversion"]["embedded_image"] is True
     assert calls[0][3]["conversion"]["vision_model_ref"] == "vision-model"
+    assert calls[0][3]["run_uuid"] == "run-123"
     assert str(sidecar / "content.md") in glob_files(
         [{"path": str(subject_dir), "material_role": "subject"}],
         "**/*",
@@ -150,6 +151,60 @@ def test_prepare_materializes_converts_and_scopes_subject_document(
 
     cleanup_runtime_resources(resources)
     assert not resources.root.exists()
+
+
+def test_prepare_emits_replayable_document_progress(monkeypatch, tmp_path):
+    content = b"%PDF-1.7\nsubject"
+    command = _command(content)
+    events = []
+
+    monkeypatch.setattr(
+        "lensnode.runtime_resources._download_run_attachment",
+        lambda config, run_uuid, document, **kwargs: content,
+    )
+
+    def convert_document(*args, **kwargs):
+        kwargs["on_progress"](
+            {
+                "stage": "recognizing_images",
+                "image_completed": 1,
+                "image_total": 2,
+            }
+        )
+        return {"chars": 35}
+
+    monkeypatch.setattr(
+        "lensnode.runtime_resources._run_document_conversion",
+        convert_document,
+    )
+
+    prepare_runtime_resources(
+        _config(tmp_path),
+        command,
+        emit_event=lambda name, detail: events.append((name, detail)),
+    )
+
+    document_events = [
+        detail
+        for name, detail in events
+        if name == "workflow.document.progress"
+    ]
+    assert [
+        event["payload"]["stage"] for event in document_events
+    ] == [
+        "downloading",
+        "extracting_text",
+        "recognizing_images",
+        "ready",
+    ]
+    assert [
+        event["payload"]["revision"] for event in document_events
+    ] == [1, 2, 3, 4]
+    assert document_events[2]["payload"]["image_completed"] == 1
+    assert document_events[2]["payload"]["image_total"] == 2
+    assert all(event["event_type"] == "document.progress" for event in document_events)
+    assert all(event["visibility"] == "user" for event in document_events)
+    assert "Tender 2026.pdf" not in str(document_events)
 
 
 def test_prepare_materializes_prior_deliverable_for_general_chat(
@@ -290,11 +345,72 @@ def test_prepare_cancels_conversion_and_removes_runtime_files(
     assert not runtime_root.exists()
 
 
-def _stall_conversion_worker(target, path, item, context, result_queue):
+def _stall_conversion_worker(
+    target,
+    path,
+    item,
+    context,
+    result_queue,
+    progress_queue,
+):
     """Record the child PID and stall until the parent terminates it."""
 
+    del target, item, context, result_queue, progress_queue
     Path(path).write_text(str(os.getpid()), encoding="utf-8")
     time.sleep(60)
+
+
+def _report_conversion_progress(target, path, item, context):
+    """Report one child-process progress update."""
+
+    del target, path, item
+    context["progress_queue"].put(
+        {
+            "stage": "recognizing_images",
+            "image_completed": 2,
+            "image_total": 5,
+        }
+    )
+    return {"chars": 1}
+
+
+def test_conversion_process_forwards_progress_to_parent(monkeypatch, tmp_path):
+    try:
+        fork_context = multiprocessing.get_context("fork")
+    except ValueError:
+        pytest.skip("fork context is required for this process test")
+
+    monkeypatch.setattr(
+        runtime_resources.multiprocessing,
+        "get_context",
+        lambda _method: fork_context,
+    )
+    monkeypatch.setattr(
+        runtime_resources,
+        "convert_one",
+        _report_conversion_progress,
+    )
+    progress = []
+
+    result = runtime_resources._run_document_conversion(
+        tmp_path,
+        tmp_path / "document.docx",
+        {},
+        {},
+        cancel_event=threading.Event(),
+        on_activity=None,
+        on_progress=progress.append,
+        deadline_at=time.monotonic() + 5,
+    )
+
+    assert result == {"chars": 1}
+    assert progress == [
+        {
+            "stage": "recognizing_images",
+            "image_completed": 2,
+            "image_total": 5,
+        }
+    ]
 
 
 def test_conversion_process_is_terminated_at_run_deadline(

--- a/release-notes/281.yaml
+++ b/release-notes/281.yaml
@@ -1,0 +1,7 @@
+type: improvement
+audience: user
+en: >-
+  Added live document preparation progress for downloads, text extraction,
+  and embedded-image recognition before an answer starts.
+zh-CN: >-
+  新增文档下载、文本提取和内嵌图片识别的实时准备进度，在回答开始前也能看到处理状态。


### PR DESCRIPTION
### **User description**
## Summary

- stream replayable, content-free document preparation progress from LensNode to the chat UI
- show localized download, text extraction, and embedded-image recognition status before generic run progress
- attribute embedded-image vision gateway usage to the originating Run and add a bilingual release note

Closes #281

## Test plan

- [x] `docker exec sourcelens-api-dev python manage.py test lens.tests.test_services --keepdb` (98 passed)
- [x] `lensnode/.venv/bin/python -m pytest lensnode/tests/test_document_convert.py lensnode/tests/test_gateway_model.py lensnode/tests/test_subject_documents.py -q` (64 passed)
- [x] `node --test tests/runtimeEvents.test.js` (61 passed)
- [x] `npx eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore` (0 errors)
- [x] `npm run build`
- [x] `.venv/bin/python -m unittest scripts.test_release_notes` (6 passed)

## Known baseline

- `npm run test:unit` still reports the existing app locale parity mismatch for 10 English registration keys; the new document progress keys are present in both locales.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Sanitize document.progress events and expose content-free metadata

- Forward conversion progress from subprocess to parent runtime

- Attribute embedded-image vision calls to the originating Run

- Show localized download, extraction, and recognition progress in chat UI

- Add regression tests for event sanitization, forwarding, and UI fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ConversionSubprocess["Conversion Subprocess"]
  ProgressQueue["Progress Queue (multiprocessing)"]
  ParentProcess["Parent Runtime Process"]
  EmitEvent["emit_event('workflow.document.progress')"]
  BackendSanitize["Backend: sanitize_runtime_event"]
  FrontendEvent["Frontend: applyRuntimeEvent"]
  FrontendUI["Chat UI: localized progress text"]
  VisionGateway["Vision Gateway Request (with run_uuid)"]
  ConversionSubprocess -- "puts progress detail" --> ProgressQueue
  ProgressQueue -- "_forward_conversion_progress" --> ParentProcess
  ParentProcess -- "emit_document_progress" --> EmitEvent
  EmitEvent -- "document.progress event" --> BackendSanitize
  BackendSanitize -- "sanitized payload" --> FrontendEvent
  FrontendEvent -- "formatDocumentProgressText" --> FrontendUI
  ConversionSubprocess -- "describe_image_bytes(run_uuid)" --> VisionGateway
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>runtime_events.py</strong><dd><code>Add document.progress event type and sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-c9a17a59ab1b816ecb943fc96701791319bddd6e65c78a3dfe42616fbd6e33b5">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document_convert.py</strong><dd><code>Emit conversion progress and pass run_uuid to vision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway_model.py</strong><dd><code>Accept run_uuid parameter in vision gateway request</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Forward child-process progress to parent runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+76/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Integrate document progress text into live progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.js</strong><dd><code>Add document.progress handling and formatting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_services.py</strong><dd><code>Add tests for document.progress event sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_document_convert.py</strong><dd><code>Verify progress events during embedded image conversion</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-d1b5eccc8b37d86afa07c94fe7a4b451abfa1697d00108d4122da56ff3df1a3b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gateway_model.py</strong><dd><code>Assert run_uuid in gateway request payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_subject_documents.py</strong><dd><code>Add tests for progress emission and subprocess forwarding</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-13e8a99ae6db55f17067bd5a4af36980fafd91af472f30a2e605c5decb52172b">+117/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.test.js</strong><dd><code>Add tests for document progress formatting and fallback</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English localization keys for document progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese localization keys for document progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>281.yaml</strong><dd><code>Add release note for document preparation progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/282/files#diff-dd41d16ec658fd520e415de4be376e490a7d1cf1aa94451b73faaa7cfbcfd23b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

