### PR TITLE
Fix tablet chat viewport constraints

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="lens-chat-page qa-screen-view" :style="mobileViewportStyle">
+  <div
+    class="lens-chat-page qa-screen-view"
+    :class="{
+      'visual-viewport-constrained': visualViewportConstrained
+    }"
+    :style="mobileViewportStyle"
+  >
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"
@@ -1565,6 +1571,7 @@ import {
 } from '@/pages/lens/chatMessageContext'
 import { prepareRunSubmission } from '@/pages/lens/chatSubmission'
 import { promptSuggestionKeys } from '@/pages/lens/chatPromptSuggestions'
+import { resolveChatViewport } from '@/pages/lens/chatViewport'
 import { compactFilename } from '@/pages/lens/filenameDisplay'
 import {
   ATTACHMENT_ACCEPT,
@@ -1663,6 +1670,7 @@ const renameDraft = ref('')
 const composerRef = ref(null)
 const scrollRef = ref(null)
 const mobileViewportStyle = ref({})
+const visualViewportConstrained = ref(false)
 const seenStepEventCounts = new Map()
 let sessionLoadGeneration = 0
 const runtimeState = ref(createRuntimeState())
@@ -2446,13 +2454,20 @@ function scrollToBottom() {
 
 function syncMobileViewport() {
   const viewport = window.visualViewport
-  if (!viewport || window.innerWidth >= 1024) {
+  const resolved = resolveChatViewport({
+    layoutHeight: window.innerHeight,
+    viewportHeight: viewport?.height,
+    viewportOffsetTop: viewport?.offsetTop,
+    viewportScale: viewport?.scale
+  })
+  visualViewportConstrained.value = resolved.constrained
+  if (!viewport) {
     mobileViewportStyle.value = {}
     return
   }
   mobileViewportStyle.value = {
-    '--chat-viewport-height': `${viewport.height}px`,
-    '--chat-viewport-offset-top': `${viewport.offsetTop}px`
+    '--chat-viewport-height': `${resolved.height}px`,
+    '--chat-viewport-offset-top': `${resolved.offsetTop}px`
   }
 }
 
@@ -3732,6 +3747,18 @@ onBeforeUnmount(() => {
   @apply flex h-screen w-full overflow-hidden;
   background: var(--sl-bg-surface);
   color: var(--sl-text-primary);
+}
+
+.lens-chat-page.visual-viewport-constrained {
+  position: fixed;
+  top: var(--chat-viewport-offset-top, 0px);
+  right: 0;
+  bottom: auto;
+  left: 0;
+  width: 100%;
+  height: var(--chat-viewport-height, 100dvh);
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 .sidebar {

--- a/frontend/src/pages/lens/chatViewport.js
+++ b/frontend/src/pages/lens/chatViewport.js
@@ -1,0 +1,25 @@
+const VIEWPORT_TOLERANCE = 1
+const SCALE_TOLERANCE = 0.01
+
+export function resolveChatViewport({
+  layoutHeight,
+  viewportHeight,
+  viewportOffsetTop,
+  viewportScale
+}) {
+  const hasViewport = Number.isFinite(viewportHeight) && viewportHeight > 0
+  const height = hasViewport ? viewportHeight : null
+  const offsetTop = Number.isFinite(viewportOffsetTop) ? viewportOffsetTop : 0
+  const scale = Number.isFinite(viewportScale) ? viewportScale : 1
+  const isZoomed = Math.abs(scale - 1) > SCALE_TOLERANCE
+  const heightReduced =
+    Number.isFinite(layoutHeight) &&
+    layoutHeight - viewportHeight > VIEWPORT_TOLERANCE
+  const viewportPanned = offsetTop > VIEWPORT_TOLERANCE
+
+  return {
+    constrained: hasViewport && !isZoomed && (heightReduced || viewportPanned),
+    height,
+    offsetTop
+  }
+}

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -201,12 +201,14 @@ test('tracks the visual viewport so keyboard panning keeps the thread top reacha
 
   assert.match(
     source,
-    /class="lens-chat-page qa-screen-view"\s+:style="mobileViewportStyle"/
+    /class="lens-chat-page qa-screen-view"[\s\S]*?'visual-viewport-constrained': visualViewportConstrained[\s\S]*?:style="mobileViewportStyle"/
   )
-  assert.match(source, /'--chat-viewport-height': `\$\{viewport\.height\}px`/)
+  assert.match(source, /resolveChatViewport\(\{[\s\S]*?layoutHeight:/)
+  assert.doesNotMatch(source, /window\.innerWidth >= 1024/)
+  assert.match(source, /'--chat-viewport-height': `\$\{resolved\.height\}px`/)
   assert.match(
     source,
-    /'--chat-viewport-offset-top': `\$\{viewport\.offsetTop\}px`/
+    /'--chat-viewport-offset-top': `\$\{resolved\.offsetTop\}px`/
   )
   assert.match(
     source,
@@ -219,6 +221,10 @@ test('tracks the visual viewport so keyboard panning keeps the thread top reacha
   assert.match(
     source,
     /@media \(max-width: 1023px\) \{[\s\S]*?\.lens-chat-page \{[\s\S]*?position: fixed;[\s\S]*?top: var\(--chat-viewport-offset-top, 0px\);[\s\S]*?right: 0;[\s\S]*?bottom: auto;[\s\S]*?left: 0;[\s\S]*?height: var\(--chat-viewport-height, 100dvh\);[\s\S]*?overflow: hidden;[\s\S]*?overscroll-behavior: none;/
+  )
+  assert.match(
+    source,
+    /\.lens-chat-page\.visual-viewport-constrained \{[\s\S]*?position: fixed;[\s\S]*?top: var\(--chat-viewport-offset-top, 0px\);[\s\S]*?height: var\(--chat-viewport-height, 100dvh\);/
   )
 })
 

--- a/frontend/tests/chatViewport.test.js
+++ b/frontend/tests/chatViewport.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveChatViewport } from '../src/pages/lens/chatViewport.js'
+
+test('leaves a full desktop visual viewport unconstrained', () => {
+  assert.deepEqual(
+    resolveChatViewport({
+      layoutHeight: 1024,
+      viewportHeight: 1024,
+      viewportOffsetTop: 0,
+      viewportScale: 1
+    }),
+    {
+      constrained: false,
+      height: 1024,
+      offsetTop: 0
+    }
+  )
+})
+
+test('constrains an iPad landscape viewport reduced by browser chrome', () => {
+  assert.deepEqual(
+    resolveChatViewport({
+      layoutHeight: 834,
+      viewportHeight: 734,
+      viewportOffsetTop: 0,
+      viewportScale: 1
+    }),
+    {
+      constrained: true,
+      height: 734,
+      offsetTop: 0
+    }
+  )
+})
+
+test('constrains an Android tablet viewport reduced by its keyboard', () => {
+  assert.deepEqual(
+    resolveChatViewport({
+      layoutHeight: 800,
+      viewportHeight: 480,
+      viewportOffsetTop: 24,
+      viewportScale: 1
+    }),
+    {
+      constrained: true,
+      height: 480,
+      offsetTop: 24
+    }
+  )
+})
+
+test('ignores viewport reduction caused by pinch zoom', () => {
+  assert.deepEqual(
+    resolveChatViewport({
+      layoutHeight: 834,
+      viewportHeight: 556,
+      viewportOffsetTop: 18,
+      viewportScale: 1.5
+    }),
+    {
+      constrained: false,
+      height: 556,
+      offsetTop: 18
+    }
+  )
+})
+
+test('returns no viewport constraint when the API is unavailable', () => {
+  assert.deepEqual(
+    resolveChatViewport({
+      layoutHeight: 834,
+      viewportHeight: undefined,
+      viewportOffsetTop: undefined,
+      viewportScale: undefined
+    }),
+    {
+      constrained: false,
+      height: null,
+      offsetTop: 0
+    }
+  )
+})

--- a/release-notes/333.yaml
+++ b/release-notes/333.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed tablet chat layouts so the composer stays visible when browser chrome
+  or the on-screen keyboard reduces the available viewport.
+zh-CN: >-
+  修复平板端聊天布局：浏览器工具栏或屏幕键盘压缩可视区域时，输入框仍保持可见。


### PR DESCRIPTION
### **User description**
## Summary
- constrain the chat shell when an unzoomed visual viewport is reduced or panned, independent of the responsive breakpoint
- keep iPad and Android tablet composers visible while preserving full desktop viewports and pinch zoom behavior
- add focused viewport tests and a bilingual user-facing release note

Closes #333

## Test plan
- [x] `npm run test:unit` (325 tests)
- [x] focused ESLint for the changed Vue, JavaScript, and test files
- [x] `npm run build`
- [x] `python -m unittest scripts.test_release_notes` with Python 3.12 and PyYAML (6 tests)
- [x] validate the PR release-note fragment
- [x] verify iPad, Android tablet, and desktop viewport flows in ego-browser task space 21


___

### **PR Type**
Bug fix


___

### **Description**
- Extract viewport constraint to dedicated module

- Remove breakpoint-based viewport limitation

- Add unit tests for viewport resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  visualViewport["visualViewport API"] --> resolveChatViewport["resolveChatViewport"]
  resolveChatViewport --> constrained{"Is constrained?"}
  constrained -- "Yes" --> applyCSS["Apply .visual-viewport-constrained"]
  constrained -- "No" --> clearCSS["Clear constraints"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Integrate viewport resolution into chat page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Replaced inline viewport logic with <code>resolveChatViewport</code> call<br> <li> Added <code>visualViewportConstrained</code> ref and CSS class for fixed <br>positioning<br> <li> Removed 1024px breakpoint condition; now applies to any reduced <br>viewport</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/334/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+31/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatViewport.js</strong><dd><code>Create dedicated viewport constraint logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatViewport.js

<ul><li>New module <code>resolveChatViewport</code> that determines constraint state<br> <li> Excludes pinch zoom by checking scale tolerance<br> <li> Returns height, offsetTop, and constrained flag</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/334/files#diff-b1913a297f4935a6ee49fb5e18cdc4fb9b99c65fa0deb61aa7539ab897d58259">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatViewport.test.js</strong><dd><code>Add unit tests for viewport resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatViewport.test.js

<ul><li>Unit tests for <code>resolveChatViewport</code> covering desktop, iPad, Android, <br>zoom, and API unavailability</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/334/files#diff-8e81b3c18b03e2f054d1693e6cfe2356ab98aa6253714367312df2d3b8264101">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Update existing test for viewport changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

- Updated assertions to match new viewport logic and CSS class


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/334/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>333.yaml</strong><dd><code>Add release note for tablet viewport fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/333.yaml

- Added bilingual release note for the fix


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/334/files#diff-5c310b53e548278a333eb930c5633a2bdbe64e83006bc6378f94256873468f1c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

