### PR TITLE
Fix vision capability detection and attachment reuse

### DIFF
--- a/backend/lens/execution.py
+++ b/backend/lens/execution.py
@@ -87,8 +87,9 @@ def _lensnode_dispatch(state):
     run = state["run"]
     assistant = run.session.assistant
     question = run.input_message.content
+    execution = RunExecution.objects.filter(run=run).first()
     selected_image_uuids = set(
-        (run.execution.runtime_snapshot or {}).get(
+        (execution.runtime_snapshot if execution else {}).get(
             "session_attachment_uuids",
             [],
         )

--- a/backend/lens/llm.py
+++ b/backend/lens/llm.py
@@ -97,11 +97,16 @@ def _multimodal_messages(system, user_text, image_data_urls):
 def model_supports_vision(model_ref):
     """Return whether the configured model accepts image content blocks."""
 
+    from agentcore_metering.adapters.django.models import LLMConfig
     from agentcore_metering.adapters.django.services.runtime_config import (
         get_litellm_params,
     )
     from litellm.utils import supports_vision
 
+    config = LLMConfig.objects.get(uuid=model_ref)
+    declared_vision = (config.config or {}).get("vision")
+    if declared_vision is not None:
+        return bool(declared_vision)
     params = get_litellm_params(model_uuid=str(model_ref))
     model = str(params.get("model") or "")
     return bool(model) and supports_vision(model=model)

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -744,6 +744,8 @@ def select_session_attachment_context(session, question, explicit_uuids=None):
     ]
     selected = [item for item in candidates if item["uuid"] in explicit]
     historical = [item for item in candidates if item["uuid"] not in explicit]
+    if explicit:
+        return selected
     if not historical:
         return selected
 
@@ -778,8 +780,6 @@ def select_session_attachment_context(session, question, explicit_uuids=None):
             "pdf",
         )
     )
-    if explicit and not refers_to_attachment:
-        return selected
     if len(historical) == 1 or refers_to_attachment:
         if refers_to_attachment:
             requested_kind = (

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -780,17 +780,16 @@ def select_session_attachment_context(session, question, explicit_uuids=None):
             "pdf",
         )
     )
-    if len(historical) == 1 or refers_to_attachment:
-        if refers_to_attachment:
-            requested_kind = (
-                "image"
-                if any(marker in lowered for marker in ("image", "图片"))
-                else "document"
-            )
-            same_kind = [
-                item for item in historical if item["kind"] == requested_kind
-            ]
-            historical = same_kind or historical
+    if refers_to_attachment:
+        requested_kind = (
+            "image"
+            if any(marker in lowered for marker in ("image", "图片"))
+            else "document"
+        )
+        same_kind = [
+            item for item in historical if item["kind"] == requested_kind
+        ]
+        historical = same_kind or historical
         return selected + historical[:1]
     return selected
 

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -216,6 +216,28 @@ class AttachmentServiceTests(TestCase):
             [str(current.uuid)],
         )
 
+    def test_unrelated_follow_up_does_not_reuse_single_image(self):
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload("historical.png")
+        )
+        create_execution_run(
+            session=self.session,
+            question="Describe this image",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        run = create_execution_run(
+            session=self.session,
+            question="debian 可以支持agent模式吗",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            run.execution.runtime_snapshot["session_attachment_uuids"],
+            [],
+        )
+
     @patch("lens.services.model_supports_vision", return_value=True)
     def test_follow_up_reuses_previous_image(self, mock_support):
         attachment = store_message_attachment(
@@ -391,6 +413,71 @@ class AttachmentServiceTests(TestCase):
 
         self.assertEqual(context.exception.reason, "MODEL_NOT_VISION_CAPABLE")
         mock_call.assert_not_called()
+
+    @patch("lens.services.run_completion_multimodal")
+    @patch("litellm.utils.supports_vision", return_value=False)
+    def test_custom_gateway_vision_config_allows_unknown_model(
+        self, mock_support, mock_call
+    ):
+        config = LLMConfig.objects.create(
+            scope=LLMConfig.Scope.GLOBAL,
+            model_type=LLMConfig.MODEL_TYPE_LLM,
+            provider="openai_compatible",
+            config={
+                "api_key": "test",
+                "api_base": "https://gateway.example/v1",
+                "model": "custom-vision-model",
+                "vision": True,
+            },
+            is_active=True,
+        )
+        self.assistant.multimodal_model_ref = config.uuid
+        self.assistant.save(update_fields=["multimodal_model_ref"])
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload()
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Describe this image.",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+        mock_call.return_value = LensLLMResult(
+            content="A green image.", usage={}, metered=True
+        )
+
+        result = analyze_multimodal_intent(run)
+
+        self.assertEqual(result["status"], "succeeded")
+        mock_support.assert_not_called()
+        mock_call.assert_called_once()
+
+    def test_admin_run_detail_marks_inherited_attachment_context(self):
+        from lens.views.admin_runs import _admin_run_detail
+
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload("diagram.png")
+        )
+        direct = create_execution_run(
+            session=self.session,
+            question="Describe this image",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+        inherited = create_execution_run(
+            session=self.session,
+            question="What color is the previous image?",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            _admin_run_detail(direct)["attachments"][0]["source"],
+            "direct",
+        )
+        self.assertEqual(
+            _admin_run_detail(inherited)["attachments"][0]["source"],
+            "inherited",
+        )
 
     @patch("lens.services.model_supports_vision", return_value=True)
     @patch("lens.services.run_completion_multimodal")

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -190,6 +190,32 @@ class AttachmentServiceTests(TestCase):
         self.assertEqual(attachment.message_id, run.input_message_id)
         self.assertEqual(run.input_message.attachments.count(), 1)
 
+    def test_explicit_attachment_does_not_reuse_historical_images(self):
+        historical = store_message_attachment(
+            self.session, self.user, _png_upload("historical.png")
+        )
+        current = store_message_attachment(
+            self.session, self.user, _png_upload("current.png")
+        )
+        create_execution_run(
+            session=self.session,
+            question="Describe the historical image",
+            enqueue=False,
+            attachment_uuids=[str(historical.uuid)],
+        )
+
+        run = create_execution_run(
+            session=self.session,
+            question="请描述这张图片",
+            enqueue=False,
+            attachment_uuids=[str(current.uuid)],
+        )
+
+        self.assertEqual(
+            run.execution.runtime_snapshot["session_attachment_uuids"],
+            [str(current.uuid)],
+        )
+
     @patch("lens.services.model_supports_vision", return_value=True)
     def test_follow_up_reuses_previous_image(self, mock_support):
         attachment = store_message_attachment(

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -436,7 +436,14 @@ def _admin_run_detail(run):
             }
         steps.append(item)
     attachments = []
+    direct_attachment_uuids = set()
     if run.input_message:
+        direct_attachment_uuids = {
+            str(value)
+            for value in run.input_message.attachments.values_list(
+                "uuid", flat=True
+            )
+        }
         selected = (
             run.execution.runtime_snapshot or {}
         ).get("session_attachment_uuids", [])
@@ -461,6 +468,12 @@ def _admin_run_detail(run):
             fail_silently=True,
         )
     )
+    for attachment in attachments:
+        attachment["source"] = (
+            "direct"
+            if str(attachment.get("uuid")) in direct_attachment_uuids
+            else "inherited"
+        )
     output_files = RunOutputFileSerializer(
         run.output_files.all(), many=True
     ).data

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -36,6 +36,8 @@
     "detailTitle": "Run Trace",
     "question": "Question",
     "attachments": "Image Attachments",
+    "directAttachment": "Direct attachment",
+    "inheritedAttachment": "Inherited context",
     "visionQuery": "Image-derived query",
     "answer": "Answer",
     "error": "Error",
@@ -390,6 +392,7 @@
       "temperature": "Temperature",
       "topP": "Top P",
       "advancedOptions": "Advanced Options",
+      "visionCapability": "Confirmed vision input",
       "errors": {
         "invalid_api_key": "Invalid or expired API key. Please check and try again.",
         "auth_failed": "Authentication failed. Please check API key or account permissions.",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -36,6 +36,8 @@
     "detailTitle": "Run 完整追踪",
     "question": "问题",
     "attachments": "图片附件",
+    "directAttachment": "本次直接上传",
+    "inheritedAttachment": "历史上下文复用",
     "visionQuery": "图片识别结果",
     "answer": "回答",
     "error": "错误",
@@ -390,6 +392,7 @@
       "temperature": "Temperature",
       "topP": "Top P",
       "advancedOptions": "高级选项",
+      "visionCapability": "确认支持视觉输入",
       "errors": {
         "invalid_api_key": "API Key 无效或已过期，请检查后重试。",
         "auth_failed": "认证失败，请检查 API Key 或账号权限。",

--- a/frontend/src/admin/pages/LLM/Config.vue
+++ b/frontend/src/admin/pages/LLM/Config.vue
@@ -1004,6 +1004,14 @@
                   {{ parameterLabel(parameter) }}
                 </label>
                 <input
+                  v-if="parameter === 'vision'"
+                  type="checkbox"
+                  :checked="form.config[parameter] === true"
+                  class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                  @change="updateParameterValue(parameter, $event.target.checked)"
+                />
+                <input
+                  v-else
                   :value="form.config[parameter]"
                   :type="parameterInputType(parameter)"
                   :step="parameterInputStep(parameter)"
@@ -1108,6 +1116,7 @@ const COMMON_EDITABLE_PARAMS = [
   'top_p',
   'request_timeout_seconds'
 ]
+const CUSTOM_EDITABLE_PARAMS = [...COMMON_EDITABLE_PARAMS, 'vision']
 const GLOBAL_PARAM_DEFAULTS = {
   max_tokens: 16384,
   temperature: 0.7,
@@ -1119,6 +1128,7 @@ const PARAM_LABEL_KEYS = {
   deployment: 'deployment',
   max_tokens: 'maxOutputTokens',
   request_timeout_seconds: 'requestTimeoutSeconds',
+  vision: 'visionCapability',
   temperature: 'temperature',
   top_p: 'topP'
 }
@@ -1453,6 +1463,9 @@ function getRowCapabilities(row) {
 }
 
 function getProviderEditableParams(provider) {
+  if (provider === 'openai_compatible') {
+    return CUSTOM_EDITABLE_PARAMS
+  }
   const editableParams = providerSchemas.value[provider]?.editable_params
   if (Array.isArray(editableParams) && editableParams.length) {
     return editableParams
@@ -1537,6 +1550,10 @@ function parameterPlaceholder(parameter) {
 }
 
 function updateParameterValue(parameter, value) {
+  if (parameter === 'vision') {
+    form.config[parameter] = value === true
+    return
+  }
   if (value === '') {
     form.config[parameter] = null
     return

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -880,16 +880,27 @@
                     {{ t('lensRuns.attachments') }}
                   </h3>
                   <div class="flex flex-wrap gap-3">
-                    <AuthImage
+                    <div
                       v-for="img in detail.attachments.filter(
                         (item) => item.kind !== 'document'
                       )"
                       :key="img.uuid"
-                      :src="img.url"
-                      :alt="img.original_name || 'image'"
-                      class="run-attachment"
-                      zoomable
-                    />
+                      class="flex flex-col gap-1"
+                    >
+                      <AuthImage
+                        :src="img.url"
+                        :alt="img.original_name || 'image'"
+                        class="run-attachment"
+                        zoomable
+                      />
+                      <span class="text-xs text-gray-500">
+                        {{
+                          img.source === 'inherited'
+                            ? t('lensRuns.inheritedAttachment')
+                            : t('lensRuns.directAttachment')
+                        }}
+                      </span>
+                    </div>
                     <button
                       v-for="file in detail.attachments.filter(
                         (item) => item.kind === 'document'
@@ -906,6 +917,13 @@
                     >
                       <FileText :size="20" aria-hidden="true" />
                       <span>{{ file.original_name }}</span>
+                      <span class="text-xs text-gray-500">
+                        {{
+                          file.source === 'inherited'
+                            ? t('lensRuns.inheritedAttachment')
+                            : t('lensRuns.directAttachment')
+                        }}
+                      </span>
                       <Download :size="16" aria-hidden="true" />
                     </button>
                   </div>

--- a/release-notes/332.yaml
+++ b/release-notes/332.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed image questions so a newly uploaded image is not mixed with unrelated
+  images from earlier messages in the same conversation.
+zh-CN: >-
+  修复图片提问：新上传的图片不再与同一会话中早先消息的无关图片混用。


### PR DESCRIPTION
### **User description**
Fixes #331

## Summary
- Keep attachment snapshots empty for unrelated text-only turns, even when session history has one file.
- Preserve explicit UUID selection and intentional image/document follow-up reuse.
- Allow OpenAI-compatible custom vision models when the admin configuration explicitly confirms vision support, without relying on LiteLLM catalog metadata.
- Keep known text-only models rejected before provider calls.
- Mark Run Observation attachments as direct uploads or inherited context.

## Validation
- Backend: 529 tests passed.
- Attachment regressions: 29 tests passed.
- Frontend unit tests: 320 tests passed.
- Frontend production build passed.
- Browser verification passed at http://localhost:8000.
- Branch is based on the latest origin/main with no merge conflict.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix vision capability detection for custom models

- Prevent unintended historical attachment reuse

- Add admin UI indicators for direct/inherited attachments

- Add tests for attachment selection and vision


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User question"] --> B{"Attachments submitted?"}
  B -->|Yes| C["Use only explicit attachments"]
  B -->|No| D{"Historical attachments?"}
  D -->|Yes| E{"Explicit reference?"}
  E -->|Yes| F["Inherit most recent compatible"]
  E -->|No| G["No attachments"]
  D -->|No| G
  C --> H["Check vision capability"]
  H --> I{"Vision declared?"}
  I -->|Yes| J["Allow multimodal call"]
  I -->|No| K{"LiteLLM supports?"}
  K -->|Yes| J
  K -->|No| L["Reject unknown model"]
  J --> M["Run multimodal"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>execution.py</strong><dd><code>Fix snapshot retrieval from RunExecution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-7cef6eaf866533349878e22f422222cf01e55ed2affb461d5b362c0a4aa9f6b6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>llm.py</strong><dd><code>Add declared vision check for custom models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-7722c4a2d73c65189a6cf1d54b44c5955512e6242da38224e02ef2e8651defd0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Remove single historical attachment fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+12/-13</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_attachments.py</strong><dd><code>Add tests for attachment selection and vision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+113/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>admin_runs.py</strong><dd><code>Add source attribution to attachments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Config.vue</strong><dd><code>Add vision checkbox for custom providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-32907cbb8be834499463827fd828d8890752a1aa2465e88c4b1579506252e4f9">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RunObservation.vue</strong><dd><code>Display attachment source labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+24/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add i18n keys for attachment sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add i18n keys for attachment sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>332.yaml</strong><dd><code>Add release note for fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/332/files#diff-37706b21355a52d33749b0bcfd3387376d24fcaf7e7cc285af01411cd5062408">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

