### PR TITLE
Improve custom vision model capability detection

### DIFF
--- a/backend/lens/llm.py
+++ b/backend/lens/llm.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 
+VISION_SUPPORTED = "supported"
+VISION_UNSUPPORTED = "unsupported"
+VISION_UNKNOWN = "unknown"
+
+
 @dataclass(frozen=True)
 class LensLLMResult:
     """LLM completion result plus metering usage."""
@@ -95,7 +100,7 @@ def _multimodal_messages(system, user_text, image_data_urls):
 
 
 def model_supports_vision(model_ref):
-    """Return whether the configured model accepts image content blocks."""
+    """Return the configured model's known image capability."""
 
     from agentcore_metering.adapters.django.models import LLMConfig
     from agentcore_metering.adapters.django.services.runtime_config import (
@@ -103,13 +108,38 @@ def model_supports_vision(model_ref):
     )
     from litellm.utils import supports_vision
 
-    config = LLMConfig.objects.get(uuid=model_ref)
-    declared_vision = (config.config or {}).get("vision")
-    if declared_vision is not None:
-        return bool(declared_vision)
     params = get_litellm_params(model_uuid=str(model_ref))
+    config = LLMConfig.objects.filter(uuid=model_ref).values(
+        "provider", "config"
+    ).first() or {}
+    config_data = config.get("config") or {}
     model = str(params.get("model") or "")
-    return bool(model) and supports_vision(model=model)
+    if not model:
+        return VISION_UNSUPPORTED
+
+    explicit = params.get("supports_vision")
+    if explicit is None:
+        explicit = params.get("vision")
+    if explicit is None:
+        explicit = config_data.get("supports_vision")
+    if explicit is None:
+        explicit = config_data.get("vision")
+    if isinstance(explicit, bool):
+        return VISION_SUPPORTED if explicit else VISION_UNSUPPORTED
+
+    if supports_vision(model=model):
+        return VISION_SUPPORTED
+
+    provider = str(
+        params.get("custom_llm_provider")
+        or params.get("provider")
+        or config.get("provider")
+        or config_data.get("provider")
+        or ""
+    ).lower()
+    if provider in {"openai_compatible", "openai-compatible"}:
+        return VISION_UNKNOWN
+    return VISION_UNSUPPORTED
 
 
 def _message_to_dict(message):

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -35,6 +35,8 @@ from .environment_variables import (
     expand_environment_references,
 )
 from .llm import (
+    VISION_SUPPORTED,
+    VISION_UNKNOWN,
     model_supports_vision,
     run_completion,
     run_completion_multimodal,
@@ -1055,7 +1057,7 @@ def analyze_multimodal_intent(run):
         raise MultimodalPreprocessingError(
             "MODEL_CONFIGURATION_INVALID"
         ) from exc
-    if not supports_vision:
+    if supports_vision not in (True, VISION_SUPPORTED, VISION_UNKNOWN):
         raise MultimodalPreprocessingError("MODEL_NOT_VISION_CAPABLE")
 
     user_text = (

--- a/backend/lens/tests/test_attachments.py
+++ b/backend/lens/tests/test_attachments.py
@@ -452,6 +452,30 @@ class AttachmentServiceTests(TestCase):
         mock_support.assert_not_called()
         mock_call.assert_called_once()
 
+    @patch("lens.services.model_supports_vision", return_value="unknown")
+    @patch("lens.services.run_completion_multimodal")
+    def test_unknown_vision_capability_attempts_multimodal_call(
+        self, mock_call, mock_support
+    ):
+        mock_call.return_value = LensLLMResult(
+            content="A green image.", usage={}, metered=True
+        )
+        attachment = store_message_attachment(
+            self.session, self.user, _png_upload()
+        )
+        run = create_execution_run(
+            session=self.session,
+            question="Describe this image.",
+            enqueue=False,
+            attachment_uuids=[str(attachment.uuid)],
+        )
+
+        result = analyze_multimodal_intent(run)
+
+        self.assertEqual(result["status"], "succeeded")
+        mock_support.assert_called_once()
+        mock_call.assert_called_once()
+
     def test_admin_run_detail_marks_inherited_attachment_context(self):
         from lens.views.admin_runs import _admin_run_detail
 


### PR DESCRIPTION
### **User description**
## Summary
- distinguish supported, unsupported, and unknown vision capabilities
- honor explicit vision configuration for custom LLM providers
- allow unknown OpenAI-compatible models to attempt multimodal requests

## Testing
- `pytest lens/tests/test_attachments.py`
- `pytest`

Both test runs passed in the shared SourceLens API container.

Closes #331


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add three-state vision capability detection (supported, unsupported, unknown)

- Honor explicit configuration for custom LLM providers

- Allow unknown OpenAI-compatible models to attempt multimodal requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Explicit supports_vision or vision config"] -->|"bool"| B["VISION_SUPPORTED or VISION_UNSUPPORTED"]
  A -->|"None"| C["LiteLLM supports_vision(model)"]
  C -->|"true"| D["VISION_SUPPORTED"]
  C -->|"false"| E["Provider is openai_compatible?"]
  E -->|"yes"| F["VISION_UNKNOWN"]
  E -->|"no"| G["VISION_UNSUPPORTED"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm.py</strong><dd><code>Three-state vision capability detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/llm.py

<ul><li>Define constants VISION_SUPPORTED, VISION_UNSUPPORTED, VISION_UNKNOWN<br> <li> Rewrite model_supports_vision to return three-state values<br> <li> Check explicit configuration from LLMConfig and parameters<br> <li> Return VISION_UNKNOWN for OpenAI-compatible providers when LiteLLM <br>does not know the model</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/339/files#diff-7722c4a2d73c65189a6cf1d54b44c5955512e6242da38224e02ef2e8651defd0">+36/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Allow unknown vision models in multimodal analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/services.py

<ul><li>Import VISION_SUPPORTED and VISION_UNKNOWN<br> <li> Update analyze_multimodal_intent to allow VISION_UNKNOWN to proceed<br> <li> Drop boolean-only check to support new constants</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/339/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_attachments.py</strong><dd><code>Test unknown vision capability behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_attachments.py

<ul><li>Add test_unknown_vision_capability_attempts_multimodal_call<br> <li> Verify that VISION_UNKNOWN result does not block multimodal requests<br> <li> Mock model_supports_vision to return "unknown"</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/339/files#diff-0c7f51b6370f56532c7c8358343f71b0b375e38ad33e7543a9431ccc755d7d09">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

