### PR TITLE
Decouple CodeGraph runtime behavior from the agent framework

### DIFF
--- a/lensnode/lensnode/agent_runtime/assembly.py
+++ b/lensnode/lensnode/agent_runtime/assembly.py
@@ -4,6 +4,8 @@ from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
 from .restrictions import NoTaskMiddleware as _NoTaskMiddleware
 from .system_prompts import _is_general_chat
+
+
 def _agent_middleware(
     command,
     summarizer,
@@ -12,12 +14,14 @@ def _agent_middleware(
     capability_middleware=None,
     mcp_middleware=None,
     trace_middleware=None,
+    runtime_middleware=(),
 ):
     """Return task-specific middleware for one Deep Agent run."""
 
     middleware = []
     if summarizer is not None:
         middleware.append(summarizer)
+    middleware.extend(runtime_middleware)
     if _is_general_chat(command):
         middleware.append(_NoTaskMiddleware(emit_event))
         if capability_middleware is not None:
@@ -29,7 +33,11 @@ def _agent_middleware(
     return middleware
 
 
-def _fast_subagent(mcp_middleware=None, trace_middleware=None):
+def _fast_subagent(
+    mcp_middleware=None,
+    trace_middleware=None,
+    runtime_middleware=(),
+):
     """General-purpose subagent that parallelizes its own tool calls.
 
     By default a delegated subagent runs deepagents' stock prompt and
@@ -53,9 +61,13 @@ def _fast_subagent(mcp_middleware=None, trace_middleware=None):
     }
     middleware = [
         item
-        for item in (trace_middleware, mcp_middleware)
+        for item in (
+            trace_middleware,
+            mcp_middleware,
+        )
         if item is not None
     ]
+    middleware.extend(runtime_middleware)
     if middleware:
         subagent["middleware"] = middleware
     return subagent

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -30,6 +30,7 @@ from ..gateway_model import (
 )
 from ..logging_utils import elapsed_since, task_log, utc_now
 from ..mcp_tools import build_deferred_mcp_tools, load_mcp_tools
+from ..plugins import collect_agent_runtime_contributions
 from ..runtime_modes import runtime_mode_for
 from .assembly import _agent_middleware, _fast_subagent
 from .capabilities import CapabilityBoundaryMiddleware
@@ -404,6 +405,31 @@ class LensDeepAgentRuntime:
                     (),
                 ),
             )
+            runtime_contributions = collect_agent_runtime_contributions(
+                self.config,
+                command,
+                mcp_tools,
+            )
+            runtime_middleware = tuple(
+                item
+                for contribution in runtime_contributions
+                for item in contribution.middleware
+            )
+            subagent_middleware = tuple(
+                item
+                for contribution in runtime_contributions
+                for item in contribution.subagent_middleware
+            )
+            runtime_guidance = tuple(
+                contribution.prompt_guidance
+                for contribution in runtime_contributions
+                if contribution.prompt_guidance
+            )
+            always_visible_tool_prefixes = tuple(
+                prefix
+                for contribution in runtime_contributions
+                for prefix in contribution.always_visible_tool_prefixes
+            )
             registered_mcp_tools, mcp_middleware = (
                 build_deferred_mcp_tools(
                     mcp_tools,
@@ -412,13 +438,10 @@ class LensDeepAgentRuntime:
                         "mcp_defer_threshold",
                         12,
                     ),
+                    always_visible_prefixes=always_visible_tool_prefixes,
                 )
             )
             tools.extend(registered_mcp_tools)
-            codegraph_available = any(
-                tool.name.startswith("mcp__codegraph__")
-                for tool in mcp_tools
-            )
             if resume_state is not None:
                 _reject_unsafe_resume_tool_replay(
                     resume_state.messages,
@@ -626,7 +649,7 @@ class LensDeepAgentRuntime:
                     command,
                     resources.context_skill_contents,
                     mcp_deferred=mcp_middleware is not None,
-                    codegraph_available=codegraph_available,
+                    runtime_guidance=runtime_guidance,
                 ),
                 "backend": FilesystemBackend(
                     root_dir=str(resources.root),
@@ -639,6 +662,7 @@ class LensDeepAgentRuntime:
                         _fast_subagent(
                             mcp_middleware,
                             trace_middleware,
+                            subagent_middleware,
                         )
                     ]
                 ),
@@ -664,6 +688,7 @@ class LensDeepAgentRuntime:
                 capability_middleware=capability_middleware,
                 mcp_middleware=mcp_middleware,
                 trace_middleware=trace_middleware,
+                runtime_middleware=runtime_middleware,
             )
             if middleware:
                 kwargs["middleware"] = middleware

--- a/lensnode/lensnode/agent_runtime/system_prompts.py
+++ b/lensnode/lensnode/agent_runtime/system_prompts.py
@@ -12,7 +12,7 @@ def _system_prompt(
     context_skill_contents=None,
     *,
     mcp_deferred=False,
-    codegraph_available=False,
+    runtime_guidance=None,
 ):
     """Build the per-task Deep Agents system prompt."""
 
@@ -23,7 +23,7 @@ def _system_prompt(
             scenario,
             command,
             context_skill_contents,
-            codegraph_available=codegraph_available,
+            runtime_guidance=runtime_guidance,
         )
     if mcp_deferred:
         prompt += (
@@ -45,7 +45,7 @@ def _knowledge_system_prompt(
     command,
     context_skill_contents=None,
     *,
-    codegraph_available=False,
+    runtime_guidance=None,
 ):
     """Build the workspace-grounded system prompt."""
 
@@ -65,6 +65,7 @@ def _knowledge_system_prompt(
     answer_language = _command_answer_language(command)
     language_requirement = _answer_language_requirement(answer_language)
     context_guidance = _context_guidance(context_skill_contents or [])
+    runtime_guidance_text = "\n".join(runtime_guidance or ())
     return (
         f"{language_requirement}\n\n"
         f"{scenario['prompt']}\n\n"
@@ -84,12 +85,13 @@ def _knowledge_system_prompt(
         "from them — that conclusion is always wrong. The workspace is "
         "always present and reachable ONLY through search_workspace / "
         "find_files / read_workspace_file.\n"
-        "- Your FIRST action for any project or code question MUST be a "
-        "search_workspace call, or a find_files call with a RECURSIVE "
+        f"{runtime_guidance_text}\n"
+        "- For exact-text questions, or when CodeGraph is unavailable, your "
+        "FIRST workspace action MUST be a search_workspace call, or a "
+        "find_files call with a RECURSIVE "
         'pattern ("**/*", never a bare "*", which only lists the top '
         "level). If find_files returns nothing, retry with \"**/*\" or a "
         "broader search_workspace before drawing any conclusion.\n"
-        f"{_codegraph_guidance(codegraph_available)}\n"
         "- Use the scratch directory (write_file / read_file / ls) only "
         "for artifacts you generate. For example, if you convert a PDF to "
         "markdown, write the result there, not into the source "
@@ -298,27 +300,6 @@ def _subagent_guidance(agent_rounds):
         "tool calls (parallel reads/searches). Do NOT delegate to `task` "
         "subagents for this — at this depth, direct batched work is "
         "faster than spinning up subagents.\n\n"
-    )
-
-
-def _codegraph_guidance(available):
-    """Return the CodeGraph-first guidance block when the tools are loaded."""
-
-    if not available:
-        return ""
-    return (
-        "- CodeGraph is available: a prebuilt knowledge graph of the "
-        "workspace source. For STRUCTURAL questions — where a symbol or "
-        "function is defined, what calls what, how a module reaches another, "
-        "what would break if something changed — PREFER the codegraph tools "
-        "(mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_callers, "
-        "mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_trace, "
-        "mcp__codegraph__codegraph_impact, "
-        "mcp__codegraph__codegraph_explore) over a ripgrep search_workspace. "
-        "They answer from the graph directly and are far faster than "
-        "scanning matching lines. Use search_workspace for literal-text "
-        "questions (exact strings, comments, log messages) and after you "
-        "already have a specific file open."
     )
 
 

--- a/lensnode/lensnode/mcp_tools.py
+++ b/lensnode/lensnode/mcp_tools.py
@@ -26,11 +26,81 @@ MCP_STDIO_MAX_ARGS = 32
 MCP_STDIO_MAX_ENV = 32
 
 
+class MCPToolFirstMiddleware(AgentMiddleware):
+    """Expose one MCP tool family on the first model turn."""
+
+    def __init__(self, tool_prefix):
+        self._tool_prefix = str(tool_prefix or "")
+        self._completed = False
+        self._lock = threading.Lock()
+
+    def _filter_tools(self, tools):
+        """Keep only the configured tool family until its first call."""
+
+        with self._lock:
+            if self._completed:
+                return list(tools)
+        return [
+            tool
+            for tool in tools
+            if str(getattr(tool, "name", "") or "").startswith(
+                self._tool_prefix
+            )
+        ]
+
+    def _tool_name(self, request):
+        """Return the invoked tool name from a middleware request."""
+
+        tool_call = getattr(request, "tool_call", None) or {}
+        return str(
+            tool_call.get("name")
+            or getattr(getattr(request, "tool", None), "name", None)
+            or ""
+        )
+
+    def _mark_completed(self):
+        """Restore the normal tool set after the first tool call."""
+
+        with self._lock:
+            self._completed = True
+
+    def wrap_model_call(self, request, handler):
+        """Filter synchronous model requests."""
+
+        request = request.override(tools=self._filter_tools(request.tools))
+        return handler(request)
+
+    async def awrap_model_call(self, request, handler):
+        """Filter asynchronous model requests."""
+
+        request = request.override(tools=self._filter_tools(request.tools))
+        return await handler(request)
+
+    def wrap_tool_call(self, request, handler):
+        """Restore tools after a synchronous first-family call."""
+
+        try:
+            return handler(request)
+        finally:
+            if self._tool_name(request).startswith(self._tool_prefix):
+                self._mark_completed()
+
+    async def awrap_tool_call(self, request, handler):
+        """Restore tools after an asynchronous first-family call."""
+
+        try:
+            return await handler(request)
+        finally:
+            if self._tool_name(request).startswith(self._tool_prefix):
+                self._mark_completed()
+
+
 class DeferredMCPToolMiddleware(AgentMiddleware):
     """Hide MCP schemas until tool_search promotes matching tools."""
 
-    def __init__(self, mcp_tools):
+    def __init__(self, mcp_tools, always_visible_prefixes=()):
         self._mcp_tools = {tool.name: tool for tool in mcp_tools}
+        self._always_visible_prefixes = tuple(always_visible_prefixes)
         self._promoted = set()
         self._lock = threading.Lock()
         self.search_tool = StructuredTool.from_function(
@@ -78,7 +148,8 @@ class DeferredMCPToolMiddleware(AgentMiddleware):
         return [
             tool
             for tool in tools
-            if not _is_mcp_tool(tool)
+            if _has_prefix(tool, self._always_visible_prefixes)
+            or not _is_mcp_tool(tool)
             or tool.name in promoted
         ]
 
@@ -264,6 +335,7 @@ def load_mcp_tools(
                         params
                     )
                 )
+            loaded_tool_names = []
             for raw_tool in discovered:
                 if len(tools) >= MCP_MAX_TOOLS:
                     _emit(
@@ -284,12 +356,14 @@ def load_mcp_tools(
                     terminate_fn=terminate_fn,
                 )
                 tools.append(tool)
+                loaded_tool_names.append(tool.name)
             _emit(
                 emit_event,
                 "mcp.server.ready",
                 {
                     "server": display_name,
                     "tool_count": len(discovered),
+                    "tool_names": loaded_tool_names,
                 },
             )
         finally:
@@ -323,12 +397,20 @@ async def _discover_mcp_servers(prepared, timeout_s):
     )
 
 
-def build_deferred_mcp_tools(mcp_tools, *, threshold=12):
+def build_deferred_mcp_tools(
+    mcp_tools,
+    *,
+    threshold=12,
+    always_visible_prefixes=(),
+):
     """Return registered MCP tools and optional schema-filter middleware."""
 
     if len(mcp_tools) <= max(int(threshold), 0):
         return list(mcp_tools), None
-    middleware = DeferredMCPToolMiddleware(mcp_tools)
+    middleware = DeferredMCPToolMiddleware(
+        mcp_tools,
+        always_visible_prefixes=always_visible_prefixes,
+    )
     return [*mcp_tools, middleware.search_tool], middleware
 
 
@@ -619,6 +701,13 @@ def _is_mcp_tool(tool):
     """Return whether a tool came from the MCP loader."""
 
     return str(getattr(tool, "name", "")).startswith(MCP_TOOL_PREFIX)
+
+
+def _has_prefix(tool, prefixes):
+    """Return whether a tool name starts with one of the prefixes."""
+
+    name = str(getattr(tool, "name", "") or "")
+    return any(name.startswith(prefix) for prefix in prefixes)
 
 
 def _emit(emit_event, event, detail):

--- a/lensnode/lensnode/plugins/__init__.py
+++ b/lensnode/lensnode/plugins/__init__.py
@@ -6,6 +6,18 @@ inside this package; external plugins remain a deferred decision (see
 docs/decisions/001-platform-connections-and-credentials.md).
 """
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentRuntimeContribution:
+    """Optional agent-runtime capabilities contributed by one plugin."""
+
+    prompt_guidance: str = ""
+    middleware: tuple = ()
+    subagent_middleware: tuple = ()
+    always_visible_tool_prefixes: tuple = ()
+
 
 class LensNodePlugin:
     """Base class for an in-process capability plugin.
@@ -27,6 +39,19 @@ class LensNodePlugin:
 
         return []
 
+    def contribute_agent_runtime(self, config, command, mcp_tools):
+        """Return optional runtime behavior after MCP discovery."""
+
+        return None
+
+
+def _plugins():
+    """Return the built-in plugin registry."""
+
+    from .codegraph import CodeGraphPlugin
+
+    return (CodeGraphPlugin(),)
+
 
 def collect_mcp_servers(config, mcp_configs, emit_event=None):
     """Merge plugin-contributed MCP servers, deduplicating by name.
@@ -35,9 +60,7 @@ def collect_mcp_servers(config, mcp_configs, emit_event=None):
     same name.
     """
 
-    from .codegraph import CodeGraphPlugin
-
-    plugins = (CodeGraphPlugin(),)
+    plugins = _plugins()
     servers = list(mcp_configs)
     for plugin in plugins:
         if not plugin.enabled(config):
@@ -54,3 +77,20 @@ def collect_mcp_servers(config, mcp_configs, emit_event=None):
                 continue
             servers.append(server)
     return servers
+
+
+def collect_agent_runtime_contributions(config, command, mcp_tools):
+    """Collect runtime behavior without exposing plugin identities upstream."""
+
+    contributions = []
+    for plugin in _plugins():
+        if not plugin.enabled(config):
+            continue
+        contribution = plugin.contribute_agent_runtime(
+            config,
+            command,
+            mcp_tools,
+        )
+        if contribution is not None:
+            contributions.append(contribution)
+    return contributions

--- a/lensnode/lensnode/plugins/codegraph.py
+++ b/lensnode/lensnode/plugins/codegraph.py
@@ -11,7 +11,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from . import LensNodePlugin
+from ..mcp_tools import MCPToolFirstMiddleware
+from . import AgentRuntimeContribution, LensNodePlugin
 
 CODEGRAPH_SERVER_NAME = "codegraph"
 CODEGRAPH_INDEX_DIR = ".codegraph"
@@ -78,6 +79,35 @@ class CodeGraphPlugin(LensNodePlugin):
                 "load_config": {},
             }
         ]
+
+    def contribute_agent_runtime(self, config, command, mcp_tools):
+        """Prioritize CodeGraph when its MCP tools are available."""
+
+        del config
+        if (command or {}).get("task") != "code_analysis":
+            return None
+        if not any(
+            str(getattr(tool, "name", "")).startswith("mcp__codegraph__")
+            for tool in mcp_tools
+        ):
+            return None
+        middleware = MCPToolFirstMiddleware("mcp__codegraph__")
+        return AgentRuntimeContribution(
+            prompt_guidance=(
+                "CodeGraph is available through the MCP tool family "
+                "mcp__codegraph__. For structural code questions — where "
+                "a symbol or function is defined, what calls what, how a "
+                "module reaches another, or what would break if something "
+                "changed — MUST call the CodeGraph MCP tool before any "
+                "workspace search or file-reading tool. Use workspace "
+                "search only for literal text such as exact traceback "
+                "lines, comments, log messages, or regex patterns, and "
+                "after CodeGraph has identified the relevant files."
+            ),
+            middleware=(middleware,),
+            subagent_middleware=(middleware,),
+            always_visible_tool_prefixes=("mcp__codegraph__",),
+        )
 
 
 def _ensure_codegraph_index(config, workspace, emit_event=None):

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -1035,12 +1035,37 @@ def test_system_prompt_injects_codegraph_guidance_when_available():
     prompt = _system_prompt(
         {"prompt": "Analyze code."},
         {"target_dirs": [{"path": "/workspace/product"}]},
-        codegraph_available=True,
+        runtime_guidance=(
+            "CodeGraph is available through exactly one MCP tool: "
+            "mcp__codegraph__codegraph_explore. MUST call "
+            "mcp__codegraph__codegraph_explore before any workspace tool.",
+        ),
     )
 
     assert "CodeGraph is available" in prompt
-    assert "mcp__codegraph__codegraph_trace" in prompt
-    assert "PREFER the codegraph" in prompt
+    assert "mcp__codegraph__codegraph_explore" in prompt
+    assert (
+        "MUST call mcp__codegraph__codegraph_explore before any"
+        in prompt
+    )
+    assert "mcp__codegraph__codegraph_trace" not in prompt
+
+
+def test_system_prompt_prioritizes_codegraph_over_workspace_search():
+    prompt = _system_prompt(
+        {"prompt": "Analyze code."},
+        {"target_dirs": [{"path": "/workspace/product"}]},
+        runtime_guidance=(
+            "CodeGraph is available through exactly one MCP tool: "
+            "mcp__codegraph__codegraph_explore. MUST call "
+            "mcp__codegraph__codegraph_explore before any workspace tool.",
+        ),
+    )
+
+    codegraph_position = prompt.index("CodeGraph is available")
+    search_position = prompt.index("FIRST workspace action")
+
+    assert codegraph_position < search_position
 
 
 def test_git_log_accepts_non_integer_max_count(tmp_path):

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -3644,6 +3644,18 @@ def test_knowledge_qa_keeps_task_tool_available():
     )
 
 
+def test_agent_middleware_includes_runtime_extensions():
+    runtime_extension = object()
+
+    middleware = agent_runtime._agent_middleware(
+        {"task": "code_analysis"},
+        summarizer=None,
+        runtime_middleware=(runtime_extension,),
+    )
+
+    assert middleware == [runtime_extension]
+
+
 def test_agent_middleware_includes_deferred_mcp_filter():
     deferred = object()
 
@@ -3662,6 +3674,16 @@ def test_fast_subagent_inherits_deferred_mcp_filter():
     subagent = agent_runtime._fast_subagent(deferred)
 
     assert subagent["middleware"] == [deferred]
+
+
+def test_fast_subagent_inherits_runtime_extensions():
+    runtime_extension = object()
+
+    subagent = agent_runtime._fast_subagent(
+        runtime_middleware=(runtime_extension,),
+    )
+
+    assert subagent["middleware"] == [runtime_extension]
 
 
 def test_summarization_middleware_forwards_run_uuid(monkeypatch):

--- a/lensnode/tests/test_mcp_tools.py
+++ b/lensnode/tests/test_mcp_tools.py
@@ -7,6 +7,7 @@ from langchain_core.tools import StructuredTool
 
 from lensnode.mcp_tools import (
     DeferredMCPToolMiddleware,
+    MCPToolFirstMiddleware,
     build_deferred_mcp_tools,
     load_mcp_tools,
 )
@@ -21,6 +22,10 @@ def _remote_tool(name="lookup"):
         name=name,
         description="Look up a remote record.",
     )
+
+
+def _named_tool(name):
+    return SimpleNamespace(name=name)
 
 
 def _install_fake_adapter(monkeypatch, clients):
@@ -389,6 +394,120 @@ def test_deferred_mcp_tools_promote_only_matching_schemas():
     }
 
 
+def test_deferred_mcp_tools_keep_codegraph_visible():
+    tools = [
+        _named_tool("mcp__codegraph__codegraph_explore"),
+        *(_named_tool(f"mcp__catalog__lookup_{index}") for index in range(3)),
+    ]
+
+    visible_tools, middleware = build_deferred_mcp_tools(
+        tools,
+        threshold=2,
+        always_visible_prefixes=("mcp__codegraph__",),
+    )
+
+    assert middleware is not None
+    assert {
+        tool.name for tool in middleware._filter_tools(visible_tools)
+    } == {
+        "mcp__codegraph__codegraph_explore",
+        "tool_search",
+    }
+
+
+def test_codegraph_first_middleware_restores_tools_after_codegraph_call():
+    middleware = MCPToolFirstMiddleware("mcp__codegraph__")
+    all_tools = [
+        _named_tool("search_workspace"),
+        _named_tool("find_files"),
+        _named_tool("read_workspace_file"),
+        _named_tool("mcp__codegraph__codegraph_explore"),
+    ]
+    request = SimpleNamespace(
+        tools=all_tools,
+        override=lambda **updates: SimpleNamespace(**updates),
+    )
+    captured = []
+
+    middleware.wrap_model_call(
+        request,
+        lambda filtered: captured.append(
+            [tool.name for tool in filtered.tools]
+        ),
+    )
+
+    assert captured == [["mcp__codegraph__codegraph_explore"]]
+
+    middleware.wrap_tool_call(
+        SimpleNamespace(
+            tool_call={
+                "name": "mcp__codegraph__codegraph_explore",
+            }
+        ),
+        lambda _request: "done",
+    )
+
+    middleware.wrap_model_call(
+        request,
+        lambda filtered: captured.append(
+            [tool.name for tool in filtered.tools]
+        ),
+    )
+
+    assert captured == [
+        ["mcp__codegraph__codegraph_explore"],
+        [tool.name for tool in all_tools],
+    ]
+
+
+def test_codegraph_first_middleware_restores_tools_after_async_failure():
+    middleware = MCPToolFirstMiddleware("mcp__codegraph__")
+    all_tools = [
+        _named_tool("search_workspace"),
+        _named_tool("mcp__codegraph__codegraph_explore"),
+    ]
+    request = SimpleNamespace(
+        tools=all_tools,
+        override=lambda **updates: SimpleNamespace(**updates),
+    )
+
+    async def exercise():
+        async def capture(filtered):
+            return filtered
+
+        await middleware.awrap_model_call(
+            request,
+            capture,
+        )
+
+        async def fail(_request):
+            raise RuntimeError("CodeGraph unavailable")
+
+        try:
+            await middleware.awrap_tool_call(
+                SimpleNamespace(
+                    tool_call={
+                        "name": "mcp__codegraph__codegraph_explore",
+                    }
+                ),
+                fail,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("the fake CodeGraph call must fail")
+
+        response = await middleware.awrap_model_call(
+            request,
+            capture,
+        )
+        assert [tool.name for tool in response.tools] == [
+            tool.name for tool in all_tools
+        ]
+
+    asyncio.run(exercise())
+
+
 def test_stdio_mcp_requires_explicit_allowlist(monkeypatch):
     clients = []
     events = []
@@ -434,6 +553,38 @@ def test_stdio_mcp_requires_explicit_allowlist(monkeypatch):
     assert not any(
         event == "mcp.server.skipped" for event, detail in events
     )
+
+
+def test_mcp_ready_event_reports_loaded_tool_names(monkeypatch):
+    clients = []
+    events = []
+    _install_fake_adapter(monkeypatch, clients)
+
+    load_mcp_tools(
+        [
+            {
+                "name": "codegraph",
+                "transport": "stdio",
+                "endpoint": "",
+                "config": {"command": "codegraph"},
+                "load_config": {},
+            }
+        ],
+        stdio_allowlist=("codegraph",),
+        emit_event=lambda event, detail: events.append((event, detail)),
+    )
+
+    ready_events = [
+        detail for event, detail in events if event == "mcp.server.ready"
+    ]
+
+    assert ready_events == [
+        {
+            "server": "codegraph",
+            "tool_count": 1,
+            "tool_names": ["mcp__codegraph__lookup"],
+        }
+    ]
 
 
 def test_stdio_mcp_allowlist_gate_and_params(monkeypatch):

--- a/lensnode/tests/test_mcp_tools_integration.py
+++ b/lensnode/tests/test_mcp_tools_integration.py
@@ -105,5 +105,9 @@ def test_streamable_http_discovers_calls_and_closes_sessions():
     assert recorder.methods.count("DELETE") == 2
     assert (
         "mcp.server.ready",
-        {"server": "Local deterministic MCP", "tool_count": 1},
+        {
+            "server": "Local deterministic MCP",
+            "tool_count": 1,
+            "tool_names": ["mcp__local_deterministic_mcp__add"],
+        },
     ) in events

--- a/lensnode/tests/test_plugins.py
+++ b/lensnode/tests/test_plugins.py
@@ -49,6 +49,30 @@ def test_codegraph_plugin_contributes_stdio_server(monkeypatch, tmp_path):
     ]
 
 
+def test_codegraph_plugin_contributes_generic_agent_runtime_behavior():
+    plugin = CodeGraphPlugin()
+    tools = [
+        SimpleNamespace(name="mcp__codegraph__codegraph_explore"),
+    ]
+
+    contribution = plugin.contribute_agent_runtime(
+        _config(),
+        {"task": "code_analysis"},
+        tools,
+    )
+
+    assert contribution.prompt_guidance.startswith("CodeGraph is available")
+    assert contribution.middleware == contribution.subagent_middleware
+    assert contribution.always_visible_tool_prefixes == (
+        "mcp__codegraph__",
+    )
+    assert plugin.contribute_agent_runtime(
+        _config(),
+        {"task": "knowledge_qa"},
+        tools,
+    ) is None
+
+
 def test_codegraph_plugin_disabled_when_toggle_off():
     config = _config(mcp_enable_codegraph=False)
     assert not CodeGraphPlugin().enabled(config)

--- a/release-notes/301.yaml
+++ b/release-notes/301.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: "Code analysis assistants now keep CodeGraph-specific runtime behavior inside the plugin boundary while still prioritizing CodeGraph before workspace searches."
+zh-CN: "代码分析助手现在将 CodeGraph 专属运行逻辑保持在插件边界内，同时仍会在工作区搜索前优先使用 CodeGraph。"


### PR DESCRIPTION
### **User description**
## Summary
- Add a generic plugin runtime contribution contract for prompt guidance, middleware, subagent middleware, and always-visible MCP tool prefixes.
- Move CodeGraph-specific first-turn prioritization and prompt guidance into the CodeGraph plugin.
- Keep deferred MCP discovery extensible while preserving CodeGraph-first behavior for code analysis.
- Add runtime tool discovery observability and regression coverage.

Closes #301

## Test plan
- [x] `uv run --project lensnode --extra dev pytest -q lensnode/tests`
- [x] `uv run --project lensnode python -m compileall -q lensnode/lensnode lensnode/tests`
- [x] `git diff --check`


___

### **PR Type**
Enhancement


___

### **Description**
- Move CodeGraph runtime behavior into plugin contract

- Add generic runtime contribution boundary for middleware, guidance, prefixes

- Preserve CodeGraph-first prioritization for code analysis

- Add regression tests and observability for MCP tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Plugin["CodeGraph Plugin"] --> Contribution["AgentRuntimeContribution"]
  Contribution --> Prompt["Prompt Guidance"]
  Contribution --> Middleware["Middleware & Subagent Middleware"]
  Contribution --> Prefixes["Always-visible Tool Prefixes"]
  Prompt --> SystemPrompt["System Prompt"]
  Middleware --> Assembly["Middleware Assembly"]
  Prefixes --> MCP["Deferred MCP Filter"]
  Assembly --> Agent["Deep Agent"]
  MCP --> Agent
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>assembly.py</strong><dd><code>Add runtime middleware support to assembly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-3d0f390c68b3bf45e981a001aa1dd4706ffaa41f219c4d5f5c048114971c4032">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Integrate plugin runtime contributions into agent run</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+30/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>system_prompts.py</strong><dd><code>Replace codegraph_available with runtime_guidance parameter</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-3412700156257c47eb378ccbe14d3ca9f3d96f4731ff1582070256d753c9df9e">+8/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp_tools.py</strong><dd><code>Add MCP first-turn middleware and always-visible prefixes</code></dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-ab4664d24df1195d965149e98912e9f1d73ef3be7b2db0afa75ea331ac4054d3">+93/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Define plugin runtime contribution contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-62dc2e10efcada1c74ff3c8a734b1d894917ffcd24129987ad46b736a58ec6a6">+43/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codegraph.py</strong><dd><code>Move CodeGraph runtime behavior into plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-bf2c1375c2f96a3dad1ff3aae3a59bb8b4c3afb78525157213880c1eb9e0c50c">+31/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_executor.py</strong><dd><code>Add tests for runtime guidance in system prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+28/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Add tests for runtime middleware extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_mcp_tools.py</strong><dd><code>Add tests for MCP first-turn and always-visible prefixes</code>&nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-afa640b41b0ec145ec2bb88bdfa0f25cc5e8b1855f3337de7dbc2b096d0534d3">+151/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_mcp_tools_integration.py</strong><dd><code>Update integration test for tool_names event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-8fab3821b32bdf334812511dbabc2471398ec42dbe362457c9ff46ff1c77d302">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_plugins.py</strong><dd><code>Add test for plugin runtime contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-7a9ee00086541166f55d3feaa00d57e727df5475a3268800f2c44a60290bc95e">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>301.yaml</strong><dd><code>Add release notes for decoupling CodeGraph runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/HyperBDR/sourcelens/pull/302/files#diff-0f30d3e0eafdb229dd3b0c4ef2d40c8c310afd8c4c24abd930b6548f7303c626">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

