### PR TITLE
Enable subagent delegation on the plan_execute route for General Chat

### DIFF
--- a/lensnode/lensnode/agent_runtime/assembly.py
+++ b/lensnode/lensnode/agent_runtime/assembly.py
@@ -15,6 +15,7 @@ def _agent_middleware(
     mcp_middleware=None,
     trace_middleware=None,
     runtime_middleware=(),
+    allow_task_tool=False,
 ):
     """Return task-specific middleware for one Deep Agent run."""
 
@@ -23,7 +24,12 @@ def _agent_middleware(
         middleware.append(summarizer)
     middleware.extend(runtime_middleware)
     if _is_general_chat(command):
-        middleware.append(_NoTaskMiddleware(emit_event))
+        middleware.append(
+            _NoTaskMiddleware(
+                emit_event,
+                allow_task_tool=allow_task_tool,
+            )
+        )
         if capability_middleware is not None:
             middleware.append(capability_middleware)
     if trace_middleware is not None:

--- a/lensnode/lensnode/agent_runtime/outcomes.py
+++ b/lensnode/lensnode/agent_runtime/outcomes.py
@@ -278,7 +278,13 @@ def _route_guidance(route):
             "execution starts, keep the task count, order, and wording fixed; "
             "later write_todos calls may only update statuses. Put newly "
             "discovered execution details under the closest existing task. "
-            "Stop when the requested outcome is verified."
+            "Stop when the requested outcome is verified.\n\n"
+            "The task subagent is available. When the plan splits into "
+            "genuinely independent, heavy subtasks, delegate each one to a "
+            "task subagent (issue multiple task calls in one message to run "
+            "them in parallel), then synthesize their results. Do NOT "
+            "delegate light work — handle it directly with batched tool "
+            "calls, which is faster."
         )
     if route == "direct_execute":
         return (

--- a/lensnode/lensnode/agent_runtime/restrictions.py
+++ b/lensnode/lensnode/agent_runtime/restrictions.py
@@ -9,12 +9,14 @@ from langchain_core.messages import ToolMessage
 class NoTaskMiddleware(AgentMiddleware):
     """Enforce General Chat restrictions on built-in agent tools."""
 
-    def __init__(self, emit_event=None):
+    def __init__(self, emit_event=None, allow_task_tool=False):
         self.emit_event = emit_event
+        self.allow_task_tool = allow_task_tool
         self.model_round = 0
 
-    @staticmethod
-    def _filter_tools(tools):
+    def _filter_tools(self, tools):
+        if self.allow_task_tool:
+            return list(tools)
         return [
             tool
             for tool in tools
@@ -170,7 +172,7 @@ class NoTaskMiddleware(AgentMiddleware):
     def wrap_tool_call(self, request, handler):
         """Block synchronous task execution for General Chat."""
 
-        if self._is_task_call(request):
+        if self._is_task_call(request) and not self.allow_task_tool:
             return self._deny_task_call(request)
         if self._is_large_result_access(request):
             return self._deny_large_result_access(request)
@@ -179,7 +181,7 @@ class NoTaskMiddleware(AgentMiddleware):
     async def awrap_tool_call(self, request, handler):
         """Block asynchronous task execution for General Chat."""
 
-        if self._is_task_call(request):
+        if self._is_task_call(request) and not self.allow_task_tool:
             return self._deny_task_call(request)
         if self._is_large_result_access(request):
             return self._deny_large_result_access(request)

--- a/lensnode/lensnode/agent_runtime/routing.py
+++ b/lensnode/lensnode/agent_runtime/routing.py
@@ -107,7 +107,7 @@ def _select_general_chat_route(
 ):
     """Classify one General Chat request without exposing control output."""
 
-    skills = "\n\n".join(context_skill_contents or [])[:16000]
+    skills = "\n\n".join(context_skill_contents or [])[:6000]
     artifact_inventory = json.dumps(
         history_artifacts or [],
         ensure_ascii=False,
@@ -126,11 +126,11 @@ def _select_general_chat_route(
         seen_tools.add(name)
         description = str(
             getattr(tool, "description", "") or ""
-        ).strip()[:500]
+        ).strip()[:200]
         tool_inventory.append(
             {"name": name, "description": description}
         )
-        if len(tool_inventory) >= 80:
+        if len(tool_inventory) >= 40:
             break
     prompt = (
         "Classify the request for a bounded agent runtime. Return JSON only "

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -252,6 +252,20 @@ class LensDeepAgentRuntime:
             state.resume_state.route_decision == _PLANNED_CODE_ANALYSIS_ROUTE
         )
 
+    def _subagents_enabled(self, state):
+        """Return whether this run may delegate work to a subagent.
+
+        General Chat exposes the task tool only on the plan_execute route,
+        where a complex multi-step task can be split across subagents;
+        simple direct-answer and direct-execute runs keep it disabled.
+        Legacy modes always keep the task tool available.
+        """
+
+        if not state.runtime_mode.general_chat:
+            return True
+        route_decision = getattr(state, "route_decision", None) or {}
+        return route_decision.get("route") == "plan_execute"
+
     def _prepare_planned_checkpoint(self, state):
         """Seed durable state before the planned pipeline invokes a model."""
 
@@ -800,6 +814,7 @@ class LensDeepAgentRuntime:
             if state.root_observation_id
             else None
         )
+        use_subagents = self._subagents_enabled(state)
         state.kwargs = {
             "model": state.model,
             "tools": state.tools,
@@ -815,19 +830,19 @@ class LensDeepAgentRuntime:
                 virtual_mode=True,
             ),
             "subagents": (
-                []
-                if state.runtime_mode.general_chat
-                else [
+                [
                     _fast_subagent(
                         state.mcp_middleware,
                         state.trace_middleware,
                         state.subagent_middleware,
                     )
                 ]
+                if use_subagents
+                else []
             ),
             "name": f"lensnode-{state.command.get('task') or 'agent'}",
         }
-        if state.resources.skill_paths and not state.runtime_mode.general_chat:
+        if state.resources.skill_paths and use_subagents:
             state.kwargs["skills"] = state.resources.skill_paths
 
         state.summarizer = _build_summarization_middleware(
@@ -848,6 +863,7 @@ class LensDeepAgentRuntime:
             mcp_middleware=state.mcp_middleware,
             trace_middleware=state.trace_middleware,
             runtime_middleware=state.runtime_middleware,
+            allow_task_tool=use_subagents,
         )
         if middleware:
             state.kwargs["middleware"] = middleware
@@ -867,7 +883,7 @@ class LensDeepAgentRuntime:
                 "skill_count": len(state.resources.skill_paths),
                 "mcp_tool_count": len(state.mcp_tools),
                 "mcp_deferred": state.mcp_middleware is not None,
-                "task_tool_enabled": not state.runtime_mode.general_chat,
+                "task_tool_enabled": use_subagents,
                 "mcp_config_path": str(state.resources.mcp_config_path),
             },
         )

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -4335,3 +4335,275 @@ def test_empty_terminal_response_raises_after_one_failed_recovery():
     assert raised is not None
     assert raised.code == "EMPTY_AGENT_RESPONSE"
     assert model.call_count == 1
+
+
+def test_plan_execute_route_enables_subagent_delegation(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 1}
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "intent": "action",
+                        "complexity": "complex",
+                        "route": "plan_execute",
+                        "required_capabilities": ["skill"],
+                        "evidence_requirement": "tool_result",
+                    }
+                )
+            )
+
+        def export_runtime_state(self):
+            return {}
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=["This Skill can query Income orders."],
+        mcp_configs=[],
+        skill_paths=["skills/income"],
+        mcp_config_path=tmp_path / "mcp.json",
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+        summary_trigger_tokens=0,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_apply_offload_thresholds",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_build_summarization_middleware",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def capture_deep_agent(**kwargs):
+        captured["subagents"] = kwargs.get("subagents")
+        captured["skills"] = kwargs.get("skills")
+        captured["middleware"] = kwargs.get("middleware")
+        return object()
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        capture_deep_agent,
+    )
+
+    def run_agent(*_args, **_kwargs):
+        return "已生成并交付流程图。", False, None
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_agent_with_turn_limit",
+        run_agent,
+    )
+
+    agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000021",
+            "task": "general_chat",
+            "question": "汇总各渠道订单并生成对比报告",
+            "agent_model_ref": "model-ref",
+        }
+    )
+
+    assert len(captured["subagents"]) == 1
+    assert captured["subagents"][0]["name"] == "general-purpose"
+    assert captured["skills"] == ["skills/income"]
+    assert any(
+        isinstance(item, agent_runtime._NoTaskMiddleware)
+        and item.allow_task_tool
+        for item in captured["middleware"]
+    )
+
+
+def test_simple_general_chat_route_keeps_subagents_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 1}
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def invoke(self, _messages, **_kwargs):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "intent": "action",
+                        "complexity": "simple",
+                        "route": "direct_execute",
+                        "required_capabilities": ["skill"],
+                        "evidence_requirement": "tool_result",
+                    }
+                )
+            )
+
+        def export_runtime_state(self):
+            return {}
+
+    resources = SimpleNamespace(
+        root=tmp_path,
+        context_skill_contents=["This Skill can query Income orders."],
+        mcp_configs=[],
+        skill_paths=["skills/income"],
+        mcp_config_path=tmp_path / "mcp.json",
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+        summary_trigger_tokens=0,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_apply_offload_thresholds",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: resources,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _resources: None,
+    )
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_general_chat_tools",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(
+                name="run_skill_artifact",
+                description="Run a bound Skill Artifact.",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_build_summarization_middleware",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def capture_deep_agent(**kwargs):
+        captured["subagents"] = kwargs.get("subagents")
+        captured["skills"] = kwargs.get("skills")
+        captured["middleware"] = kwargs.get("middleware")
+        return object()
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        capture_deep_agent,
+    )
+
+    def run_agent(*_args, **_kwargs):
+        return "已查询订单。", False, None
+
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_agent_with_turn_limit",
+        run_agent,
+    )
+
+    agent_runtime.LensDeepAgentRuntime(config)._answer_sync(
+        {
+            "run_uuid": "00000000-0000-0000-0000-000000000022",
+            "task": "general_chat",
+            "question": "查询最近一笔订单",
+            "agent_model_ref": "model-ref",
+        }
+    )
+
+    assert captured["subagents"] == []
+    assert "skills" not in captured or captured["skills"] is None
+    assert any(
+        isinstance(item, agent_runtime._NoTaskMiddleware)
+        and not item.allow_task_tool
+        for item in captured["middleware"]
+    )
+
+
+def test_general_chat_prompt_adds_subagent_guidance_for_plan_execute():
+    prompt = agent_runtime._general_chat_system_prompt(
+        {"question": "汇总订单并生成报告", "runtime_route": "plan_execute"},
+        ["This Skill can query Income orders."],
+    )
+
+    assert "task subagent is available" in prompt
+    assert "multiple task calls in one message" in prompt
+
+
+def test_general_chat_prompt_omits_subagent_guidance_for_simple_routes():
+    prompt = agent_runtime._general_chat_system_prompt(
+        {"question": "解释什么是订单", "runtime_route": "direct_answer"},
+        [],
+    )
+
+    assert "task subagent is available" not in prompt

--- a/release-notes/353.yaml
+++ b/release-notes/353.yaml
@@ -1,0 +1,7 @@
+type: improvement
+audience: user
+en: >-
+  Accelerated multi-step assistant tasks by delegating independent heavy
+  subtasks to parallel subagents and trimming plan-classification input.
+zh-CN: >-
+  加快多步助手任务：将独立的重型子任务委托给并行子代理，并精简计划分类输入。


### PR DESCRIPTION
### **User description**
## Summary
- `NoTaskMiddleware` gains `allow_task_tool` to pass the `task` tool through for subagent delegation while still blocking `/large_tool_results/` direct access
- `_build_agent` decides subagents via new `_subagents_enabled`: non-General-Chat modes keep them; General Chat enables them **only on `plan_execute`** (complex multi-step work), disables for `direct_answer` / `direct_execute`
- Subagent state is mirrored into skills, middleware, and the `task_tool_enabled` runtime event
- `plan_execute` route guidance tells the model to delegate heavy independent subtasks to task subagents (issued in parallel), and to handle light work directly
- Trim General Chat route-classifier input to cut planning latency: skills `16000 -> 6000`, tool description `500 -> 200`, tool cap `80 -> 40`

## Test plan
- [x] `pytest tests/ -q` in `lensnode/` — 493 passed, 2 pre-existing image-mock failures unrelated to this change
- [x] New tests: plan_execute enables subagent + task tool; direct route keeps them disabled; prompt guidance present/absent per route
- [x] Syntax + 79-char line width checks pass


___

### **PR Type**
Enhancement


___

### **Description**
- Enable subagent delegation on plan_execute route for General Chat

- Restrict subagents to complex multi-step tasks only

- Trim route-classifier input to reduce latency

- Add tests verifying delegation behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["General Chat request"] --> B["route classification"]
  B --> C["plan_execute"]
  B --> D["direct_answer / direct_execute"]
  C --> E["enable subagents & task tool"]
  D --> F["disable subagents"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>assembly.py</strong><dd><code>Pass allow_task_tool to NoTaskMiddleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-3d0f390c68b3bf45e981a001aa1dd4706ffaa41f219c4d5f5c048114971c4032">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>outcomes.py</strong><dd><code>Add subagent delegation guidance to plan_execute route</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-acc06a6eb203c99d009c8a5885d0b5c8bc3b39e2193c05e0f7e9b3970c0a39fc">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>restrictions.py</strong><dd><code>Support allow_task_tool in NoTaskMiddleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-1a20d2c5241dc6c5b5b5bff34c56af5d507448062232b32abf334ae715625592">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routing.py</strong><dd><code>Trim General Chat classifier input sizes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-4ecc565e7d9f142f7b43f6c72106b1f44d3abfacbacb0b49355805e875f9a60e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Add _subagents_enabled and wire into agent build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_history.py</strong><dd><code>Add tests for subagent delegation behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+272/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>353.yaml</strong><dd><code>Add release-note fragment for subagent delegation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/353/files#diff-1660fda018cdc9b657b44f7c1ecc2695104bcbe37c235eb1718a33f5e786a056">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

