### PR TITLE
Preserve Simplified Chinese output language in LensNode

### DIFF
--- a/lensnode/lensnode/agent_runtime/prompts.py
+++ b/lensnode/lensnode/agent_runtime/prompts.py
@@ -1,6 +1,19 @@
 """Language selection and reusable prompt fragments for LensNode runs."""
 
 
+ANSWER_LANGUAGE_NAMES = {
+    "en": "English",
+    "es": "Spanish",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+    "zh-cn": "Simplified Chinese",
+    "zh-hans": "Simplified Chinese",
+    "zh-hk": "Traditional Chinese",
+    "zh-tw": "Traditional Chinese",
+}
+
+
 def detect_answer_language(question):
     """Return the answer language name detected from the question."""
 
@@ -27,14 +40,13 @@ def detect_answer_language(question):
 def command_answer_language(command):
     """Return the requested answer language or infer it from the question."""
 
-    language_code = str(command.get("answer_language") or "").lower()
-    language = {
-        "en": "English",
-        "es": "Spanish",
-        "ja": "Japanese",
-        "ko": "Korean",
-        "zh": "Chinese",
-    }.get(language_code.split("-", 1)[0])
+    language_code = str(command.get("answer_language") or "")
+    normalized_code = language_code.strip().replace("_", "-").lower()
+    language = ANSWER_LANGUAGE_NAMES.get(normalized_code)
+    if language is None:
+        language = ANSWER_LANGUAGE_NAMES.get(
+            normalized_code.split("-", 1)[0]
+        )
     return language or detect_answer_language(command.get("question", ""))
 
 
@@ -52,9 +64,17 @@ def answer_language_requirement(answer_language):
 
 
 def pick_text(zh_text, en_text, answer_language):
-    """Return Chinese text only when Chinese is the output language."""
+    """Return Chinese text for any Chinese output language variant."""
 
-    return zh_text if answer_language == "Chinese" else en_text
+    return (
+        zh_text
+        if answer_language in {
+            "Chinese",
+            "Simplified Chinese",
+            "Traditional Chinese",
+        }
+        else en_text
+    )
 
 
 def history_artifact_guidance(command):

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -23,6 +23,7 @@ from lensnode.agent_runtime import (
     _strip_dangling_tool_call,
     _synthesize_wrapup_answer,
 )
+from lensnode.agent_runtime.prompts import command_answer_language
 from lensnode.checkpoint import CheckpointResumeError, ResumeState
 from lensnode.gateway_model import GatewayStreamError
 
@@ -2481,9 +2482,28 @@ def test_general_chat_prompt_repeats_configured_language_requirement():
         }
     )
 
-    assert prompt.startswith("ANSWER LANGUAGE REQUIREMENT: Chinese")
+    assert prompt.startswith(
+        "ANSWER LANGUAGE REQUIREMENT: Simplified Chinese"
+    )
     assert "Conversation history" in prompt
-    assert prompt.count("ANSWER LANGUAGE REQUIREMENT: Chinese") == 2
+    assert (
+        prompt.count("ANSWER LANGUAGE REQUIREMENT: Simplified Chinese") == 2
+    )
+
+
+def test_command_answer_language_preserves_chinese_script_variant():
+    assert (
+        command_answer_language({"answer_language": "zh-CN"})
+        == "Simplified Chinese"
+    )
+    assert (
+        command_answer_language({"answer_language": "zh-TW"})
+        == "Traditional Chinese"
+    )
+    assert (
+        command_answer_language({"answer_language": "zh-HK"})
+        == "Traditional Chinese"
+    )
 
 
 def test_plan_execute_prompt_requires_a_stable_initial_plan():
@@ -4056,8 +4076,13 @@ def test_provider_loop_gate_is_preserved_after_natural_agent_finish():
     assert termination_reason == "loop_capped"
 
 
-def test_pick_text_picks_chinese_only_for_chinese():
-    assert _pick_text("zh", "en", "Chinese") == "zh"
+def test_pick_text_picks_chinese_for_all_chinese_variants():
+    for language in (
+        "Chinese",
+        "Simplified Chinese",
+        "Traditional Chinese",
+    ):
+        assert _pick_text("zh", "en", language) == "zh"
     assert _pick_text("zh", "en", "English") == "en"
     # every other detected language falls back to English text too
     assert _pick_text("zh", "en", "Japanese") == "en"

--- a/lensnode/tests/test_subject_documents.py
+++ b/lensnode/tests/test_subject_documents.py
@@ -585,3 +585,34 @@ def test_knowledge_prompt_uses_explicit_answer_language():
     assert prompt.startswith("ANSWER LANGUAGE REQUIREMENT: English")
     assert "Conversation history" in prompt
     assert prompt.count("ANSWER LANGUAGE REQUIREMENT: English") == 2
+
+
+def test_knowledge_prompt_preserves_simplified_chinese():
+    prompt = _knowledge_system_prompt(
+        {"prompt": "Analyze grounded evidence."},
+        {
+            "question": "请分析所附文档",
+            "answer_language": "zh-CN",
+            "target_dirs": [],
+        },
+    )
+
+    assert prompt.startswith(
+        "ANSWER LANGUAGE REQUIREMENT: Simplified Chinese"
+    )
+    assert "ANSWER LANGUAGE REQUIREMENT: Chinese" not in prompt
+
+
+def test_knowledge_prompt_preserves_traditional_chinese():
+    prompt = _knowledge_system_prompt(
+        {"prompt": "Analyze grounded evidence."},
+        {
+            "question": "請分析所附文件",
+            "answer_language": "zh-TW",
+            "target_dirs": [],
+        },
+    )
+
+    assert prompt.startswith(
+        "ANSWER LANGUAGE REQUIREMENT: Traditional Chinese"
+    )

--- a/release-notes/320.yaml
+++ b/release-notes/320.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: "Fixed LensNode answers switching from Simplified Chinese to Traditional Chinese by preserving the configured Chinese script."
+zh-CN: "修复 LensNode 回答从简体中文切换为繁体中文的问题，确保保留用户配置的中文简繁体变体。"


### PR DESCRIPTION
### **User description**
### User description

## Summary

- Preserve the configured Chinese script when dispatching runs to LensNode.
- Map Simplified and Traditional Chinese locales to explicit output-language
  requirements.
- Keep Chinese fallback text selection working for both script variants.

## Validation

- LensNode pytest suite: 467 passed, 1 warning.
- Python syntax checks: passed.
- `git diff --check`: passed.
- Language mapping smoke checks: passed.

Closes #320

___

### PR Type

Bug fix, Tests

___

### Description

- Map `zh-CN` and `zh-Hans` to `Simplified Chinese`.
- Map `zh-TW` and `zh-HK` to `Traditional Chinese`.
- Prevent history, tool, and source-language handling from collapsing
  configured Chinese script variants into generic `Chinese`.
- Add regression coverage for General Chat and Knowledge QA prompts.

### File Walkthrough

| Area | Files | Change |
| --- | --- | --- |
| Language mapping | `lensnode/lensnode/agent_runtime/prompts.py` | Preserve locale-specific Chinese script names and fallback text selection. |
| Regression tests | `lensnode/tests/test_history.py` | Verify language mapping, prompt requirements, and Chinese variants. |
| Regression tests | `lensnode/tests/test_subject_documents.py` | Verify Simplified and Traditional Chinese Knowledge QA prompts. |


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Map zh-CN and zh-Hans to Simplified Chinese, zh-TW/HK to Traditional Chinese

- Update pick_text to accept all Chinese script variants

- Add regression tests for General Chat and Knowledge QA prompts

- Release note: fix Chinese script switching issue


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Language code input"] --> B["normalize_code()"]
  B --> C["ANSWER_LANGUAGE_NAMES dict"]
  C -->|zh-CN/zh-Hans| D["Simplified Chinese"]
  C -->|zh-TW/zh-HK| E["Traditional Chinese"]
  C -->|other| F["generic mapping"]
  D --> G["System prompt: ANSWER LANGUAGE REQUIREMENT"]
  E --> G
  G --> H["pick_text() with Chinese variant"]
  H --> I["Chinese fallback text"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompts.py</strong><dd><code>Locale-aware Chinese script mapping and prompt logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/prompts.py

<ul><li>Added ANSWER_LANGUAGE_NAMES mapping with locale-specific Chinese <br>script variants<br> <li> Updated command_answer_language to normalize locale codes (strip, <br>replace underscores, lower)<br> <li> Updated pick_text to accept "Simplified Chinese" and "Traditional <br>Chinese" in addition to "Chinese"</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/323/files#diff-d316fee25870ef0e786fc1cafc72729297ac12bbf6d06d8d6dc3307876778cdf">+30/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history.py</strong><dd><code>Regression tests for Chinese script preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_history.py

<ul><li>Added test_command_answer_language_preserves_chinese_script_variant<br> <li> Updated <br>test_general_chat_prompt_repeats_configured_language_requirement to <br>assert "Simplified Chinese"<br> <li> Updated test_pick_text_picks_chinese_for_all_chinese_variants to cover <br>all three Chinese variants</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/323/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+29/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_subject_documents.py</strong><dd><code>Knowledge QA prompt tests for Chinese variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_subject_documents.py

<ul><li>Added test_knowledge_prompt_preserves_simplified_chinese<br> <li> Added test_knowledge_prompt_preserves_traditional_chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/323/files#diff-13e8a99ae6db55f17067bd5a4af36980fafd91af472f30a2e605c5decb52172b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>320.yaml</strong><dd><code>Release note for Chinese script fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/320.yaml

<ul><li>Added release note documenting the fix for LensNode switching from <br>Simplified to Traditional Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/323/files#diff-56fcbb39eb1aafda5d516f1d1c544688b6c8d7819da9e4ba0fec7e1053eeb2b8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

