### PR TITLE
Fix duplicate empty sessions and unreliable chat titles

### DIFF
--- a/backend/lens/assistant_lifecycle.py
+++ b/backend/lens/assistant_lifecycle.py
@@ -26,7 +26,7 @@ def _find_reusable_empty_session(assistant, user):
         status=Session.Status.ACTIVE,
         title="",
         title_manually_edited=False,
-    ).order_by("created_at", "pk")
+    ).select_for_update().order_by("created_at", "pk")
     for session in candidates:
         if session.message_set.exists():
             continue
@@ -53,7 +53,6 @@ def lock_assistant_for_new_work(assistant, user=None):
     return locked
 
 
-@transaction.atomic
 @transaction.atomic
 def create_assistant_session(assistant_uuid, user, title=""):
     """Create a session while serializing against assistant archival."""

--- a/backend/lens/assistant_lifecycle.py
+++ b/backend/lens/assistant_lifecycle.py
@@ -54,6 +54,7 @@ def lock_assistant_for_new_work(assistant, user=None):
 
 
 @transaction.atomic
+@transaction.atomic
 def create_assistant_session(assistant_uuid, user, title=""):
     """Create a session while serializing against assistant archival."""
 

--- a/backend/lens/assistant_lifecycle.py
+++ b/backend/lens/assistant_lifecycle.py
@@ -1,5 +1,6 @@
 """Transactional guards for creating work against an assistant."""
 
+from django.core.cache import cache
 from django.db import transaction
 
 from .models import Assistant, Session
@@ -7,6 +8,36 @@ from .models import Assistant, Session
 
 class AssistantNotRunnableError(RuntimeError):
     """Raised when an assistant cannot accept new work."""
+
+
+def _has_document_attachments(session):
+    """Return whether cached document uploads still belong to a session."""
+
+    key = f"lens:session_document_attachments:{session.uuid}"
+    return bool(cache.get(key) or [])
+
+
+def _find_reusable_empty_session(assistant, user):
+    """Return the oldest active empty session for an assistant and user."""
+
+    candidates = Session.objects.filter(
+        assistant=assistant,
+        user=user,
+        status=Session.Status.ACTIVE,
+        title="",
+        title_manually_edited=False,
+    ).order_by("created_at", "pk")
+    for session in candidates:
+        if session.message_set.exists():
+            continue
+        if session.run_set.exists():
+            continue
+        if session.attachments.exists():
+            continue
+        if _has_document_attachments(session):
+            continue
+        return session
+    return None
 
 
 def lock_assistant_for_new_work(assistant, user=None):
@@ -29,6 +60,10 @@ def create_assistant_session(assistant_uuid, user, title=""):
     assistant = Assistant.objects.get(uuid=assistant_uuid)
     assistant = lock_assistant_for_new_work(assistant, user)
     normalized_title = " ".join(str(title or "").split())
+    if not normalized_title:
+        existing = _find_reusable_empty_session(assistant, user)
+        if existing is not None:
+            return existing
     return Session.objects.create(
         assistant=assistant,
         user=user,

--- a/backend/lens/document_attachments.py
+++ b/backend/lens/document_attachments.py
@@ -335,6 +335,10 @@ def delete_document_attachment(
         return False
     document_attachment_storage().delete(metadata["storage_name"])
     cache.delete(_attachment_key(attachment_uuid))
+    _remove_from_index(
+        _session_index_key(metadata["session_uuid"]),
+        attachment_uuid,
+    )
     _release_user_quota(
         metadata["uploaded_by_id"],
         metadata.get("quota_slot"),
@@ -440,6 +444,19 @@ def _append_index(key, attachment_uuid, metadata):
         attachment_uuids,
         timeout=max(_remaining_seconds(metadata), 1),
     )
+
+
+def _remove_from_index(key, attachment_uuid):
+    """Remove one attachment UUID without retaining a stale session entry."""
+
+    attachment_uuids = list(cache.get(key) or [])
+    remaining = [
+        value for value in attachment_uuids if value != attachment_uuid
+    ]
+    if not remaining:
+        cache.delete(key)
+        return
+    cache.set(key, remaining, timeout=_attachment_ttl_seconds())
 
 
 def _remaining_seconds(metadata):

--- a/backend/lens/management/commands/backfill_session_titles.py
+++ b/backend/lens/management/commands/backfill_session_titles.py
@@ -1,0 +1,114 @@
+from django.core.management.base import BaseCommand
+
+from lens.models import Message, Run, Session
+from lens.session_titles import fallback_session_title
+from lens.tasks import generate_session_title
+
+
+class Command(BaseCommand):
+    """Backfill readable titles for historical sessions with messages."""
+
+    help = "Backfill missing titles for sessions that contain messages."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=(
+                "Report candidates without changing sessions or "
+                "enqueueing tasks."
+            ),
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="Limit the number of sessions to inspect; zero means all.",
+        )
+
+    def handle(self, *args, **options):
+        sessions = Session.objects.filter(
+            title="",
+            title_manually_edited=False,
+        ).order_by("created_at", "pk")
+        limit = options["limit"]
+        if limit > 0:
+            sessions = sessions[:limit]
+
+        counts = {"fallback": 0, "queued": 0, "skipped": 0, "failed": 0}
+        for session in sessions:
+            user_message = session.message_set.filter(
+                role=Message.Role.USER,
+            ).order_by("sequence", "uuid").first()
+            if user_message is None:
+                counts["skipped"] += 1
+                continue
+
+            title = fallback_session_title(user_message.content)
+            if not title:
+                counts["skipped"] += 1
+                continue
+
+            runs = session.run_set.filter(
+                status=Run.Status.DONE,
+                output_message__isnull=False,
+            ).exclude(
+                outcome=Run.Outcome.BLOCKED,
+            ).select_related("input_message").order_by(
+                "created_at",
+                "pk",
+            )
+            run = next(
+                (
+                    candidate
+                    for candidate in runs
+                    if (candidate.output_message.content or "").strip()
+                ),
+                None,
+            )
+            status = (
+                Session.TitleGenerationStatus.PENDING
+                if run is not None
+                else Session.TitleGenerationStatus.FAILED
+            )
+            if options["dry_run"]:
+                counts["fallback"] += 1
+                counts["queued"] += int(run is not None)
+                continue
+
+            updated = Session.objects.filter(
+                pk=session.pk,
+                title="",
+                title_manually_edited=False,
+            ).update(
+                title=title,
+                title_generation_status=status,
+            )
+            if not updated:
+                continue
+
+            counts["fallback"] += 1
+            if run is None:
+                counts["failed"] += 1
+                continue
+
+            try:
+                generate_session_title.delay(str(session.uuid), str(run.uuid))
+                counts["queued"] += 1
+            except Exception:
+                Session.objects.filter(
+                    pk=session.pk,
+                    title_generation_status=(
+                        Session.TitleGenerationStatus.PENDING
+                    ),
+                ).update(
+                    title_generation_status=(
+                        Session.TitleGenerationStatus.FAILED
+                    ),
+                )
+                counts["failed"] += 1
+
+        self.stdout.write(
+            "Backfilled {fallback} fallback title(s); queued {queued}; "
+            "marked {failed} failed; skipped {skipped}.".format(**counts)
+        )

--- a/backend/lens/management/commands/backfill_session_titles.py
+++ b/backend/lens/management/commands/backfill_session_titles.py
@@ -2,7 +2,10 @@ from django.core.management.base import BaseCommand
 
 from lens.models import Message, Run, Session
 from lens.session_titles import fallback_session_title
-from lens.tasks import generate_session_title
+from lens.tasks import (
+    SESSION_TITLE_TASK_EXPIRY_SECONDS,
+    generate_session_title,
+)
 
 
 class Command(BaseCommand):
@@ -93,7 +96,10 @@ class Command(BaseCommand):
                 continue
 
             try:
-                generate_session_title.delay(str(session.uuid), str(run.uuid))
+                generate_session_title.apply_async(
+                    args=[str(session.uuid), str(run.uuid)],
+                    expires=SESSION_TITLE_TASK_EXPIRY_SECONDS,
+                )
                 counts["queued"] += 1
             except Exception:
                 Session.objects.filter(

--- a/backend/lens/management/commands/backfill_session_titles.py
+++ b/backend/lens/management/commands/backfill_session_titles.py
@@ -48,10 +48,6 @@ class Command(BaseCommand):
                 continue
 
             title = fallback_session_title(user_message.content)
-            if not title:
-                counts["skipped"] += 1
-                continue
-
             runs = session.run_set.filter(
                 status=Run.Status.DONE,
                 output_message__isnull=False,
@@ -69,13 +65,17 @@ class Command(BaseCommand):
                 ),
                 None,
             )
+            if not title and run is None:
+                counts["skipped"] += 1
+                continue
+
             status = (
                 Session.TitleGenerationStatus.PENDING
                 if run is not None
                 else Session.TitleGenerationStatus.FAILED
             )
             if options["dry_run"]:
-                counts["fallback"] += 1
+                counts["fallback"] += int(bool(title))
                 counts["queued"] += int(run is not None)
                 continue
 
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             if not updated:
                 continue
 
-            counts["fallback"] += 1
+            counts["fallback"] += int(bool(title))
             if run is None:
                 counts["failed"] += 1
                 continue

--- a/backend/lens/periodic_tasks.py
+++ b/backend/lens/periodic_tasks.py
@@ -300,6 +300,14 @@ def register_periodic_tasks():
         enabled=True,
     )
 
+    TASK_REGISTRY.add(
+        name="lens-session-title-timeout",
+        task="lens.expire_stale_session_titles",
+        schedule=60,
+        queue="lens",
+        enabled=True,
+    )
+
     datasources = DataSource.objects.filter(
         status=DataSource.Status.ACTIVE,
     ).exclude(source_type=DataSource.SourceType.MANAGED_WORKSPACE)

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -718,16 +718,20 @@ def create_execution_run(
 
     validate_retry_run(session, retry_of_run)
 
-    if (
-        not session.title_manually_edited
-        and session.title_generation_status
-        == Session.TitleGenerationStatus.PENDING
-        and not session.message_set.exists()
-    ):
+    if not session.title_manually_edited and not session.message_set.exists():
         fallback_title = fallback_session_title(question)
         if fallback_title:
             session.title = fallback_title
-            session.save(update_fields=["title", "updated_at"])
+            session.title_generation_status = (
+                Session.TitleGenerationStatus.PENDING
+            )
+            session.save(
+                update_fields=[
+                    "title",
+                    "title_generation_status",
+                    "updated_at",
+                ]
+            )
 
     input_message = Message.objects.create(
         session=session,

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -860,9 +860,15 @@ def supports_run_admission_checkpoint(lensnode):
 def _enqueue_session_title_generation(session_uuid, run_uuid):
     """Enqueue semantic title generation after the answer is committed."""
 
-    from .tasks import generate_session_title
+    from .tasks import (
+        SESSION_TITLE_TASK_EXPIRY_SECONDS,
+        generate_session_title,
+    )
 
-    generate_session_title.delay(str(session_uuid), str(run_uuid))
+    generate_session_title.apply_async(
+        args=[str(session_uuid), str(run_uuid)],
+        expires=SESSION_TITLE_TASK_EXPIRY_SECONDS,
+    )
 
 
 def analyze_multimodal_intent(run):

--- a/backend/lens/session_titles.py
+++ b/backend/lens/session_titles.py
@@ -86,24 +86,27 @@ def generate_semantic_session_title(session_uuid, run_uuid):
     if not claimed:
         return ""
 
-    session = Session.objects.select_related("assistant", "user").get(
-        uuid=session_uuid
-    )
-    run = session.run_set.select_related(
-        "input_message",
-        "output_message",
-    ).get(uuid=run_uuid)
-    model_ref = (
-        session.assistant.postprocess_model_ref
-        or session.assistant.agent_model_ref
-    )
-
-    question = (run.input_message.content or "")[
-        :TITLE_INPUT_QUESTION_MAX_CHARS
-    ]
-    answer = (run.output_message.content or "")[:TITLE_INPUT_ANSWER_MAX_CHARS]
-    user_prompt = f"First question:\n{question}\n\nCompleted answer:\n{answer}"
     try:
+        session = Session.objects.select_related("assistant", "user").get(
+            uuid=session_uuid
+        )
+        run = session.run_set.select_related(
+            "input_message",
+            "output_message",
+        ).get(uuid=run_uuid)
+        model_ref = (
+            session.assistant.postprocess_model_ref
+            or session.assistant.agent_model_ref
+        )
+        question = (run.input_message.content or "")[
+            :TITLE_INPUT_QUESTION_MAX_CHARS
+        ]
+        answer = (run.output_message.content or "")[
+            :TITLE_INPUT_ANSWER_MAX_CHARS
+        ]
+        user_prompt = (
+            f"First question:\n{question}\n\nCompleted answer:\n{answer}"
+        )
         result = run_completion(
             model_ref=model_ref,
             system=_title_system_prompt(_run_answer_language(run)),

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -161,6 +161,13 @@ def generate_session_title(session_uuid, run_uuid):
     return generate_semantic_session_title(session_uuid, run_uuid)
 
 
+@shared_task(name="lens.generate_session_title", queue="lens")
+def generate_session_title_legacy(session_uuid, run_uuid):
+    """Support title tasks published by the previous application revision."""
+
+    return generate_session_title(session_uuid, run_uuid)
+
+
 @shared_task(name="lens.expire_stale_session_titles", queue="lens")
 def expire_stale_session_titles():
     """Fail title tasks that were not completed within their lease."""
@@ -174,10 +181,17 @@ def expire_stale_session_titles():
         Session.TitleGenerationStatus.PENDING,
         Session.TitleGenerationStatus.GENERATING,
     ]
+    active_run_statuses = [
+        Run.Status.QUEUED,
+        Run.Status.RUNNING,
+        Run.Status.STREAMING,
+    ]
     return Session.objects.filter(
         title_manually_edited=False,
         title_generation_status__in=stale_statuses,
         updated_at__lt=cutoff,
+    ).exclude(
+        run_set__status__in=active_run_statuses,
     ).update(
         title_generation_status=Session.TitleGenerationStatus.FAILED,
         updated_at=timezone.now(),

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -191,7 +191,7 @@ def expire_stale_session_titles():
         title_generation_status__in=stale_statuses,
         updated_at__lt=cutoff,
     ).exclude(
-        run_set__status__in=active_run_statuses,
+        run__status__in=active_run_statuses,
     ).update(
         title_generation_status=Session.TitleGenerationStatus.FAILED,
         updated_at=timezone.now(),

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -23,10 +23,13 @@ from .models import (
     RunExecution,
     RunTraceExport,
     ScheduledTask,
+    Session,
 )
 
 logger = logging.getLogger(__name__)
 ANSWER_RUN_DOCUMENT_COUNT_HEADER = "sourcelens_expected_document_count"
+SESSION_TITLE_TASK_EXPIRY_SECONDS = 900
+SESSION_TITLE_TASK_NAME = "lens.generate_session_title.v2"
 
 
 @shared_task(name="lens.execute_run_diagnostic", queue="lens")
@@ -149,13 +152,36 @@ def execute_answer_run(task, run_uuid, expected_document_count=None):
     return str(run.uuid)
 
 
-@shared_task(name="lens.generate_session_title", queue="lens")
+@shared_task(name=SESSION_TITLE_TASK_NAME, queue="lens")
 def generate_session_title(session_uuid, run_uuid):
     """Generate one semantic title without delaying its completed answer."""
 
     from .session_titles import generate_semantic_session_title
 
     return generate_semantic_session_title(session_uuid, run_uuid)
+
+
+@shared_task(name="lens.expire_stale_session_titles", queue="lens")
+def expire_stale_session_titles():
+    """Fail title tasks that were not completed within their lease."""
+
+    from django.utils import timezone
+
+    cutoff = timezone.now() - timedelta(
+        seconds=SESSION_TITLE_TASK_EXPIRY_SECONDS
+    )
+    stale_statuses = [
+        Session.TitleGenerationStatus.PENDING,
+        Session.TitleGenerationStatus.GENERATING,
+    ]
+    return Session.objects.filter(
+        title_manually_edited=False,
+        title_generation_status__in=stale_statuses,
+        updated_at__lt=cutoff,
+    ).update(
+        title_generation_status=Session.TitleGenerationStatus.FAILED,
+        updated_at=timezone.now(),
+    )
 
 
 def enqueue_answer_run_task(

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -494,7 +494,7 @@ class DocumentAttachmentTests(TestCase):
             cache.get(
                 f"lens:session_document_attachments:{self.session.uuid}"
             ),
-            [],
+            None,
         )
         self.assertFalse(
             storages["document_attachments"].exists(metadata["storage_name"])

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -490,6 +490,12 @@ class DocumentAttachmentTests(TestCase):
 
         self.assertTrue(deleted)
         self.assertIsNone(get_document_attachment(metadata["uuid"]))
+        self.assertEqual(
+            cache.get(
+                f"lens:session_document_attachments:{self.session.uuid}"
+            ),
+            [],
+        )
         self.assertFalse(
             storages["document_attachments"].exists(metadata["storage_name"])
         )

--- a/backend/lens/tests/test_session_titles.py
+++ b/backend/lens/tests/test_session_titles.py
@@ -18,7 +18,11 @@ from lens.session_titles import (
     generate_semantic_session_title,
     normalize_generated_title,
 )
-from lens.tasks import expire_stale_session_titles, generate_session_title
+from lens.tasks import (
+    expire_stale_session_titles,
+    generate_session_title,
+    generate_session_title_legacy,
+)
 
 
 class SessionTitleTests(TestCase):
@@ -185,6 +189,31 @@ class SessionTitleTests(TestCase):
             900,
         )
 
+    @patch("lens.tasks.generate_session_title.apply_async")
+    def test_backfill_queues_attachment_only_completed_session(self, delay):
+        legacy = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title_generation_status=Session.TitleGenerationStatus.SKIPPED,
+        )
+        run = self._completed_run(question="", session=legacy)
+        run.status = Run.Status.DONE
+        run.outcome = Run.Outcome.COMPLETED
+        run.save(update_fields=["status", "outcome"])
+
+        call_command("backfill_session_titles")
+
+        legacy.refresh_from_db()
+        self.assertEqual(legacy.title, "")
+        self.assertEqual(
+            legacy.title_generation_status,
+            Session.TitleGenerationStatus.PENDING,
+        )
+        delay.assert_called_once_with(
+            args=[str(legacy.uuid), str(run.uuid)],
+            expires=900,
+        )
+
     def test_title_task_is_versioned_and_stale_titles_expire(self):
         stale_pending = Session.objects.create(
             assistant=self.assistant,
@@ -198,6 +227,15 @@ class SessionTitleTests(TestCase):
             title="Stale generating fallback",
             title_generation_status=Session.TitleGenerationStatus.GENERATING,
         )
+        active = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title="Active run fallback",
+            title_generation_status=Session.TitleGenerationStatus.PENDING,
+        )
+        active_run = self._completed_run(session=active)
+        active_run.status = Run.Status.RUNNING
+        active_run.save(update_fields=["status"])
         fresh = Session.objects.create(
             assistant=self.assistant,
             user=self.user,
@@ -206,7 +244,7 @@ class SessionTitleTests(TestCase):
         )
         stale_time = timezone.now() - timedelta(minutes=16)
         Session.objects.filter(
-            pk__in=[stale_pending.pk, stale_generating.pk],
+            pk__in=[stale_pending.pk, stale_generating.pk, active.pk],
         ).update(updated_at=stale_time)
 
         expired = expire_stale_session_titles()
@@ -214,6 +252,7 @@ class SessionTitleTests(TestCase):
         self.assertEqual(expired, 2)
         stale_pending.refresh_from_db()
         stale_generating.refresh_from_db()
+        active.refresh_from_db()
         fresh.refresh_from_db()
         self.assertEqual(
             stale_pending.title_generation_status,
@@ -224,12 +263,20 @@ class SessionTitleTests(TestCase):
             Session.TitleGenerationStatus.FAILED,
         )
         self.assertEqual(
+            active.title_generation_status,
+            Session.TitleGenerationStatus.PENDING,
+        )
+        self.assertEqual(
             fresh.title_generation_status,
             Session.TitleGenerationStatus.PENDING,
         )
         self.assertEqual(
             generate_session_title.name,
             "lens.generate_session_title.v2",
+        )
+        self.assertEqual(
+            generate_session_title_legacy.name,
+            "lens.generate_session_title",
         )
 
     def test_database_defaults_support_old_session_inserts(self):

--- a/backend/lens/tests/test_session_titles.py
+++ b/backend/lens/tests/test_session_titles.py
@@ -167,6 +167,9 @@ class SessionTitleTests(TestCase):
         run.status = Run.Status.DONE
         run.outcome = Run.Outcome.COMPLETED
         run.save(update_fields=["status", "outcome"])
+        legacy.title = ""
+        legacy.title_generation_status = Session.TitleGenerationStatus.SKIPPED
+        legacy.save(update_fields=["title", "title_generation_status"])
 
         call_command("backfill_session_titles")
 

--- a/backend/lens/tests/test_session_titles.py
+++ b/backend/lens/tests/test_session_titles.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import uuid
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from lens.session_titles import (
     generate_semantic_session_title,
     normalize_generated_title,
 )
+from lens.tasks import expire_stale_session_titles, generate_session_title
 
 
 class SessionTitleTests(TestCase):
@@ -150,7 +152,7 @@ class SessionTitleTests(TestCase):
             Session.TitleGenerationStatus.PENDING,
         )
 
-    @patch("lens.tasks.generate_session_title.delay")
+    @patch("lens.tasks.generate_session_title.apply_async")
     def test_backfill_command_queues_completed_legacy_session(self, delay):
         legacy = Session.objects.create(
             assistant=self.assistant,
@@ -173,7 +175,62 @@ class SessionTitleTests(TestCase):
             legacy.title_generation_status,
             Session.TitleGenerationStatus.PENDING,
         )
-        delay.assert_called_once_with(str(legacy.uuid), str(run.uuid))
+        delay.assert_called_once()
+        self.assertEqual(
+            delay.call_args.kwargs["args"],
+            [str(legacy.uuid), str(run.uuid)],
+        )
+        self.assertEqual(
+            delay.call_args.kwargs["expires"],
+            900,
+        )
+
+    def test_title_task_is_versioned_and_stale_titles_expire(self):
+        stale_pending = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title="Stale fallback",
+            title_generation_status=Session.TitleGenerationStatus.PENDING,
+        )
+        stale_generating = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title="Stale generating fallback",
+            title_generation_status=Session.TitleGenerationStatus.GENERATING,
+        )
+        fresh = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title="Fresh fallback",
+            title_generation_status=Session.TitleGenerationStatus.PENDING,
+        )
+        stale_time = timezone.now() - timedelta(minutes=16)
+        Session.objects.filter(
+            pk__in=[stale_pending.pk, stale_generating.pk],
+        ).update(updated_at=stale_time)
+
+        expired = expire_stale_session_titles()
+
+        self.assertEqual(expired, 2)
+        stale_pending.refresh_from_db()
+        stale_generating.refresh_from_db()
+        fresh.refresh_from_db()
+        self.assertEqual(
+            stale_pending.title_generation_status,
+            Session.TitleGenerationStatus.FAILED,
+        )
+        self.assertEqual(
+            stale_generating.title_generation_status,
+            Session.TitleGenerationStatus.FAILED,
+        )
+        self.assertEqual(
+            fresh.title_generation_status,
+            Session.TitleGenerationStatus.PENDING,
+        )
+        self.assertEqual(
+            generate_session_title.name,
+            "lens.generate_session_title.v2",
+        )
 
     def test_database_defaults_support_old_session_inserts(self):
         session_uuid = uuid.uuid4()

--- a/backend/lens/tests/test_session_titles.py
+++ b/backend/lens/tests/test_session_titles.py
@@ -2,13 +2,14 @@ import uuid
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.db import connection
 from django.test import TestCase
 from django.utils import timezone
 
 from lens.assistant_lifecycle import create_assistant_session
 from lens.llm import LensLLMResult
-from lens.models import Assistant, LensNode, Run, Session
+from lens.models import Assistant, LensNode, Message, Run, Session
 from lens.serializers import SessionSerializer
 from lens.services import create_execution_run, finish_lensnode_run
 from lens.session_titles import (
@@ -48,9 +49,10 @@ class SessionTitleTests(TestCase):
             title_generation_status=Session.TitleGenerationStatus.PENDING,
         )
 
-    def _completed_run(self, question="What caused this error?"):
+    def _completed_run(self, question="What caused this error?", session=None):
+        session = session or self.session
         run = create_execution_run(
-            session=self.session,
+            session=session,
             question=question,
             enqueue=False,
         )
@@ -97,6 +99,81 @@ class SessionTitleTests(TestCase):
             Session.TitleGenerationStatus.SKIPPED,
         )
         self.assertTrue(manual.title_manually_edited)
+
+    def test_empty_session_creation_reuses_existing_session(self):
+        first = create_assistant_session(self.assistant.uuid, self.user)
+        second = create_assistant_session(self.assistant.uuid, self.user)
+
+        self.assertEqual(first.uuid, second.uuid)
+        self.assertEqual(
+            Session.objects.filter(
+                assistant=self.assistant,
+                user=self.user,
+                title="",
+            ).count(),
+            1,
+        )
+
+    def test_session_with_messages_is_not_reused(self):
+        first = create_assistant_session(self.assistant.uuid, self.user)
+        Message.objects.create(
+            session=first,
+            role=Message.Role.USER,
+            content="Existing conversation",
+            sequence=1,
+        )
+
+        second = create_assistant_session(self.assistant.uuid, self.user)
+
+        self.assertNotEqual(first.uuid, second.uuid)
+
+    def test_legacy_session_gets_fallback_on_first_run(self):
+        legacy = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title_generation_status=Session.TitleGenerationStatus.SKIPPED,
+        )
+
+        run = create_execution_run(
+            session=legacy,
+            question="Explain the legacy session title behavior",
+            enqueue=False,
+        )
+
+        legacy.refresh_from_db()
+        self.assertEqual(
+            legacy.title,
+            fallback_session_title(run.input_message.content),
+        )
+        self.assertEqual(
+            legacy.title_generation_status,
+            Session.TitleGenerationStatus.PENDING,
+        )
+
+    @patch("lens.tasks.generate_session_title.delay")
+    def test_backfill_command_queues_completed_legacy_session(self, delay):
+        legacy = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+            title_generation_status=Session.TitleGenerationStatus.SKIPPED,
+        )
+        run = self._completed_run(session=legacy)
+        run.status = Run.Status.DONE
+        run.outcome = Run.Outcome.COMPLETED
+        run.save(update_fields=["status", "outcome"])
+
+        call_command("backfill_session_titles")
+
+        legacy.refresh_from_db()
+        self.assertEqual(
+            legacy.title,
+            fallback_session_title(run.input_message.content),
+        )
+        self.assertEqual(
+            legacy.title_generation_status,
+            Session.TitleGenerationStatus.PENDING,
+        )
+        delay.assert_called_once_with(str(legacy.uuid), str(run.uuid))
 
     def test_database_defaults_support_old_session_inserts(self):
         session_uuid = uuid.uuid4()

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -27,28 +27,31 @@
           class="sidebar-brand"
           :class="sidebarCollapsedActive ? 'sidebar-brand-collapsed' : ''"
         >
-          <router-link
-            v-if="!sidebarCollapsedActive"
-            to="/dashboard"
-            class="sidebar-brand-link"
-            @click="isMobile && (sidebarOpen = false)"
-          >
-            <BrandLogo
-              :variant="sidebarLogoVariant"
-              :wrapperClass="sidebarLogoWrapperClass"
-            />
-          </router-link>
           <button
-            v-else
             type="button"
             class="sidebar-brand-link"
-            :aria-label="t('common.expand')"
-            @click="sidebarCollapsed = false"
+            :aria-label="
+              sidebarCollapsedActive
+                ? t('common.expand')
+                : t('management.logoTitle')
+            "
+            @click="handleSidebarLogoClick"
           >
-            <BrandLogo
-              :variant="sidebarLogoVariant"
-              :wrapperClass="sidebarLogoWrapperClass"
-            />
+            <span
+              class="sidebar-logo-stage"
+              :class="
+                sidebarCollapsedActive ? 'sidebar-logo-stage-collapsed' : ''
+              "
+            >
+              <BrandLogo
+                variant="wordmark"
+                wrapperClass="sidebar-logo-layer sidebar-wordmark-layer"
+              />
+              <BrandLogo
+                variant="mark"
+                wrapperClass="sidebar-logo-layer sidebar-mark-layer"
+              />
+            </span>
           </button>
           <button
             v-if="!isMobile"
@@ -1712,19 +1715,20 @@ const avatarBgColor = computed(() => {
   return colors[charCode % colors.length]
 })
 
-const sidebarLogoVariant = computed(() =>
-  sidebarCollapsed.value && !isMobile.value ? 'mark' : 'wordmark'
-)
-
-const sidebarLogoWrapperClass = computed(() =>
-  sidebarCollapsed.value && !isMobile.value
-    ? 'sidebar-brand-logo origin-center scale-[0.72]'
-    : 'sidebar-brand-logo origin-left'
-)
-
 const sidebarCollapsedActive = computed(
   () => sidebarCollapsed.value && !isMobile.value
 )
+
+function handleSidebarLogoClick() {
+  if (sidebarCollapsedActive.value) {
+    sidebarCollapsed.value = false
+    return
+  }
+  if (isMobile.value) {
+    sidebarOpen.value = false
+  }
+  router.push('/dashboard')
+}
 
 const isRunActive = computed(() =>
   ['queued', 'running', 'streaming'].includes(currentRun.value?.status)
@@ -2487,7 +2491,16 @@ async function createNewSession(notify = true) {
     return null
   }
 
-  sessions.value = [session, ...sessions.value]
+  const existingIndex = sessions.value.findIndex(
+    (item) => item.uuid === session.uuid
+  )
+  if (existingIndex >= 0) {
+    sessions.value = sessions.value.map((item) =>
+      item.uuid === session.uuid ? session : item
+    )
+  } else {
+    sessions.value = [session, ...sessions.value]
+  }
   sortManagedSessions()
   selectedSessionUuid.value = session.uuid
   question.value = ''
@@ -2502,7 +2515,7 @@ async function createNewSession(notify = true) {
     query: { session: session.uuid }
   })
 
-  if (notify) {
+  if (notify && existingIndex < 0) {
     showSuccess(t('lens.chat.sessionCreated'))
   }
 
@@ -3565,7 +3578,8 @@ onBeforeUnmount(() => {
 }
 
 .sidebar {
-  @apply flex h-full flex-shrink-0 flex-col border-r transition-all duration-300 ease-in-out;
+  @apply flex h-full flex-shrink-0 flex-col border-r transition-[width] duration-300 ease-in-out;
+  will-change: width;
   background: var(--sl-bg-surface);
   border-color: var(--sl-border-default);
 }
@@ -3583,32 +3597,73 @@ onBeforeUnmount(() => {
 }
 
 .sidebar-brand {
-  @apply flex items-center justify-between gap-2 px-1 pb-4;
+  @apply relative block px-1 pb-4;
+  height: 48px;
+  transition: height 300ms ease-in-out;
 }
 
 .sidebar-brand-collapsed {
-  @apply flex-col items-center justify-start gap-2;
-}
-
-.sidebar-brand-collapsed .sidebar-brand-link {
-  @apply flex-none flex w-full items-center justify-center;
-}
-
-.sidebar-brand-collapsed .sidebar-collapse-btn {
-  @apply self-center;
+  height: 96px;
 }
 
 .sidebar-brand-link {
-  @apply min-w-0 flex-1 overflow-hidden border-0 bg-transparent p-0 text-left;
+  @apply absolute left-0 top-0 flex h-12 items-center;
+  width: calc(100% - 48px);
+  transition:
+    width 300ms ease-in-out,
+    transform 300ms ease-in-out;
 }
 
-.sidebar-brand-logo {
-  @apply max-w-full;
+.sidebar-brand-collapsed .sidebar-brand-link {
+  @apply left-1/2;
+  width: 100%;
+  transform: translateX(-50%);
+}
+
+.sidebar-logo-stage {
+  @apply relative block h-12 w-[190px] overflow-hidden;
+  contain: layout paint;
+  will-change: width;
+  transition: width 300ms ease-in-out;
+}
+
+.sidebar-logo-stage-collapsed {
+  @apply w-10;
+}
+
+.sidebar-logo-layer {
+  @apply absolute inset-0 flex h-12 items-center;
+  will-change: opacity, transform;
+  transition:
+    opacity 200ms ease-in-out,
+    transform 300ms ease-in-out;
+}
+
+.sidebar-wordmark-layer {
+  @apply origin-left opacity-100;
+}
+
+.sidebar-mark-layer {
+  @apply justify-center origin-center opacity-0 scale-[0.72];
+}
+
+.sidebar-logo-stage-collapsed .sidebar-wordmark-layer {
+  @apply pointer-events-none opacity-0 -translate-x-2;
+}
+
+.sidebar-logo-stage-collapsed .sidebar-mark-layer {
+  @apply opacity-100 translate-x-0;
 }
 
 .sidebar-collapse-btn {
-  @apply flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors;
+  @apply absolute right-0 top-1 flex h-10 w-10 shrink-0 items-center
+    justify-center rounded-md transition-all duration-300 ease-in-out;
   color: var(--sl-text-secondary);
+}
+
+.sidebar-brand-collapsed .sidebar-collapse-btn {
+  @apply left-1/2 right-auto top-14;
+  transform: translateX(-50%);
 }
 
 .sidebar-collapse-btn:hover {

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -5,6 +5,12 @@ import test from 'node:test'
 const chatSource = () =>
   readFile(new URL('../src/pages/lens/Chat.vue', import.meta.url), 'utf8')
 
+const assistantSwitcherSource = () =>
+  readFile(
+    new URL('../src/components/lens/AssistantSwitcher.vue', import.meta.url),
+    'utf8'
+  )
+
 test('reveals loaded chat before waiting for active run recovery', async () => {
   const source = await chatSource()
   const messagesLoaded = source.indexOf('messages.value = loadedMessages')
@@ -66,4 +72,25 @@ test('selects a conversation when its route query changes', async () => {
   assert.notEqual(queryWatcher, -1)
   assert.notEqual(sessionLookup, -1)
   assert.notEqual(selectWithoutRouteUpdate, -1)
+})
+
+test('switches assistants through the assistant chat route', async () => {
+  const source = await assistantSwitcherSource()
+
+  assert.match(
+    source,
+    /await router\.push\(`\/lens\/assistants\/\$\{slug\}\/chat`\)/
+  )
+})
+
+test('loads sessions after selecting the route assistant', async () => {
+  const source = await chatSource()
+  const selectAssistant = source.indexOf(
+    'selectedAssistantUuid.value = current.uuid'
+  )
+  const loadSessions = source.indexOf('await loadSessions()', selectAssistant)
+
+  assert.notEqual(selectAssistant, -1)
+  assert.notEqual(loadSessions, -1)
+  assert.ok(loadSessions > selectAssistant)
 })

--- a/release-notes/304.yaml
+++ b/release-notes/304.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: "Chat sessions now reuse truly empty sessions and reliably receive readable fallback and semantic titles, including historical title backfill. The chat sidebar also has smoother Logo transitions between expanded and collapsed states."
+zh-CN: "聊天会话现在会复用真正的空会话，并可靠地获得可读的 fallback 标题和语义标题，历史会话也支持标题回填。聊天侧边栏在展开和收起状态之间的 Logo 切换也更加平滑。"


### PR DESCRIPTION
### **User description**
## Summary

- Reuse the existing truly empty session for the same user and Assistant with backend concurrency protection.
- Persist a first-question fallback title for legacy and new conversations.
- Recover semantic title generation failures and add an idempotent historical backfill command.
- Prevent duplicate frontend session entries when the backend reuses an empty session.
- Integrate the appearance-2 sidebar Logo transition and interaction refinement.

## Verification

- Python compile checks passed.
- Prettier and git diff checks passed.
- ego-browser verification passed for empty-session reuse, content-session isolation, fallback titles, semantic titles, multiple independent conversation titles, and sidebar collapse/Logo behavior.
- Test-created conversations were cleaned up.

Closes #304


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reuse existing empty sessions per user and assistant with backend concurrency protection.

- Persist fallback titles immediately and add semantic title generation with timeout and retry.

- Add idempotent backfill command for historical sessions with missing titles.

- Improve sidebar logo transition and prevent duplicate session entries in frontend.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["New Session Request"] --> B{Existing empty session?}
  B -- Yes --> C["Reuse session"]
  B -- No --> D["Create session"]
  C --> E["First user message"]
  D --> E
  E --> F["Fallback title persisted"]
  F --> G["Answer complete"]
  G --> H["Enqueue semantic title task"]
  H --> I{Task succeeds?}
  I -- Yes --> J["Persist semantic title"]
  I -- No --> K["Task fails; fallback remains"]
  K --> L["Expiry marks stale as failed"]
  J --> M["Session title final"]
  L --> M
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>assistant_lifecycle.py</strong><dd><code>Reuse empty session per user and assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-abda41b88cbac8d986428ddbcfcfe9d79a7487d464ccc705efaa4b99df2e82ac">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document_attachments.py</strong><dd><code>Remove session cache index on attachment deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-9529757592a8b4c153bde0e5c97a6cd0784013623692800121570309482c8289">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backfill_session_titles.py</strong><dd><code>Add backfill command for historical sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-25c0f03c2fc213f7a649e4b38579708eb4434f47ea7639b6a6078dcc6b4320b6">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>periodic_tasks.py</strong><dd><code>Register periodic task for stale title expiry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-b4f2328e7ea6c16451ba79cb137983af97f02a8cb9a5f22e0c05f81a732a0084">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Version title task and add legacy alias; add expiry task</code>&nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+41/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Refactor sidebar logo and prevent duplicate sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+96/-41</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Set fallback title and generation status on first run</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+19/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>session_titles.py</strong><dd><code>Move session/run queries inside try block for error safety</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-59c56db8eb9946df5f5deedbeb7f95d1553aee09472b3607092226d7e592350a">+20/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_document_attachments.py</strong><dd><code>Verify cache key removal on attachment delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-abb5e8fe2ed314bd844c7f25d56c651e637f0a72584e61b2d938b0018f41a437">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_session_titles.py</strong><dd><code>Add tests for reuse, backfill, and expiry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-3162a7b61d4fdc04ad063068349d071f79778281071bcd0445937e023e308da3">+187/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chatBootstrap.test.js</strong><dd><code>Add tests for assistant switching and session loading</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>304.yaml</strong><dd><code>Add release notes for session title fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/310/files#diff-8941e0755d96d3551455a6dfad236ce7337395ccaf7c5b9eea6e344689e6c30e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

