### PR TITLE
Fix mobile chat composer and actions

### DIFF
--- a/frontend/src/components/lens/AssistantSwitcher.vue
+++ b/frontend/src/components/lens/AssistantSwitcher.vue
@@ -301,7 +301,12 @@
           <div v-if="assistants.length > 2" class="assistant-switcher-search">
             <input
               v-model="query"
-              type="text"
+              type="search"
+              name="assistant-search"
+              autocomplete="off"
+              inputmode="search"
+              autocapitalize="none"
+              spellcheck="false"
               class="assistant-switcher-input"
               :placeholder="t('common.search')"
             />

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -757,6 +757,40 @@
                       />
                     </svg>
                   </button>
+                  <button
+                    v-if="isMobile && !isAnonymous && message.run"
+                    type="button"
+                    class="icon-btn mobile-share-btn"
+                    :class="{ 'icon-btn-shared': isMessageShared(message) }"
+                    :title="
+                      isMessageShared(message)
+                        ? t('lens.qa.sharedButton')
+                        : t('lens.qa.shareButton')
+                    "
+                    :aria-label="
+                      isMessageShared(message)
+                        ? t('lens.qa.sharedButton')
+                        : t('lens.qa.shareButton')
+                    "
+                    @click="openShare(message)"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      aria-hidden="true"
+                    >
+                      <circle cx="18" cy="5" r="3" />
+                      <circle cx="6" cy="12" r="3" />
+                      <circle cx="18" cy="19" r="3" />
+                      <path
+                        d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
                   <template v-if="!isMobile">
                     <button
                       v-if="message.content"
@@ -862,13 +896,6 @@
                       />
                     </svg>
                   </button>
-                  <RowActionMenu
-                    v-if="isMobile && messageSecondaryActions(message).length"
-                    class="message-more-actions"
-                    :actions="messageSecondaryActions(message)"
-                    :label="t('lens.chat.messageActions')"
-                    @select="handleMessageAction(message, $event)"
-                  />
                 </div>
               </div>
             </div>
@@ -1239,6 +1266,16 @@
                 </div>
               </div>
             </div>
+
+            <p
+              v-if="canCompose && isMobile"
+              class="disclaimer mobile-disclaimer"
+            >
+              {{
+                t('lens.chat.disclaimer') ||
+                '回答由 AI 生成，请自行核实关键信息。'
+              }}
+            </p>
           </div>
         </div>
 
@@ -1294,6 +1331,21 @@
                     <span aria-hidden="true">×</span>
                   </button>
                 </div>
+              </div>
+              <div
+                v-if="isEmptyConversation"
+                class="prompt-suggestions"
+                :aria-label="t('lens.chat.suggestions.label')"
+              >
+                <button
+                  v-for="suggestion in promptSuggestions"
+                  :key="suggestion"
+                  type="button"
+                  class="prompt-suggestion"
+                  @click="applyPromptSuggestion(suggestion)"
+                >
+                  {{ suggestion }}
+                </button>
               </div>
               <div class="composer">
                 <input
@@ -1371,21 +1423,6 @@
                   </svg>
                 </button>
               </div>
-              <div
-                v-if="isEmptyConversation"
-                class="prompt-suggestions"
-                :aria-label="t('lens.chat.suggestions.label')"
-              >
-                <button
-                  v-for="suggestion in promptSuggestions"
-                  :key="suggestion"
-                  type="button"
-                  class="prompt-suggestion"
-                  @click="applyPromptSuggestion(suggestion)"
-                >
-                  {{ suggestion }}
-                </button>
-              </div>
             </div>
 
             <p v-if="!isMobile" class="disclaimer">
@@ -1396,12 +1433,6 @@
             </p>
           </div>
         </div>
-
-        <p v-if="canCompose && isMobile" class="disclaimer mobile-disclaimer">
-          {{
-            t('lens.chat.disclaimer') || '回答由 AI 生成，请自行核实关键信息。'
-          }}
-        </p>
       </template>
     </main>
 
@@ -3579,52 +3610,6 @@ function canRetryLastQuestion(message = null) {
   return retryableUserMessage(messages.value, message) !== null
 }
 
-function messageSecondaryActions(message) {
-  const actions = []
-  if (message.content) {
-    actions.push({
-      key: 'pdf',
-      label: t('lens.qa.exportPdf'),
-      icon: Download
-    })
-  }
-  if (!isAnonymous.value && message.run && message.content) {
-    actions.push(
-      {
-        key: 'feedback-positive',
-        label: t('lens.chat.feedbackHelpful'),
-        icon: ThumbsUp,
-        loading: isFeedbackUpdating(message.run)
-      },
-      {
-        key: 'feedback-negative',
-        label: t('lens.chat.feedbackUnhelpful'),
-        icon: ThumbsDown,
-        loading: isFeedbackUpdating(message.run)
-      }
-    )
-  }
-  if (!isAnonymous.value && message.run) {
-    actions.push({
-      key: 'share',
-      label: isMessageShared(message)
-        ? t('lens.qa.sharedButton')
-        : t('lens.qa.shareButton'),
-      icon: Share2
-    })
-  }
-  return actions
-}
-
-async function handleMessageAction(message, action) {
-  if (action === 'pdf') await exportQa(message)
-  else if (action === 'feedback-positive') {
-    await setFeedback(message, 'positive')
-  } else if (action === 'feedback-negative') {
-    await setFeedback(message, 'negative')
-  } else if (action === 'share') openShare(message)
-}
-
 function formatTime(isoString) {
   if (!isoString) return ''
   return new Date(isoString).toLocaleTimeString('zh-CN', {
@@ -4686,15 +4671,16 @@ onBeforeUnmount(() => {
   .message-actions .icon-btn {
     @apply h-11 w-11;
   }
-
-  .message-actions :deep(.message-more-actions .row-action-trigger) {
-    @apply h-11 w-11;
-  }
 }
 
 @media (max-width: 1023px) {
   .lens-chat-page {
+    position: fixed;
+    inset: 0;
+    width: 100%;
     height: 100dvh;
+    overflow: hidden;
+    overscroll-behavior: none;
   }
 
   .mobile-topbar {
@@ -4913,24 +4899,20 @@ onBeforeUnmount(() => {
     max-width: 100%;
   }
 
-  .main-shell .composer-wrap {
-    bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  .main-shell .composer-wrap,
+  .main-shell .composer-wrap-empty {
+    position: fixed;
+    top: auto;
+    bottom: calc(0.75rem + env(safe-area-inset-bottom));
     padding-right: 0.5rem;
     padding-bottom: 0;
     padding-left: 0.5rem;
     background: transparent;
+    transform: none;
   }
 
   .composer-inner {
     max-width: 47.5rem;
-  }
-
-  .main-shell .composer-wrap-empty {
-    top: 49dvh;
-    bottom: auto;
-    padding-bottom: 0;
-    transform: translateY(-50%);
-    background: transparent;
   }
 
   .composer {
@@ -4973,7 +4955,7 @@ onBeforeUnmount(() => {
     flex-wrap: wrap;
     justify-content: center;
     gap: 0.5rem;
-    margin: 0.75rem auto 0;
+    margin: 0 auto 0.75rem;
   }
 
   .prompt-suggestion {
@@ -5006,13 +4988,8 @@ onBeforeUnmount(() => {
   }
 
   .mobile-disclaimer {
-    position: absolute;
-    inset-inline: 0;
-    bottom: calc(0.25rem + env(safe-area-inset-bottom));
-    z-index: 21;
-    margin: 0;
+    margin: 1.5rem 0 0;
     padding: 0 0.75rem;
-    pointer-events: none;
   }
 
   .archived-session-notice {
@@ -5039,12 +5016,6 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 1023px) and (max-height: 600px) {
-  .main-shell .composer-wrap-empty {
-    top: auto;
-    bottom: calc(1.5rem + env(safe-area-inset-bottom));
-    transform: none;
-  }
-
   .prompt-suggestions {
     display: none;
   }

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -89,6 +89,16 @@ test('switches assistants through the assistant chat route', async () => {
   )
 })
 
+test('marks assistant filtering as search without autofill', async () => {
+  const source = await assistantSwitcherSource()
+
+  assert.match(
+    source,
+    /v-model="query"\s+type="search"\s+name="assistant-search"\s+autocomplete="off"/
+  )
+  assert.match(source, /inputmode="search"/)
+})
+
 test('loads sessions after selecting the route assistant', async () => {
   const source = await chatSource()
   const selectAssistant = source.indexOf(
@@ -122,15 +132,15 @@ test('keeps the closed mobile sidebar out of keyboard navigation', async () => {
   assert.match(source, /:aria-hidden="isMobile && !sidebarOpen"/)
 })
 
-test('groups secondary answer actions into a mobile more menu', async () => {
+test('shows only a direct share action for mobile answer tools', async () => {
   const source = await chatSource()
 
   assert.match(
     source,
-    /v-if="isMobile && messageSecondaryActions\(message\)\.length"/
+    /v-if="isMobile && !isAnonymous && message\.run"\s+type="button"\s+class="icon-btn mobile-share-btn"/
   )
-  assert.match(source, /:actions="messageSecondaryActions\(message\)"/)
-  assert.match(source, /@select="handleMessageAction\(message, \$event\)"/)
+  assert.doesNotMatch(source, /messageSecondaryActions\(message\)/)
+  assert.doesNotMatch(source, /handleMessageAction\(message, \$event\)/)
 })
 
 test('reduces secondary account information in the mobile drawer', async () => {
@@ -170,29 +180,54 @@ test('keeps every conversation layout free of repeated message avatars', async (
   assert.doesNotMatch(source, /const avatarBgColor = computed/)
 })
 
-test('separates the mobile AI disclaimer from the floating composer', async () => {
+test('keeps the mobile composer docked below its prompt suggestions', async () => {
+  const source = await chatSource()
+  const promptSuggestions = source.indexOf('class="prompt-suggestions"')
+  const composer = source.indexOf('class="composer"', promptSuggestions)
+
+  assert.notEqual(promptSuggestions, -1)
+  assert.notEqual(composer, -1)
+  assert.ok(promptSuggestions < composer)
+  assert.match(
+    source,
+    /\.main-shell \.composer-wrap,\s*\.main-shell \.composer-wrap-empty \{[\s\S]*?position: fixed;[\s\S]*?top: auto;[\s\S]*?bottom: calc\(0\.75rem \+ env\(safe-area-inset-bottom\)\);[\s\S]*?transform: none;/
+  )
+  assert.match(source, /\.prompt-suggestions \{[^}]*margin: 0 auto 0\.75rem;/)
+  assert.doesNotMatch(source, /top: 49dvh;/)
+})
+
+test('locks the mobile chat shell when the keyboard changes the viewport', async () => {
   const source = await chatSource()
 
-  assert.match(source, /v-if="!isMobile" class="disclaimer"/)
   assert.match(
     source,
-    /v-if="canCompose && isMobile"\s+class="disclaimer mobile-disclaimer"/
-  )
-  assert.match(
-    source,
-    /\.main-shell \.composer-wrap \{[\s\S]*?background: transparent;/
-  )
-  assert.match(
-    source,
-    /\.main-shell \.composer-wrap \{[\s\S]*?background: transparent;[\s\S]*?\.composer \{[\s\S]*?box-shadow:[\s\S]*?0 10px 30px/
-  )
-  assert.match(
-    source,
-    /\.mobile-disclaimer \{[\s\S]*?position: absolute;[\s\S]*?bottom: calc\(0\.25rem \+ env\(safe-area-inset-bottom\)\);/
+    /@media \(max-width: 1023px\) \{[\s\S]*?\.lens-chat-page \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;[\s\S]*?width: 100%;[\s\S]*?height: 100dvh;[\s\S]*?overflow: hidden;[\s\S]*?overscroll-behavior: none;/
   )
 })
 
-test('keeps the mobile welcome copy clear of the centered composer', async () => {
+test('keeps the mobile AI disclaimer in the scrolling thread', async () => {
+  const source = await chatSource()
+  const mobileDisclaimer = source.indexOf(
+    'class="disclaimer mobile-disclaimer"'
+  )
+  const composerWrap = source.indexOf('class="composer-wrap"')
+
+  assert.notEqual(mobileDisclaimer, -1)
+  assert.notEqual(composerWrap, -1)
+  assert.ok(mobileDisclaimer < composerWrap)
+  assert.match(source, /v-if="!isMobile" class="disclaimer"/)
+  assert.match(
+    source,
+    /\.main-shell \.composer-wrap,\s*\.main-shell \.composer-wrap-empty \{[^}]*background: transparent;/
+  )
+  assert.match(
+    source,
+    /\.main-shell \.composer-wrap,\s*\.main-shell \.composer-wrap-empty \{[^}]*background: transparent;[\s\S]*?\.composer \{[\s\S]*?box-shadow:[\s\S]*?0 10px 30px/
+  )
+  assert.doesNotMatch(source, /\.mobile-disclaimer \{[^}]*position: absolute;/)
+})
+
+test('keeps the mobile welcome copy clear of the docked composer', async () => {
   const source = await chatSource()
 
   assert.match(source, /\.chat-welcome \{[\s\S]*?padding: 0 1\.5rem 13\.5rem;/)

--- a/release-notes/327.yaml
+++ b/release-notes/327.yaml
@@ -1,0 +1,9 @@
+type: fix
+audience: user
+en: >-
+  Fixed mobile chat controls so the composer stays visible during scrolling
+  and keyboard input, sharing is easier to access, and assistant search no
+  longer triggers unrelated autofill suggestions.
+zh-CN: >-
+  修复移动端聊天交互：输入框在滚动和键盘输入时保持可见，分享入口更易访问，
+  助手搜索不再触发无关的自动填充建议。


### PR DESCRIPTION
### **User description**
## Summary

- Keep the mobile composer fixed above the safe area and lock the outer chat
  shell so page scrolling and virtual keyboard resizing cannot move it away.
- Place prompt suggestions above the composer and keep the AI disclaimer in the
  scrolling conversation.
- Replace mobile PDF, feedback, and More actions with a direct Share button
  while preserving desktop controls.
- Mark assistant filtering as a search input with browser autofill disabled.
- Add regression coverage for the responsive layout and mobile action contract.

Closes #327

## Test plan

- [x] `npm run test:unit` (315 tests)
- [x] Targeted ESLint for the three changed files
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser task space 20 at 390x844 and simulated 390x500 keyboard
  viewport
- [x] Confirm desktop composer and answer actions remain unchanged


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed mobile composer staying visible during scrolling and keyboard input

- Added direct Share button on mobile answers, removed PDF/feedback More menu

- Marked assistant filtering as search input with autofill disabled

- Moved prompt suggestions above composer, disclaimer to scrolling thread

- Locked mobile chat shell viewport to prevent keyboard resizing scroll

- Added regression tests and release notes for mobile chat fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile Chat Layout"] --> B["Composer fixed at bottom"]
  A --> C["Prompt suggestions above composer"]
  A --> D["Disclaimer in scrolling thread"]
  A --> E["Direct Share button on answers"]
  B --> F["Locked viewport prevents keyboard scroll"]
  C --> G["Assistant search: type=search, autocomplete=off"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AssistantSwitcher.vue</strong><dd><code>Mark assistant search as search input with autofill off</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/lens/AssistantSwitcher.vue

<ul><li>Changed filter input type from "text" to "search"<br> <li> Added name, autocomplete, inputmode, autocapitalize, spellcheck <br>attributes<br> <li> Prevents browser autofill and improves mobile keyboard behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/328/files#diff-8ebe891ec13cade36d347b93c2ec34d251724dabf21d3077cc7c0396baefc129">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Refactor mobile answer actions and composer layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added direct Share button on mobile answers (visible for non-anonymous <br>with run)<br> <li> Removed RowActionMenu (More menu) for PDF, feedback, share on mobile<br> <li> Deleted messageSecondaryActions and handleMessageAction functions<br> <li> Moved prompt suggestions block above composer in template<br> <li> Moved mobile disclaimer into scrolling thread area (above <br>composer-wrap)<br> <li> Updated CSS: fixed composer-wrap position, locked lens-chat-page <br>viewport<br> <li> Removed absolute positioning for mobile-disclaimer, adjusted margins<br> <li> Removed empty composer-wrap-empty top centering breakpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/328/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+72/-101</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Update regression tests for mobile chat changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Replaced test for mobile More menu with direct share action test<br> <li> Added test for assistant search input attributes<br> <li> Added test for composer docked below prompt suggestions<br> <li> Added test for locked mobile chat shell viewport<br> <li> Updated test for mobile disclaimer in scrolling thread<br> <li> Updated test for welcome copy with docked composer</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/328/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+46/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>327.yaml</strong><dd><code>Add release note for mobile chat fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/327.yaml

<ul><li>Added release note entry for mobile chat fixes<br> <li> Describes composer visibility, easier sharing, disabled autofill</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/328/files#diff-354ef59506b6dec1332ae6428246967e3a66929b29d551353ca1b1f6596b71b4">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

