### PR TITLE
Fix User Settings modal interaction and mobile UX

### DIFF
--- a/frontend/src/components/settings/UserSettingsModal.vue
+++ b/frontend/src/components/settings/UserSettingsModal.vue
@@ -10,9 +10,11 @@
     <div
       v-if="show"
       class="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
-      @click.self="emit('close')"
     >
-      <div class="absolute inset-0 bg-black/30 backdrop-blur-[2px]" />
+      <div
+        class="absolute inset-0 bg-black/30 backdrop-blur-[2px]"
+        @click="emit('close')"
+      />
 
       <Transition
         enter-active-class="transition duration-200 ease-out"
@@ -24,14 +26,19 @@
       >
         <section
           v-if="show"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="settings-modal-title"
           class="settings-modal relative flex h-[526px] max-h-[82vh] w-full max-w-[700px] overflow-hidden rounded-2xl border border-line bg-surface shadow-soft-lg"
         >
           <!-- Left nav -->
           <nav
-            class="settings-nav flex w-14 shrink-0 flex-col border-r border-line bg-surface-sunken py-4 sm:w-48"
+            class="settings-nav flex w-36 shrink-0 flex-col border-r border-line bg-surface-sunken py-4 sm:w-48"
           >
-            <div class="hidden px-4 pb-3 sm:block">
-              <div class="settings-nav-title text-sm font-semibold text-theme-subtle">
+            <div class="px-3 pb-3 sm:px-4">
+              <div
+                class="settings-nav-title text-sm font-semibold text-theme-subtle"
+              >
                 {{ t('settings.modal.label') }}
               </div>
             </div>
@@ -41,7 +48,7 @@
                 v-for="section in sections"
                 :key="section.key"
                 type="button"
-                class="flex w-full items-center justify-center gap-2.5 rounded-lg px-2 py-2 text-left text-sm transition-colors sm:justify-start sm:px-3"
+                class="flex min-h-11 w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors sm:min-h-0 sm:px-3"
                 :aria-label="section.label"
                 :class="
                   activeSection === section.key
@@ -51,7 +58,7 @@
                 @click="activeSection = section.key"
               >
                 <component :is="section.icon" class="h-4 w-4 shrink-0" />
-                <span class="hidden min-w-0 flex-1 truncate sm:block">
+                <span class="min-w-0 flex-1 truncate text-xs sm:text-sm">
                   {{ section.label }}
                 </span>
                 <span
@@ -71,7 +78,7 @@
             <div class="settings-logout-wrap border-t border-line px-2 pt-2">
               <button
                 type="button"
-                class="settings-logout flex w-full items-center justify-center gap-2.5 rounded-lg px-2 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 sm:justify-start sm:px-3"
+                class="settings-logout flex min-h-11 w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 sm:min-h-0 sm:px-3"
                 :aria-label="t('common.logout')"
                 @click="handleLogout"
               >
@@ -95,7 +102,9 @@
                   />
                   <line x1="21" y1="12" x2="9" y2="12" stroke-linecap="round" />
                 </svg>
-                <span class="hidden sm:block">{{ t('common.logout') }}</span>
+                <span class="truncate text-xs sm:text-sm">{{
+                  t('common.logout')
+                }}</span>
               </button>
             </div>
           </nav>
@@ -105,10 +114,14 @@
             <header
               class="settings-header flex items-center justify-between border-b border-line px-4 pb-2 pt-5 sm:px-6"
             >
-              <h2 class="text-base font-semibold text-theme">
+              <h2
+                id="settings-modal-title"
+                class="text-base font-semibold text-theme"
+              >
                 {{ sections.find((s) => s.key === activeSection)?.label }}
               </h2>
               <button
+                ref="closeButtonRef"
                 type="button"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-theme-subtle transition-colors hover:bg-surface-hover hover:text-theme-secondary"
                 :aria-label="t('common.close')"
@@ -154,21 +167,25 @@
                 </div>
 
                 <div class="divide-y divide-line rounded-xl border border-line">
-                  <div class="flex items-center justify-between px-4 py-3">
-                    <span class="text-sm text-theme-muted">{{
-                      t('settings.modal.username')
-                    }}</span>
-                    <span class="text-sm font-medium text-theme">
+                  <div class="space-y-1 px-3 py-3 sm:px-4">
+                    <div class="text-xs font-medium text-theme-muted">
+                      {{ t('settings.modal.username') }}
+                    </div>
+                    <div
+                      class="break-all text-sm font-medium leading-snug text-theme"
+                    >
                       {{ userStore.userInfo?.username || '—' }}
-                    </span>
+                    </div>
                   </div>
-                  <div class="flex items-center justify-between px-4 py-3">
-                    <span class="text-sm text-theme-muted">{{
-                      t('settings.modal.email')
-                    }}</span>
-                    <span class="text-sm font-medium text-theme">
+                  <div class="space-y-1 px-3 py-3 sm:px-4">
+                    <div class="text-xs font-medium text-theme-muted">
+                      {{ t('settings.modal.email') }}
+                    </div>
+                    <div
+                      class="break-all text-sm font-medium leading-snug text-theme"
+                    >
                       {{ userStore.userInfo?.email || '—' }}
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -178,38 +195,19 @@
                 <p class="text-sm text-theme-muted">
                   {{ t('settings.modal.languageDesc') }}
                 </p>
-                <div class="relative">
-                  <BaseSelect
-                    id="ui-language"
-                    :model-value="locale"
-                    @update:model-value="selectLanguage"
+                <BaseSelect
+                  id="ui-language"
+                  :model-value="locale"
+                  @update:model-value="selectLanguage"
+                >
+                  <option
+                    v-for="lang in languages"
+                    :key="lang.value"
+                    :value="lang.value"
                   >
-                    <option
-                      v-for="lang in languages"
-                      :key="lang.value"
-                      :value="lang.value"
-                    >
-                      {{ lang.flag }} {{ lang.label }}
-                    </option>
-                  </BaseSelect>
-                  <div
-                    class="pointer-events-none absolute inset-y-0 right-3 flex items-center"
-                  >
-                    <svg
-                      class="h-4 w-4 text-theme-subtle"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2.5"
-                    >
-                      <path
-                        d="m6 9 6 6 6-6"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                    {{ lang.flag }} {{ lang.label }}
+                  </option>
+                </BaseSelect>
               </div>
 
               <!-- Appearance section -->
@@ -276,7 +274,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import AnswerNotificationSettings from '@/components/settings/AnswerNotificationSettings.vue'
@@ -302,6 +300,7 @@ const uiStore = useUiStore()
 const preferencesStore = usePreferencesStore()
 const languages = computed(() => getUiLanguageOptions(t))
 const activeSection = ref('profile')
+const closeButtonRef = ref(null)
 
 const UserIcon = {
   template: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke-linecap="round"/></svg>`
@@ -423,13 +422,19 @@ const handleLogout = async () => {
 }
 
 const handleKeydown = (event) => {
-  if (event.key === 'Escape' && props.show) uiStore.closeSettings()
+  if (event.key === 'Escape' && props.show && !event.defaultPrevented) {
+    uiStore.closeSettings()
+  }
 }
 
 watch(
   () => props.show,
-  (show) => {
-    if (show) activeSection.value = uiStore.settingsTab || 'profile'
+  async (show) => {
+    if (show) {
+      activeSection.value = uiStore.settingsTab || 'profile'
+      await nextTick()
+      closeButtonRef.value?.focus()
+    }
     if (typeof document !== 'undefined')
       document.body.style.overflow = show ? 'hidden' : ''
   },

--- a/frontend/src/components/ui/BaseSelect.vue
+++ b/frontend/src/components/ui/BaseSelect.vue
@@ -454,6 +454,7 @@ function handleTriggerKeydown(event) {
 
   if (event.key === 'Escape' && isOpen.value) {
     event.preventDefault()
+    event.stopPropagation()
     closeMenu()
     return
   }

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -4479,7 +4479,12 @@ onBeforeUnmount(() => {
   }
 
   .message-actions {
-    flex-wrap: wrap;
+    gap: 0.125rem;
+    flex-wrap: nowrap;
+  }
+
+  .message-actions .icon-btn {
+    @apply h-9 w-9;
   }
 }
 

--- a/frontend/tests/userSettingsModalInteractions.test.js
+++ b/frontend/tests/userSettingsModalInteractions.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const modalSource = readFileSync(
+  new URL('../src/components/settings/UserSettingsModal.vue', import.meta.url),
+  'utf8'
+)
+const selectSource = readFileSync(
+  new URL('../src/components/ui/BaseSelect.vue', import.meta.url),
+  'utf8'
+)
+
+test('BaseSelect stops Escape from bubbling while the listbox is open', () => {
+  assert.match(
+    selectSource,
+    /if \(event\.key === 'Escape' && isOpen\.value\) \{[\s\S]*?event\.stopPropagation\(\)/
+  )
+})
+
+test('User Settings exposes dialog semantics and focuses the close control', () => {
+  assert.match(modalSource, /role="dialog"/)
+  assert.match(modalSource, /aria-modal="true"/)
+  assert.match(modalSource, /aria-labelledby="settings-modal-title"/)
+  assert.match(modalSource, /id="settings-modal-title"/)
+  assert.match(modalSource, /ref="closeButtonRef"/)
+  assert.match(modalSource, /closeButtonRef\.value\?\.focus\(/)
+})
+
+test('User Settings closes from the visible backdrop click target', () => {
+  assert.match(
+    modalSource,
+    /class="absolute inset-0 bg-black\/30 backdrop-blur-\[2px\]"[\s\S]*?@click="emit\('close'\)"/
+  )
+  assert.doesNotMatch(modalSource, /@click\.self="emit\('close'\)"/)
+})
+
+test('User Settings mobile navigation uses larger touch targets', () => {
+  assert.match(
+    modalSource,
+    /min-h-11[\s\S]*?rounded-lg[\s\S]*?px-2\.5[\s\S]*?sm:min-h-0/
+  )
+})
+
+test('User Settings navigation shows section labels on mobile', () => {
+  assert.match(modalSource, /settings-nav flex w-36/)
+  assert.doesNotMatch(
+    modalSource,
+    /class="hidden min-w-0 flex-1 truncate sm:block"/
+  )
+  assert.match(
+    modalSource,
+    /class="min-w-0 flex-1 truncate text-xs sm:text-sm"/
+  )
+})
+
+test('User Settings profile fields stack labels above values', () => {
+  assert.match(
+    modalSource,
+    /space-y-1 px-3 py-3[\s\S]*?text-xs font-medium text-theme-muted[\s\S]*?break-all text-sm font-medium leading-snug text-theme/
+  )
+  assert.doesNotMatch(
+    modalSource,
+    /flex items-center justify-between px-4 py-3/
+  )
+})
+
+test('User Settings language selector does not add a second chevron', () => {
+  const languageBlock = modalSource.match(
+    /<!-- Language section -->[\s\S]*?<!-- Appearance section -->/
+  )
+  assert.ok(languageBlock, 'language section is present')
+  assert.match(languageBlock[0], /<BaseSelect[\s\S]*?<\/BaseSelect>/)
+  assert.doesNotMatch(
+    languageBlock[0],
+    /pointer-events-none absolute inset-y-0 right-3/
+  )
+})

--- a/release-notes/290.yaml
+++ b/release-notes/290.yaml
@@ -1,0 +1,9 @@
+type: fix
+audience: user
+en: >-
+  Improved User Settings so Escape closes nested menus first, mobile
+  navigation shows section names and is easier to tap, backdrop dismiss
+  works, and the dialog is announced correctly to assistive technologies.
+zh-CN: >-
+  改进用户设置：Esc 先关闭嵌套菜单、手机端显示设置项名称且更易点击、
+  点击遮罩可关闭，并为辅助技术正确声明对话框。


### PR DESCRIPTION
### **User description**
## Summary

- stop Escape from closing User Settings while a nested BaseSelect listbox is open
- restore backdrop dismiss, dialog semantics, initial focus, and a single language chevron
- show mobile settings nav labels with usable touch targets, and stack profile Username/Email to avoid overlap
- tighten mobile chat message action buttons so the toolbar stays compact
- add regression coverage and a bilingual release-note fragment

## Testing

- `node --test tests/userSettingsModalInteractions.test.js tests/baseSelect.test.js tests/answerLanguageSettings.test.js` (18/18)
- ESLint on the changed Vue and test files
- `npm run build`
- `PYTHONPATH=. python3 scripts/test_release_notes.py` (6/6); `release-notes/290.yaml` parses
- `npm run test:unit` (279/282; the same three unrelated failures reproduce on `origin/main`: app locale parity and two Run Observation diagnosis assertions)

Fixes #290

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Escape to close only nested listbox first

- Add dialog semantics, focus management, and backdrop dismiss

- Improve mobile touch targets and show section labels

- Remove duplicate chevron from language selector

- Add regression tests and release note


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User presses Escape"] --> B{"BaseSelect open?"}
  B -- Yes --> C["BaseSelect: stopPropagation, close listbox"]
  B -- No --> D["UserSettingsModal: close modal"]
  E["Click backdrop"] --> F["Backdrop click handler emits 'close'"]
  G["Mobile nav item"] --> H["min-h-11, show labels"]
  I["Language selector"] --> J["Remove absolute chevron, use BaseSelect only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserSettingsModal.vue</strong><dd><code>Fix dialog semantics, backdrop, touch targets, chevron</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/settings/UserSettingsModal.vue

<ul><li>Added <code>role="dialog"</code>, <code>aria-modal="true"</code>, <code>aria-labelledby</code>, and <code>id</code> on <br>heading for dialog semantics<br> <li> Moved backdrop click handler from outer div to the backdrop element to <br>enable dismiss<br> <li> Added <code>ref="closeButtonRef"</code> and <code>nextTick</code> focus on close button when <br>modal opens<br> <li> Changed nav width to <code>w-36</code> on mobile, added <code>min-h-11</code> and <code>px-2.5</code> for <br>larger touch targets<br> <li> Show section labels on mobile by removing <code>hidden sm:block</code> classes<br> <li> Restructured profile fields to stack labels above values (removed flex <br>row layout)<br> <li> Removed duplicate absolute-positioned chevron from language section<br> <li> Added <code>!event.defaultPrevented</code> check in Escape handler to allow nested <br>BaseSelect to stop propagation</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/292/files#diff-aa6410cf6949d28f892578c56dc32520cf22ed90043fa5a4d5c266acc570041b">+62/-57</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BaseSelect.vue</strong><dd><code>Stop Escape propagation in BaseSelect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/BaseSelect.vue

<ul><li>Added <code>event.stopPropagation()</code> when handling Escape key to close the <br>listbox, preventing the modal from also closing</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/292/files#diff-4177eda97a5d6c29bb073653137833de16ec48a50175575548028eb1039007a9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Compact message action buttons on mobile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Changed message-actions flex-wrap to nowrap and reduced gap to <br>0.125rem<br> <li> Applied <code>h-9 w-9</code> to <code>.message-actions .icon-btn</code> to keep toolbar compact <br>on mobile</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/292/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>userSettingsModalInteractions.test.js</strong><dd><code>Add regression tests for modal fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/userSettingsModalInteractions.test.js

<ul><li>Added 7 regression tests covering Escape propagation, dialog <br>semantics, backdrop dismiss, touch targets, label visibility, profile <br>layout, and single chevron<br> <li> Tests use static source parsing to verify markup patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/292/files#diff-0d2a41865460ddbd59df48943e03ecbe725609f9b1216e09be3d9ca3ee7b8f43">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>290.yaml</strong><dd><code>Add release note for user settings fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/290.yaml

<ul><li>Added bilingual release note fragment for the user settings fixes <br>(English and zh-CN)</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/292/files#diff-1e659c9eb0114e574e0c49262f80f2f8de9a05623003dbf8100f425de4f432b9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

