### PR TITLE
Fix dark-mode Markdown file preview contrast

### DIFF
--- a/frontend/src/components/lens/FilePreviewModal.vue
+++ b/frontend/src/components/lens/FilePreviewModal.vue
@@ -228,7 +228,7 @@ onUnmounted(() => {
   height: 100%;
   max-height: 90vh;
   overflow: hidden;
-  background: #fff;
+  background: var(--sl-bg-surface);
   border-radius: 12px;
   box-shadow: 0 12px 48px rgba(0, 0, 0, 0.4);
 }
@@ -238,14 +238,14 @@ onUnmounted(() => {
   justify-content: space-between;
   gap: 12px;
   padding: 12px 16px;
-  border-bottom: 1px solid #eceff3;
+  border-bottom: 1px solid var(--sl-border-default);
 }
 .preview-title {
   min-width: 0;
   overflow: hidden;
   font-size: 14px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--sl-text-primary);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -260,24 +260,24 @@ onUnmounted(() => {
   justify-content: center;
   width: 32px;
   height: 32px;
-  color: #6b7280;
+  color: var(--sl-text-muted);
   border-radius: 8px;
   transition: all 0.15s;
 }
 .preview-tool:hover {
-  color: #2563eb;
-  background: #eff6ff;
+  color: var(--sl-accent);
+  background: var(--sl-bg-hover);
 }
 .preview-body {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  background: #f8fafc;
+  background: var(--sl-bg-canvas);
 }
 .preview-status {
   padding: 48px 16px;
   font-size: 14px;
-  color: #6b7280;
+  color: var(--sl-text-muted);
   text-align: center;
 }
 .preview-image {
@@ -289,7 +289,7 @@ onUnmounted(() => {
   width: 100%;
   height: 100%;
   min-height: 70vh;
-  background: #fff;
+  background: var(--sl-bg-surface);
   border: 0;
 }
 .preview-markdown {
@@ -302,7 +302,7 @@ onUnmounted(() => {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 13px;
   line-height: 1.6;
-  color: #1f2937;
+  color: var(--sl-text-primary);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/frontend/tests/filePreviewModalTheme.test.js
+++ b/frontend/tests/filePreviewModalTheme.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const modalSource = readFileSync(
+  new URL('../src/components/lens/FilePreviewModal.vue', import.meta.url),
+  'utf8'
+)
+
+const styleMatch = modalSource.match(/<style scoped>([\s\S]*?)<\/style>/)
+
+assert.ok(styleMatch, 'FilePreviewModal must define a scoped style block')
+
+const styleSource = styleMatch[1]
+
+const getCssBlock = (selector) => {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = styleSource.match(
+    new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`)
+  )
+  assert.ok(match, `Missing CSS block for ${selector}`)
+  return match[1]
+}
+
+test('preview panel and body use theme surface tokens instead of light hex', () => {
+  const panel = getCssBlock('.preview-panel')
+  const body = getCssBlock('.preview-body')
+
+  assert.match(panel, /background:\s*var\(--sl-bg-surface\)/)
+  assert.match(body, /background:\s*var\(--sl-bg-canvas\)/)
+  assert.doesNotMatch(panel, /background:\s*#fff\b/)
+  assert.doesNotMatch(body, /background:\s*#f8fafc\b/)
+})
+
+test('preview text chrome follows theme foreground tokens', () => {
+  const title = getCssBlock('.preview-title')
+  const status = getCssBlock('.preview-status')
+  const text = getCssBlock('.preview-text')
+
+  assert.match(title, /color:\s*var\(--sl-text-primary\)/)
+  assert.match(status, /color:\s*var\(--sl-text-muted\)/)
+  assert.match(text, /color:\s*var\(--sl-text-primary\)/)
+})

--- a/release-notes/289.yaml
+++ b/release-notes/289.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed Dark-mode Markdown file preview so document text stays readable
+  against the preview background.
+zh-CN: >-
+  修复深色模式下 Markdown 文件预览文字对比度不足、几乎不可读的问题。


### PR DESCRIPTION
### **User description**
## Summary

- theme File Preview modal chrome with shared appearance CSS variables
- keep MarkdownRenderer text tokens matched to the preview paper in Dark and Light modes
- add regression coverage for preview surface and foreground token usage
- add a bilingual release-note fragment for the fix

## Testing

- `node --test tests/filePreviewModalTheme.test.js` (2/2)
- ego-browser against `http://localhost:8000` on Issue 196 Markdown Preview:
  - Dark: panel `rgb(37,37,38)`, body `rgb(30,30,30)`, H1 contrast **10.38:1**, paragraph **8.04:1**
  - Light: H1 contrast **17.44:1**, paragraph **7.23:1**
- preview open/close behavior unchanged

Fixes #289


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Theme FilePreviewModal with CSS custom properties for dark/light mode

- Add regression tests for preview surface and foreground tokens

- Add release note fragment for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FilePreviewModal.vue"] -- "use CSS variables" --> B["--sl-bg-surface, --sl-bg-canvas, --sl-text-primary, etc."]
  B --> C["Dark mode readable contrast"]
  A -- "tokens" --> D["Regeneration tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FilePreviewModal.vue</strong><dd><code>Theme preview modal with CSS variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/lens/FilePreviewModal.vue

<ul><li>Replaced hardcoded light hex colors with theme CSS custom properties<br> <li> Preview panel, header, title, tools, body, text, iframe, status now <br>use var(--sl-*) tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/291/files#diff-5877269b3f6b5f20f5c1c0b908ee8d40929fdca3a7f23c65338e8f1bde92833f">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filePreviewModalTheme.test.js</strong><dd><code>Add regression tests for preview theme tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/filePreviewModalTheme.test.js

<ul><li>Added tests that verify CSS custom properties are used for backgrounds <br>and text colors<br> <li> Ensures no hardcoded light hex values remain</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/291/files#diff-cdaccb7f9b09b64efab8ca607ce354b532f501d4a8ea66240b12ca8655b78319">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>289.yaml</strong><dd><code>Add release note fragment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/289.yaml

- Added bilingual release note for the dark-mode fix


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/291/files#diff-ac5e4c7571d7de0154c7cc1c9c06c0c810694161fad0d0d0d991208086c712ca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

