### PR TITLE
Prevent concurrent empty session creation

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -102,6 +102,7 @@
           class="new-chat-btn"
           :class="sidebarCollapsedActive ? 'new-chat-btn-collapsed' : ''"
           type="button"
+          :disabled="creatingSession"
           @click="createNewSession"
         >
           <Plus :size="18" :stroke-width="2.25" aria-hidden="true" />
@@ -272,6 +273,7 @@
           type="button"
           class="sidebar-collapse-btn"
           :aria-label="t('lens.chat.newSession')"
+          :disabled="creatingSession"
           @click="createNewSession"
         >
           <Plus :size="20" :stroke-width="2.1" aria-hidden="true" />
@@ -1556,6 +1558,7 @@ const sidebarCollapsed = ref(false)
 const showArchivedSessions = ref(false)
 const deleteSessionTarget = ref(null)
 const deletingSession = ref(false)
+const creatingSession = ref(false)
 const renamingSessionUuid = ref('')
 const renameDraft = ref('')
 const composerRef = ref(null)
@@ -2474,9 +2477,10 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
 }
 
 async function createNewSession(notify = true) {
-  if (!selectedAssistant.value) {
+  if (!selectedAssistant.value || creatingSession.value) {
     return null
   }
+  creatingSession.value = true
   mySharesOpen.value = false
   const leavingArchivedView = showArchivedSessions.value
   showArchivedSessions.value = false
@@ -2491,6 +2495,7 @@ async function createNewSession(notify = true) {
       title: ''
     })
   } catch {
+    creatingSession.value = false
     showError(t('lens.chat.sessionCreateFailed'))
     return null
   }
@@ -2523,6 +2528,7 @@ async function createNewSession(notify = true) {
     showSuccess(t('lens.chat.sessionCreated'))
   }
 
+  creatingSession.value = false
   return session
 }
 

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -94,3 +94,20 @@ test('loads sessions after selecting the route assistant', async () => {
   assert.notEqual(loadSessions, -1)
   assert.ok(loadSessions > selectAssistant)
 })
+
+test('locks new-session creation while the request is pending', async () => {
+  const source = await chatSource()
+  const createSession = source.indexOf('async function createNewSession(')
+  const createRequest = source.indexOf(
+    'session = await createSession(',
+    createSession
+  )
+  const lock = source.indexOf('creatingSession.value = true', createSession)
+  const guard = source.indexOf('creatingSession.value)', createSession)
+
+  assert.notEqual(createSession, -1)
+  assert.notEqual(createRequest, -1)
+  assert.ok(lock < createRequest)
+  assert.ok(guard < createRequest)
+  assert.match(source, /:disabled="creatingSession"/)
+})


### PR DESCRIPTION
### **User description**
## Summary

- Prevent concurrent clicks on New Session from issuing duplicate client-side creation requests.
- Disable both New Session controls while the request is pending.
- Add a regression test covering the creation lock.

## Verification

- Chat bootstrap tests: 7/7 passed.
- Browser rapid-click verification: one session UUID remained.
- Backend concurrent API verification: both requests returned the same session UUID.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added creatingSession lock to prevent concurrent requests

- Added regression test for the creation lock


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Click New Session"] --> B{"creatingSession?"}
  B -- "No" --> C["Set creatingSession=true"]
  C --> D["Create session"]
  D --> E["Set creatingSession=false"]
  B -- "Yes" --> F["Return null"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Add creation lock to session creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added <code>creatingSession</code> ref to guard concurrent session creation<br> <li> Disabled both New Session buttons while the request is pending<br> <li> Added guard in <code>createNewSession</code> function to return early when locked</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/316/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add regression test for creation lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Added test to verify the lock is set before the API call<br> <li> Checks that the <code>:disabled</code> attribute is bound to <code>creatingSession</code></ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/316/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

