### PR TITLE
Remove answer-completed browser title hint

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,7 +16,6 @@
 
 <script setup>
 import { onBeforeUnmount, onMounted, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { useSessionActivity } from '@/composables/useSessionActivity'
 import { useUserStore } from '@/store/user'
@@ -27,33 +26,18 @@ import ActivityNotificationStack from '@/components/ui/ActivityNotificationStack
 import Toast from '@/components/ui/Toast.vue'
 import UserSettingsModal from '@/components/settings/UserSettingsModal.vue'
 import {
-  answerCompletionTitle,
   readUnreadSessions,
   UNREAD_STORAGE_KEY
 } from '@/utils/answerCompletionNotifications'
 import { stopRunCompletionTracking } from '@/utils/runCompletionTracking'
 
-const { t } = useI18n()
 const userStore = useUserStore()
 const uiStore = useUiStore()
 const preferencesStore = usePreferencesStore()
 const sessionActivity = useSessionActivity()
-const baseDocumentTitle = document.title || 'SourceLens'
 
 function refreshUnreadSessions() {
   sessionActivity.setUnreadSessions(readUnreadSessions(window.localStorage))
-}
-
-function refreshDocumentTitle() {
-  const hasUnread =
-    Boolean(userStore.token) &&
-    preferencesStore.answerCompletionIndicator &&
-    Object.keys(sessionActivity.state.unreadSessions).length > 0
-  document.title = answerCompletionTitle({
-    baseTitle: baseDocumentTitle,
-    completionLabel: t('lens.chat.tabAnswerCompleted'),
-    hasUnread
-  })
 }
 
 function handleCompletionStorage(event) {
@@ -69,19 +53,9 @@ function handleCompletionStorage(event) {
 }
 
 watch(
-  [
-    () => preferencesStore.currentLanguage,
-    () => Object.keys(sessionActivity.state.unreadSessions).join(','),
-    () => userStore.token
-  ],
-  refreshDocumentTitle
-)
-
-watch(
   () => preferencesStore.answerCompletionIndicator,
   () => {
     refreshUnreadSessions()
-    refreshDocumentTitle()
   }
 )
 
@@ -99,7 +73,6 @@ watch(
 onMounted(() => {
   window.addEventListener('storage', handleCompletionStorage)
   refreshUnreadSessions()
-  refreshDocumentTitle()
   // Check if user is logged in, but only if we have a token and user is not loaded
   // This avoids duplicate calls with router guard
   const hasToken = !!localStorage.getItem('access_token')

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -306,7 +306,6 @@
       "stop": "Stop",
       "runStopped": "Execution stopped.",
       "runSubmitted": "Run submitted.",
-      "tabAnswerCompleted": "Answer completed",
       "submitFailed": "Failed to submit query.",
       "waitingForResult": "Still waiting for execution result.",
       "thinking": "Analyzing project context",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -306,7 +306,6 @@
       "stop": "停止",
       "runStopped": "已停止执行。",
       "runSubmitted": "Run 已提交。",
-      "tabAnswerCompleted": "回答已完成",
       "submitFailed": "提交查询失败。",
       "waitingForResult": "仍在等待执行结果。",
       "thinking": "正在分析项目内容",

--- a/release-notes/351.yaml
+++ b/release-notes/351.yaml
@@ -1,0 +1,8 @@
+type: improvement
+audience: user
+en: >-
+  Removed the "answer completed" browser-tab title hint; completion is now
+  surfaced only through in-app badges and optional system notifications.
+zh-CN: >-
+  移除浏览器标签页的“回答已完成”标题提示；回答完成改为仅通过站内未读标记和
+  可选系统通知提示。


### PR DESCRIPTION
### **User description**
## Summary
- Stop rewriting `document.title` with an "answer completed" prefix driven by unread sessions
- Drop the now-unused `lens.chat.tabAnswerCompleted` translation keys
- Unread session badges and in-app/native notifications are unchanged

## Test plan
- [x] `npm run lint`
- [x] `node --test tests/answerCompletionNotifications.test.js tests/nativeBrowserNotifications.test.js`


___

### **PR Type**
Other


___

### **Description**
- Remove answer-completed browser title hint

- Drop unused translation keys

- Add release note for removal


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Remove answer-completed title update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/App.vue

<ul><li>Remove refreshDocumentTitle function and its watch on <br>language/unread/token<br> <li> Remove call to refreshDocumentTitle in onMounted<br> <li> Remove import of useI18n and answerCompletionTitle<br> <li> Keep other completion-related logic (badge/notification)</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/351/files#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878">+0/-27</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Remove unused translation key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/en.json

- Remove "tabAnswerCompleted" translation key under lens.chat


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/351/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Remove unused translation key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/zh-CN.json

- Remove "tabAnswerCompleted" translation key under lens.chat


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/351/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>351.yaml</strong><dd><code>Add release note for removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/351.yaml

- Add release note for removal of answer-completed tab title hint


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/351/files#diff-86d9d1031862f916ea117a80212173c8281952caf83d187a583fdd20520f88db">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

