### PR TITLE
Allow users to switch AI answer language within a session

### DIFF
--- a/backend/lens/execution.py
+++ b/backend/lens/execution.py
@@ -16,6 +16,7 @@ from .services import (
     dispatch_run_to_lensnode,
     finish_lensnode_run,
     rewrite_query,
+    resolve_run_answer_language,
     validate_run_dispatch,
 )
 
@@ -155,7 +156,14 @@ def _lensnode_dispatch(state):
     if has_documents and not (question or "").strip():
         question = _document_analysis_prompt(run)
     with run_step(run, RunStep.StepType.RETRIEVAL, 1) as step:
-        execution = create_run_execution_snapshot(run)
+        execution = create_run_execution_snapshot(
+            run,
+            answer_language=resolve_run_answer_language(
+                run.session,
+                run.input_message.content,
+                run.retry_of_run,
+            ),
+        )
         execution.loaded_skills = build_loaded_skills(assistant)
         execution.save(update_fields=["loaded_skills"])
         validate_run_dispatch(run)

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -794,6 +794,95 @@ def select_session_attachment_context(session, question, explicit_uuids=None):
     return selected
 
 
+def _explicit_answer_language(question):
+    """Return the language explicitly requested by the current message."""
+
+    text = str(question or "").strip().lower()
+    if not text:
+        return None
+    chinese_request = re.search(
+        r"(?:用|使用|切换到|切換到|改用|改成|请用|請用)"
+        r"(?:简体中文|簡體中文|中文|普通话|普通話)"
+        r"(?:回答|回复|回覆|作答|答复|答覆)?",
+        text,
+    )
+    if chinese_request and re.search(
+        r"(?:回答|回复|回覆|作答|答复|答覆|语言|語言)|^请|^請",
+        text,
+    ):
+        return "zh-CN"
+    chinese_english_request = re.search(
+        r"(?:用|使用|切换到|切換到|改用|改成|请用|請用)"
+        r"(?:英文|英语|英語)"
+        r"(?:回答|回复|回覆|作答|答复|答覆)?",
+        text,
+    )
+    if chinese_english_request:
+        return "en-US"
+    english_request = re.search(
+        r"(?:answer|respond|reply|write|speak|use|switch)"
+        r"(?:\s+(?:in|to))?\s+(?:english|en-us|en)\b",
+        text,
+    )
+    if english_request:
+        return "en-US"
+    english_chinese_request = re.search(
+        r"(?:answer|respond|reply|write|speak|use|switch)"
+        r"(?:\s+(?:in|to))?\s+(?:chinese|simplified chinese|中文)",
+        text,
+    )
+    if english_chinese_request:
+        return "zh-CN"
+    return None
+
+
+def _latest_session_answer_language(session):
+    """Return the latest resolved language stored for a Session."""
+
+    latest_run = (
+        Run.objects.filter(session=session)
+        .select_related("execution")
+        .order_by("-input_message__sequence", "-pk")
+        .first()
+    )
+    if latest_run is None:
+        return None
+    try:
+        execution = latest_run.execution
+    except RunExecution.DoesNotExist:
+        execution = None
+    if execution is None:
+        return None
+    snapshot = execution.runtime_snapshot or {}
+    return snapshot.get("answer_language")
+
+
+def resolve_run_answer_language(session, question, retry_of_run=None):
+    """Resolve one Run language without allowing context to override intent."""
+
+    if retry_of_run is not None:
+        try:
+            execution = retry_of_run.execution
+        except RunExecution.DoesNotExist:
+            execution = None
+        if execution is not None:
+            snapshot = execution.runtime_snapshot or {}
+            retry_language = snapshot.get("answer_language")
+            if retry_language:
+                return normalize_answer_language(retry_language)
+
+    explicit_language = _explicit_answer_language(question)
+    if explicit_language:
+        return explicit_language
+
+    session_language = _latest_session_answer_language(session)
+    if session_language:
+        return normalize_answer_language(session_language)
+
+    profile = getattr(session.user, "profile", None)
+    return normalize_answer_language(getattr(profile, "language", None))
+
+
 @transaction.atomic
 def create_execution_run(
     session,
@@ -809,6 +898,12 @@ def create_execution_run(
     assistant = lock_assistant_for_new_work(session.assistant, user)
     session = lock_active_session(session)
     session.assistant = assistant
+
+    answer_language = resolve_run_answer_language(
+        session,
+        question,
+        retry_of_run,
+    )
 
     if idempotency_key:
         existing = (
@@ -862,7 +957,7 @@ def create_execution_run(
     )
     input_message.run = run
     input_message.save(update_fields=["run"])
-    create_run_execution_snapshot(run)
+    create_run_execution_snapshot(run, answer_language=answer_language)
     requested_attachment_uuids = [
         str(value) for value in (attachment_uuids or [])
     ]
@@ -1384,14 +1479,14 @@ def run_timeout_for_rounds(agent_rounds):
 
 
 @transaction.atomic
-def create_run_execution_snapshot(run):
+def create_run_execution_snapshot(run, answer_language=None):
     """Create or return the per-run LensNode execution snapshot."""
 
     assistant = run.session.assistant
     token_budget = token_budget_for_profile(assistant.token_budget_profile)
     profile = getattr(run.session.user, "profile", None)
     answer_language = normalize_answer_language(
-        getattr(profile, "language", None)
+        answer_language or getattr(profile, "language", None)
     )
     runtime_snapshot = _build_run_runtime_snapshot(
         assistant,

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -154,6 +154,83 @@ class LensServiceTests(TransactionTestCase):
                     timeout_s,
                 )
 
+    def test_explicit_language_request_overrides_profile_language(self):
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
+
+        run = create_execution_run(
+            session=self.session,
+            question="请用中文回答，可以吗？",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            run.execution.runtime_snapshot["answer_language"],
+            "zh-CN",
+        )
+
+    def test_follow_up_inherits_latest_resolved_language(self):
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
+        first = create_execution_run(
+            session=self.session,
+            question="Please answer in Chinese.",
+            enqueue=False,
+        )
+
+        follow_up = create_execution_run(
+            session=self.session,
+            question="继续",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            first.execution.runtime_snapshot["answer_language"],
+            "zh-CN",
+        )
+        self.assertEqual(
+            follow_up.execution.runtime_snapshot["answer_language"],
+            "zh-CN",
+        )
+
+    def test_retry_inherits_original_run_language(self):
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
+        original = create_execution_run(
+            session=self.session,
+            question="请用中文回答。",
+            enqueue=False,
+        )
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
+
+        retry = create_execution_run(
+            session=self.session,
+            question="Retry this answer in English.",
+            retry_of_run=original,
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            retry.execution.runtime_snapshot["answer_language"],
+            "zh-CN",
+        )
+
+    def test_unrelated_message_language_does_not_override_profile(self):
+        self.user.profile.language = "en-US"
+        self.user.profile.save(update_fields=["language"])
+
+        run = create_execution_run(
+            session=self.session,
+            question="请分析这份中文文档。",
+            enqueue=False,
+        )
+
+        self.assertEqual(
+            run.execution.runtime_snapshot["answer_language"],
+            "en-US",
+        )
+
     def test_timeout_migration_backfills_from_current_assistant(self):
         self.assistant.agent_rounds = Assistant.AgentRounds.MAX
         self.assistant.save(update_fields=["agent_rounds"])

--- a/release-notes/321.yaml
+++ b/release-notes/321.yaml
@@ -1,0 +1,8 @@
+type: improvement
+audience: user
+en: >-
+  Users can now explicitly switch the AI answer language within an existing
+  conversation, while follow-ups and retries preserve the resolved language.
+zh-CN: >-
+  用户现在可以在现有会话中明确切换 AI 回答语言，后续追问和重试会保持已解析的
+  回答语言。


### PR DESCRIPTION
### **User description**
## Summary

Allow users to explicitly switch the AI answer language within an existing session. The resolved language is preserved per Run so follow-ups, retries, titles, diagnostics, and LensNode dispatch remain consistent.

## Changes

- Detect explicit English and Chinese answer-language requests in the current user message.
- Inherit the latest resolved session language for short follow-ups.
- Preserve the original Run language when creating retries.
- Store the resolved language in the Run execution snapshot.
- Recreate legacy snapshots with the same language-resolution policy.
- Add regression coverage for switching, inheritance, retry stability, and unrelated source-language content.

## Testing

- [x] Backend pytest: 564 passed, 42 subtests passed
- [x] Frontend production build
- [x] Python compilation
- [x] `git diff --check`
- [x] ego-browser verified an explicit Chinese language request returns a Chinese answer

Closes #321


___

### **PR Type**
Enhancement


___

### **Description**
- Detect explicit language requests in user messages.

- Store resolved language in Run execution snapshot.

- Inherit language for follow-ups, preserve for retries.

- Add regression tests for language switching.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User Message"] --> B["resolve_run_answer_language"]
  B --> C{Explicit language?}
  C --> |"Yes"| D["Use requested language"]
  C --> |"No"| E{Recent session language?}
  E --> |"Yes"| F["Inherit session language"]
  E --> |"No"| G["Use profile language"]
  D --> H["Store in Run execution snapshot"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution.py</strong><dd><code>Integrate language resolution into dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/execution.py

<ul><li>Import resolve_run_answer_language.<br> <li> Pass resolved answer_language to create_run_execution_snapshot.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/338/files#diff-7cef6eaf866533349878e22f422222cf01e55ed2affb461d5b362c0a4aa9f6b6">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Implement language detection and resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/services.py

<ul><li>Add _explicit_answer_language to detect Chinese/English requests.<br> <li> Add _latest_session_answer_language to retrieve last resolved <br>language.<br> <li> Add resolve_run_answer_language to chain explicit, session, then <br>profile.<br> <li> Modify create_execution_run and create_run_execution_snapshot to <br>accept answer_language parameter.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/338/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+98/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_services.py</strong><dd><code>Add regression tests for language switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_services.py

<ul><li>Test explicit language overrides profile.<br> <li> Test follow-up inherits session language.<br> <li> Test retry preserves original run language.<br> <li> Test unrelated message does not override profile.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/338/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+77/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>321.yaml</strong><dd><code>Add release note for language switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/321.yaml

- Add release note entry for the language switching feature.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/338/files#diff-99134dd2873588061556cf36bd5021ba2588a051b65dc74135b4b976880f8b06">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

