### PR TITLE
Improve mobile chat, settings, and Markdown tables

### DIFF
--- a/frontend/src/components/settings/UserSettingsModal.vue
+++ b/frontend/src/components/settings/UserSettingsModal.vue
@@ -9,7 +9,7 @@
   >
     <div
       v-if="show"
-      class="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+      class="fixed inset-0 z-50 flex items-center justify-center p-0 sm:p-6"
     >
       <div
         class="absolute inset-0 bg-black/30 backdrop-blur-[2px]"
@@ -29,242 +29,301 @@
           role="dialog"
           aria-modal="true"
           aria-labelledby="settings-modal-title"
-          class="settings-modal relative flex h-[526px] max-h-[82vh] w-full max-w-[700px] overflow-hidden rounded-2xl border border-line bg-surface shadow-soft-lg"
+          class="settings-modal relative flex h-[100dvh] max-h-none w-full max-w-none flex-col overflow-hidden rounded-none border-0 border-line bg-surface shadow-soft-lg sm:h-[526px] sm:max-h-[82vh] sm:max-w-[700px] sm:rounded-2xl sm:border"
         >
-          <!-- Left nav -->
-          <nav
-            class="settings-nav flex w-36 shrink-0 flex-col border-r border-line bg-surface-sunken py-4 sm:w-48"
-          >
-            <div class="px-3 pb-3 sm:px-4">
-              <div
-                class="settings-nav-title text-sm font-semibold text-theme-subtle"
-              >
-                {{ t('settings.modal.label') }}
-              </div>
-            </div>
-
-            <div class="flex-1 space-y-0.5 px-2">
-              <button
-                v-for="section in sections"
-                :key="section.key"
-                type="button"
-                class="flex min-h-11 w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors sm:min-h-0 sm:px-3"
-                :aria-label="section.label"
-                :class="
-                  activeSection === section.key
-                    ? 'settings-nav-active bg-surface font-medium text-theme shadow-sm'
-                    : 'text-theme-secondary hover:bg-surface-hover hover:text-theme'
-                "
-                @click="activeSection = section.key"
-              >
-                <component :is="section.icon" class="h-4 w-4 shrink-0" />
-                <span class="min-w-0 flex-1 truncate text-xs sm:text-sm">
-                  {{ section.label }}
-                </span>
-                <span
-                  v-if="
-                    section.key === 'release-notes' &&
-                    uiStore.hasUnreadReleaseNotes
-                  "
-                  class="h-2 w-2 shrink-0 rounded-full bg-primary-500"
-                >
-                  <span class="sr-only">
-                    {{ t('settings.modal.releaseNotesUnread') }}
-                  </span>
-                </span>
-              </button>
-            </div>
-
-            <div class="settings-logout-wrap border-t border-line px-2 pt-2">
-              <button
-                type="button"
-                class="settings-logout flex min-h-11 w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 sm:min-h-0 sm:px-3"
-                :aria-label="t('common.logout')"
-                @click="handleLogout"
-              >
-                <svg
-                  class="h-4 w-4 shrink-0"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                  <polyline
-                    points="16 17 21 12 16 7"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                  <line x1="21" y1="12" x2="9" y2="12" stroke-linecap="round" />
-                </svg>
-                <span class="truncate text-xs sm:text-sm">{{
-                  t('common.logout')
-                }}</span>
-              </button>
-            </div>
-          </nav>
-
-          <!-- Right content -->
-          <div class="flex min-w-0 flex-1 flex-col">
-            <header
-              class="settings-header flex items-center justify-between border-b border-line px-4 pb-2 pt-5 sm:px-6"
+          <div class="settings-layout flex min-h-0 flex-1 flex-col sm:flex-row">
+            <!-- Left nav -->
+            <nav
+              class="settings-nav flex w-full shrink-0 flex-row border-b border-line bg-surface-sunken px-2 py-2 sm:w-48 sm:flex-col sm:border-b-0 sm:border-r sm:px-0 sm:py-4"
             >
-              <h2
-                id="settings-modal-title"
-                class="text-base font-semibold text-theme"
-              >
-                {{ sections.find((s) => s.key === activeSection)?.label }}
-              </h2>
-              <button
-                ref="closeButtonRef"
-                type="button"
-                class="flex h-8 w-8 items-center justify-center rounded-lg text-theme-subtle transition-colors hover:bg-surface-hover hover:text-theme-secondary"
-                :aria-label="t('common.close')"
-                @click="emit('close')"
-              >
-                <svg
-                  class="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.25"
-                  aria-hidden="true"
+              <div class="hidden px-3 pb-3 sm:block sm:px-4">
+                <div
+                  class="settings-nav-title text-sm font-semibold text-theme-subtle"
                 >
-                  <path
-                    d="M6 18L18 6M6 6l12 12"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </button>
-            </header>
-
-            <div class="min-h-0 flex-1 overflow-y-auto px-4 pb-6 pt-3 sm:px-6">
-              <!-- Profile section -->
-              <div v-if="activeSection === 'profile'" class="space-y-5">
-                <div class="flex items-center gap-4">
-                  <div
-                    class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl text-xl font-semibold text-white"
-                    :class="avatarBgColor"
-                  >
-                    {{ userInitials }}
-                  </div>
-                  <div class="min-w-0">
-                    <div class="truncate text-base font-semibold text-theme">
-                      {{ displayName }}
-                    </div>
-                    <div class="mt-0.5 truncate text-sm text-theme-muted">
-                      {{
-                        userStore.userInfo?.email || t('settings.modal.noEmail')
-                      }}
-                    </div>
-                  </div>
-                </div>
-
-                <div class="divide-y divide-line rounded-xl border border-line">
-                  <div class="space-y-1 px-3 py-3 sm:px-4">
-                    <div class="text-xs font-medium text-theme-muted">
-                      {{ t('settings.modal.username') }}
-                    </div>
-                    <div
-                      class="break-all text-sm font-medium leading-snug text-theme"
-                    >
-                      {{ userStore.userInfo?.username || '—' }}
-                    </div>
-                  </div>
-                  <div class="space-y-1 px-3 py-3 sm:px-4">
-                    <div class="text-xs font-medium text-theme-muted">
-                      {{ t('settings.modal.email') }}
-                    </div>
-                    <div
-                      class="break-all text-sm font-medium leading-snug text-theme"
-                    >
-                      {{ userStore.userInfo?.email || '—' }}
-                    </div>
-                  </div>
+                  {{ t('settings.modal.label') }}
                 </div>
               </div>
 
-              <!-- Language section -->
-              <div v-if="activeSection === 'language'" class="space-y-3">
-                <p class="text-sm text-theme-muted">
-                  {{ t('settings.modal.languageDesc') }}
-                </p>
-                <BaseSelect
-                  id="ui-language"
-                  :model-value="locale"
-                  @update:model-value="selectLanguage"
+              <div
+                class="settings-nav-tabs settings-nav-scrollbar flex min-w-0 flex-1 gap-1 overflow-x-auto sm:block sm:space-y-0.5 sm:overflow-visible sm:px-2"
+              >
+                <button
+                  v-for="section in sections"
+                  :key="section.key"
+                  type="button"
+                  class="flex min-h-11 w-auto shrink-0 items-center justify-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors sm:min-h-0 sm:w-full sm:justify-start"
+                  :aria-label="section.label"
+                  :aria-current="
+                    activeSection === section.key ? 'page' : undefined
+                  "
+                  :class="
+                    activeSection === section.key
+                      ? 'settings-nav-active bg-surface font-medium text-theme shadow-sm'
+                      : 'text-theme-secondary hover:bg-surface-hover hover:text-theme'
+                  "
+                  @click="activeSection = section.key"
                 >
-                  <option
-                    v-for="lang in languages"
-                    :key="lang.value"
-                    :value="lang.value"
+                  <component :is="section.icon" class="h-4 w-4 shrink-0" />
+                  <span
+                    class="whitespace-nowrap text-sm sm:min-w-0 sm:flex-1 sm:truncate"
                   >
-                    {{ lang.flag }} {{ lang.label }}
-                  </option>
-                </BaseSelect>
-              </div>
-
-              <!-- Appearance section -->
-              <div v-if="activeSection === 'appearance'" class="space-y-3">
-                <p class="text-sm text-theme-muted">
-                  {{ t('settings.modal.appearanceDesc') }}
-                </p>
-                <div class="grid gap-2 sm:grid-cols-2" role="radiogroup">
-                  <label
-                    v-for="option in themeOptions"
-                    :key="option.value"
-                    class="flex min-h-20 cursor-pointer items-center gap-3 rounded-xl border px-3 py-3 text-sm text-theme transition-colors"
-                    :class="
-                      preferencesStore.themeMode === option.value
-                        ? 'border-primary-500 bg-surface-selected'
-                        : 'border-line/80 bg-surface-raised hover:border-line-strong hover:bg-surface-hover'
+                    {{ section.label }}
+                  </span>
+                  <span
+                    v-if="
+                      section.key === 'release-notes' &&
+                      uiStore.hasUnreadReleaseNotes
                     "
+                    class="h-2 w-2 shrink-0 rounded-full bg-primary-500"
                   >
-                    <span
-                      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-hover text-theme-secondary"
-                    >
-                      <component :is="option.icon" class="h-4 w-4" />
+                    <span class="sr-only">
+                      {{ t('settings.modal.releaseNotesUnread') }}
                     </span>
-                    <span class="min-w-0 flex-1">
-                      <span class="block font-medium">{{ option.label }}</span>
-                      <span class="mt-0.5 block text-xs text-theme-muted">
-                        {{ option.description }}
-                      </span>
-                    </span>
-                    <input
-                      v-model="preferencesStore.themeMode"
-                      type="radio"
-                      name="appearance-mode"
-                      :value="option.value"
-                      class="h-4 w-4 shrink-0 accent-primary-500"
-                      @change="preferencesStore.setThemeMode(option.value)"
-                    />
-                  </label>
-                </div>
-                <p
-                  v-if="preferencesStore.themeMode === 'scheduled'"
-                  class="text-sm text-theme-muted"
-                >
-                  {{ t('settings.modal.themeScheduleDescription') }}
-                </p>
-                <p class="text-xs text-theme-subtle">
-                  {{ t('settings.modal.themeAdminNote') }}
-                </p>
+                  </span>
+                </button>
               </div>
 
-              <AnswerNotificationSettings
-                v-if="activeSection === 'notifications'"
-              />
+              <div
+                class="settings-logout-wrap hidden border-t border-line px-2 pt-2 sm:block"
+              >
+                <button
+                  type="button"
+                  class="settings-logout flex min-h-11 w-full items-center justify-start gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 sm:min-h-0"
+                  :aria-label="t('common.logout')"
+                  @click="handleLogout"
+                >
+                  <svg
+                    class="h-4 w-4 shrink-0"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <polyline
+                      points="16 17 21 12 16 7"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <line
+                      x1="21"
+                      y1="12"
+                      x2="9"
+                      y2="12"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                  <span class="truncate text-sm">{{ t('common.logout') }}</span>
+                </button>
+              </div>
+            </nav>
 
-              <ReleaseNotesSettings v-if="activeSection === 'release-notes'" />
+            <!-- Right content -->
+            <div class="settings-content-shell flex min-w-0 flex-1 flex-col">
+              <header
+                class="settings-header flex min-h-14 items-center justify-between border-b border-line px-4 py-2 sm:min-h-0 sm:px-6 sm:pb-2 sm:pt-5"
+              >
+                <h2
+                  id="settings-modal-title"
+                  class="text-base font-semibold text-theme"
+                >
+                  {{ sections.find((s) => s.key === activeSection)?.label }}
+                </h2>
+                <button
+                  ref="closeButtonRef"
+                  type="button"
+                  class="flex h-11 w-11 items-center justify-center rounded-lg text-theme-subtle transition-colors hover:bg-surface-hover hover:text-theme-secondary sm:h-8 sm:w-8"
+                  :aria-label="t('common.close')"
+                  @click="emit('close')"
+                >
+                  <svg
+                    class="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.25"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M6 18L18 6M6 6l12 12"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </button>
+              </header>
 
-              <PasswordChangeSettings v-if="activeSection === 'security'" />
+              <div
+                class="settings-content min-h-0 flex-1 overflow-y-auto px-4 pb-[calc(1.5rem+env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pb-6 sm:pt-3"
+              >
+                <!-- Profile section -->
+                <div v-if="activeSection === 'profile'" class="space-y-5">
+                  <div class="flex items-center gap-4">
+                    <div
+                      class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl text-xl font-semibold text-white"
+                      :class="avatarBgColor"
+                    >
+                      {{ userInitials }}
+                    </div>
+                    <div class="min-w-0">
+                      <div class="truncate text-base font-semibold text-theme">
+                        {{ displayName }}
+                      </div>
+                      <div class="mt-0.5 truncate text-sm text-theme-muted">
+                        {{
+                          userStore.userInfo?.email ||
+                          t('settings.modal.noEmail')
+                        }}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div
+                    class="divide-y divide-line rounded-xl border border-line"
+                  >
+                    <div class="space-y-1 px-3 py-3 sm:px-4">
+                      <div class="text-xs font-medium text-theme-muted">
+                        {{ t('settings.modal.username') }}
+                      </div>
+                      <div
+                        class="break-all text-sm font-medium leading-snug text-theme"
+                      >
+                        {{ userStore.userInfo?.username || '—' }}
+                      </div>
+                    </div>
+                    <div class="space-y-1 px-3 py-3 sm:px-4">
+                      <div class="text-xs font-medium text-theme-muted">
+                        {{ t('settings.modal.email') }}
+                      </div>
+                      <div
+                        class="break-all text-sm font-medium leading-snug text-theme"
+                      >
+                        {{ userStore.userInfo?.email || '—' }}
+                      </div>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    class="settings-mobile-logout flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border border-red-200 px-4 py-3 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 sm:hidden"
+                    :aria-label="t('common.logout')"
+                    @click="handleLogout"
+                  >
+                    <svg
+                      class="h-4 w-4 shrink-0"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                      <polyline
+                        points="16 17 21 12 16 7"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                      <line
+                        x1="21"
+                        y1="12"
+                        x2="9"
+                        y2="12"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                    {{ t('common.logout') }}
+                  </button>
+                </div>
+
+                <!-- Language section -->
+                <div v-if="activeSection === 'language'" class="space-y-3">
+                  <p class="text-sm text-theme-muted">
+                    {{ t('settings.modal.languageDesc') }}
+                  </p>
+                  <BaseSelect
+                    id="ui-language"
+                    :model-value="locale"
+                    @update:model-value="selectLanguage"
+                  >
+                    <option
+                      v-for="lang in languages"
+                      :key="lang.value"
+                      :value="lang.value"
+                    >
+                      {{ lang.flag }} {{ lang.label }}
+                    </option>
+                  </BaseSelect>
+                </div>
+
+                <!-- Appearance section -->
+                <div v-if="activeSection === 'appearance'" class="space-y-3">
+                  <p class="text-sm text-theme-muted">
+                    {{ t('settings.modal.appearanceDesc') }}
+                  </p>
+                  <div class="grid gap-2 sm:grid-cols-2" role="radiogroup">
+                    <label
+                      v-for="option in themeOptions"
+                      :key="option.value"
+                      class="flex min-h-20 cursor-pointer items-center gap-3 rounded-xl border px-3 py-3 text-sm text-theme transition-colors"
+                      :class="
+                        preferencesStore.themeMode === option.value
+                          ? 'border-primary-500 bg-surface-selected'
+                          : 'border-line/80 bg-surface-raised hover:border-line-strong hover:bg-surface-hover'
+                      "
+                    >
+                      <span
+                        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-hover text-theme-secondary"
+                      >
+                        <component :is="option.icon" class="h-4 w-4" />
+                      </span>
+                      <span class="min-w-0 flex-1">
+                        <span class="block font-medium">{{
+                          option.label
+                        }}</span>
+                        <span class="mt-0.5 block text-xs text-theme-muted">
+                          {{ option.description }}
+                        </span>
+                      </span>
+                      <input
+                        v-model="preferencesStore.themeMode"
+                        type="radio"
+                        name="appearance-mode"
+                        :value="option.value"
+                        class="h-4 w-4 shrink-0 accent-primary-500"
+                        @change="preferencesStore.setThemeMode(option.value)"
+                      />
+                    </label>
+                  </div>
+                  <p
+                    v-if="preferencesStore.themeMode === 'scheduled'"
+                    class="text-sm text-theme-muted"
+                  >
+                    {{ t('settings.modal.themeScheduleDescription') }}
+                  </p>
+                  <p class="text-xs text-theme-subtle">
+                    {{ t('settings.modal.themeAdminNote') }}
+                  </p>
+                </div>
+
+                <AnswerNotificationSettings
+                  v-if="activeSection === 'notifications'"
+                />
+
+                <ReleaseNotesSettings
+                  v-if="activeSection === 'release-notes'"
+                />
+
+                <PasswordChangeSettings v-if="activeSection === 'security'" />
+              </div>
             </div>
           </div>
         </section>
@@ -462,6 +521,14 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.settings-nav-scrollbar {
+  scrollbar-width: none;
+}
+
+.settings-nav-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 :global(:root[data-theme='dark'] .settings-modal) {
   border-color: rgb(var(--sl-border-default-rgb) / 60%);
 }
@@ -481,7 +548,8 @@ onBeforeUnmount(() => {
   box-shadow: none;
 }
 
-:global(:root[data-theme='dark'] .settings-logout:hover) {
+:global(:root[data-theme='dark'] .settings-logout:hover),
+:global(:root[data-theme='dark'] .settings-mobile-logout:hover) {
   background: var(--sl-bg-hover);
 }
 </style>

--- a/frontend/src/components/ui/MarkdownRenderer.vue
+++ b/frontend/src/components/ui/MarkdownRenderer.vue
@@ -324,6 +324,19 @@ const renderedContent = computed(() => {
   @apply border border-line-strong px-3 py-2 text-theme-secondary;
 }
 
+@media (max-width: 639px) {
+  .markdown-content :deep(table) {
+    width: max-content;
+    min-width: 100%;
+  }
+
+  .markdown-content :deep(th),
+  .markdown-content :deep(td) {
+    word-break: keep-all;
+    overflow-wrap: normal;
+  }
+}
+
 .markdown-content :deep(a) {
   @apply text-primary-600 hover:text-primary-700 underline;
 }

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lens-chat-page qa-screen-view">
+  <div class="lens-chat-page qa-screen-view" :style="mobileViewportStyle">
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"
@@ -1662,6 +1662,7 @@ const renamingSessionUuid = ref('')
 const renameDraft = ref('')
 const composerRef = ref(null)
 const scrollRef = ref(null)
+const mobileViewportStyle = ref({})
 const seenStepEventCounts = new Map()
 let sessionLoadGeneration = 0
 const runtimeState = ref(createRuntimeState())
@@ -2441,6 +2442,18 @@ function scrollToBottom() {
   if (!el) return
   el.scrollTop = el.scrollHeight
   answerAutoScroller.handleScroll()
+}
+
+function syncMobileViewport() {
+  const viewport = window.visualViewport
+  if (!viewport || window.innerWidth >= 1024) {
+    mobileViewportStyle.value = {}
+    return
+  }
+  mobileViewportStyle.value = {
+    '--chat-viewport-height': `${viewport.height}px`,
+    '--chat-viewport-offset-top': `${viewport.offsetTop}px`
+  }
 }
 
 async function bootstrap() {
@@ -3687,7 +3700,10 @@ watch(
 onMounted(async () => {
   window.addEventListener('storage', handleCompletionStorage)
   window.addEventListener('focus', handleCompletionVisibility)
+  window.visualViewport?.addEventListener('resize', syncMobileViewport)
+  window.visualViewport?.addEventListener('scroll', syncMobileViewport)
   document.addEventListener('visibilitychange', handleCompletionVisibility)
+  syncMobileViewport()
   refreshUnreadSessions()
   if (window.innerWidth < 1024) {
     sidebarOpen.value = false
@@ -3702,6 +3718,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   window.removeEventListener('storage', handleCompletionStorage)
   window.removeEventListener('focus', handleCompletionVisibility)
+  window.visualViewport?.removeEventListener('resize', syncMobileViewport)
+  window.visualViewport?.removeEventListener('scroll', syncMobileViewport)
   document.removeEventListener('visibilitychange', handleCompletionVisibility)
   streamController.value?.abort()
   answerAutoScroller.dispose()
@@ -4676,9 +4694,12 @@ onBeforeUnmount(() => {
 @media (max-width: 1023px) {
   .lens-chat-page {
     position: fixed;
-    inset: 0;
+    top: var(--chat-viewport-offset-top, 0px);
+    right: 0;
+    bottom: auto;
+    left: 0;
     width: 100%;
-    height: 100dvh;
+    height: var(--chat-viewport-height, 100dvh);
     overflow: hidden;
     overscroll-behavior: none;
   }
@@ -4901,7 +4922,7 @@ onBeforeUnmount(() => {
 
   .main-shell .composer-wrap,
   .main-shell .composer-wrap-empty {
-    position: fixed;
+    position: absolute;
     top: auto;
     bottom: calc(0.75rem + env(safe-area-inset-bottom));
     padding-right: 0.5rem;

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -190,18 +190,35 @@ test('keeps the mobile composer docked below its prompt suggestions', async () =
   assert.ok(promptSuggestions < composer)
   assert.match(
     source,
-    /\.main-shell \.composer-wrap,\s*\.main-shell \.composer-wrap-empty \{[\s\S]*?position: fixed;[\s\S]*?top: auto;[\s\S]*?bottom: calc\(0\.75rem \+ env\(safe-area-inset-bottom\)\);[\s\S]*?transform: none;/
+    /\.main-shell \.composer-wrap,\s*\.main-shell \.composer-wrap-empty \{[\s\S]*?position: absolute;[\s\S]*?top: auto;[\s\S]*?bottom: calc\(0\.75rem \+ env\(safe-area-inset-bottom\)\);[\s\S]*?transform: none;/
   )
   assert.match(source, /\.prompt-suggestions \{[^}]*margin: 0 auto 0\.75rem;/)
   assert.doesNotMatch(source, /top: 49dvh;/)
 })
 
-test('locks the mobile chat shell when the keyboard changes the viewport', async () => {
+test('tracks the visual viewport so keyboard panning keeps the thread top reachable', async () => {
   const source = await chatSource()
 
   assert.match(
     source,
-    /@media \(max-width: 1023px\) \{[\s\S]*?\.lens-chat-page \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;[\s\S]*?width: 100%;[\s\S]*?height: 100dvh;[\s\S]*?overflow: hidden;[\s\S]*?overscroll-behavior: none;/
+    /class="lens-chat-page qa-screen-view"\s+:style="mobileViewportStyle"/
+  )
+  assert.match(source, /'--chat-viewport-height': `\$\{viewport\.height\}px`/)
+  assert.match(
+    source,
+    /'--chat-viewport-offset-top': `\$\{viewport\.offsetTop\}px`/
+  )
+  assert.match(
+    source,
+    /window\.visualViewport\?\.addEventListener\(\s*'resize',\s*syncMobileViewport\s*\)/
+  )
+  assert.match(
+    source,
+    /window\.visualViewport\?\.addEventListener\(\s*'scroll',\s*syncMobileViewport\s*\)/
+  )
+  assert.match(
+    source,
+    /@media \(max-width: 1023px\) \{[\s\S]*?\.lens-chat-page \{[\s\S]*?position: fixed;[\s\S]*?top: var\(--chat-viewport-offset-top, 0px\);[\s\S]*?right: 0;[\s\S]*?bottom: auto;[\s\S]*?left: 0;[\s\S]*?height: var\(--chat-viewport-height, 100dvh\);[\s\S]*?overflow: hidden;[\s\S]*?overscroll-behavior: none;/
   )
 })
 

--- a/frontend/tests/markdownRendererTables.test.js
+++ b/frontend/tests/markdownRendererTables.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const rendererSource = readFileSync(
+  new URL('../src/components/ui/MarkdownRenderer.vue', import.meta.url),
+  'utf8'
+)
+
+test('Markdown tables render inside a bounded horizontal scroll container', () => {
+  assert.match(
+    rendererSource,
+    /<div class="markdown-table-scroll">[\s\S]*?renderTable\(token\)/
+  )
+  assert.match(
+    rendererSource,
+    /\.markdown-content :deep\(\.markdown-table-scroll\) \{[\s\S]*?max-w-full[\s\S]*?overflow-x-auto/
+  )
+})
+
+test('Markdown tables keep readable intrinsic columns on mobile only', () => {
+  assert.match(
+    rendererSource,
+    /@media \(max-width: 639px\) \{[\s\S]*?\.markdown-content :deep\(table\) \{[\s\S]*?width: max-content;[\s\S]*?min-width: 100%;/
+  )
+  assert.match(
+    rendererSource,
+    /@media \(max-width: 639px\) \{[\s\S]*?\.markdown-content :deep\(th\),[\s\S]*?\.markdown-content :deep\(td\) \{[\s\S]*?word-break: keep-all;[\s\S]*?overflow-wrap: normal;/
+  )
+})

--- a/frontend/tests/themePreferences.test.js
+++ b/frontend/tests/themePreferences.test.js
@@ -673,7 +673,10 @@ test('settings expose four mutually exclusive appearance modes', () => {
 
 test('settings modal preserves light colors and softens dark dividers', () => {
   assert.match(settingsSource, /bg-surface-sunken/)
-  assert.match(settingsSource, /border-r border-line/)
+  assert.match(
+    settingsSource,
+    /settings-nav[\s\S]*?border-b border-line[\s\S]*?sm:border-b-0[\s\S]*?sm:border-r/
+  )
   assert.match(settingsSource, /border-b border-line/)
   assert.match(settingsSource, /border-t border-line/)
   assert.match(settingsSource, /hover:bg-red-50/)

--- a/frontend/tests/userSettingsModalInteractions.test.js
+++ b/frontend/tests/userSettingsModalInteractions.test.js
@@ -38,19 +38,59 @@ test('User Settings closes from the visible backdrop click target', () => {
 test('User Settings mobile navigation uses larger touch targets', () => {
   assert.match(
     modalSource,
-    /min-h-11[\s\S]*?rounded-lg[\s\S]*?px-2\.5[\s\S]*?sm:min-h-0/
+    /min-h-11[\s\S]*?shrink-0[\s\S]*?rounded-lg[\s\S]*?px-3[\s\S]*?sm:min-h-0/
   )
 })
 
-test('User Settings navigation shows section labels on mobile', () => {
-  assert.match(modalSource, /settings-nav flex w-36/)
-  assert.doesNotMatch(
+test('User Settings uses a full-screen mobile panel with desktop constraints', () => {
+  assert.match(
     modalSource,
-    /class="hidden min-w-0 flex-1 truncate sm:block"/
+    /settings-modal[\s\S]*?h-\[100dvh\][\s\S]*?max-h-none[\s\S]*?max-w-none[\s\S]*?flex-col[\s\S]*?rounded-none[\s\S]*?border-0/
   )
   assert.match(
     modalSource,
-    /class="min-w-0 flex-1 truncate text-xs sm:text-sm"/
+    /sm:h-\[526px\][\s\S]*?sm:max-h-\[82vh\][\s\S]*?sm:max-w-\[700px\][\s\S]*?sm:rounded-2xl[\s\S]*?sm:border/
+  )
+})
+
+test('User Settings moves mobile sections into a horizontal scroll rail', () => {
+  assert.match(
+    modalSource,
+    /settings-nav-tabs[\s\S]*?flex[\s\S]*?overflow-x-auto[\s\S]*?sm:block[\s\S]*?sm:overflow-visible/
+  )
+  assert.match(
+    modalSource,
+    /whitespace-nowrap[\s\S]*?sm:min-w-0[\s\S]*?sm:flex-1[\s\S]*?sm:truncate/
+  )
+  assert.match(
+    modalSource,
+    /\.settings-nav-scrollbar \{[\s\S]*?scrollbar-width: none;/
+  )
+  assert.match(
+    modalSource,
+    /\.settings-nav-scrollbar::-webkit-scrollbar \{[\s\S]*?display: none;/
+  )
+})
+
+test('User Settings gives mobile content the full width and keeps desktop sidebar', () => {
+  assert.match(
+    modalSource,
+    /settings-layout[\s\S]*?flex-col[\s\S]*?sm:flex-row/
+  )
+  assert.match(
+    modalSource,
+    /settings-nav[\s\S]*?w-full[\s\S]*?border-b[\s\S]*?sm:w-48[\s\S]*?sm:border-b-0[\s\S]*?sm:border-r/
+  )
+  assert.match(
+    modalSource,
+    /settings-content[\s\S]*?min-h-0[\s\S]*?flex-1[\s\S]*?overflow-y-auto/
+  )
+})
+
+test('User Settings places logout in the mobile profile content', () => {
+  assert.match(
+    modalSource,
+    /settings-mobile-logout[\s\S]*?sm:hidden[\s\S]*?@click="handleLogout"/
   )
 })
 

--- a/release-notes/329.yaml
+++ b/release-notes/329.yaml
@@ -1,0 +1,9 @@
+type: improvement
+audience: user
+en: >-
+  Improved mobile chat and settings so conversations stay reachable with the
+  keyboard open, settings use a roomier full-screen layout, and wide Markdown
+  tables scroll horizontally.
+zh-CN: >-
+  优化移动端聊天与设置：键盘展开时仍可滚动到对话顶部，设置使用更宽松的全屏
+  布局，多列 Markdown 表格支持横向滚动。


### PR DESCRIPTION
### **User description**
## Summary
- Track the visual viewport so the mobile keyboard cannot make the top of a conversation unreachable.
- Redesign User Settings as a full-screen mobile panel with horizontally scrollable section navigation while preserving the desktop modal.
- Keep wide Markdown table columns readable through bounded horizontal scrolling on mobile without causing page-level overflow.

Closes #329

## Test plan
- [x] Run all 320 frontend unit tests.
- [x] Run scoped ESLint checks for the changed Markdown renderer and regression test.
- [x] Build the Vite production bundle.
- [x] Verify keyboard scrolling, User Settings, and Markdown table layouts with ego-browser at mobile and desktop viewports.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix mobile chat keyboard hiding top of conversation

- Redesign User Settings as full-screen mobile panel

- Add horizontal scroll for wide Markdown tables on mobile

- Add unit tests for new mobile behaviors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  chat["Mobile Chat"] --> viewport["Visual Viewport Tracking"]
  settings["User Settings"] --> fullscreen["Full-screen Mobile Panel"]
  tables["Markdown Tables"] --> scroll["Horizontal Scroll Container"]
  viewport -- "keeps top reachable" --> chat
  fullscreen -- "full-width, header/nav/scroll" --> settings
  scroll -- "max-content, keep-all" --> tables
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>UserSettingsModal.vue</strong><dd><code>Redesign settings as full-screen mobile panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-aa6410cf6949d28f892578c56dc32520cf22ed90043fa5a4d5c266acc570041b">+274/-206</a></td>

</tr>

<tr>
  <td><strong>MarkdownRenderer.vue</strong><dd><code>Add mobile horizontal scroll for tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-8acab9a2284f91e2714ae018e98389ad38d85c55215ce785163b9cf790b4c5d3">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Chat.vue</strong><dd><code>Track visual viewport for keyboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+25/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>chatBootstrap.test.js</strong><dd><code>Update test for viewport tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>markdownRendererTables.test.js</strong><dd><code>Add test for table scroll container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-aa2b8e8005d55efa6a0fd8e7f3f0d68a0bf16cb14acdfc35b076e88f959f9219">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>themePreferences.test.js</strong><dd><code>Update test for settings nav layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-f08fa9718c61097053ed63886486d887251e9a708b9ff5ce683fedee51329ffa">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>userSettingsModalInteractions.test.js</strong><dd><code>Add tests for mobile settings layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-0d2a41865460ddbd59df48943e03ecbe725609f9b1216e09be3d9ca3ee7b8f43">+46/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>329.yaml</strong><dd><code>Add release note for mobile improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/330/files#diff-ec6a47a855fe817cb5281ffa0b8c72bf2dcddcbdebb4db03c19f4a2ac1fcda6c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

