### PR TITLE
Improve runtime failure guidance for chat and code analysis

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -598,6 +598,7 @@
                   v-if="
                     message._runtimeState?.outcome === 'partial' ||
                     (message._runtimeState?.outcome === 'blocked' &&
+                      !message._runtimeState?.clarificationRequest &&
                       !message._runtimeState?.capabilityBlock &&
                       !message._runtimeState?.executionFailure &&
                       !message._runtimeState?.verificationFailure)
@@ -1311,6 +1312,7 @@
                   v-if="
                     runtimeState.outcome === 'partial' ||
                     (runtimeState.outcome === 'blocked' &&
+                      !runtimeState.clarificationRequest &&
                       !runtimeState.capabilityBlock &&
                       !runtimeState.executionFailure &&
                       !runtimeState.verificationFailure)

--- a/frontend/src/pages/lens/chatRetryHint.js
+++ b/frontend/src/pages/lens/chatRetryHint.js
@@ -13,5 +13,6 @@ export function shouldShowRetryHint({
 }) {
   if (runStatusResolving || isRunActive) return false
   const last = messages[messages.length - 1]
+  if (last?.thinking) return false
   return !!last && last.role === 'assistant' && !(last.content || '').trim()
 }

--- a/frontend/tests/chatRetryHint.test.js
+++ b/frontend/tests/chatRetryHint.test.js
@@ -85,6 +85,54 @@ test('does not show retry guidance when the last message has answer text', () =>
   )
 })
 
+test('does not show retry guidance for a pending clarification', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: [
+        { role: 'user', content: 'Analyze the deployment.' },
+        {
+          role: 'assistant',
+          content: '',
+          thinking: {
+            status: 'awaiting_user_input',
+            outcome: 'blocked',
+            termination_detail: {
+              reason: 'needs_user_input'
+            }
+          }
+        }
+      ],
+      runStatusResolving: false
+    }),
+    false
+  )
+})
+
+test('does not show retry guidance when runtime details explain an empty answer', () => {
+  assert.equal(
+    shouldShowRetryHint({
+      isRunActive: false,
+      messages: [
+        { role: 'user', content: 'Analyze the deployment.' },
+        {
+          role: 'assistant',
+          content: '',
+          thinking: {
+            status: 'done',
+            outcome: 'blocked',
+            termination_detail: {
+              reason: 'evidence_unavailable'
+            }
+          }
+        }
+      ],
+      runStatusResolving: false
+    }),
+    false
+  )
+})
+
 test('keeps retry guidance hidden when run status cannot be loaded', async () => {
   const resolution = await resolveRunStatus(async () => {
     throw new Error('temporary network failure')

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -1334,9 +1334,29 @@ def _run_planned_code_analysis(
         termination_detail = {"reason": "evidence_insufficient"}
     if outcome == "blocked":
         answer = _pick_text(
-            "当前代码证据不足，暂时无法给出可靠结论。",
-            "The available code evidence is insufficient for a reliable "
-            "answer.",
+            (
+                "当前代码证据不足，暂时无法给出"
+                "可靠结论。\n\n"
+                "我已按当前范围检索，但还没有找到能"
+                "将问题与具体代码路径关联起来的"
+                "可靠证据。\n"
+                "你可以补充任一线索："
+                "文件路径、类或函数名、"
+                "完整错误堆栈，或涉及的业务调用链。\n"
+                "如果只想了解异常概念，请回复"
+                "“只解释概念”。"
+            ),
+            (
+                "The available code evidence is insufficient for a "
+                "reliable conclusion.\n\n"
+                "I searched the current scope but could not find reliable "
+                "evidence linking the issue to a specific code path.\n"
+                "Please provide any of these clues: a file path, class or "
+                "function name, full traceback, or the relevant business "
+                "call chain.\n"
+                'If you only want a conceptual explanation, reply "explain '
+                'the concept only".'
+            ),
             _command_answer_language(command),
         )
     return {

--- a/lensnode/tests/test_planned_runtime.py
+++ b/lensnode/tests/test_planned_runtime.py
@@ -380,7 +380,14 @@ def test_planned_code_analysis_retries_truncated_final_concisely(tmp_path):
     )
 
     assert result["answer"] == (
-        "The available code evidence is insufficient for a reliable answer."
+        "The available code evidence is insufficient for a "
+        "reliable conclusion.\n\n"
+        "I searched the current scope but could not find reliable evidence "
+        "linking the issue to a specific code path.\n"
+        "Please provide any of these clues: a file path, class or function "
+        "name, full traceback, or the relevant business call chain.\n"
+        'If you only want a conceptual explanation, reply "explain the '
+        'concept only".'
     )
     assert result["outcome"] == "blocked"
     assert result["planned_evidence"]["final_retry_count"] == 1
@@ -566,6 +573,9 @@ def test_insufficient_evidence_is_not_completed_or_added_to_answer(tmp_path):
     assert result["planned_evidence"]["gap_categories"] == ["source"]
     assert "Evidence gap" not in result["answer"]
     assert "unverified" not in result["answer"].lower()
+    assert "file path" in result["answer"]
+    assert "full traceback" in result["answer"]
+    assert "explain the concept only" in result["answer"]
 
 
 def test_unsupported_claims_prevent_completed_outcome(tmp_path):
@@ -617,7 +627,7 @@ def test_unsupported_claims_prevent_completed_outcome(tmp_path):
         "reason": "evidence_insufficient"
     }
     assert result["planned_evidence"]["sufficient"] is True
-    assert "reliable answer" in result["answer"]
+    assert "reliable conclusion" in result["answer"]
 
 
 def test_structural_evidence_without_source_citation_returns_answer(tmp_path):

--- a/release-notes/350.yaml
+++ b/release-notes/350.yaml
@@ -1,0 +1,9 @@
+type: fix
+audience: user
+en: >-
+  Improved runtime failure guidance: when code evidence is insufficient,
+  SourceLens now asks for concrete clues (file path, class or function name,
+  traceback) and no longer shows duplicate retry hints in chat.
+zh-CN: >-
+  改进运行失败引导：当代码证据不足时，SourceLens 会提示补充具体线索（文件路径、
+  类名或函数名、错误堆栈），并且聊天中不再重复显示重试提示。


### PR DESCRIPTION
### **User description**
## Summary
- **lensnode**: When code evidence is insufficient, guide the user toward actionable clues (file path, class/function name, full traceback, or business call chain) instead of returning a generic "insufficient evidence" message; supports "explain the concept only" as an escape hatch
- **chat (frontend)**: Avoid showing duplicate runtime-failure guidance for pending clarifications and for blocked runs whose `thinking` state already explains the empty answer

## Test plan
- [x] `pytest lensnode/tests/test_planned_runtime.py` covers the new guidance text and the "insufficient evidence" path
- [x] `frontend/tests/chatRetryHint.test.js` covers clarification and evidence-unavailable empty-answer cases


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improve code-analysis guidance text when evidence is insufficient

- Avoid duplicate runtime failure hints in chat for pending clarifications or blocked runs with thinking state

- Update tests to match new guidance and add new test cases for chat retry hint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Code analysis insufficient evidence"] --> B["Generate detailed guidance asking for clues"]
  B --> C["lensnode runtime"]
  D["Chat message empty with thinking state"] --> E["Suppress retry hint"]
  E --> F["frontend chatRetryHint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Enhance blocked-answer guidance text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Updated the blocked-answer guidance to include actionable clues (file <br>path, class/function name, traceback, call chain)<br> <li> Added a conceptual-explanation escape hatch in the guidance text</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+23/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_planned_runtime.py</strong><dd><code>Update tests for new guidance text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_planned_runtime.py

<ul><li>Updated expected guidance text in tests to match new wording<br> <li> Added assertions for presence of clue phrases in the answer<br> <li> Fixed assertion for "reliable conclusion" vs "reliable answer"</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-79e1634cca7781e7914aaf562aba435aef0bae4993a973b4925f200f3f619949">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.test.js</strong><dd><code>Add tests for clarification and thinking state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatRetryHint.test.js

<ul><li>Added test for pending clarification where thinking state blocks retry <br>hint<br> <li> Added test for blocked run with thinking state and <br>evidence_unavailable termination</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-d1cdab0ee92331aa422aa4192dfc264de922675d700662ddcce4e40134bf4f33">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Avoid duplicate guidance for clarification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added condition to hide duplicate runtime failure guidance when <br>clarificationRequest is present<br> <li> Applied same condition to both blocked-outcome sections in Chat.vue</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatRetryHint.js</strong><dd><code>Suppress retry hint when thinking state exists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatRetryHint.js

<ul><li>Added check for last message's thinking state to suppress retry hint</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-d52f24027c77c1e80e8d552fee09f04ce67f209ee900d56fcec7c0a71b5c23b6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>350.yaml</strong><dd><code>Add release note for runtime guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/350.yaml

<ul><li>Added release note fragment for the runtime failure guidance <br>improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/350/files#diff-7e636505a03aaaaced9daa1b4d5b72c542df2e3355bfe27ffb037c9d80ca1e19">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

