### PR TITLE
Preserve uploaded images and documents across session follow-ups

### DIFF
--- a/backend/lens/attachments.py
+++ b/backend/lens/attachments.py
@@ -160,6 +160,21 @@ def bind_attachments_to_message(
     return bound
 
 
+def get_session_image_attachments(session, attachment_uuids):
+    """Return selected session images in the requested order."""
+
+    wanted = [str(value) for value in attachment_uuids or []]
+    by_uuid = {
+        str(item.uuid): item
+        for item in MessageAttachment.objects.filter(
+            session=session,
+            kind=MessageAttachment.Kind.IMAGE,
+            uuid__in=wanted,
+        )
+    }
+    return [by_uuid[value] for value in wanted if value in by_uuid]
+
+
 def attachment_data_url(attachment):
     """Return a base64 data URL for an image attachment, or None."""
 

--- a/backend/lens/document_attachments.py
+++ b/backend/lens/document_attachments.py
@@ -153,6 +153,26 @@ def get_document_attachment(attachment_uuid):
     return metadata
 
 
+def get_session_document_attachments(session_uuid):
+    """Return all unexpired documents indexed for one Session."""
+
+    attachment_uuids = cache.get(_session_index_key(session_uuid)) or []
+    documents = []
+    expired = []
+    for attachment_uuid in attachment_uuids:
+        metadata = get_document_attachment(attachment_uuid)
+        if metadata is None:
+            expired.append(attachment_uuid)
+            continue
+        documents.append(metadata)
+    for attachment_uuid in expired:
+        _remove_from_index(
+            _session_index_key(session_uuid),
+            attachment_uuid,
+        )
+    return sorted(documents, key=lambda item: item.get("order", 0))
+
+
 def document_attachment_response(metadata):
     """Return client-safe metadata matching the attachment API shape."""
 
@@ -195,12 +215,15 @@ def bind_document_attachments_to_run(
             return []
         if metadata["session_uuid"] != str(session.uuid):
             return []
-        if metadata.get("run_uuid") not in {"", str(run.uuid)}:
-            return []
+        bound_runs = set(metadata.get("run_uuids") or [])
+        if metadata.get("run_uuid"):
+            bound_runs.add(metadata["run_uuid"])
+        bound_runs.add(str(run.uuid))
         candidates.append(
             {
                 **metadata,
                 "run_uuid": str(run.uuid),
+                "run_uuids": sorted(bound_runs),
                 "lensnode_uuid": str(run.lensnode.uuid),
                 "order": order_by_uuid.get(str(attachment_uuid), order),
             }
@@ -297,7 +320,10 @@ def get_runs_document_attachments(run_uuids, *, fail_silently=False):
                 if _remaining_seconds(metadata) <= 0:
                     expired_keys.append(attachment_key)
                     continue
-                if metadata.get("run_uuid") != run_uuid:
+                bound_runs = set(metadata.get("run_uuids") or [])
+                if metadata.get("run_uuid"):
+                    bound_runs.add(metadata["run_uuid"])
+                if run_uuid not in bound_runs:
                     continue
                 documents_by_run[run_uuid].append(metadata)
             documents_by_run[run_uuid].sort(

--- a/backend/lens/execution.py
+++ b/backend/lens/execution.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from .document_attachments import get_run_document_attachments
-from .models import Run, RunExecution, RunStep
+from .models import MessageAttachment, Run, RunExecution, RunStep
 from .services import (
     LensNodeDispatchError,
     MultimodalPreprocessingError,
@@ -87,7 +87,17 @@ def _lensnode_dispatch(state):
     run = state["run"]
     assistant = run.session.assistant
     question = run.input_message.content
-    has_images = run.input_message.attachments.exists()
+    selected_image_uuids = set(
+        (run.execution.runtime_snapshot or {}).get(
+            "session_attachment_uuids",
+            [],
+        )
+    )
+    has_images = MessageAttachment.objects.filter(
+        session=run.session,
+        kind=MessageAttachment.Kind.IMAGE,
+        uuid__in=selected_image_uuids,
+    ).exists()
     subject_documents = get_run_document_attachments(run.uuid)
     expected_document_count = int(state.get("expected_document_count") or 0)
     if expected_document_count < 0:

--- a/backend/lens/llm.py
+++ b/backend/lens/llm.py
@@ -95,7 +95,7 @@ def _multimodal_messages(system, user_text, image_data_urls):
 
 
 def model_supports_vision(model_ref):
-    """Return whether a configured model accepts image content blocks."""
+    """Return whether the configured model accepts image content blocks."""
 
     from agentcore_metering.adapters.django.services.runtime_config import (
         get_litellm_params,
@@ -175,5 +175,3 @@ def run_completion_multimodal(
         node_name=node_name,
         user_id=user_id,
     )
-
-

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 import uuid
 from datetime import timedelta
 from time import sleep
@@ -26,6 +27,7 @@ from .document_attachments import (
     bind_document_attachments_to_run,
     get_run_document_attachments,
     get_run_document_expectation,
+    get_session_document_attachments,
     set_run_document_expectation,
 )
 from .environment_variables import (
@@ -702,6 +704,97 @@ def _next_sequence(session):
     return (last_sequence or 0) + 1
 
 
+def _attachment_name_tokens(name):
+    """Return normalized searchable tokens from an attachment name."""
+
+    return {
+        token.lower()
+        for token in re.split(r"[^\w]+", name or "")
+        if token
+    }
+
+
+def select_session_attachment_context(session, question, explicit_uuids=None):
+    """Select current or clearly referenced attachments for a new Run."""
+
+    explicit = {str(value) for value in explicit_uuids or []}
+    images = list(
+        MessageAttachment.objects.filter(session=session).order_by(
+            "-created_at",
+            "-pk",
+        )
+    )
+    documents = get_session_document_attachments(session.uuid)
+    candidates = [
+        {
+            "uuid": str(item.uuid),
+            "kind": "image",
+            "name": item.original_name,
+            "created_at": item.created_at,
+        }
+        for item in images
+    ] + [
+        {
+            "uuid": item["uuid"],
+            "kind": "document",
+            "name": item["original_name"],
+            "created_at": item.get("created_at", ""),
+        }
+        for item in documents
+    ]
+    selected = [item for item in candidates if item["uuid"] in explicit]
+    historical = [item for item in candidates if item["uuid"] not in explicit]
+    if not historical:
+        return selected
+
+    question_tokens = _attachment_name_tokens(question)
+    named = [
+        item
+        for item in historical
+        if question_tokens & _attachment_name_tokens(item["name"])
+    ]
+    if named:
+        return selected + named
+
+    lowered = (question or "").lower()
+    refers_to_attachment = any(
+        marker in lowered
+        for marker in (
+            "previous",
+            "earlier",
+            "before",
+            "that image",
+            "this image",
+            "that document",
+            "this document",
+            "that pdf",
+            "this pdf",
+            "之前",
+            "刚才",
+            "上一个",
+            "图片",
+            "文档",
+            "文件",
+            "pdf",
+        )
+    )
+    if explicit and not refers_to_attachment:
+        return selected
+    if len(historical) == 1 or refers_to_attachment:
+        if refers_to_attachment:
+            requested_kind = (
+                "image"
+                if any(marker in lowered for marker in ("image", "图片"))
+                else "document"
+            )
+            same_kind = [
+                item for item in historical if item["kind"] == requested_kind
+            ]
+            historical = same_kind or historical
+        return selected + historical[:1]
+    return selected
+
+
 @transaction.atomic
 def create_execution_run(
     session,
@@ -774,6 +867,11 @@ def create_execution_run(
     requested_attachment_uuids = [
         str(value) for value in (attachment_uuids or [])
     ]
+    selected_context = select_session_attachment_context(
+        session,
+        question,
+        requested_attachment_uuids,
+    )
     attachment_order = {
         value: order for order, value in enumerate(requested_attachment_uuids)
     }
@@ -784,9 +882,9 @@ def create_execution_run(
         order_by_uuid=attachment_order,
     )
     document_uuids = [
-        value
-        for value in requested_attachment_uuids
-        if str(value) not in image_uuids
+        item["uuid"]
+        for item in selected_context
+        if item["kind"] == "document"
     ]
     if document_uuids and run.execution.task == "general_chat":
         raise AttachmentError("ATTACHMENT_UNSUPPORTED_TYPE")
@@ -798,8 +896,22 @@ def create_execution_run(
         document_uuids,
         order_by_uuid=attachment_order,
     )
-    if len(image_uuids) + len(documents) != len(requested_attachment_uuids):
+    document_uuid_set = {item["uuid"] for item in documents}
+    requested_document_uuids = {
+        value for value in requested_attachment_uuids if value not in image_uuids
+    }
+    if not requested_document_uuids.issubset(document_uuid_set):
         raise AttachmentError("ATTACHMENT_NOT_FOUND")
+
+    execution = run.execution
+    runtime_snapshot = dict(execution.runtime_snapshot or {})
+    runtime_snapshot["session_attachment_uuids"] = [
+        item["uuid"]
+        for item in selected_context
+        if item["kind"] == "image"
+    ]
+    execution.runtime_snapshot = runtime_snapshot
+    execution.save(update_fields=["runtime_snapshot"])
 
     document_count = len(documents)
     set_run_document_expectation(run.uuid, document_count)
@@ -897,9 +1009,25 @@ def analyze_multimodal_intent(run):
 
     assistant = run.session.assistant
     original = run.input_message.content
-    attachments = list(
-        run.input_message.attachments.filter(kind=MessageAttachment.Kind.IMAGE)
+    selected_uuids = set(
+        (run.execution.runtime_snapshot or {}).get(
+            "session_attachment_uuids",
+            [],
+        )
     )
+    attachments = list(
+        MessageAttachment.objects.filter(
+            session=run.session,
+            kind=MessageAttachment.Kind.IMAGE,
+            uuid__in=selected_uuids,
+        ).order_by("created_at", "pk")
+    )
+    if not selected_uuids:
+        attachments = list(
+            run.input_message.attachments.filter(
+                kind=MessageAttachment.Kind.IMAGE
+            )
+        )
     if not attachments or not assistant.multimodal_model_ref:
         return {
             "question": original,
@@ -1734,6 +1862,30 @@ def dispatch_run_to_lensnode(
     answer_language = normalize_answer_language(
         runtime_snapshot.get("answer_language")
         or getattr(profile, "language", None)
+    )
+    selected_image_uuids = set(
+        runtime_snapshot.get("session_attachment_uuids") or []
+    )
+    image_attachments = MessageAttachment.objects.filter(
+        session=run.session,
+        kind=MessageAttachment.Kind.IMAGE,
+        uuid__in=selected_image_uuids,
+    )
+    if not selected_image_uuids:
+        image_attachments = run.input_message.attachments.filter(
+            kind=MessageAttachment.Kind.IMAGE
+        )
+    image_data_urls = [
+        data_url
+        for attachment in image_attachments.order_by("created_at", "pk")
+        if (data_url := attachment_data_url(attachment))
+    ]
+    agent_model_ref = (
+        model_refs.get("multimodal")
+        or str(run.session.assistant.multimodal_model_ref or "")
+        if image_data_urls
+        else model_refs.get("agent")
+        or str(run.session.assistant.agent_model_ref or "")
     )
     async_to_sync(channel_layer.group_send)(
         lensnode_group_name(run.lensnode.uuid),

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -191,6 +191,64 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(run.input_message.attachments.count(), 1)
 
     @patch("lens.services.model_supports_vision", return_value=True)
+    def test_follow_up_reuses_previous_image(self, mock_support):
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload("diagram.png")
+        )
+        first = create_execution_run(
+            session=self.session,
+            question="Describe this image",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+        second = create_execution_run(
+            session=self.session,
+            question="What color is the previous image?",
+            enqueue=False,
+        )
+
+        selected = second.execution.runtime_snapshot[
+            "session_attachment_uuids"
+        ]
+        self.assertEqual(selected, [str(attachment.uuid)])
+        with patch("lens.services.run_completion_multimodal") as call:
+            call.return_value = LensLLMResult(
+                content="green",
+                usage={},
+                metered=True,
+            )
+            result = analyze_multimodal_intent(second)
+
+        self.assertEqual(result["image_count"], 1)
+        self.assertNotEqual(first.uuid, second.uuid)
+
+    def test_multiple_previous_attachments_are_not_all_reused(self):
+        first = store_message_attachment(
+            self.session, self.user, _png_upload("first.png")
+        )
+        second = store_message_attachment(
+            self.session, self.user, _png_upload("second.png")
+        )
+        create_execution_run(
+            session=self.session,
+            question="Describe the first image",
+            enqueue=False,
+            attachment_uuids=[str(first.uuid)],
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Tell me something unrelated",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            run.execution.runtime_snapshot["session_attachment_uuids"],
+            [],
+        )
+        second.refresh_from_db()
+        self.assertIsNone(second.message_id)
+
+    @patch("lens.services.model_supports_vision", return_value=True)
     @patch("lens.services.run_completion_multimodal")
     def test_analyze_multimodal_intent_folds_image_and_text(
         self, mock_call, mock_support

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -444,7 +444,7 @@ class DocumentAttachmentTests(TestCase):
             [second["uuid"]],
         )
 
-    def test_document_cannot_be_rebound_to_another_run(self):
+    def test_document_can_be_reused_by_another_run_in_same_session(self):
         metadata = store_document_attachment(
             self.session,
             self.user,
@@ -472,8 +472,38 @@ class DocumentAttachmentTests(TestCase):
             [metadata["uuid"]],
         )
 
-        self.assertEqual(rebound, [])
-        self.assertEqual(get_run_document_attachments(second.uuid), [])
+        self.assertEqual(len(rebound), 1)
+        self.assertEqual(
+            get_run_document_attachments(second.uuid)[0]["uuid"],
+            metadata["uuid"],
+        )
+        self.assertEqual(
+            get_run_document_attachments(first.uuid)[0]["uuid"],
+            metadata["uuid"],
+        )
+
+    def test_follow_up_reuses_previous_document(self):
+        metadata = store_document_attachment(
+            self.session,
+            self.user,
+            _pdf_upload("contract.pdf"),
+        )
+        create_execution_run(
+            session=self.session,
+            question="Summarize this PDF",
+            enqueue=False,
+            attachment_uuids=[metadata["uuid"]],
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="What is the deadline in the previous PDF?",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            get_run_document_attachments(run.uuid)[0]["uuid"],
+            metadata["uuid"],
+        )
 
     def test_delete_removes_cache_metadata_and_original_file(self):
         metadata = store_document_attachment(

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -8,6 +8,7 @@ from rest_framework.views import APIView
 from agentcore_metering.adapters.django.models import LLMUsage
 
 from accounts.permissions import HasRequiredFeature
+from lens.attachments import get_session_image_attachments
 from lens.document_attachments import (
     document_attachment_response,
     get_run_document_attachments,
@@ -434,13 +435,25 @@ def _admin_run_detail(run):
                 "rewritten": detail.get("rewritten"),
             }
         steps.append(item)
-    attachments = (
-        MessageAttachmentSerializer(
-            run.input_message.attachments.all(), many=True
-        ).data
-        if run.input_message
-        else []
-    )
+    attachments = []
+    if run.input_message:
+        selected = (
+            run.execution.runtime_snapshot or {}
+        ).get("session_attachment_uuids", [])
+        selected_images = get_session_image_attachments(
+            run.session,
+            selected,
+        )
+        if selected:
+            attachments = MessageAttachmentSerializer(
+                selected_images,
+                many=True,
+            ).data
+        else:
+            attachments = MessageAttachmentSerializer(
+                run.input_message.attachments.all(),
+                many=True,
+            ).data
     attachments.extend(
         document_attachment_response(item)
         for item in get_run_document_attachments(

--- a/lensnode/lensnode/agent_runtime/messages.py
+++ b/lensnode/lensnode/agent_runtime/messages.py
@@ -48,7 +48,7 @@ def activity_from_event(event):
 
 
 def build_initial_messages(history, question, image_data_urls=None):
-    """Build the current turn and optional text-only conversation history."""
+    """Build history and the current question with optional images."""
 
     messages = []
     if not image_data_urls:

--- a/release-notes/326.yaml
+++ b/release-notes/326.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Follow-up questions can now reuse clearly referenced images and documents
+  uploaded earlier in the same chat session.
+zh-CN: >-
+  后续问题现在可以复用同一聊天会话中之前上传且明确引用的图片和文档。


### PR DESCRIPTION
### **User description**
## Summary

- Reuse clearly referenced images and documents from the same Session in follow-up Runs.
- Preserve selected image UUIDs in the Run snapshot and deliver reused images through multimodal preprocessing and LensNode execution.
- Allow a Session document attachment to be bound to multiple Runs.
- Keep attachment reuse isolated across Sessions and expose reused attachments in Admin Run diagnostics.

## Validation

- Backend attachment regression tests: 73 passed.
- Frontend attachment tests: 28 passed.
- Browser validation covered image, PDF, DOCX, PPTX, and XLSX reuse.
- git diff --check passed.

The branch includes the latest main at commit 482fd34. PR #322 was not modified.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reuse uploaded images and documents in follow-up runs

- Select relevant attachments via token matching or reference markers

- Persist selected image UUIDs in runtime snapshot

- Update admin diagnostics and LensNode dispatch


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Upload attachment"] --> B["First run binds to message"]
  B --> C["Follow-up question mentions attachment"]
  C --> D["select_session_attachment_context()"]
  D --> E["Reuse images in runtime snapshot"]
  D --> F["Reuse documents via multi-run binding"]
  E --> G["LensNode dispatch includes image data URLs"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>attachments.py</strong><dd><code>Add get_session_image_attachments helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-97384f8eadbdf1361ec654c54ed29161ee0b55ff909be3cb9fb09cfce32b046f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document_attachments.py</strong><dd><code>Allow document reuse across runs; add session document retrieval</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-9529757592a8b4c153bde0e5c97a6cd0784013623692800121570309482c8289">+29/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add attachment context selection and runtime snapshot updates</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+157/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>admin_runs.py</strong><dd><code>Display selected images in admin run detail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+20/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>execution.py</strong><dd><code>Use session_attachment_uuids for image detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-7cef6eaf866533349878e22f422222cf01e55ed2affb461d5b362c0a4aa9f6b6">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>llm.py</strong><dd><code>Minor docstring correction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-7722c4a2d73c65189a6cf1d54b44c5955512e6242da38224e02ef2e8651defd0">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>messages.py</strong><dd><code>Update docstring for build_initial_messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-b8db8a0cd06f0053d04ff1f9cd30ffe4aed04e5f12600ca880b7f4fa4c693367">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>326.yaml</strong><dd><code>Add release note for attachment reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-dd3e31b5d6d6427159a48eff480aea331cb5688460c748a150461a8f2ebf376d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_attachments.py</strong><dd><code>Add tests for follow-up image reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_document_attachments.py</strong><dd><code>Update tests for document reuse and follow-up</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/326/files#diff-abb5e8fe2ed314bd844c7f25d56c651e637f0a72584e61b2d938b0018f41a437">+33/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

