### PR TITLE
Fix BaseSelect page-size option wrapping

### DIFF
--- a/frontend/src/components/ui/BaseSelect.vue
+++ b/frontend/src/components/ui/BaseSelect.vue
@@ -104,7 +104,7 @@
           @click="selectOption(option, index)"
           @mouseenter="activateOption(option, index)"
         >
-          <span class="min-w-0 flex-1 break-words">
+          <span class="min-w-0 flex-1 truncate">
             {{ option.label }}
           </span>
 
@@ -518,7 +518,11 @@ function updateMenuPosition() {
   const availableAbove = rect.top - menuGap
   const opensAbove = availableBelow < 160 && availableAbove > availableBelow
   const availableHeight = opensAbove ? availableAbove : availableBelow
-  const width = Math.min(rect.width, window.innerWidth - viewportMargin * 2)
+  const minMenuWidth = 88
+  const width = Math.max(
+    minMenuWidth,
+    Math.min(rect.width, window.innerWidth - viewportMargin * 2)
+  )
   const left = Math.max(
     viewportMargin,
     Math.min(rect.left, window.innerWidth - width - viewportMargin)

--- a/release-notes/295.yaml
+++ b/release-notes/295.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed page-size dropdown options wrapping digits onto two lines in narrow
+  select menus.
+zh-CN: >-
+  修复每页条数等窄下拉菜单中数字选项被拆成两行显示的问题。


### PR DESCRIPTION
### **User description**
## Summary
- Stop dropdown option labels from wrapping mid-text (`10` → `1` / `0`) by using `truncate` instead of `break-words` in `BaseSelect`
- Enforce a minimum listbox width so narrow triggers (e.g. pagination page-size) still render readable menus

## Test plan
- [x] Open pagination page-size dropdown on `/management/lens/runs`
- [x] Confirm `10`, `20`, `50`, `100` each stay on one line with checkmark aligned
- [ ] Smoke-test a long-label select (assistant filter) still truncates with ellipsis instead of breaking awkwardly


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix option label wrapping in BaseSelect dropdown

- Enforce minimum menu width for narrow triggers

- Add release note for the fix


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseSelect.vue</strong><dd><code>Fix option text wrapping and menu width</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/BaseSelect.vue

<ul><li>Replaced <code>break-words</code> with <code>truncate</code> on option labels to prevent <br>mid-text wrapping<br> <li> Added a minimum menu width (<code>88px</code>) to ensure readable dropdowns on <br>narrow triggers</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/295/files#diff-4177eda97a5d6c29bb073653137833de16ec48a50175575548028eb1039007a9">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>295.yaml</strong><dd><code>Add release note for dropdown fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/295.yaml

<ul><li>Added a release note YAML file documenting the fix for page-size <br>dropdown option wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/295/files#diff-0e268d1063aaa6709c9726914e1e3abc213b9b9acaca45e1ac50c70ba776e057">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

