### PR TITLE
Fix planned Code Analysis recovery

### DIFF
--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -117,6 +117,8 @@ from ..runtime_resources import (
 
 LOGGER = logging.getLogger("lensnode")
 
+_PLANNED_CODE_ANALYSIS_ROUTE = {"route": "planned_code_analysis"}
+
 register_harness_profile(
     "lensgatewaychatmodel",
     HarnessProfile(
@@ -211,10 +213,8 @@ class LensDeepAgentRuntime:
             on_checkpoint_ready,
         )
         try:
-            if (
-                state.runtime_mode.name == "code_analysis"
-                and state.resume_state is None
-            ):
+            if self._uses_planned_code_analysis(state):
+                self._prepare_planned_checkpoint(state)
                 return _run_planned_code_analysis(
                     model=state.model,
                     command=state.command,
@@ -231,6 +231,44 @@ class LensDeepAgentRuntime:
         finally:
             if cancel_event is None or not cancel_event.is_set():
                 cleanup_runtime_resources(state.resources)
+
+    def _uses_planned_code_analysis(self, state):
+        """Return whether this run belongs to the planned evidence path."""
+
+        runtime_mode = getattr(state, "runtime_mode", None)
+        if getattr(runtime_mode, "name", None) != "code_analysis":
+            return False
+        if state.resume_state is None:
+            return True
+        return (
+            state.resume_state.route_decision == _PLANNED_CODE_ANALYSIS_ROUTE
+        )
+
+    def _prepare_planned_checkpoint(self, state):
+        """Seed durable state before the planned pipeline invokes a model."""
+
+        if state.resume_state is not None or not checkpoint_enabled():
+            return
+        try:
+            get_checkpoint_saver(self.config.workspace_path)
+            save_resume_metadata(
+                state.run_uuid,
+                self.config.workspace_path,
+                route_decision=_PLANNED_CODE_ANALYSIS_ROUTE,
+                history_assistant_turns=state.history_assistant_turns,
+            )
+            save_initial_checkpoint(
+                state.run_uuid,
+                self.config.workspace_path,
+                state.initial_messages,
+            )
+            state.checkpoint_ready = True
+            state.initial_checkpoint_seeded = True
+            state.notify_checkpoint_ready()
+        except Exception:
+            LOGGER.exception(
+                "Failed to enable planned code analysis checkpoint"
+            )
 
     def _prepare_runtime(
         self,
@@ -1230,12 +1268,21 @@ def _validated_planned_answer(response, bundle, workspace_root):
     content = _message_content(response)
     payload = _json_object(content)
     if payload is None:
+        if _looks_like_planned_answer_envelope(content):
+            return (
+                "The code analysis result could not be validated.\n\n"
+                "No verified citations were returned.",
+                (),
+                1,
+            )
         return (
             content + "\n\nNo verified citations were returned.",
             (),
             1,
         )
     answer = str(payload.get("answer") or "").strip()
+    if not answer:
+        answer = "The code analysis result could not be validated."
     valid, invalid = validate_citations(
         payload.get("citations"),
         bundle,
@@ -1255,7 +1302,7 @@ def _validated_planned_answer(response, bundle, workspace_root):
         )
     else:
         answer += "\n\nNo verified citations were returned."
-    return answer or content, valid, len(unsupported)
+    return answer, valid, len(unsupported)
 
 
 def _message_content(message):
@@ -1275,16 +1322,37 @@ def _message_content(message):
 
 
 def _json_object(content):
-    """Parse strict JSON or a single fenced JSON object."""
+    """Extract one planned-answer JSON object from model text."""
 
     text = str(content or "").strip()
-    if text.startswith("```") and text.endswith("```"):
-        text = text.split("\n", 1)[-1][:-3].strip()
-    try:
-        value = json.loads(text)
-    except json.JSONDecodeError:
-        return None
-    return value if isinstance(value, dict) else None
+    decoder = json.JSONDecoder()
+    starts = [0, *(match.start() for match in re.finditer(r"\{", text))]
+    for start in dict.fromkeys(starts):
+        try:
+            value, _end = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(value, dict):
+            continue
+        if {
+            "answer",
+            "citations",
+            "unsupported_claims",
+        }.intersection(value):
+            return value
+    return None
+
+
+def _looks_like_planned_answer_envelope(content):
+    """Detect a malformed internal final-answer protocol envelope."""
+
+    text = str(content or "")
+    keys = {
+        key
+        for key in ("answer", "citations", "unsupported_claims")
+        if f'"{key}"' in text
+    }
+    return len(keys) >= 2
 
 
 def _planned_planner_prompt(command):

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -1866,7 +1866,7 @@ def test_delivered_artifact_completes_after_token_budget_wrapup():
     assert termination_detail == {}
 
 
-def test_legacy_runtime_modes_skip_general_chat_execution_gates(
+def test_knowledge_qa_skips_general_chat_execution_gates(
     monkeypatch,
     tmp_path,
 ):
@@ -1962,23 +1962,22 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
     runtime = agent_runtime.LensDeepAgentRuntime(config)
     wrapup_event = threading.Event()
 
-    for task in ("knowledge_qa", "code_analysis"):
-        result = runtime._answer_sync(
-            {
-                "run_uuid": f"legacy-{task}",
-                "task": task,
-                "question": "Question",
-                "agent_model_ref": "model-ref",
-            },
-            wrapup_event=wrapup_event,
-            on_checkpoint_ready=lambda task=task: checkpoint_actions.append(
-                ("ready", task)
-            ),
-        )
+    result = runtime._answer_sync(
+        {
+            "run_uuid": "legacy-knowledge_qa",
+            "task": "knowledge_qa",
+            "question": "Question",
+            "agent_model_ref": "model-ref",
+        },
+        wrapup_event=wrapup_event,
+        on_checkpoint_ready=lambda: checkpoint_actions.append(
+            ("ready", "knowledge_qa")
+        ),
+    )
 
-        assert result["answer"] == "legacy answer"
-        assert result["outcome"] == "completed"
-        assert result["termination_detail"] == {}
+    assert result["answer"] == "legacy answer"
+    assert result["outcome"] == "completed"
+    assert result["termination_detail"] == {}
 
     assert all(
         options["general_chat_execution_gates"] is False
@@ -1996,10 +1995,6 @@ def test_legacy_runtime_modes_skip_general_chat_execution_gates(
         "metadata",
         "checkpoint",
         ("ready", "knowledge_qa"),
-        "saver",
-        "metadata",
-        "checkpoint",
-        ("ready", "code_analysis"),
     ]
 
 

--- a/lensnode/tests/test_planned_runtime.py
+++ b/lensnode/tests/test_planned_runtime.py
@@ -1,0 +1,179 @@
+from types import SimpleNamespace
+
+from lensnode import agent_runtime
+from lensnode.checkpoint import ResumeState
+from lensnode.planned_evidence import build_evidence_bundle
+
+
+def _runtime_state(tmp_path, resume_state=None):
+    ready_events = []
+    state = SimpleNamespace(
+        runtime_mode=SimpleNamespace(name="code_analysis"),
+        resume_state=resume_state,
+        run_uuid="planned-run",
+        model=SimpleNamespace(),
+        command={
+            "run_uuid": "planned-run",
+            "task": "code_analysis",
+        },
+        tools=[],
+        mcp_tools=[],
+        emit_agent_event=lambda *_args, **_kwargs: None,
+        resources=SimpleNamespace(),
+        initial_messages=[],
+        history_assistant_turns=0,
+        checkpoint_ready=resume_state is not None,
+        initial_checkpoint_seeded=False,
+        notify_checkpoint_ready=lambda: ready_events.append("ready"),
+    )
+    return state, ready_events
+
+
+def test_planned_code_analysis_seeds_checkpoint_before_execution(
+    monkeypatch,
+    tmp_path,
+):
+    actions = []
+    state, ready_events = _runtime_state(tmp_path)
+    runtime = agent_runtime.LensDeepAgentRuntime(
+        SimpleNamespace(workspace_path=str(tmp_path))
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "_prepare_runtime",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(agent_runtime, "checkpoint_enabled", lambda: True)
+    monkeypatch.setattr(
+        agent_runtime,
+        "get_checkpoint_saver",
+        lambda _workspace: actions.append("saver") or object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_resume_metadata",
+        lambda *_args, **kwargs: actions.append(("metadata", kwargs["route_decision"])),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "save_initial_checkpoint",
+        lambda *_args, **_kwargs: actions.append("checkpoint"),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_planned_code_analysis",
+        lambda **_kwargs: actions.append("planned") or {"answer": "done"},
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+
+    result = runtime._answer_sync(state.command)
+
+    assert result == {"answer": "done"}
+    assert actions == [
+        "saver",
+        (
+            "metadata",
+            {"route": "planned_code_analysis"},
+        ),
+        "checkpoint",
+        "planned",
+    ]
+    assert ready_events == ["ready"]
+    assert state.checkpoint_ready is True
+    assert state.initial_checkpoint_seeded is True
+
+
+def test_planned_code_analysis_resume_replays_planned_pipeline(
+    monkeypatch,
+    tmp_path,
+):
+    resume_state = ResumeState(
+        messages=(),
+        route_decision={"route": "planned_code_analysis"},
+        history_assistant_turns=0,
+        checkpoint_step=-1,
+    )
+    state, _ready_events = _runtime_state(tmp_path, resume_state)
+    runtime = agent_runtime.LensDeepAgentRuntime(
+        SimpleNamespace(workspace_path=str(tmp_path))
+    )
+    calls = []
+
+    monkeypatch.setattr(
+        runtime,
+        "_prepare_runtime",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_agent",
+        lambda _state: calls.append("deep-agent"),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_planned_code_analysis",
+        lambda **_kwargs: calls.append("planned") or {"answer": "recovered"},
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+
+    result = runtime._answer_sync({**state.command, "resume": True})
+
+    assert result == {"answer": "recovered"}
+    assert calls == ["planned"]
+
+
+def test_planned_answer_extracts_json_after_explanatory_prefix(tmp_path):
+    bundle = build_evidence_bundle([], max_tokens=100)
+    response = SimpleNamespace(
+        content=(
+            "Here is the structured result:\n"
+            "```json\n"
+            '{"answer":"Readable answer","citations":[],'
+            '"unsupported_claims":[]}\n'
+            "```"
+        )
+    )
+
+    answer, citations, unsupported = agent_runtime._validated_planned_answer(
+        response,
+        bundle,
+        tmp_path,
+    )
+
+    assert answer == ("Readable answer\n\nNo verified citations were returned.")
+    assert citations == ()
+    assert unsupported == 0
+    assert "structured result" not in answer
+    assert '"citations"' not in answer
+
+
+def test_invalid_planned_envelope_is_not_exposed(tmp_path):
+    bundle = build_evidence_bundle([], max_tokens=100)
+    response = SimpleNamespace(
+        content=(
+            '{"answer":"Internal answer","citations":['
+            '{"path":"private.py","supports":"internal rationale"}]'
+        )
+    )
+
+    answer, citations, unsupported = agent_runtime._validated_planned_answer(
+        response,
+        bundle,
+        tmp_path,
+    )
+
+    assert "Internal answer" not in answer
+    assert "private.py" not in answer
+    assert "supports" not in answer
+    assert "could not be validated" in answer
+    assert citations == ()
+    assert unsupported == 1

--- a/release-notes/311.yaml
+++ b/release-notes/311.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Code analysis now preserves planned evidence recovery after interruptions
+  and safely handles malformed structured answers.
+zh-CN: >-
+  代码分析现在可在中断后恢复计划证据流程，并安全处理格式异常的结构化回答。


### PR DESCRIPTION
### **User description**
## Summary
- persist the planned Code Analysis route before the planner model call
- resume interrupted planned runs through the deterministic evidence pipeline
- extract valid structured answers with harmless prefixes and hide malformed internal envelopes
- add focused recovery and response-validation regressions plus a localized release note

Closes #311
Refs #303

## Test plan
- [x] `uv run --project lensnode --extra dev pytest -q` (461 passed)
- [x] `uv run --python 3.12 --with "PyYAML>=6.0,<7.0" python -m unittest scripts.test_release_notes` (6 passed)
- [x] `uv run --python 3.12 --with "PyYAML>=6.0,<7.0" python scripts/release_notes.py validate-pr --base origin/main --head HEAD`
- [x] `git diff --check origin/main...HEAD`


___

### **PR Type**
Bug fix


___

### **Description**
- Seed checkpoint for planned runs before model call.

- Resume interrupted planned runs through evidence pipeline.

- Validate structured answers and hide malformed envelopes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  state["Run state"] --> checkPlanned["Uses planned analysis?"]
  checkPlanned -- yes --> seedCheckpoint["Seed checkpoint"]
  seedCheckpoint --> runPlanned["Run planned evidence pipeline"]
  runPlanned --> validateAnswer["Validate answer envelope"]
  validateAnswer -- valid --> output["Valid answer"]
  validateAnswer -- malformed --> safeMessage["Safe fallback message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Add planned route detection, checkpoint seeding, and answer </code><br><code>sanitization</code></dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Added <code>_PLANNED_CODE_ANALYSIS_ROUTE</code> constant and <br><code>_uses_planned_code_analysis</code> method to detect planned route.<br> <li> Added <code>_prepare_planned_checkpoint</code> to seed durable state before model <br>execution.<br> <li> Modified <code>_answer_sync</code> to call <code>_prepare_planned_checkpoint</code> for fresh <br>planned runs and to resume via <code>_uses_planned_code_analysis</code>.<br> <li> Updated <code>_validated_planned_answer</code> to detect malformed internal answer <br>envelopes and return a safe fallback message.<br> <li> Enhanced <code>_json_object</code> to extract JSON from surrounding text, accepting <br>valid planned answers with prefixes.<br> <li> Added <code>_looks_like_planned_answer_envelope</code> helper to identify malformed <br>envelopes.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/312/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+81/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Limit legacy runtime test to Knowledge Q&A only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_history.py

<ul><li>Refactored <code>test_legacy_runtime_modes_skip_general_chat_execution_gates</code> <br>to <code>test_knowledge_qa_skips_general_chat_execution_gates</code>.<br> <li> Removed <code>code_analysis</code> from the test loop, now only tests <code>knowledge_qa</code> <br>to reflect that planned code analysis uses a different path.<br> <li> Updated checkpoint action expectations accordingly.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/312/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+16/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_planned_runtime.py</strong><dd><code>Add regression tests for planned recovery and answer validation</code></dd></summary>
<hr>

lensnode/tests/test_planned_runtime.py

<ul><li>Added <code>test_planned_code_analysis_seeds_checkpoint_before_execution</code> to <br>verify checkpoint seeding order.<br> <li> Added <code>test_planned_code_analysis_resume_replays_planned_pipeline</code> to <br>ensure resumed runs use planned evidence pipeline.<br> <li> Added <code>test_planned_answer_extracts_json_after_explanatory_prefix</code> to <br>verify valid JSON extraction with prefix text.<br> <li> Added <code>test_invalid_planned_envelope_is_not_exposed</code> to verify malformed <br>envelopes are hidden.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/312/files#diff-79e1634cca7781e7914aaf562aba435aef0bae4993a973b4925f200f3f619949">+179/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>311.yaml</strong><dd><code>Add release note for planned Code Analysis fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/311.yaml

<ul><li>Added release note entry for the fix: planned evidence recovery <br>preservation and safe handling of malformed structured answers.<br> <li> Includes English and Chinese (zh-CN) versions.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/312/files#diff-ca7e85786eaa57656d1b3b279173f9869a00136d76d1199fea198b6276c80324">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

