### PR TITLE
Preserve assistant session across admin navigation

### DIFF
--- a/frontend/e2e/admin-chat-return.spec.js
+++ b/frontend/e2e/admin-chat-return.spec.js
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test'
+
+const assistants = [
+  { uuid: 'assistant-alpha', slug: 'alpha', name: 'Alpha', status: 'active' },
+  { uuid: 'assistant-beta', slug: 'beta', name: 'Beta', status: 'active' },
+  { uuid: 'assistant-gamma', slug: 'gamma', name: 'Gamma', status: 'active' }
+]
+
+async function mockAdminChat(page, { missingSession = false } = {}) {
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'test-token')
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const path = new URL(request.url()).pathname
+    if (path === '/api/lens/sessions/' && request.method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            uuid: 'replacement-session',
+            title: '',
+            assistant_slug: 'alpha',
+            status: 'active'
+          }
+        })
+      })
+      return
+    }
+
+    const payloads = {
+      '/api/v1/auth/user': {
+        username: 'admin',
+        is_staff: true,
+        features: ['workspace'],
+        permissions: []
+      },
+      '/api/lens/assistants/': assistants,
+      '/api/lens/shares/': [],
+      '/api/lens/sessions/': missingSession
+        ? []
+        : [{ uuid: 'alpha-session', title: 'Alpha history' }],
+      '/api/lens/sessions/alpha-session/messages/': [
+        { uuid: 'message-1', role: 'user', content: 'Keep this history' }
+      ],
+      '/api/lens/sessions/replacement-session/messages/': [],
+      '/api/v1/management/users/': []
+    }
+
+    const payload = payloads[path] ?? []
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ data: payload })
+    })
+  })
+}
+
+test('returning from admin restores the current assistant and session', async ({
+  page
+}) => {
+  await mockAdminChat(page)
+  await page.goto('/lens/assistants/alpha/chat?session=alpha-session')
+
+  await page.getByRole('button', { name: '切换助手' }).click()
+  await page.getByRole('button', { name: 'Beta' }).click()
+  await expect(page).toHaveURL(/\/lens\/assistants\/beta\/chat/)
+  await page.getByRole('button', { name: '切换助手' }).click()
+  await page.getByRole('button', { name: 'Gamma' }).click()
+  await expect(page).toHaveURL(/\/lens\/assistants\/gamma\/chat/)
+  await page.getByRole('button', { name: '切换助手' }).click()
+  await page.getByRole('button', { name: 'Alpha' }).click()
+  await expect(page).toHaveURL(/\/lens\/assistants\/alpha\/chat/)
+  await expect(page.getByText('Keep this history')).toBeVisible()
+  await page.locator('.dock-trigger').click()
+  await page.getByText('Admin Console', { exact: true }).click()
+  await expect(page).toHaveURL(/\/management\/users/)
+
+  await page.getByRole('link', { name: 'Back to Assistant' }).click()
+  await expect(page).toHaveURL(
+    /\/lens\/assistants\/alpha\/chat\?session=alpha-session/
+  )
+  await expect(page.getByText('Keep this history')).toBeVisible()
+})
+
+test('a missing preserved session creates a session for the same assistant', async ({
+  page
+}) => {
+  await mockAdminChat(page, { missingSession: true })
+  await page.goto('/lens/assistants/alpha/chat?session=deleted-session')
+
+  await expect(page).toHaveURL(
+    /\/lens\/assistants\/alpha\/chat\?session=replacement-session/
+  )
+  await expect(page).not.toHaveURL(/\/lens\/assistants\/beta|gamma/)
+})

--- a/frontend/e2e/admin-chat-return.spec.js
+++ b/frontend/e2e/admin-chat-return.spec.js
@@ -6,7 +6,12 @@ const assistants = [
   { uuid: 'assistant-gamma', slug: 'gamma', name: 'Gamma', status: 'active' }
 ]
 
-async function mockAdminChat(page, { missingSession = false } = {}) {
+async function mockAdminChat(
+  page,
+  { deleteSessionOnAdminNavigation = false } = {}
+) {
+  let sessionDeleted = false
+
   await page.addInitScript(() => {
     localStorage.setItem('access_token', 'test-token')
   })
@@ -14,6 +19,12 @@ async function mockAdminChat(page, { missingSession = false } = {}) {
   await page.route('**/api/**', async (route) => {
     const request = route.request()
     const path = new URL(request.url()).pathname
+    if (
+      deleteSessionOnAdminNavigation &&
+      path === '/api/v1/management/users/'
+    ) {
+      sessionDeleted = true
+    }
     if (path === '/api/lens/sessions/' && request.method() === 'POST') {
       await route.fulfill({
         status: 201,
@@ -39,7 +50,7 @@ async function mockAdminChat(page, { missingSession = false } = {}) {
       },
       '/api/lens/assistants/': assistants,
       '/api/lens/shares/': [],
-      '/api/lens/sessions/': missingSession
+      '/api/lens/sessions/': sessionDeleted
         ? []
         : [{ uuid: 'alpha-session', title: 'Alpha history' }],
       '/api/lens/sessions/alpha-session/messages/': [
@@ -84,11 +95,17 @@ test('returning from admin restores the current assistant and session', async ({
   await expect(page.getByText('Keep this history')).toBeVisible()
 })
 
-test('a missing preserved session creates a session for the same assistant', async ({
+test('a deleted session is replaced after returning from admin', async ({
   page
 }) => {
-  await mockAdminChat(page, { missingSession: true })
-  await page.goto('/lens/assistants/alpha/chat?session=deleted-session')
+  await mockAdminChat(page, { deleteSessionOnAdminNavigation: true })
+  await page.goto('/lens/assistants/alpha/chat?session=alpha-session')
+  await expect(page.getByText('Keep this history')).toBeVisible()
+  await page.locator('.dock-trigger').click()
+  await page.getByText('Admin Console', { exact: true }).click()
+  await expect(page).toHaveURL(/\/management\/users/)
+
+  await page.getByRole('link', { name: 'Back to Assistant' }).click()
 
   await expect(page).toHaveURL(
     /\/lens\/assistants\/alpha\/chat\?session=replacement-session/

--- a/frontend/src/admin/layout/AdminHeader.vue
+++ b/frontend/src/admin/layout/AdminHeader.vue
@@ -41,7 +41,8 @@
             <LanguageSwitcher variant="dark" />
           </div>
           <router-link
-            to="/"
+            :to="assistantReturnPath"
+            @click="clearAssistantReturnPath"
             :aria-label="t('management.backToUserPlatform')"
             class="flex min-h-11 min-w-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-slate-600 bg-slate-800 px-2 py-2 text-sm font-medium text-slate-100 shadow-sm transition-colors hover:border-slate-500 hover:bg-slate-700 sm:px-3"
           >
@@ -171,6 +172,10 @@ import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/store/user'
 import { useUiStore } from '@/store/ui'
 import LanguageSwitcher from '@/components/ui/LanguageSwitcher.vue'
+import {
+  consumeAdminReturnPath,
+  getAdminReturnPath
+} from '@/utils/platformAccess'
 
 defineProps({
   showMobileMenu: {
@@ -186,6 +191,11 @@ const route = useRoute()
 const router = useRouter()
 const userStore = useUserStore()
 const uiStore = useUiStore()
+const assistantReturnPath = ref(getAdminReturnPath())
+
+const clearAssistantReturnPath = () => {
+  consumeAdminReturnPath()
+}
 
 const showUserMenu = ref(false)
 const userMenuRef = ref(null)

--- a/frontend/src/admin/layout/AdminSidebar.vue
+++ b/frontend/src/admin/layout/AdminSidebar.vue
@@ -1033,9 +1033,9 @@
 
       <div class="mt-auto border-t border-ink-800 pt-4">
         <router-link
-          to="/"
+          :to="assistantReturnPath"
           class="admin-nav-item"
-          @click="isMobile && $emit('close')"
+          @click="clearAssistantReturnPath"
           @mouseenter="preloadRoute('/')"
         >
           <svg
@@ -1066,6 +1066,10 @@ import BrandLogo from '@/components/layout/BrandLogo.vue'
 import { useIsMobile } from '@/composables/useIsMobile'
 import { useUiStore } from '@/store/ui'
 import { useUserStore } from '@/store/user'
+import {
+  consumeAdminReturnPath,
+  getAdminReturnPath
+} from '@/utils/platformAccess'
 
 defineProps({
   showMobileMenu: {
@@ -1074,13 +1078,19 @@ defineProps({
   }
 })
 
-defineEmits(['close'])
+const emit = defineEmits(['close'])
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const uiStore = useUiStore()
 const userStore = useUserStore()
+const assistantReturnPath = ref(getAdminReturnPath())
+
+const clearAssistantReturnPath = () => {
+  consumeAdminReturnPath()
+  if (isMobile.value) emit('close')
+}
 
 const navigation = ref(null)
 const userManagementMenuOpen = ref(true)

--- a/frontend/src/components/layout/SidebarQuickMenu.vue
+++ b/frontend/src/components/layout/SidebarQuickMenu.vue
@@ -73,7 +73,7 @@
             <router-link
               to="/management/users"
               class="quick-menu-link"
-              @click="open = false"
+              @click="openAdminConsole"
             >
               <span class="truncate">{{ t('platforms.adminConsole') }}</span>
             </router-link>
@@ -108,7 +108,8 @@ import { useUserStore } from '@/store/user'
 import {
   getAvailablePlatforms,
   getCurrentPlatformKey,
-  getPlatformByKey
+  getPlatformByKey,
+  saveAdminReturnPath
 } from '@/utils/platformAccess'
 
 const { t } = useI18n()
@@ -161,6 +162,11 @@ const currentPlatformLabel = computed(() => {
 
 const toggleMenu = () => {
   open.value = !open.value
+}
+
+const openAdminConsole = () => {
+  saveAdminReturnPath(route.fullPath)
+  open.value = false
 }
 
 const openSettings = () => {

--- a/frontend/src/components/lens/UserDock.vue
+++ b/frontend/src/components/lens/UserDock.vue
@@ -60,7 +60,7 @@
           <router-link
             to="/management/users"
             class="dock-link"
-            @click="dockMenuOpen = false"
+            @click="openAdminConsole"
           >
             <Shield :size="18" :stroke-width="2" aria-hidden="true" />
             <span class="truncate">{{ t('platforms.adminConsole') }}</span>
@@ -104,6 +104,7 @@ import { LogIn, LogOut, Settings, Share2, Shield } from '@lucide/vue'
 
 import { useUserStore } from '@/store/user'
 import { useUiStore } from '@/store/ui'
+import { saveAdminReturnPath } from '@/utils/platformAccess'
 
 defineProps({
   collapsed: { type: Boolean, default: false },
@@ -161,6 +162,11 @@ const avatarBgColor = computed(() => {
 
 function openMyShares() {
   emit('open-my-shares')
+  dockMenuOpen.value = false
+}
+
+function openAdminConsole() {
+  saveAdminReturnPath(router.currentRoute.value.fullPath)
   dockMenuOpen.value = false
 }
 

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2583,14 +2583,8 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
     requestedUuid &&
     !sessions.value.some((session) => session.uuid === requestedUuid)
   ) {
-    showError(t('lens.chat.sessionAccessDenied'))
-    targetUuid = sessions.value[0]?.uuid
-    if (targetUuid) {
-      router.replace({
-        path: route.path,
-        query: { session: targetUuid }
-      })
-    }
+    const replacement = await createNewSession(false)
+    targetUuid = replacement?.uuid || ''
   }
   if (targetUuid) {
     await selectSession({ uuid: targetUuid })

--- a/frontend/src/utils/platformAccess.js
+++ b/frontend/src/utils/platformAccess.js
@@ -19,6 +19,24 @@ export const FEATURE_DEFINITIONS = [
   }
 ]
 
+const ADMIN_RETURN_PATH_KEY = 'sourcelens.adminReturnPath'
+
+export function saveAdminReturnPath(path) {
+  if (!path || !path.startsWith('/')) return
+  window.sessionStorage.setItem(ADMIN_RETURN_PATH_KEY, path)
+}
+
+export function getAdminReturnPath() {
+  const path = window.sessionStorage.getItem(ADMIN_RETURN_PATH_KEY)
+  return path && path.startsWith('/') ? path : '/'
+}
+
+export function consumeAdminReturnPath() {
+  const path = getAdminReturnPath()
+  window.sessionStorage.removeItem(ADMIN_RETURN_PATH_KEY)
+  return path
+}
+
 export const FEATURE_KEY_SET = new Set(
   FEATURE_DEFINITIONS.map((item) => item.key)
 )

--- a/release-notes/335.yaml
+++ b/release-notes/335.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed admin-console navigation so returning to chat preserves the active
+  assistant, session, and conversation history.
+zh-CN: >-
+  修复管理台导航：返回聊天页面时保留当前助手、会话和对话历史。


### PR DESCRIPTION
### **User description**
Closes #335

### **PR Type**
Enhancement, Bug fix

### **Description**

- Save assistant route before admin navigation.
- Restore assistant and session on return.
- Create new session if preserved session is missing.
- Add e2e tests for admin return flow.

### **Review Notes**

- No backend API, database schema, migration, or authorization behavior is changed.
- The return path is stored in sessionStorage and consumed after returning to the assistant interface.
- Direct entry to the admin console keeps the existing default behavior.
- The focused Playwright E2E file is included, but was not successfully executed in the canonical runtime because of a worktree/runtime mismatch.

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Admin Console Entry"] -- "save path" --> B["Admin page"]
  B -- "Back to Assistant" --> C["Consume path"]
  C -- "Restore session" --> D["Chat with same assistant"]
```

### File Walkthrough

| Area | Files | Change |
| --- | --- | --- |
| Navigation state | `frontend/src/utils/platformAccess.js` | Store, retrieve, and consume the admin return path. |
| Admin navigation | `frontend/src/admin/layout/AdminHeader.vue` | Return to the preserved assistant conversation. |
| Admin navigation | `frontend/src/admin/layout/AdminSidebar.vue` | Restore the preserved conversation from the sidebar. |
| Platform entry points | `frontend/src/components/layout/SidebarQuickMenu.vue` | Save the current chat path before opening the admin console. |
| Platform entry points | `frontend/src/components/lens/UserDock.vue` | Save the current chat path before opening the admin console. |
| Session recovery | `frontend/src/pages/lens/Chat.vue` | Create a replacement session for the same assistant when needed. |
| Browser tests | `frontend/e2e/admin-chat-return.spec.js` | Cover assistant switching, admin round trips, history preservation, and missing-session recovery. |
| Release note | `release-notes/335.yaml` | Document the user-visible navigation fix. |


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Save assistant route before admin navigation.

- Restore assistant and session on return.

- Create new session if preserved session missing.

- Add e2e tests for admin return flow.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Admin Console Entry"] -->|"save path"| B["Admin page"]
  B -->|"Back to Assistant"| C["Consume path"]
  C -->|"Restore session"| D["Chat with same assistant"]
  C -->|"Session missing"| E["Create new session"]
  E --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>platformAccess.js</strong><dd><code>Add admin return path utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-f5d31b5caff49be234f09b35887bb84bd0ec40216e91b65d232ddea053d9643b">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AdminHeader.vue</strong><dd><code>Use preserved return path in header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-72b027d627396e485c9cc13fc1b63078364fa57d249b1af9b940fef26d8e5334">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AdminSidebar.vue</strong><dd><code>Use preserved return path in sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-68245495c461d476760afe3a8f4ca43037fde7fb7ad1a6e64bdc24b2c67dc8e1">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarQuickMenu.vue</strong><dd><code>Save current path before admin navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-a9643e06699a868da4933fb08db868d59085202793f8cd19ef5664d3885c6af5">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserDock.vue</strong><dd><code>Save current path before admin navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-3af2b7b57c4fd4db8ba89ac090e204a86783c9801d13d30ff6cb164a5612a512">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Chat.vue</strong><dd><code>Create new session when preserved session missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>admin-chat-return.spec.js</strong><dd><code>Add e2e tests for admin return flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-d1b1cd93440699ae5c2ae4a591b56a14af3591380c5e032be19cd83823f7f626">+114/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>335.yaml</strong><dd><code>Add release note for admin navigation fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/337/files#diff-b1d35f315c2c8d6fffd578036615948f650ff0671a11ae64371771f0eed6f875">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

