### PR TITLE
Fix image attachment processing and delivery

### DIFF
--- a/backend/accounts/tests/pytest_management_bulk.py
+++ b/backend/accounts/tests/pytest_management_bulk.py
@@ -44,7 +44,7 @@ class TestManagementUserBulk:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not User.objects.filter(
             pk__in=[user.pk for user in users],
             is_active=True,
@@ -93,7 +93,7 @@ class TestManagementRoleBulk:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not Role.objects.filter(
             pk__in=[role.pk for role in roles],
             is_active=True,
@@ -128,7 +128,7 @@ class TestManagementGroupBulkDelete:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not Group.objects.filter(
             pk__in=[group.pk for group in groups]
         ).exists()

--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -440,3 +440,6 @@ def source_type_from_credential(credential):
     if credential.auth_type == DataSourceCredential.AuthType.FEISHU_APP:
         return DataSource.SourceType.FEISHU
     return DataSource.SourceType.GIT
+
+
+test_datasource_connection.__test__ = False

--- a/backend/lens/execution.py
+++ b/backend/lens/execution.py
@@ -9,6 +9,7 @@ from .document_attachments import get_run_document_attachments
 from .models import Run, RunExecution, RunStep
 from .services import (
     LensNodeDispatchError,
+    MultimodalPreprocessingError,
     analyze_multimodal_intent,
     build_loaded_skills,
     create_run_execution_snapshot,
@@ -54,8 +55,11 @@ def run_step(run, step_type, sequence):
         step.status = RunStep.Status.FAILED
         step.detail = {
             **step.detail,
-            "error": str(exc),
+            "status": "failed",
+            "error": getattr(exc, "code", str(exc)),
         }
+        if hasattr(exc, "reason"):
+            step.detail["reason"] = exc.reason
         step.save(update_fields=["status", "detail", "updated_at"])
         raise
     else:
@@ -94,7 +98,13 @@ def _lensnode_dispatch(state):
     if has_images and assistant.multimodal_model_ref:
         with run_step(run, RunStep.StepType.MULTIMODAL, 0) as step:
             analysis = analyze_multimodal_intent(run)
-            question = analysis["question"]
+            question = (
+                "已成功接收并分析用户上传的图片。以下是视觉模型从图片中"
+                "提取的关键信息，请基于这些图片证据回答当前问题，不要声称"
+                "没有上传图片。图片识别结果已经包含在下面；不要因为工作区"
+                "中没有图片文件而否认这张上传图片，也不要为图片问题搜索工作区：\n"
+                f"{analysis['question']}"
+            )
             step.detail = {
                 "rewritten": analysis["rewritten"],
                 "original": analysis.get(
@@ -102,11 +112,17 @@ def _lensnode_dispatch(state):
                 ),
                 "query": question,
                 "image_count": analysis.get("image_count", 0),
+                "status": analysis.get("status", "succeeded"),
             }
             if analysis.get("usage"):
                 step.detail["usage"] = analysis["usage"]
-            if analysis.get("error"):
-                step.detail["error"] = analysis["error"]
+    elif has_images:
+        with run_step(run, RunStep.StepType.MULTIMODAL, 0) as step:
+            step.detail = {
+                "status": "skipped",
+                "reason": "NO_MULTIMODAL_MODEL",
+                "image_count": run.input_message.attachments.count(),
+            }
     elif assistant.preprocess_model_ref and (question or "").strip():
         with run_step(run, RunStep.StepType.QUERY_REWRITE, 0) as step:
             rewrite = rewrite_query(run)
@@ -271,7 +287,7 @@ def execute_answer_run(
             run.status = Run.Status.STREAMING
             run.save(update_fields=["status", "updated_at"])
 
-    except LensNodeDispatchError as exc:
+    except (LensNodeDispatchError, MultimodalPreprocessingError) as exc:
         logger.error("run %s: dispatch failed: %s", run.uuid, exc)
         _mark_run_failed(run, exc)
         raise

--- a/backend/lens/llm.py
+++ b/backend/lens/llm.py
@@ -94,6 +94,19 @@ def _multimodal_messages(system, user_text, image_data_urls):
     ]
 
 
+def model_supports_vision(model_ref):
+    """Return whether a configured model accepts image content blocks."""
+
+    from agentcore_metering.adapters.django.services.runtime_config import (
+        get_litellm_params,
+    )
+    from litellm.utils import supports_vision
+
+    params = get_litellm_params(model_uuid=str(model_ref))
+    model = str(params.get("model") or "")
+    return bool(model) and supports_vision(model=model)
+
+
 def _message_to_dict(message):
     """Convert a LangChain message to the metering tracker shape."""
 
@@ -162,6 +175,5 @@ def run_completion_multimodal(
         node_name=node_name,
         user_id=user_id,
     )
-
 
 

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -32,7 +32,11 @@ from .environment_variables import (
     declared_environment_references,
     expand_environment_references,
 )
-from .llm import run_completion, run_completion_multimodal
+from .llm import (
+    model_supports_vision,
+    run_completion,
+    run_completion_multimodal,
+)
 from .models import (
     Assistant,
     EnvironmentVariableSet,
@@ -105,6 +109,16 @@ MULTIMODAL_INTENT_SYSTEM = (
 
 class LensNodeDispatchError(RuntimeError):
     """Raised when a run cannot be dispatched to its LensNode."""
+
+
+class MultimodalPreprocessingError(RuntimeError):
+    """Raised when image preprocessing cannot produce a safe query."""
+
+    code = "IMAGE_PREPROCESSING_FAILED"
+
+    def __init__(self, reason):
+        self.reason = reason
+        super().__init__(self.code)
 
 
 def lensnode_group_name(lensnode_uuid):
@@ -874,11 +888,11 @@ def _enqueue_session_title_generation(session_uuid, run_uuid):
 def analyze_multimodal_intent(run):
     """Fold a run's image attachments and text into one search query.
 
-    Calls the assistant's multimodal model with the question, recent
-    history and the attached images, returning a consolidated textual
-    query that drives retrieval and the node answer. Falls back to the
-    original question when no multimodal model is set, no images decode,
-    or the call fails, so dispatch never blocks on this step.
+    Calls the assistant's multimodal model with the current question and
+    attached images, returning a consolidated textual query that drives
+    retrieval and the node answer. Skips preprocessing when it is not
+    applicable and fails the run when a configured multimodal request cannot
+    produce an image-aware query.
     """
 
     assistant = run.session.assistant
@@ -887,7 +901,12 @@ def analyze_multimodal_intent(run):
         run.input_message.attachments.filter(kind=MessageAttachment.Kind.IMAGE)
     )
     if not attachments or not assistant.multimodal_model_ref:
-        return {"question": original, "rewritten": False, "image_count": 0}
+        return {
+            "question": original,
+            "rewritten": False,
+            "image_count": 0,
+            "status": "skipped",
+        }
 
     image_data_urls = []
     for attachment in attachments:
@@ -895,12 +914,25 @@ def analyze_multimodal_intent(run):
         if data_url:
             image_data_urls.append(data_url)
     if not image_data_urls:
-        return {"question": original, "rewritten": False, "image_count": 0}
+        raise MultimodalPreprocessingError("ATTACHMENT_UNREADABLE")
+    try:
+        supports_vision = model_supports_vision(
+            assistant.multimodal_model_ref
+        )
+    except Exception as exc:
+        logger.warning(
+            "multimodal model capability check failed for run %s: %s",
+            run.uuid,
+            exc,
+        )
+        raise MultimodalPreprocessingError(
+            "MODEL_CONFIGURATION_INVALID"
+        ) from exc
+    if not supports_vision:
+        raise MultimodalPreprocessingError("MODEL_NOT_VISION_CAPABLE")
 
-    context = _recent_history_context(run)
     user_text = (
-        (f"Conversation so far:\n{context}\n\n" if context else "")
-        + f"User question: {original or '(no text, analyze the image)'}\n\n"
+        f"User question: {original or '(no text, analyze the image)'}\n\n"
         + "Combined search query:"
     )
     try:
@@ -916,29 +948,20 @@ def analyze_multimodal_intent(run):
         logger.warning(
             "multimodal intent failed for run %s: %s", run.uuid, exc
         )
-        return {
-            "question": original,
-            "rewritten": False,
-            "image_count": len(image_data_urls),
-            "error": str(exc),
-        }
+        raise MultimodalPreprocessingError("MODEL_REQUEST_FAILED") from exc
 
     text = " ".join((result.content or "").split())[
         :MULTIMODAL_INTENT_MAX_CHARS
     ]
     if not text:
-        return {
-            "question": original,
-            "rewritten": False,
-            "image_count": len(image_data_urls),
-            "usage": result.usage,
-        }
+        raise MultimodalPreprocessingError("EMPTY_MODEL_RESPONSE")
     return {
         "question": text,
         "rewritten": text != (original or "").strip(),
         "original": original,
         "image_count": len(image_data_urls),
         "usage": result.usage,
+        "status": "succeeded",
     }
 
 
@@ -1670,6 +1693,20 @@ def dispatch_run_to_lensnode(
         raise LensNodeDispatchError(
             "DOCUMENT_ATTACHMENTS_UNSUPPORTED_BY_LENSNODE"
         )
+    image_data_urls = []
+    if run.input_message_id:
+        for attachment in run.input_message.attachments.all():
+            data_url = attachment_data_url(attachment)
+            if not data_url:
+                raise LensNodeDispatchError("ATTACHMENT_UNREADABLE")
+            image_data_urls.append(data_url)
+    agent_model_ref = (
+        model_refs.get("multimodal")
+        or str(run.session.assistant.multimodal_model_ref or "")
+        if image_data_urls
+        else model_refs.get("agent")
+        or str(run.session.assistant.agent_model_ref or "")
+    )
     channel_layer = get_channel_layer()
     if channel_layer is None:
         raise LensNodeDispatchError("LENS_CHANNEL_LAYER_UNAVAILABLE")
@@ -1709,6 +1746,7 @@ def dispatch_run_to_lensnode(
                 "task": execution.task,
                 "features": features_payload,
                 "question": rewritten_question,
+                "image_data_urls": image_data_urls,
                 "answer_language": answer_language,
                 "subject_documents": subject_documents,
                 "vision_model_ref": (
@@ -1725,8 +1763,7 @@ def dispatch_run_to_lensnode(
                     execution.loaded_mcps
                 ),
                 "agent_model_ref": (
-                    model_refs.get("agent")
-                    or str(run.session.assistant.agent_model_ref or "")
+                    agent_model_ref
                 ),
                 "max_agent_turns": AGENT_TURNS_BY_ROUNDS.get(agent_rounds, 26),
                 "agent_rounds": agent_rounds,

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -33,7 +33,7 @@ from agentcore_task.adapters.django.models import TaskExecution
 from accounts.models import Role
 from lens.datasource_services import (
     DataSourceDispatchError,
-    test_datasource_connection,
+    test_datasource_connection as run_datasource_connection_test,
 )
 from lens.lensnode_auth import hash_lensnode_token
 from lens.models import (
@@ -70,6 +70,7 @@ from lens.services import (
     resolve_loaded_skill_environment,
     validate_run_dispatch,
 )
+
 from lens.skill_packages import package_zip_bytes
 from lens.tasks import acquire_datasource_lock, release_datasource_lock
 
@@ -4621,7 +4622,7 @@ class LensApiTests(TestCase):
                 return_value={"status": "success"},
             ),
         ):
-            test_datasource_connection(
+            run_datasource_connection_test(
                 self.lensnode,
                 "git",
                 config={

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -9,8 +9,16 @@ from django.test import TestCase, override_settings
 from PIL import Image
 from rest_framework.test import APIClient
 
-from agentcore_metering.adapters.django.models import LLMUsage
-from lens.llm import LensLLMResult
+from agentcore_metering.adapters.django.models import LLMConfig, LLMUsage
+from lens.attachments import (
+    ATTACHMENT_MAX_ASPECT_RATIO,
+    ATTACHMENT_MAX_PIXELS,
+    AttachmentError,
+    bind_attachments_to_message,
+    store_message_attachment,
+)
+from lens.execution import execute_answer_run
+from lens.llm import LensLLMResult, _multimodal_messages
 from lens.models import (
     Assistant,
     LensNode,
@@ -19,14 +27,11 @@ from lens.models import (
     Session,
 )
 from lens.serializers import RunCreateSerializer
-from lens.attachments import (
-    ATTACHMENT_MAX_ASPECT_RATIO,
-    ATTACHMENT_MAX_PIXELS,
-    AttachmentError,
-    bind_attachments_to_message,
-    store_message_attachment,
+from lens.services import (
+    MultimodalPreprocessingError,
+    analyze_multimodal_intent,
+    create_execution_run,
 )
-from lens.services import analyze_multimodal_intent, create_execution_run
 
 User = get_user_model()
 
@@ -185,8 +190,11 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(attachment.message_id, run.input_message_id)
         self.assertEqual(run.input_message.attachments.count(), 1)
 
+    @patch("lens.services.model_supports_vision", return_value=True)
     @patch("lens.services.run_completion_multimodal")
-    def test_analyze_multimodal_intent_folds_image_and_text(self, mock_call):
+    def test_analyze_multimodal_intent_folds_image_and_text(
+        self, mock_call, mock_support
+    ):
         mock_call.return_value = LensLLMResult(
             content="KeyError missing 'token' in auth middleware",
             usage={
@@ -214,6 +222,122 @@ class AttachmentServiceTests(TestCase):
         self.assertTrue(result["rewritten"])
         self.assertIn("KeyError", result["question"])
         self.assertEqual(result["usage"]["total_tokens"], 1234)
+        self.assertEqual(result["status"], "succeeded")
+        mock_call.assert_called_once()
+        call = mock_call.call_args.kwargs
+        self.assertIn("为什么报错", call["user_text"])
+        self.assertEqual(len(call["image_data_urls"]), 1)
+
+    @patch("lens.services.model_supports_vision", return_value=True)
+    @patch("lens.services._recent_history_context")
+    @patch("lens.services.run_completion_multimodal")
+    def test_analyze_multimodal_intent_does_not_replay_history(
+        self, mock_call, mock_history, mock_support
+    ):
+        mock_call.return_value = LensLLMResult(
+            content="The image contains a console error.",
+            usage={},
+            metered=True,
+        )
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload()
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Describe this image.",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        result = analyze_multimodal_intent(run)
+
+        self.assertEqual(result["status"], "succeeded")
+        mock_history.assert_not_called()
+        self.assertNotIn("There is no image", mock_call.call_args.kwargs[
+            "user_text"
+        ])
+
+    def test_multimodal_messages_include_text_and_image_content_blocks(self):
+        messages = _multimodal_messages(
+            "system prompt",
+            "user question",
+            ["data:image/png;base64,encoded-image"],
+        )
+
+        self.assertEqual(messages[0].content, "system prompt")
+        self.assertEqual(
+            messages[1].content,
+            [
+                {"type": "text", "text": "user question"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,encoded-image"
+                    },
+                },
+            ],
+        )
+
+    @patch("lens.services.run_completion_multimodal")
+    def test_non_vision_model_fails_before_multimodal_call(self, mock_call):
+        config = LLMConfig.objects.create(
+            scope=LLMConfig.Scope.GLOBAL,
+            model_type=LLMConfig.MODEL_TYPE_LLM,
+            provider="deepseek",
+            config={
+                "api_key": "test",
+                "model": "deepseek-v4-pro",
+            },
+            is_active=True,
+        )
+        self.assistant.multimodal_model_ref = config.uuid
+        self.assistant.save(update_fields=["multimodal_model_ref"])
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload()
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Describe this image.",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        with self.assertRaises(MultimodalPreprocessingError) as context:
+            analyze_multimodal_intent(run)
+
+        self.assertEqual(context.exception.reason, "MODEL_NOT_VISION_CAPABLE")
+        mock_call.assert_not_called()
+
+    @patch("lens.services.model_supports_vision", return_value=True)
+    @patch("lens.services.run_completion_multimodal")
+    def test_multimodal_failure_does_not_fallback_to_workspace_search(
+        self, mock_call, mock_support
+    ):
+        mock_call.side_effect = RuntimeError("provider secret must not leak")
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload()
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="为什么报错",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        with self.assertRaises(MultimodalPreprocessingError):
+            execute_answer_run(run, dispatch=False)
+
+        run.refresh_from_db()
+        step = run.steps.get(step_type="multimodal")
+        self.assertEqual(run.status, run.Status.FAILED)
+        self.assertEqual(run.error, "IMAGE_PREPROCESSING_FAILED")
+        self.assertEqual(step.status, step.Status.FAILED)
+        self.assertEqual(step.detail["status"], "failed")
+        self.assertEqual(
+            step.detail["error"], "IMAGE_PREPROCESSING_FAILED"
+        )
+        self.assertEqual(step.detail["reason"], "MODEL_REQUEST_FAILED")
+        self.assertNotIn("provider secret", step.detail)
 
     def test_admin_run_step_counts_includes_preprocess_usage(self):
         from lens.models import RunStep
@@ -438,6 +562,7 @@ class AttachmentServiceTests(TestCase):
 
         self.assertFalse(result["rewritten"])
         self.assertEqual(result["question"], "原始问题")
+        self.assertEqual(result["status"], "skipped")
 
     def test_run_create_serializer_requires_text_or_image(self):
         serializer = RunCreateSerializer(

--- a/backend/lens/tests/test_run_lifecycle.py
+++ b/backend/lens/tests/test_run_lifecycle.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.utils import timezone
 
 from lens.consumers import LensNodeConsumer
@@ -36,7 +36,7 @@ from lens.tasks import (
 User = get_user_model()
 
 
-class RunLifecycleTests(TestCase):
+class RunLifecycleTests(TransactionTestCase):
     def setUp(self):
         expiration_patcher = patch(
             "lens.tasks.expire_awaiting_run.apply_async"
@@ -633,7 +633,6 @@ class RunLifecycleTests(TestCase):
                 return_value=2,
             ),
             patch("lens.tasks.enqueue_answer_run_task") as enqueue,
-            self.captureOnCommitCallbacks(execute=True),
         ):
             first = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)
             second = resume_awaiting_runs_for_lensnode(self.lensnode.uuid)

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -4,6 +4,7 @@ import hashlib
 from importlib import import_module
 from pathlib import Path
 from unittest.mock import patch
+from uuid import uuid4
 
 from agentcore_task.adapters.django.models import TaskExecution
 from asgiref.sync import async_to_sync
@@ -35,6 +36,7 @@ from lens.models import (
     GlobalSetting,
     LensNode,
     Message,
+    MessageAttachment,
     Run,
     RunOutputFile,
     RunStep,
@@ -808,6 +810,48 @@ class LensServiceTests(TransactionTestCase):
             build_artifacts.return_value,
         )
         build_artifacts.assert_called_once_with(run)
+
+    @patch("lens.services.attachment_data_url")
+    @patch("lens.services.async_to_sync")
+    @patch("lens.services.get_channel_layer")
+    def test_dispatch_includes_images_for_final_agent(
+        self,
+        get_channel_layer,
+        mock_async_to_sync,
+        mock_attachment_data_url,
+    ):
+        sender = mock_async_to_sync.return_value
+        mock_attachment_data_url.return_value = (
+            "data:image/png;base64,encoded"
+        )
+        self.assistant.multimodal_model_ref = uuid4()
+        self.assistant.save(update_fields=["multimodal_model_ref"])
+        attachment = MessageAttachment.objects.create(
+            session=self.session,
+            uploaded_by=self.user,
+            kind=MessageAttachment.Kind.IMAGE,
+            original_name="error.png",
+            mime_type="image/png",
+            byte_size=7,
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="What is wrong?",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        dispatch_run_to_lensnode(run, "What is wrong?")
+
+        payload = sender.call_args.args[1]["payload"]
+        self.assertEqual(
+            payload["image_data_urls"],
+            ["data:image/png;base64,encoded"],
+        )
+        self.assertEqual(
+            payload["agent_model_ref"],
+            str(self.assistant.multimodal_model_ref),
+        )
 
     @patch("lens.services.async_to_sync")
     @patch("lens.services.get_channel_layer")

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --import-mode=importlib
+testpaths = accounts core lens tests
+python_files = test_*.py pytest_*.py

--- a/backend/tests/pytest_admin_bulk.py
+++ b/backend/tests/pytest_admin_bulk.py
@@ -49,7 +49,7 @@ class TestNotificationChannelBulkDelete:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not NotificationChannel.objects.filter(
             pk__in=[channel.pk for channel in channels]
         ).exists()
@@ -103,7 +103,7 @@ class TestLLMConfigBulk:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not LLMConfig.objects.filter(
             pk__in=[config.pk for config in configs],
             is_active=True,
@@ -178,7 +178,7 @@ class TestLLMConfigBulk:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"count": 2}
+        assert response.json()["data"] == {"count": 2}
         assert not LLMConfig.objects.filter(
             pk__in=[config.pk for config in configs]
         ).exists()

--- a/frontend/e2e/lens-image-qa.spec.js
+++ b/frontend/e2e/lens-image-qa.spec.js
@@ -53,10 +53,40 @@ test.describe('Lens image Q&A', () => {
     }, token)
 
     await page.goto(`/lens/assistants/${ASSISTANT_SLUG}/chat`)
-    await page.waitForSelector('.composer-input', { timeout: 20000 })
+    const sessionUuid = await page.evaluate(async (slug) => {
+      const token = window.localStorage.getItem('access_token')
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+      const assistantResponse = await fetch(
+        '/api/lens/assistants/?page_size=1000&page=1',
+        { headers }
+      )
+      const assistantPayload = await assistantResponse.json()
+      const assistants =
+        assistantPayload.results ||
+        assistantPayload.data?.results ||
+        assistantPayload.data ||
+        []
+      const assistant = assistants.find((item) => item.slug === slug)
+      if (!assistant) throw new Error(`assistant not found: ${slug}`)
+      const sessionResponse = await fetch('/api/lens/sessions/', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ assistant_uuid: assistant.uuid, title: '' })
+      })
+      const sessionPayload = await sessionResponse.json()
+      if (!sessionResponse.ok) {
+        throw new Error(JSON.stringify(sessionPayload))
+      }
+      return sessionPayload.uuid || sessionPayload.data?.uuid
+    }, ASSISTANT_SLUG)
 
-    // Start a clean session so no in-flight run blocks the send button.
-    await page.click('text=New session')
+    await page.goto(
+      `/lens/assistants/${ASSISTANT_SLUG}/chat?session=${sessionUuid}`
+    )
+    await page.waitForSelector('.composer-input', { timeout: 20000 })
     await page.waitForFunction(
       () => !document.querySelector('.composer-action-btn-stop'),
       { timeout: 20000 }
@@ -77,7 +107,9 @@ test.describe('Lens image Q&A', () => {
     await page.click('.composer-action-btn')
 
     // 1) The user bubble shows the uploaded image.
-    await expect(page.locator('.message-images img').first()).toBeVisible({
+    await expect(
+      page.locator('img[alt="error-screenshot.png"]').first()
+    ).toBeVisible({
       timeout: 20000
     })
 
@@ -98,6 +130,8 @@ test.describe('Lens image Q&A', () => {
       .toBe('ANSWER')
 
     // 3) After the server reload, the user image still renders (authed fetch).
-    await expect(page.locator('.message-images img').first()).toBeVisible()
+    await expect(
+      page.locator('img[alt="error-screenshot.png"]').first()
+    ).toBeVisible()
   })
 })

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -247,6 +247,7 @@
       "emptyAnswerHint": "The reply didn't come through — this is usually a temporary network hiccup. Tap Retry to send it again.",
       "errorModelTimeout": "No answer was returned: the language model is responding too slowly and timed out after several retries. This is usually the model service being busy, not a platform fault. Please tap Retry.",
       "errorNodeLost": "The answer was interrupted: the execution node connection dropped. Please tap Retry.",
+      "errorImagePreprocessing": "Image analysis failed. Check the image and model, then tap Retry.",
       "retryAction": "Retry",
       "loadFailed": "Failed to load Lens chat.",
       "assistantNotFound": "The assistant you're trying to access doesn't exist. Please contact your administrator for a valid link.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -247,6 +247,7 @@
       "emptyAnswerHint": "回答没能顺利返回，可能是网络波动等临时原因。点「重试」再发送一次即可。",
       "errorModelTimeout": "回答未能返回：大语言模型当前响应过慢，系统多次重试后仍超时。这通常是模型服务繁忙所致，并非平台故障。请稍后点「重试」。",
       "errorNodeLost": "回答中断：执行节点连接异常。请点「重试」。",
+      "errorImagePreprocessing": "图片识别失败，请检查配置后重试。",
       "retryAction": "重试",
       "loadFailed": "加载 Lens chat 失败。",
       "assistantNotFound": "你访问的助手不存在，请联系管理员获取有效的助手链接。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2122,6 +2122,9 @@ const showRetryHint = computed(() => {
 // timeout is the model being slow (after retries), not a platform fault.
 function mapRunError(code) {
   const c = String(code || '').toUpperCase()
+  if (c.includes('IMAGE_PREPROCESSING')) {
+    return t('lens.chat.errorImagePreprocessing')
+  }
   if (c.includes('TIMEOUT')) {
     return t('lens.chat.errorModelTimeout')
   }

--- a/lensnode/lensnode/agent_runtime/direct_answer.py
+++ b/lensnode/lensnode/agent_runtime/direct_answer.py
@@ -64,6 +64,7 @@ def _answer_general_chat_directly(
             else _build_initial_messages(
                 command.get("history"),
                 command.get("question", ""),
+                command.get("image_data_urls"),
             )
         ),
     ]

--- a/lensnode/lensnode/agent_runtime/messages.py
+++ b/lensnode/lensnode/agent_runtime/messages.py
@@ -47,16 +47,27 @@ def activity_from_event(event):
     return "running"
 
 
-def build_initial_messages(history, question):
-    """Prepend bounded conversation history to the current question."""
+def build_initial_messages(history, question, image_data_urls=None):
+    """Build the current turn and optional text-only conversation history."""
 
     messages = []
-    for item in history or []:
-        role = item.get("role")
-        content = item.get("content")
-        if role in ("user", "assistant") and content:
-            messages.append({"role": role, "content": content})
-    messages.append({"role": "user", "content": question})
+    if not image_data_urls:
+        for item in history or []:
+            role = item.get("role")
+            content = item.get("content")
+            if role in ("user", "assistant") and content:
+                messages.append({"role": role, "content": content})
+    content = question
+    if image_data_urls:
+        content = [{"type": "text", "text": question}]
+        content.extend(
+            {
+                "type": "image_url",
+                "image_url": {"url": data_url},
+            }
+            for data_url in image_data_urls
+        )
+    messages.append({"role": "user", "content": content})
     return messages
 
 

--- a/lensnode/lensnode/agent_runtime/routing.py
+++ b/lensnode/lensnode/agent_runtime/routing.py
@@ -103,6 +103,7 @@ def _select_general_chat_route(
     context_skill_contents=None,
     available_tools=None,
     has_bound_skills=None,
+    image_data_urls=None,
 ):
     """Classify one General Chat request without exposing control output."""
 
@@ -187,7 +188,11 @@ def _select_general_chat_route(
         response = model.invoke(
             [
                 SystemMessage(content=prompt),
-                *_build_initial_messages(history, question),
+                *_build_initial_messages(
+                    history,
+                    question,
+                    image_data_urls,
+                ),
             ],
             runtime_control_call=True,
             temperature=0,

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -404,6 +404,7 @@ class LensDeepAgentRuntime:
         state.initial_messages = _build_initial_messages(
             state.command.get("history"),
             state.question,
+            state.command.get("image_data_urls"),
         )
         state.history_assistant_turns = sum(
             1
@@ -638,6 +639,7 @@ class LensDeepAgentRuntime:
                 ),
                 available_tools=[*state.tools, *state.mcp_tools],
                 has_bound_skills=bool(state.resources.skill_paths),
+                image_data_urls=state.command.get("image_data_urls"),
             )
             if state.checkpoint_ready:
                 save_resume_metadata(

--- a/lensnode/tests/test_agent_runtime_messages.py
+++ b/lensnode/tests/test_agent_runtime_messages.py
@@ -1,0 +1,60 @@
+from lensnode.agent_runtime.messages import build_initial_messages
+from lensnode.agent_runtime.direct_answer import _answer_general_chat_directly
+
+
+def test_build_initial_messages_includes_current_images():
+    messages = build_initial_messages(
+        [],
+        "What is wrong?",
+        ["data:image/png;base64,encoded"],
+    )
+
+    assert messages[-1] == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What is wrong?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,encoded"},
+            },
+        ],
+    }
+
+
+def test_build_initial_messages_does_not_replay_history_for_images():
+    messages = build_initial_messages(
+        [{"role": "assistant", "content": "There is no image."}],
+        "Describe this image.",
+        ["data:image/png;base64,encoded"],
+    )
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,encoded"},
+                },
+            ],
+        }
+    ]
+
+
+def test_direct_answer_includes_current_images():
+    class Model:
+        def invoke(self, messages, runtime_control_call=False):
+            assert messages[-1].content[1]["type"] == "image_url"
+            return type("Response", (), {"content": "Image described."})()
+
+    answer = _answer_general_chat_directly(
+        Model(),
+        {
+            "question": "Describe this image.",
+            "image_data_urls": ["data:image/png;base64,encoded"],
+        },
+        "System prompt",
+    )
+
+    assert answer == "Image described."

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -1113,6 +1113,29 @@ def test_route_selection_matches_intent_against_skill_and_tool_capabilities():
     assert model.options["temperature"] == 0
 
 
+def test_route_selection_includes_current_images_in_classifier_input():
+    class Model:
+        def invoke(self, messages, **_kwargs):
+            current = messages[-1]
+            assert current.content[0]["type"] == "text"
+            assert current.content[1]["type"] == "image_url"
+            return SimpleNamespace(
+                content=(
+                    '{"intent":"informational","complexity":"simple",'
+                    '"route":"direct_answer","required_capabilities":[],'
+                    '"evidence_requirement":"none"}'
+                )
+            )
+
+    decision = agent_runtime._select_general_chat_route(
+        Model(),
+        "这个报错是什么原因",
+        image_data_urls=["data:image/png;base64,encoded"],
+    )
+
+    assert decision["route"] == "direct_answer"
+
+
 def test_route_selection_recovers_missing_tool_evidence_capabilities():
     class Model:
         def invoke(self, _messages, **_kwargs):

--- a/release-notes/318.yaml
+++ b/release-notes/318.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: "Fixed image attachments being ignored by final answers. Uploaded images are now passed through image analysis and delivered to the answering model."
+zh-CN: "修复图片附件被最终回答忽略的问题。上传的图片现在会经过图像分析并传递给最终回答模型。"


### PR DESCRIPTION
### **User description**
## Summary
- Prevent image preprocessing failures from silently falling back to workspace search.
- Deliver uploaded image evidence through the LensNode run flow and preserve it for final model responses.
- Add localized error handling and regression coverage for image attachment processing.

## Validation
- Backend: 557 passed, 42 subtests passed
- Frontend ESLint: 0 errors
- Frontend production build: passed
- Manual image flow: passed with a vision model describing the uploaded image

Closes #318


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent image preprocessing failures from silently falling back to workspace search.

- Deliver uploaded image evidence to LensNode for final model responses.

- Add localized error handling and regression coverage.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A[Image uploaded] --> B[Multimodal preprocessing]
  B --> C{Success?}
  C -- Yes --> D[Generate image-aware query]
  C -- No --> E[Fail run with clear error]
  D --> F[Include image in dispatch payload]
  F --> G[LensNode uses image in messages]
  G --> H[Final answer uses image]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>execution.py</strong><dd><code>Improve multimodal step detail and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-7cef6eaf866533349878e22f422222cf01e55ed2affb461d5b362c0a4aa9f6b6">+21/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>llm.py</strong><dd><code>Add vision capability check for multimodal models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-7722c4a2d73c65189a6cf1d54b44c5955512e6242da38224e02ef2e8651defd0">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add MultimodalPreprocessingError and image dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+62/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>direct_answer.py</strong><dd><code>Pass image_data_urls to initial messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-f81d21a609e59464c1ab173ae07c43364baa1f37e8d839b566fc669eaf93dfe7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>messages.py</strong><dd><code>Build messages with image content blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-b8db8a0cd06f0053d04ff1f9cd30ffe4aed04e5f12600ca880b7f4fa4c693367">+19/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routing.py</strong><dd><code>Pass image_data_urls to initial messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-4ecc565e7d9f142f7b43f6c72106b1f44d3abfacbacb0b49355805e875f9a60e">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Pass image_data_urls to initial messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Map image preprocessing error code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add error message for image preprocessing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add error message for image preprocessing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>test_attachments.py</strong><dd><code>Add tests for multimodal intent and failure handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+135/-10</a></td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add test for dispatch includes image data URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_run_lifecycle.py</strong><dd><code>Change to TransactionTestCase for commit hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-235e02953052226ef74eea2a154dedce1a2bd26f3ffeb8c029e6d7cfe60d2682">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_api.py</strong><dd><code>Rename test_datasource_connection import alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_services.py</strong><dd><code>Prevent pytest collection of test function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_agent_runtime_messages.py</strong><dd><code>Add tests for message building with images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-2c3d283c8b118d3dcfe2cb200ad314b45286f1bb230ed373e09ffb093f991ab6">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Add test for route selection includes images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens-image-qa.spec.js</strong><dd><code>Update e2e test for image Q&A flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-8fd2d6665ce50a819dcc27aca436949a4aba26716b6df41e5f8b07252ff03d60">+39/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pytest.ini</strong><dd><code>Add pytest configuration for backend tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-58d81dff705ad540aab75d2f98bcf5e72fff95508a1408e8b8c9fbf89bc325e9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>318.yaml</strong><dd><code>Add release note for image attachment fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-808c603767ceff03e6eb2a7e31a94fca0995a3b0279cd552b9fef7e1df322d34">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pytest_management_bulk.py</strong></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-e48663c2ba2b1f5317d92dd8f24d2bd8a1e48b0b1fc5874b829d087d63025b6e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pytest_admin_bulk.py</strong></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/322/files#diff-9a51c6439fa4d68f69515f56aad37e710419b9be8dd24d641c6660345c966ae4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

