### PR TITLE
Keep CodeGraph index fresh and steer the agent toward it

### DIFF
--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -415,6 +415,10 @@ class LensDeepAgentRuntime:
                 )
             )
             tools.extend(registered_mcp_tools)
+            codegraph_available = any(
+                tool.name.startswith("mcp__codegraph__")
+                for tool in mcp_tools
+            )
             if resume_state is not None:
                 _reject_unsafe_resume_tool_replay(
                     resume_state.messages,
@@ -622,6 +626,7 @@ class LensDeepAgentRuntime:
                     command,
                     resources.context_skill_contents,
                     mcp_deferred=mcp_middleware is not None,
+                    codegraph_available=codegraph_available,
                 ),
                 "backend": FilesystemBackend(
                     root_dir=str(resources.root),

--- a/lensnode/lensnode/agent_runtime/system_prompts.py
+++ b/lensnode/lensnode/agent_runtime/system_prompts.py
@@ -12,6 +12,7 @@ def _system_prompt(
     context_skill_contents=None,
     *,
     mcp_deferred=False,
+    codegraph_available=False,
 ):
     """Build the per-task Deep Agents system prompt."""
 
@@ -22,6 +23,7 @@ def _system_prompt(
             scenario,
             command,
             context_skill_contents,
+            codegraph_available=codegraph_available,
         )
     if mcp_deferred:
         prompt += (
@@ -38,7 +40,13 @@ def _is_general_chat(command):
 
     return command.get("task") == "general_chat"
 
-def _knowledge_system_prompt(scenario, command, context_skill_contents=None):
+def _knowledge_system_prompt(
+    scenario,
+    command,
+    context_skill_contents=None,
+    *,
+    codegraph_available=False,
+):
     """Build the workspace-grounded system prompt."""
 
     target_dirs = command.get("target_dirs") or []
@@ -78,9 +86,10 @@ def _knowledge_system_prompt(scenario, command, context_skill_contents=None):
         "find_files / read_workspace_file.\n"
         "- Your FIRST action for any project or code question MUST be a "
         "search_workspace call, or a find_files call with a RECURSIVE "
-        "pattern (\"**/*\", never a bare \"*\", which only lists the top "
+        'pattern ("**/*", never a bare "*", which only lists the top '
         "level). If find_files returns nothing, retry with \"**/*\" or a "
         "broader search_workspace before drawing any conclusion.\n"
+        f"{_codegraph_guidance(codegraph_available)}\n"
         "- Use the scratch directory (write_file / read_file / ls) only "
         "for artifacts you generate. For example, if you convert a PDF to "
         "markdown, write the result there, not into the source "
@@ -289,6 +298,27 @@ def _subagent_guidance(agent_rounds):
         "tool calls (parallel reads/searches). Do NOT delegate to `task` "
         "subagents for this — at this depth, direct batched work is "
         "faster than spinning up subagents.\n\n"
+    )
+
+
+def _codegraph_guidance(available):
+    """Return the CodeGraph-first guidance block when the tools are loaded."""
+
+    if not available:
+        return ""
+    return (
+        "- CodeGraph is available: a prebuilt knowledge graph of the "
+        "workspace source. For STRUCTURAL questions — where a symbol or "
+        "function is defined, what calls what, how a module reaches another, "
+        "what would break if something changed — PREFER the codegraph tools "
+        "(mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_callers, "
+        "mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_trace, "
+        "mcp__codegraph__codegraph_impact, "
+        "mcp__codegraph__codegraph_explore) over a ripgrep search_workspace. "
+        "They answer from the graph directly and are far faster than "
+        "scanning matching lines. Use search_workspace for literal-text "
+        "questions (exact strings, comments, log messages) and after you "
+        "already have a specific file open."
     )
 
 

--- a/lensnode/lensnode/plugins/codegraph.py
+++ b/lensnode/lensnode/plugins/codegraph.py
@@ -6,6 +6,7 @@ first use.
 """
 
 import fcntl
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -80,12 +81,14 @@ class CodeGraphPlugin(LensNodePlugin):
 
 
 def _ensure_codegraph_index(config, workspace, emit_event=None):
-    """Build the workspace CodeGraph index once, guarded by a lock."""
+    """Build the workspace CodeGraph index once, guarded by a lock.
+
+    Creates the index on first use; afterwards refreshes it only when the
+    source worktree has pending changes or the tooling version changed.
+    """
 
     index_dir = workspace / CODEGRAPH_INDEX_DIR
-    if index_dir.is_dir():
-        return True
-    if not _has_indexable_code(workspace):
+    if not index_dir.is_dir() and not _has_indexable_code(workspace):
         return False
     lock_dir = workspace / ".sourcelens"
     lock_path = lock_dir / CODEGRAPH_INIT_LOCK
@@ -96,7 +99,9 @@ def _ensure_codegraph_index(config, workspace, emit_event=None):
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
             try:
                 if index_dir.is_dir():
-                    return True
+                    return _refresh_codegraph_index(
+                        config, workspace, emit_event=emit_event
+                    )
                 subprocess.run(
                     [
                         str(config.codegraph_command),
@@ -118,6 +123,115 @@ def _ensure_codegraph_index(config, workspace, emit_event=None):
             )
         return False
     return index_dir.is_dir()
+
+
+def _refresh_codegraph_index(config, workspace, emit_event=None):
+    """Refresh an existing index only when the worktree or tooling changed.
+
+    Must be called under the same lock that guards init, so a refresh never
+    races an in-progress build or another run's sync.
+    """
+
+    status = _codegraph_status(config, workspace)
+    if status is None:
+        return True
+    if status.get("reindex") or status.get("state") != "complete":
+        return _codegraph_rebuild(config, workspace, emit_event=emit_event)
+    if status.get("pending"):
+        return _codegraph_sync(config, workspace, emit_event=emit_event)
+    return True
+
+
+def _codegraph_status(config, workspace):
+    """Return (pending, reindex, state) from `codegraph status --json`.
+
+    Returns None when the index is not initialized or status cannot be
+    parsed, in which case the caller keeps the existing index untouched.
+    """
+
+    try:
+        result = subprocess.run(
+            [
+                str(config.codegraph_command),
+                "status",
+                str(workspace),
+                "--json",
+            ],
+            timeout=int(getattr(config, "codegraph_init_timeout_s", 300)),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    try:
+        payload = json.loads(result.stdout.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not payload.get("initialized"):
+        return None
+    pending = payload.get("pendingChanges") or {}
+    has_pending = bool(
+        pending.get("added") or pending.get("modified") or pending.get("removed")
+    )
+    index_info = payload.get("index") or {}
+    return {
+        "pending": has_pending,
+        "reindex": bool(index_info.get("reindexRecommended")),
+        "state": index_info.get("state"),
+    }
+
+
+def _codegraph_sync(config, workspace, emit_event=None):
+    """Incrementally update the index for changed source files."""
+
+    try:
+        subprocess.run(
+            [
+                str(config.codegraph_command),
+                "sync",
+                str(workspace),
+                "--quiet",
+            ],
+            timeout=int(getattr(config, "codegraph_init_timeout_s", 300)),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        if emit_event is not None:
+            emit_event(
+                "codegraph.sync.failed",
+                {"reason": type(exc).__name__},
+            )
+        return False
+    return True
+
+
+def _codegraph_rebuild(config, workspace, emit_event=None):
+    """Rebuild the index when the tooling or extraction format changed."""
+
+    try:
+        subprocess.run(
+            [
+                str(config.codegraph_command),
+                "index",
+                str(workspace),
+                "--quiet",
+            ],
+            timeout=int(getattr(config, "codegraph_init_timeout_s", 300)),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        if emit_event is not None:
+            emit_event(
+                "codegraph.rebuild.failed",
+                {"reason": type(exc).__name__},
+            )
+        return False
+    return True
 
 
 def _has_indexable_code(workspace):

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -1022,6 +1022,27 @@ def test_system_prompt_includes_context_skill_guidance():
     assert "/workspace/product" in prompt
 
 
+def test_system_prompt_omits_codegraph_guidance_by_default():
+    prompt = _system_prompt(
+        {"prompt": "Analyze code."},
+        {"target_dirs": [{"path": "/workspace/product"}]},
+    )
+
+    assert "CodeGraph is available" not in prompt
+
+
+def test_system_prompt_injects_codegraph_guidance_when_available():
+    prompt = _system_prompt(
+        {"prompt": "Analyze code."},
+        {"target_dirs": [{"path": "/workspace/product"}]},
+        codegraph_available=True,
+    )
+
+    assert "CodeGraph is available" in prompt
+    assert "mcp__codegraph__codegraph_trace" in prompt
+    assert "PREFER the codegraph" in prompt
+
+
 def test_git_log_accepts_non_integer_max_count(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/lensnode/tests/test_plugins.py
+++ b/lensnode/tests/test_plugins.py
@@ -4,6 +4,10 @@ from lensnode.plugins import collect_mcp_servers
 from lensnode.plugins.codegraph import (
     CODEGRAPH_SERVER_NAME,
     CodeGraphPlugin,
+    _codegraph_rebuild,
+    _codegraph_sync,
+    _ensure_codegraph_index,
+    _refresh_codegraph_index,
 )
 from lensnode.runtime_resources import _apply_feature_flags
 
@@ -91,6 +95,326 @@ def test_codegraph_index_skipped_without_indexable_code(tmp_path):
 
     assert result == []
     assert not (tmp_path / ".codegraph").exists()
+
+
+def test_codegraph_refresh_skips_sync_when_index_fresh(monkeypatch, tmp_path):
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: {
+            "pending": False,
+            "reindex": False,
+            "state": "complete",
+        },
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_sync",
+        lambda *_args, **_kwargs: calls.append("sync"),
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_rebuild",
+        lambda *_args, **_kwargs: calls.append("rebuild"),
+    )
+
+    result = _refresh_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == []
+
+
+def test_codegraph_refresh_syncs_when_pending(monkeypatch, tmp_path):
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: {
+            "pending": True,
+            "reindex": False,
+            "state": "complete",
+        },
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_sync",
+        lambda *_args, **_kwargs: calls.append("sync") or True,
+    )
+
+    result = _refresh_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == ["sync"]
+
+
+def test_codegraph_refresh_rebuilds_when_recommended(monkeypatch, tmp_path):
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: {
+            "pending": False,
+            "reindex": True,
+            "state": "complete",
+        },
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_rebuild",
+        lambda *_args, **_kwargs: calls.append("rebuild") or True,
+    )
+
+    result = _refresh_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == ["rebuild"]
+
+
+def test_codegraph_refresh_rebuilds_when_incomplete(monkeypatch, tmp_path):
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: {
+            "pending": False,
+            "reindex": False,
+            "state": "incomplete",
+        },
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_rebuild",
+        lambda *_args, **_kwargs: calls.append("rebuild") or True,
+    )
+
+    result = _refresh_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == ["rebuild"]
+
+
+def test_codegraph_refresh_keeps_index_when_status_unreadable(
+    monkeypatch, tmp_path
+):
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: None,
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_sync",
+        lambda *_args, **_kwargs: calls.append("sync"),
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_rebuild",
+        lambda *_args, **_kwargs: calls.append("rebuild"),
+    )
+
+    result = _refresh_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == []
+
+
+def test_codegraph_sync_propagates_success(monkeypatch, tmp_path):
+    ran = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run",
+        lambda *_args, **_kwargs: ran.append(_args),
+    )
+
+    assert _codegraph_sync(_config(), tmp_path) is True
+    assert ran
+
+
+def test_codegraph_status_parses_nested_reindex_flag(monkeypatch, tmp_path):
+    import subprocess as real_subprocess
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run",
+        lambda *_args, **_kwargs: real_subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                '{"initialized": true, "pendingChanges": {"added": 0, '
+                '"modified": 0, "removed": 0}, "index": {'
+                '"reindexRecommended": true, "state": "complete"}}'
+            ).encode(),
+        ),
+    )
+
+    from lensnode.plugins.codegraph import _codegraph_status
+
+    status = _codegraph_status(_config(), tmp_path)
+
+    assert status == {
+        "pending": False,
+        "reindex": True,
+        "state": "complete",
+    }
+
+
+def test_codegraph_status_reports_pending_changes(monkeypatch, tmp_path):
+    import subprocess as real_subprocess
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run",
+        lambda *_args, **_kwargs: real_subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                '{"initialized": true, "pendingChanges": {"added": 2, '
+                '"modified": 0, "removed": 0}, "index": {'
+                '"reindexRecommended": false, "state": "complete"}}'
+            ).encode(),
+        ),
+    )
+
+    from lensnode.plugins.codegraph import _codegraph_status
+
+    status = _codegraph_status(_config(), tmp_path)
+
+    assert status["pending"] is True
+
+
+def test_codegraph_status_returns_none_on_uninitialized(monkeypatch, tmp_path):
+    import subprocess as real_subprocess
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run",
+        lambda *_args, **_kwargs: real_subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=('{"initialized": false}').encode(),
+        ),
+    )
+
+    from lensnode.plugins.codegraph import _codegraph_status
+
+    assert _codegraph_status(_config(), tmp_path) is None
+
+
+def test_codegraph_sync_failure_returns_false(monkeypatch, tmp_path):
+    import subprocess as real_subprocess
+
+    def fail(*_args, **_kwargs):
+        raise real_subprocess.CalledProcessError(1, "codegraph")
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run", fail
+    )
+
+    assert _codegraph_sync(_config(), tmp_path) is False
+
+
+def test_codegraph_rebuild_failure_returns_false(monkeypatch, tmp_path):
+    import subprocess as real_subprocess
+
+    def fail(*_args, **_kwargs):
+        raise real_subprocess.CalledProcessError(1, "codegraph")
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run", fail
+    )
+
+    assert _codegraph_rebuild(_config(), tmp_path) is False
+
+
+def test_ensure_refreshes_existing_index_under_lock(monkeypatch, tmp_path):
+    (tmp_path / "app.py").write_text("print('hi')")
+    (tmp_path / ".codegraph").mkdir()
+    calls = []
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status",
+        lambda _config, _workspace: {
+            "pending": True,
+            "reindex": False,
+            "state": "complete",
+        },
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_sync",
+        lambda *_args, **_kwargs: calls.append("sync") or True,
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("init must not run for an existing index")
+        ),
+    )
+
+    result = _ensure_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert calls == ["sync"]
+
+
+def test_ensure_inits_missing_index(monkeypatch, tmp_path):
+    (tmp_path / "app.py").write_text("print('hi')")
+    ran = []
+
+    def fake_run(args, *_args, **_kwargs):
+        ran.append(args)
+        (tmp_path / ".codegraph").mkdir()
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph.subprocess.run", fake_run
+    )
+
+    result = _ensure_codegraph_index(_config(), tmp_path)
+
+    assert result is True
+    assert ran and ran[0][1] == "init"
+
+
+def test_ensure_concurrent_runs_serialize_on_lock(monkeypatch, tmp_path):
+    import threading
+    import time
+
+    (tmp_path / "app.py").write_text("print('hi')")
+    (tmp_path / ".codegraph").mkdir()
+    active = 0
+    max_active = 0
+    counter_lock = threading.Lock()
+    calls = []
+
+    def fake_sync(*_args, **_kwargs):
+        nonlocal active, max_active
+        with counter_lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with counter_lock:
+            active -= 1
+        calls.append("sync")
+        return True
+
+    def fake_status(_config, _workspace):
+        return {
+            "pending": True,
+            "reindex": False,
+            "state": "complete",
+        }
+
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_sync", fake_sync
+    )
+    monkeypatch.setattr(
+        "lensnode.plugins.codegraph._codegraph_status", fake_status
+    )
+
+    threads = [
+        threading.Thread(
+            target=_ensure_codegraph_index,
+            args=(_config(), tmp_path),
+        )
+        for _ in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert max_active == 1
+    assert len(calls) == 4
 
 
 def test_feature_flags_override_codegraph_off():

--- a/release-notes/299.yaml
+++ b/release-notes/299.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: "Code-analysis assistants now keep their code graph up to date as the workspace changes, and prefer the code graph for structural questions such as where a symbol is defined and what calls what."
+zh-CN: "代码分析助手现在会在工作区代码变化时自动更新代码图，并在询问符号定义位置、调用关系等结构性问题时优先使用代码图。"


### PR DESCRIPTION
### **User description**
## Summary
- Refresh the CodeGraph index per run instead of treating it as immutable: `codegraph status --json` decides between incremental `sync`, full `index` rebuild (stale extraction format / incomplete state), or no-op on a clean index
- All index writes (init, sync, rebuild) run under the existing flock so concurrent runs serialize; previously the refresh path bypassed the lock
- Steer the workspace system prompt to prefer CodeGraph tools for structural questions (symbol lookup, call graph, impact) over ripgrep search_workspace, only when the `mcp__codegraph__*` tools are actually loaded
- Prompt uses the real `mcp__codegraph__` tool-name prefix so the model calls tools that exist

## Test plan
- [x] 441 lensnode tests pass (23 codegraph plugin tests, incl. fresh/pending/reindex/incomplete branches, unreadable-status fallback, concurrent-lock serialization)
- [x] End-to-end against real `codegraph` CLI: init → no-op on clean index → sync after code change → pendingChanges returns to zero

This is a follow-up hardening to the CodeGraph MCP feature (#297).

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refresh CodeGraph index per run instead of immutable

- Steer agent toward CodeGraph tools for structural questions

- Add comprehensive tests for new refresh logic

- Add release note fragment


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Runtime: detect codegraph tools"] --> B["system_prompt: inject guidance"]
    C["codegraph plugin: index refresh"] --> D{"codegraph status --json"}
    D -->|pending| sync["sync"]
    D -->|reindex/incomplete| rebuild["rebuild"]
    sync --> E["updated index"]
    rebuild --> E
    E --> F["Agent uses codegraph tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Add codegraph availability detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Detect codegraph tool availability from MCP tools list<br> <li> Pass <code>codegraph_available</code> flag to system prompt</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>system_prompts.py</strong><dd><code>Add CodeGraph guidance to system prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/system_prompts.py

<ul><li>Add <code>_codegraph_guidance</code> function returning prompt text<br> <li> Conditionally inject CodeGraph guidance when tools are available<br> <li> Steer agent toward codegraph tools for structural questions</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-3412700156257c47eb378ccbe14d3ca9f3d96f4731ff1582070256d753c9df9e">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegraph.py</strong><dd><code>Implement CodeGraph index refresh logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/plugins/codegraph.py

<ul><li>Replace static index check with refresh logic on existing index<br> <li> Add <code>_codegraph_status</code> to parse <code>codegraph status --json</code><br> <li> Add <code>_codegraph_sync</code> and <code>_codegraph_rebuild</code> for incremental/full <br>refresh<br> <li> All index writes remain under the existing flock lock</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-bf2c1375c2f96a3dad1ff3aae3a59bb8b4c3afb78525157213880c1eb9e0c50c">+119/-5</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_executor.py</strong><dd><code>Add tests for codegraph prompt guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_executor.py

<ul><li>Add test verifying codegraph guidance is omitted by default<br> <li> Add test verifying codegraph guidance is present when available</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_plugins.py</strong><dd><code>Add tests for codegraph refresh logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_plugins.py

<ul><li>Add tests for <code>_refresh_codegraph_index</code> decision branches (fresh, <br>pending, reindex, incomplete)<br> <li> Add tests for <code>_codegraph_status</code> parsing and error cases<br> <li> Add tests for sync and rebuild failure propagation<br> <li> Add concurrent lock serialization test</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-7a9ee00086541166f55d3feaa00d57e727df5475a3268800f2c44a60290bc95e">+324/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>299.yaml</strong><dd><code>Add release note fragment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/299.yaml

- Add release note fragment for CodeGraph index freshness feature


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/299/files#diff-8ee158ff749713b0eec28498100ccf7f00dfa7f75c3290df9d3e4ff1780a5a59">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

