### PR TITLE
Improve Code Analysis final output

### DIFF
--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -118,6 +118,8 @@ from ..runtime_resources import (
 LOGGER = logging.getLogger("lensnode")
 
 _PLANNED_CODE_ANALYSIS_ROUTE = {"route": "planned_code_analysis"}
+_MAX_PRESENTED_CITATIONS = 5
+_MAX_INVALID_CITATION_LABELS = 3
 
 register_harness_profile(
     "lensgatewaychatmodel",
@@ -1143,25 +1145,31 @@ def _run_planned_code_analysis(
     bundle.metrics["planned_codegraph_operations"] = sorted(
         {query.operation for query in plan.codegraph_queries}
     )
-    final_response = model.invoke(
-        [
-            SystemMessage(content=_planned_final_prompt()),
-            HumanMessage(
-                content=json.dumps(
-                    {
-                        "question": question,
-                        "project": plan.project,
-                        "repository": plan.repository,
-                        "revision": plan.revision,
-                        "evidence": bundle.as_dict(),
-                        "evidence_gaps": list(sufficiency.gaps),
-                    },
-                    ensure_ascii=False,
-                )
-            ),
-        ],
-        runtime_final_synthesis=True,
+    final_input = json.dumps(
+        {
+            "question": question,
+            "project": plan.project,
+            "repository": plan.repository,
+            "revision": plan.revision,
+            "evidence": bundle.as_dict(),
+            "evidence_gaps": list(sufficiency.gaps),
+        },
+        ensure_ascii=False,
     )
+    final_response = _invoke_planned_synthesis(
+        model,
+        final_input,
+    )
+    final_retry_count = 0
+    if _planned_response_needs_retry(final_response):
+        final_response = _invoke_planned_synthesis(
+            model,
+            final_input,
+            compact=True,
+        )
+        final_retry_count = 1
+    bundle.metrics["final_retry_count"] = final_retry_count
+    bundle.metrics["model_call_count"] += final_retry_count
     answer, citations, unsupported_claim_count = _validated_planned_answer(
         final_response,
         bundle,
@@ -1270,31 +1278,42 @@ def _validated_planned_answer(response, bundle, workspace_root):
     if payload is None:
         if _looks_like_planned_answer_envelope(content):
             return (
+                "## Conclusion\n\n"
                 "The code analysis result could not be validated.\n\n"
                 "No verified citations were returned.",
                 (),
                 1,
             )
         return (
-            content + "\n\nNo verified citations were returned.",
+            "## Conclusion\n\n"
+            + content
+            + "\n\nNo verified citations were returned.",
             (),
             1,
         )
     answer = str(payload.get("answer") or "").strip()
     if not answer:
         answer = "The code analysis result could not be validated."
-    valid, invalid = validate_citations(
+    validated, invalid = validate_citations(
         payload.get("citations"),
         bundle,
         workspace_root,
     )
+    valid = _select_presented_citations(validated)
+    answer = "## Conclusion\n\n" + answer
     if invalid:
-        answer += "\n\nUnverified citations: " + ", ".join(invalid)
+        shown = ", ".join(invalid[:_MAX_INVALID_CITATION_LABELS])
+        remaining = len(invalid) - _MAX_INVALID_CITATION_LABELS
+        suffix = f" and {remaining} more" if remaining > 0 else ""
+        answer += f"\n\nUnverified citations: {shown}{suffix}."
     unsupported = payload.get("unsupported_claims") or []
     if unsupported:
-        answer += "\n\nUnverified claims remain in the response."
+        answer += (
+            f"\n\n{len(unsupported)} unverified claim(s) remain in "
+            "the response."
+        )
     if valid:
-        answer += "\n\nEvidence citations:\n"
+        answer += "\n\n## Key evidence\n\n"
         answer += "\n".join(
             "- {project} / {repository} @ {revision}: `{path}` "
             "({symbol}, lines {start_line}-{end_line})".format(**citation)
@@ -1303,6 +1322,56 @@ def _validated_planned_answer(response, bundle, workspace_root):
     else:
         answer += "\n\nNo verified citations were returned."
     return answer, valid, len(unsupported)
+
+
+def _select_presented_citations(citations):
+    """Keep a small, non-duplicated set of user-facing citations."""
+
+    selected = []
+    seen = set()
+    for citation in citations:
+        key = (
+            citation.get("project"),
+            citation.get("repository"),
+            citation.get("revision"),
+            citation.get("path"),
+            citation.get("symbol"),
+            citation.get("start_line"),
+            citation.get("end_line"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        selected.append(citation)
+        if len(selected) >= _MAX_PRESENTED_CITATIONS:
+            break
+    return tuple(selected)
+
+
+def _invoke_planned_synthesis(model, final_input, compact=False):
+    """Generate one hidden structured response for final validation."""
+
+    return model.invoke(
+        [
+            SystemMessage(content=_planned_final_prompt(compact=compact)),
+            HumanMessage(content=final_input),
+        ],
+        runtime_final_synthesis=True,
+        runtime_structured_output=True,
+    )
+
+
+def _planned_response_needs_retry(response):
+    """Return whether one compact retry can recover a broken envelope."""
+
+    metadata = getattr(response, "response_metadata", None) or {}
+    if metadata.get("model_length_capped"):
+        return True
+    content = _message_content(response)
+    return (
+        _json_object(content) is None
+        and _looks_like_planned_answer_envelope(content)
+    )
 
 
 def _message_content(message):
@@ -1382,16 +1451,30 @@ def _planned_fallback_prompt():
     )
 
 
-def _planned_final_prompt():
+def _planned_final_prompt(compact=False):
     """Build the final answer contract for compact evidence only."""
 
-    return (
+    prompt = (
         "Answer the user's code-analysis question only from the supplied "
         "evidence bundle. Return JSON with answer, citations, and "
-        "unsupported_claims. Every material code claim needs a citation "
+        "unsupported_claims. In answer, state the direct conclusion in the "
+        "first two sentences, explain at most three decisive findings, and "
+        "end with a recommended next step or an explicit limitation. Keep "
+        "answer under 800 words. Do not include an evidence inventory or "
+        "citation appendix inside answer. Return at most five citations, "
+        "using only the strongest non-duplicated source evidence. Every "
+        "material code claim needs a citation "
         "containing project, repository, revision, path, symbol, "
         "start_line, end_line, evidence_type, and supports. Never invent "
         "paths, symbols, revisions, or line ranges. If evidence is missing, "
         "put the claim in unsupported_claims and say it is unverified. "
-        "Keep runtime evidence separate from source evidence."
+        "Keep runtime evidence separate from source evidence. Return the "
+        "JSON object only, with answer as the first field."
     )
+    if compact:
+        prompt += (
+            " The previous structured response was incomplete. Retry once "
+            "with answer under 350 words, at most two findings, and at most "
+            "three citations. Finish and close the JSON object."
+        )
+    return prompt

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -468,13 +468,20 @@ class LensGatewayChatModel(BaseChatModel):
             payload["max_tokens"] = kwargs["max_tokens"]
 
         if self.emit_output is not None and not control_call:
+            structured_output = bool(
+                kwargs.get("runtime_structured_output")
+            )
             try:
                 result = self._generate_streaming(
                     payload,
                     publish_tokens=(
-                        bool(kwargs.get("runtime_final_synthesis"))
-                        or completed_plan_followup
+                        not structured_output
+                        and (
+                            bool(kwargs.get("runtime_final_synthesis"))
+                            or completed_plan_followup
+                        )
                     ),
+                    suppress_output=structured_output,
                 )
             except Exception as exc:
                 self._finish_model_observation(
@@ -574,7 +581,13 @@ class LensGatewayChatModel(BaseChatModel):
             event["error_type"] = type(error).__name__
         self.emit_observation(event)
 
-    def _generate_streaming(self, payload, *, publish_tokens=False):
+    def _generate_streaming(
+        self,
+        payload,
+        *,
+        publish_tokens=False,
+        suppress_output=False,
+    ):
         """Consume a gateway stream and publish only a final answer turn."""
 
         content_parts = []
@@ -663,6 +676,7 @@ class LensGatewayChatModel(BaseChatModel):
             and content
             and not tool_calls
             and not publish_tokens
+            and not suppress_output
         ):
             self.emit_output(content)
 

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -285,6 +285,42 @@ def test_final_synthesis_streams_content_chunks_as_they_arrive(monkeypatch):
     assert "tool_choice" not in captured["payload"]
 
 
+def test_structured_final_synthesis_does_not_publish_protocol_chunks(
+    monkeypatch,
+):
+    body = (
+        'data: {"type": "token", "kind": "content", '
+        '"content": "{\\"answer\\":"}\n\n'
+        'data: {"type": "token", "kind": "content", '
+        '"content": "\\"Complete\\"}"}\n\n'
+        'data: {"type": "done", "usage": {"total_tokens": 8}, '
+        '"finish_reason": "stop", "tool_calls": []}\n\n'
+    )
+
+    def handler(_request):
+        return httpx.Response(200, content=body.encode("utf-8"))
+
+    _install_transport(monkeypatch, handler)
+    outputs = []
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        emit_output=outputs.append,
+    )
+
+    result = model._generate(
+        [HumanMessage(content="summarize")],
+        runtime_final_synthesis=True,
+        runtime_structured_output=True,
+    )
+
+    assert result.generations[0].message.content == (
+        '{"answer":"Complete"}'
+    )
+    assert outputs == []
+
+
 def test_completed_plan_followup_repeats_hidden_draft_and_streams(
     monkeypatch,
 ):

--- a/lensnode/tests/test_planned_runtime.py
+++ b/lensnode/tests/test_planned_runtime.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from lensnode import agent_runtime
@@ -149,7 +150,10 @@ def test_planned_answer_extracts_json_after_explanatory_prefix(tmp_path):
         tmp_path,
     )
 
-    assert answer == ("Readable answer\n\nNo verified citations were returned.")
+    assert answer == (
+        "## Conclusion\n\nReadable answer\n\n"
+        "No verified citations were returned."
+    )
     assert citations == ()
     assert unsupported == 0
     assert "structured result" not in answer
@@ -177,3 +181,121 @@ def test_invalid_planned_envelope_is_not_exposed(tmp_path):
     assert "could not be validated" in answer
     assert citations == ()
     assert unsupported == 1
+
+
+def test_planned_answer_leads_with_conclusion_and_limits_evidence(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("\n".join(f"line {index}" for index in range(1, 8)))
+    bundle = build_evidence_bundle(
+        [
+            {
+                "evidence_type": "source",
+                "path": "app.py",
+                "symbol": "analyze",
+                "start_line": 1,
+                "end_line": 7,
+                "content": source.read_text(),
+            }
+        ],
+        max_tokens=100,
+    )
+    citations = [
+        {
+            "project": "SourceLens",
+            "repository": "SourceLens",
+            "revision": "workspace",
+            "path": "app.py",
+            "symbol": f"analyze_{index}",
+            "start_line": index,
+            "end_line": index,
+            "evidence_type": "source",
+            "supports": f"finding {index}",
+        }
+        for index in range(1, 8)
+    ]
+    response = SimpleNamespace(
+        content=json.dumps(
+            {
+                "answer": "The implementation has one root cause.",
+                "citations": citations,
+                "unsupported_claims": [],
+            }
+        )
+    )
+
+    answer, valid, unsupported = agent_runtime._validated_planned_answer(
+        response,
+        bundle,
+        tmp_path,
+    )
+
+    assert answer.startswith(
+        "## Conclusion\n\nThe implementation has one root cause."
+    )
+    assert answer.count("- SourceLens / SourceLens") == 5
+    assert len(valid) == 5
+    assert unsupported == 0
+
+
+def test_planned_code_analysis_retries_truncated_final_concisely(tmp_path):
+    plan = {
+        "objective": "Find the root cause",
+        "project": "SourceLens",
+        "repository": "SourceLens",
+        "revision": "workspace",
+        "question_type": "implementation",
+        "evidence_requirements": [],
+        "codegraph_queries": [],
+        "literal_queries": [],
+        "source_windows": [],
+        "max_files": 3,
+        "max_fallback_rounds": 0,
+        "budgets": {"max_evidence_tokens": 100},
+    }
+    responses = [
+        SimpleNamespace(content=json.dumps(plan)),
+        SimpleNamespace(
+            content='{"answer":"An incomplete result",',
+            response_metadata={"model_length_capped": True},
+        ),
+        SimpleNamespace(
+            content=json.dumps(
+                {
+                    "answer": "The retry produced a complete conclusion.",
+                    "citations": [],
+                    "unsupported_claims": [],
+                }
+            ),
+            response_metadata={},
+        ),
+    ]
+
+    class Model:
+        stop_reason = "model_length_capped"
+        token_usage = {}
+
+        def __init__(self):
+            self.calls = []
+
+        def invoke(self, messages, **kwargs):
+            self.calls.append((messages, kwargs))
+            return responses[len(self.calls) - 1]
+
+    model = Model()
+    result = agent_runtime._run_planned_code_analysis(
+        model=model,
+        command={"question": "Why is the output incomplete?"},
+        tools=[],
+        mcp_tools=[],
+        emit_agent_event=lambda *_args: None,
+        workspace_root=tmp_path,
+    )
+
+    assert result["answer"].startswith(
+        "## Conclusion\n\nThe retry produced a complete conclusion."
+    )
+    assert result["planned_evidence"]["final_retry_count"] == 1
+    assert result["planned_evidence"]["model_call_count"] == 3
+    assert len(model.calls) == 3
+    assert model.calls[1][1]["runtime_structured_output"] is True
+    assert model.calls[2][1]["runtime_structured_output"] is True

--- a/release-notes/313.yaml
+++ b/release-notes/313.yaml
@@ -1,0 +1,7 @@
+type: improvement
+audience: user
+en: >-
+  Code analysis now leads with a complete conclusion and shows only the
+  strongest supporting source citations.
+zh-CN: >-
+  代码分析现在优先给出完整结论，并仅展示最有力的源代码依据。


### PR DESCRIPTION
### **User description**
## Summary

- lead Code Analysis responses with a direct conclusion and focused findings
- limit user-facing source citations to five strong, deduplicated references
- keep the internal structured synthesis protocol out of the answer stream
- retry a truncated or malformed structured final response once with a compact contract
- preserve existing streaming behavior for ordinary final synthesis

Closes #313

## Test plan

- [x] `./lensnode/.venv/bin/pytest -q lensnode/tests` (464 passed)
- [x] `PYTHONPATH=. ./lensnode/.venv/bin/python scripts/test_release_notes.py` (6 passed)
- [x] `git diff --check`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Lead Code Analysis answer with a direct conclusion.

- Limit user-facing source citations to at most five.

- Hide internal structured JSON protocol from streaming output.

- Retry truncated final synthesis once with a compact contract.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  Input["Question & Evidence"] --> Synthesis["Final Synthesis (structured)"]
  Synthesis --> Check{"Valid JSON?"}
  Check -- "Yes" --> Validate["Validate citations"]
  Validate --> Output["## Conclusion + limited citations"]
  Check -- "No / truncated" --> Retry["Compact retry (max 350 words)"]
  Retry --> Check2{"Valid after retry?"}
  Check2 -- "Yes" --> Validate
  Check2 -- "No" --> Fallback["Fallback: 'could not be validated'"]
  Synthesis -- "structured output" --> Hidden["Not published to stream"]
  Hidden --> Output
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Refactor final synthesis and add citation limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Added constants for max presented citations and invalid citation <br>labels.<br> <li> Refactored final synthesis invocation into <code>_invoke_planned_synthesis</code> <br>and retry logic.<br> <li> Added <code>_select_presented_citations</code> to deduplicate and limit to 5 <br>citations.<br> <li> Modified <code>_validated_planned_answer</code> to prepend "## Conclusion" and <br>format evidence.<br> <li> Updated <code>_planned_final_prompt</code> to accept a <code>compact</code> parameter for retry <br>instructions.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/314/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+110/-27</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway_model.py</strong><dd><code>Suppress structured output from streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/gateway_model.py

<ul><li>Added <code>suppress_output</code> parameter to <code>_generate_streaming</code>.<br> <li> Skipped token publishing and final output emission when <br><code>runtime_structured_output</code> is True.<br> <li> Ensured internal structured JSON is not streamed to users.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/314/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gateway_model.py</strong><dd><code>Add test for structured output suppression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_gateway_model.py

<ul><li>Added test <br><code>test_structured_final_synthesis_does_not_publish_protocol_chunks</code> to <br>verify that structured output is not emitted.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/314/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_planned_runtime.py</strong><dd><code>Add tests for conclusion, citation limits, and retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_planned_runtime.py

<ul><li>Added test for conclusion being prepended and citation limit of 5.<br> <li> Added test for retry logic when final response is truncated.<br> <li> Updated existing test to expect "## Conclusion" prefix.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/314/files#diff-79e1634cca7781e7914aaf562aba435aef0bae4993a973b4925f200f3f619949">+123/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>313.yaml</strong><dd><code>Add release note for Code Analysis output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/313.yaml

<ul><li>Added release note entry describing the improvement in both English <br>and Chinese.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/314/files#diff-530cdb6592e5b4b8fea2f79056907b7953f0b0bb0abbba042e24bf326c5e30fe">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

