### PR TITLE
Cut routing LLM overhead and harden planned-runtime feedback

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -2388,6 +2388,23 @@ class GlobalSettingSerializer(serializers.ModelSerializer):
                     {"value": f"{model_ref_keys[key]} must be a string or empty"}
                 )
 
+        if key == "lens.history_budget":
+            if not isinstance(value, dict):
+                raise serializers.ValidationError(
+                    {"value": "must be a JSON object"}
+                )
+            for sub_key in ("pairs", "message_chars", "total_chars"):
+                if sub_key in value and (
+                    not isinstance(value[sub_key], int) or value[sub_key] <= 0
+                ):
+                    raise serializers.ValidationError(
+                        {
+                            "value": (
+                                f"{sub_key} must be a positive integer"
+                            )
+                        }
+                    )
+
         return attrs
 
     class Meta:

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -88,6 +88,48 @@ HISTORY_ARTIFACT_MAX_FILES = 3
 
 QUERY_REWRITE_HISTORY_TURNS = 3
 QUERY_REWRITE_MAX_CHARS = 400
+
+
+def get_history_budget():
+    """Return the conversation history replay budget.
+
+    Admin-tunable via the GlobalSetting key ``lens.history_budget`` holding
+    a JSON object with optional ``pairs``, ``message_chars``, and
+    ``total_chars`` keys. Missing or invalid values fall back to the module
+    defaults so a bad setting can never break history replay.
+    """
+
+    setting = GlobalSetting.objects.filter(key="lens.history_budget").first()
+    value = setting.value if setting else {}
+    if not isinstance(value, dict):
+        value = {}
+    return {
+        "pairs": _bounded_int(value, "pairs", HISTORY_MAX_PAIRS, 1, 20),
+        "message_chars": _bounded_int(
+            value,
+            "message_chars",
+            HISTORY_MAX_MESSAGE_CHARS,
+            200,
+            20000,
+        ),
+        "total_chars": _bounded_int(
+            value,
+            "total_chars",
+            HISTORY_MAX_TOTAL_CHARS,
+            500,
+            100000,
+        ),
+    }
+
+
+def _bounded_int(mapping, key, default, minimum, maximum):
+    """Return an int setting clamped to a safe range, or the default."""
+
+    try:
+        value = int(mapping.get(key) or default)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(value, maximum))
 QUERY_REWRITE_SYSTEM = (
     "You rewrite a user's latest question into ONE concise, self-contained "
     "search query for a document and code knowledge base. Resolve pronouns "
@@ -1634,6 +1676,7 @@ def build_clarification_continuation_question(run, current_question):
 
     if not run.retry_of_run_id:
         return current_question
+    budget = get_history_budget()
     runs_by_id = {
         item.pk: item
         for item in Run.objects.filter(
@@ -1665,11 +1708,11 @@ def build_clarification_continuation_question(run, current_question):
             break
         turns.append(
             (
-                clarification_question[:HISTORY_MAX_MESSAGE_CHARS],
+                clarification_question[:budget["message_chars"]],
                 answer[:CLARIFICATION_MAX_ANSWER_CHARS],
             )
         )
-        if len(turns) > HISTORY_MAX_PAIRS:
+        if len(turns) > budget["pairs"]:
             turns.pop()
         current = parent
 
@@ -1692,7 +1735,7 @@ def build_clarification_continuation_question(run, current_question):
             answer,
         ]
         block_chars = sum(len(item) for item in block)
-        if clarification_chars + block_chars > HISTORY_MAX_TOTAL_CHARS:
+        if clarification_chars + block_chars > budget["total_chars"]:
             continue
         selected_turns.append(block)
         clarification_chars += block_chars
@@ -1705,7 +1748,7 @@ def build_clarification_continuation_question(run, current_question):
             [
                 "",
                 "Current execution prompt:",
-                current_question[:HISTORY_MAX_MESSAGE_CHARS],
+                current_question[:budget["message_chars"]],
             ]
         )
     return "\n".join(sections)[:CLARIFICATION_MAX_PROMPT_CHARS]
@@ -1786,6 +1829,7 @@ def build_run_history_manifest(run):
 def _build_run_history_data(run):
     """Build trusted history and the corresponding filter counts."""
 
+    budget = get_history_budget()
     all_prior_runs = list(
         Run.objects.filter(
             session=run.session,
@@ -1816,9 +1860,12 @@ def _build_run_history_data(run):
     limited_manifests = []
     total_chars = 0
     for prior in reversed(latest_attempts):
-        entries = _trusted_history_entries(prior)
+        entries = _trusted_history_entries(
+            prior,
+            budget["message_chars"],
+        )
         pair_chars = sum(len(item["content"]) for item in entries)
-        if total_chars + pair_chars > HISTORY_MAX_TOTAL_CHARS:
+        if total_chars + pair_chars > budget["total_chars"]:
             break
         if entries:
             limited_pairs.append(entries)
@@ -1846,7 +1893,7 @@ def _build_run_history_data(run):
                 }
             )
             total_chars += pair_chars
-        if len(limited_pairs) >= HISTORY_MAX_PAIRS:
+        if len(limited_pairs) >= budget["pairs"]:
             break
     history = [item for pair in reversed(limited_pairs) for item in pair]
     metadata = {
@@ -1906,7 +1953,7 @@ def _latest_retry_attempts(prior_runs):
     )
 
 
-def _trusted_history_entries(run):
+def _trusted_history_entries(run, message_chars=HISTORY_MAX_MESSAGE_CHARS):
     """Build one bounded Run turn, excluding untrusted assistant output."""
 
     entries = []
@@ -1915,7 +1962,7 @@ def _trusted_history_entries(run):
         entries.append(
             {
                 "role": Message.Role.USER,
-                "content": question[:HISTORY_MAX_MESSAGE_CHARS],
+                "content": question[:message_chars],
             }
         )
     if _assistant_output_is_trusted(run) and run.output_message_id:
@@ -1924,7 +1971,7 @@ def _trusted_history_entries(run):
             entries.append(
                 {
                     "role": Message.Role.ASSISTANT,
-                    "content": answer[:HISTORY_MAX_MESSAGE_CHARS],
+                    "content": answer[:message_chars],
                 }
             )
     return entries

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -1075,6 +1075,39 @@ class LensApiTests(TestCase):
             "016d5cf7-2245-4015-b242-d6323e795b58",
         )
 
+    def test_global_setting_accepts_history_budget_object(self):
+        response = self.client.post(
+            "/api/lens/admin/global-settings/",
+            {
+                "key": "lens.history_budget",
+                "value": {
+                    "pairs": 8,
+                    "message_chars": 3000,
+                    "total_chars": 15000,
+                },
+                "description": "History replay budget",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        setting = GlobalSetting.objects.get(key="lens.history_budget")
+        self.assertEqual(setting.value["pairs"], 8)
+
+    def test_global_setting_rejects_non_positive_history_budget(self):
+        response = self.client.post(
+            "/api/lens/admin/global-settings/",
+            {
+                "key": "lens.history_budget",
+                "value": {"pairs": -2, "message_chars": 0},
+                "description": "History replay budget",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("pairs", str(response.data["value"]))
+
     def test_global_setting_list_returns_every_setting(self):
         GlobalSetting.objects.bulk_create(
             [

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -604,7 +604,9 @@ class LensServiceTests(TransactionTestCase):
             enqueue=False,
         )
 
-        with self.assertNumQueries(1):
+        # One query walks the retry chain; the second reads the admin-tunable
+        # history budget from GlobalSetting (fixed cost, not N+1).
+        with self.assertNumQueries(2):
             history = build_run_history(current)
 
         self.assertEqual(history, [])
@@ -680,6 +682,77 @@ class LensServiceTests(TransactionTestCase):
             [item["content"] for item in history[2:]],
             [f"blocked question {index}" for index in range(4)],
         )
+
+    def test_history_budget_override_from_globalsetting(self):
+        GlobalSetting.objects.create(
+            key="lens.history_budget",
+            value={
+                "pairs": 1,
+                "message_chars": 300,
+                "total_chars": 2000,
+            },
+            description="",
+        )
+        for index in range(3):
+            prior = create_execution_run(
+                session=self.session,
+                question=f"prior question {index} " + "x" * 2000,
+                enqueue=False,
+            )
+            prior.output_message.content = f"prior answer {index}"
+            prior.output_message.save(update_fields=["content"])
+            prior.status = Run.Status.DONE
+            prior.outcome = Run.Outcome.COMPLETED
+            prior.save(update_fields=["status", "outcome"])
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        # message_chars=300 caps the long question, pairs=1 keeps only
+        # the newest turn.
+        self.assertEqual(
+            history,
+            [
+                {
+                    "role": "user",
+                    "content": "prior question 2 " + "x" * (300 - 17),
+                },
+                {"role": "assistant", "content": "prior answer 2"},
+            ],
+        )
+
+    def test_history_budget_clamps_invalid_globalsetting(self):
+        GlobalSetting.objects.create(
+            key="lens.history_budget",
+            value={"pairs": "nope", "message_chars": -5, "total_chars": []},
+            description="",
+        )
+        prior = create_execution_run(
+            session=self.session,
+            question="x" * 4000,
+            enqueue=False,
+        )
+        prior.output_message.content = "answer"
+        prior.output_message.save(update_fields=["content"])
+        prior.status = Run.Status.DONE
+        prior.outcome = Run.Outcome.COMPLETED
+        prior.save(update_fields=["status", "outcome"])
+        current = create_execution_run(
+            session=self.session,
+            question="follow up",
+            enqueue=False,
+        )
+
+        history = build_run_history(current)
+
+        # message_chars clamps up to 200 (never a negative slice); pairs
+        # falls back to the default of 5.
+        self.assertEqual(history[0]["role"], "user")
+        self.assertEqual(len(history[0]["content"]), 200)
 
     def test_rewrite_query_passthrough_without_preprocess_model(self):
         run = create_execution_run(

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -130,6 +130,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
             tool_choice=request.data.get("tool_choice"),
             temperature=request.data.get("temperature"),
             max_tokens=request.data.get("max_tokens"),
+            reasoning_effort=request.data.get("reasoning_effort"),
             return_message=bool(request.data.get("return_message")),
         )
         data = {
@@ -201,6 +202,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                         tool_choice=payload.get("tool_choice"),
                         temperature=payload.get("temperature"),
                         max_tokens=payload.get("max_tokens"),
+                        reasoning_effort=payload.get("reasoning_effort"),
                     )
                     token_count = 0
                     while True:

--- a/lensnode/lensnode/agent_runtime/routing.py
+++ b/lensnode/lensnode/agent_runtime/routing.py
@@ -196,6 +196,13 @@ def _select_general_chat_route(
             ],
             runtime_control_call=True,
             temperature=0,
+            # Route classification only picks an execution path; a light
+            # reasoning budget keeps this control call fast. "none" is
+            # deliberate: DeepSeek maps low/medium/high all to thinking
+            # enabled, while none disables thinking (measured ~40% faster
+            # with identical route decisions). Providers that lack the
+            # parameter drop it via gateway drop_params handling.
+            reasoning_effort="none",
         )
     except RunCancelledError:
         raise

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import threading
+import time
 import uuid
 from types import SimpleNamespace
 
@@ -266,27 +267,50 @@ class LensDeepAgentRuntime:
         route_decision = getattr(state, "route_decision", None) or {}
         return route_decision.get("route") == "plan_execute"
 
+    def _seed_run_checkpoint(
+        self,
+        state,
+        route_decision=None,
+        call_saver=True,
+    ):
+        """Seed durable checkpoint state for a run before its first model
+        call.
+
+        Shared by the planned, route-classified, and deep-agent paths so the
+        saver, resume metadata, and initial checkpoint are always seeded the
+        same way. Callers guard on resume/checkpoint availability and own any
+        error handling on top of the returned success flag. ``call_saver`` is
+        False when the caller already resolved the saver (e.g. to store it as
+        the graph checkpointer) to avoid a duplicate saver lookup.
+        """
+
+        if call_saver:
+            get_checkpoint_saver(self.config.workspace_path)
+        save_resume_metadata(
+            state.run_uuid,
+            self.config.workspace_path,
+            route_decision=route_decision,
+            history_assistant_turns=state.history_assistant_turns,
+        )
+        save_initial_checkpoint(
+            state.run_uuid,
+            self.config.workspace_path,
+            state.initial_messages,
+        )
+        state.checkpoint_ready = True
+        state.initial_checkpoint_seeded = True
+        state.notify_checkpoint_ready()
+
     def _prepare_planned_checkpoint(self, state):
         """Seed durable state before the planned pipeline invokes a model."""
 
         if state.resume_state is not None or not checkpoint_enabled():
             return
         try:
-            get_checkpoint_saver(self.config.workspace_path)
-            save_resume_metadata(
-                state.run_uuid,
-                self.config.workspace_path,
+            self._seed_run_checkpoint(
+                state,
                 route_decision=_PLANNED_CODE_ANALYSIS_ROUTE,
-                history_assistant_turns=state.history_assistant_turns,
             )
-            save_initial_checkpoint(
-                state.run_uuid,
-                self.config.workspace_path,
-                state.initial_messages,
-            )
-            state.checkpoint_ready = True
-            state.initial_checkpoint_seeded = True
-            state.notify_checkpoint_ready()
         except Exception:
             LOGGER.exception(
                 "Failed to enable planned code analysis checkpoint"
@@ -520,6 +544,7 @@ class LensDeepAgentRuntime:
                 0.8,
             ),
             token_budget_wrapup_event=state.token_budget_wrapup_event,
+            reasoning_effort=getattr(self.config, "reasoning_effort", None),
             on_runtime_state_change=lambda runtime_state: (
                 state.persist_execution_state(
                     guardrail_state=runtime_state
@@ -629,22 +654,7 @@ class LensDeepAgentRuntime:
         else:
             if state.resume_state is None and checkpoint_enabled():
                 try:
-                    get_checkpoint_saver(self.config.workspace_path)
-                    save_resume_metadata(
-                        state.run_uuid,
-                        self.config.workspace_path,
-                        history_assistant_turns=(
-                            state.history_assistant_turns
-                        ),
-                    )
-                    save_initial_checkpoint(
-                        state.run_uuid,
-                        self.config.workspace_path,
-                        state.initial_messages,
-                    )
-                    state.checkpoint_ready = True
-                    state.initial_checkpoint_seeded = True
-                    state.notify_checkpoint_ready()
+                    self._seed_run_checkpoint(state)
                 except Exception:
                     LOGGER.exception("Failed to enable route checkpoint")
             state.route_decision = _select_general_chat_route(
@@ -903,24 +913,15 @@ class LensDeepAgentRuntime:
                     state.kwargs["checkpointer"] = get_checkpoint_saver(
                         self.config.workspace_path
                     )
-                    save_resume_metadata(
-                        state.run_uuid,
-                        self.config.workspace_path,
+                    self._seed_run_checkpoint(
+                        state,
                         route_decision=(
                             state.route_decision
                             if state.runtime_mode.execution_gates
                             else {}
                         ),
-                        history_assistant_turns=state.history_assistant_turns,
+                        call_saver=False,
                     )
-                    save_initial_checkpoint(
-                        state.run_uuid,
-                        self.config.workspace_path,
-                        state.initial_messages,
-                    )
-                    state.checkpoint_ready = True
-                    state.initial_checkpoint_seeded = True
-                    state.notify_checkpoint_ready()
                 except Exception:
                     state.kwargs.pop("checkpointer", None)
                     LOGGER.exception(
@@ -1082,6 +1083,38 @@ def _scenario_for_task(task):
     return SCENARIOS.get(task or "", SCENARIOS["knowledge_qa"])
 
 
+def _planned_reasoning_pulse(
+    emit_agent_event,
+    *,
+    throttle_s=3.0,
+):
+    """Return a reasoning callback that throttles lightweight phase pulses.
+
+    Reasoning tokens prove the planner is still working without leaking
+    the chain of thought. The callback re-emits `phase.changed: planning`
+    at most once every throttle_s so the frontend sees continued liveness
+    (elapsed timer keeps advancing) instead of a frozen "planning" state.
+    """
+
+    last_pulse = [0.0]
+
+    def on_reasoning_delta(_text):
+        now = time.monotonic()
+        if now - last_pulse[0] < throttle_s:
+            return
+        last_pulse[0] = now
+        emit_agent_event(
+            "workflow.phase.changed",
+            {
+                "event_type": "phase.changed",
+                "visibility": "user",
+                "payload": {"phase": "planning"},
+            },
+        )
+
+    return on_reasoning_delta
+
+
 def _run_planned_code_analysis(
     *,
     model,
@@ -1145,12 +1178,22 @@ def _run_planned_code_analysis(
         command,
         context_skill_contents=context_skill_contents,
     )
+    emit_agent_event(
+        "workflow.phase.changed",
+        {
+            "event_type": "phase.changed",
+            "visibility": "user",
+            "payload": {"phase": "planning"},
+        },
+    )
+    pulse_callback = _planned_reasoning_pulse(emit_agent_event)
     planner_response = model.invoke(
         [
             SystemMessage(content=planner_prompt),
             HumanMessage(content=question),
         ],
-        runtime_control_call=True,
+        runtime_structured_output=True,
+        on_reasoning_delta=pulse_callback,
     )
     planner_status = "valid"
     planner_retry_count = 0
@@ -1173,7 +1216,8 @@ def _run_planned_code_analysis(
                     )
                 ),
             ],
-            runtime_control_call=True,
+            runtime_structured_output=True,
+            on_reasoning_delta=pulse_callback,
         )
         try:
             plan = parse_retrieval_plan(_message_content(repair_response))
@@ -1249,7 +1293,8 @@ def _run_planned_code_analysis(
                     )
                 ),
             ],
-            runtime_control_call=True,
+            runtime_structured_output=True,
+            on_reasoning_delta=pulse_callback,
         )
         fallback_plan = _parse_planner_response(
             fallback_response,

--- a/lensnode/lensnode/agent_runtime/summarization.py
+++ b/lensnode/lensnode/agent_runtime/summarization.py
@@ -123,6 +123,13 @@ def build_summarization_middleware(
     trigger_tokens = config.summary_trigger_tokens
     if trigger_tokens <= 0:
         return None
+    context_window = getattr(config, "context_window_tokens", 0)
+    trigger_ratio = getattr(config, "summary_trigger_ratio", 0.0)
+    window_trigger = (
+        int(context_window * trigger_ratio) if context_window > 0 else 0
+    )
+    if window_trigger > 0:
+        trigger_tokens = min(trigger_tokens, window_trigger)
     summary_model = model_class(
         model_ref=str(model_ref),
         ai_gateway_url=config.ai_gateway_url,

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -26,6 +26,8 @@ class LensNodeConfig:
     summary_keep_tokens: int
     offload_tool_tokens: int
     offload_human_tokens: int | None
+    context_window_tokens: int = 128000
+    summary_trigger_ratio: float = 0.75
     token_budget_max_tokens: int = 200000
     token_budget_hard_max_tokens: int = 500000
     token_budget_final_reserve_tokens: int = 40000
@@ -37,6 +39,7 @@ class LensNodeConfig:
     mcp_enable_codegraph: bool = True
     codegraph_command: str = "codegraph"
     codegraph_init_timeout_s: int = 300
+    reasoning_effort: str | None = None
 
 
 def _optional_int(value):
@@ -110,6 +113,12 @@ def load_config():
         summary_keep_tokens=int(
             os.getenv("LENSNODE_SUMMARY_KEEP_TOKENS", "16000")
         ),
+        context_window_tokens=int(
+            os.getenv("LENSNODE_CONTEXT_WINDOW_TOKENS", "128000")
+        ),
+        summary_trigger_ratio=float(
+            os.getenv("LENSNODE_SUMMARY_TRIGGER_RATIO", "0.75")
+        ),
         token_budget_max_tokens=int(
             os.getenv("LENSNODE_TOKEN_BUDGET_MAX_TOKENS", "200000")
         ),
@@ -153,6 +162,7 @@ def load_config():
         codegraph_init_timeout_s=int(
             os.getenv("LENSNODE_CODEGRAPH_INIT_TIMEOUT_S", "300")
         ),
+        reasoning_effort=os.getenv("LENSNODE_REASONING_EFFORT") or None,
         offload_tool_tokens=int(
             os.getenv("LENSNODE_OFFLOAD_TOOL_TOKENS") or "5000"
         ),

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -164,6 +164,20 @@ def _http_client_context(
     )
 
 
+_LENGTH_CAPPED_RETRY_PROMPT = (
+    "Your previous response hit the model's output length limit before "
+    "you produced a usable result. Do not continue long reasoning. If the "
+    "task needs data, issue the tool call now. Otherwise give a short, "
+    "direct answer. Reply concisely."
+)
+
+_LENGTH_NOTICE = (
+    "This response is incomplete because the provider reached its "
+    "output length limit. Any unfinished tool calls were suppressed."
+)
+_LENGTH_NOTICE_NORMALIZED = " ".join(_LENGTH_NOTICE.split())
+
+
 class LensGatewayChatModel(BaseChatModel):
     """LangChain chat model that delegates calls to the control plane."""
 
@@ -179,6 +193,10 @@ class LensGatewayChatModel(BaseChatModel):
     # heartbeats, done) to prove transport liveness to the run watchdog.
     # emit_output stays content-only for the user-facing stream.
     on_activity: Optional[Any] = None
+    # Called with each reasoning token as it arrives on a streaming call.
+    # Lets control calls surface a "model is thinking" pulse without
+    # leaking the reasoning text into the user-facing stream.
+    on_reasoning_delta: Optional[Any] = None
     cancel_event: Optional[Any] = None
     run_uuid: str = ""
     trace_context: dict[str, Any] = Field(default_factory=dict)
@@ -190,6 +208,7 @@ class LensGatewayChatModel(BaseChatModel):
     token_budget_warn_ratio: float = 0.8
     token_budget_wrapup_event: Optional[Any] = None
     on_runtime_state_change: Optional[Any] = None
+    reasoning_effort: Optional[str] = None
     loop_repeat_warn: int = 3
     loop_repeat_hard: int = 5
     loop_tool_warn: int = 30
@@ -466,6 +485,11 @@ class LensGatewayChatModel(BaseChatModel):
             payload["temperature"] = kwargs["temperature"]
         if kwargs.get("max_tokens") is not None:
             payload["max_tokens"] = kwargs["max_tokens"]
+        effective_reasoning_effort = (
+            kwargs.get("reasoning_effort") or self.reasoning_effort
+        )
+        if effective_reasoning_effort is not None:
+            payload["reasoning_effort"] = effective_reasoning_effort
 
         if self.emit_output is not None and not control_call:
             structured_output = bool(
@@ -482,6 +506,7 @@ class LensGatewayChatModel(BaseChatModel):
                         )
                     ),
                     suppress_output=structured_output,
+                    on_reasoning_delta=kwargs.get("on_reasoning_delta"),
                 )
             except Exception as exc:
                 self._finish_model_observation(
@@ -490,10 +515,46 @@ class LensGatewayChatModel(BaseChatModel):
                     exc,
                 )
                 raise
+            if self._should_retry_length_capped(result):
+                result = self._retry_length_capped(
+                    payload,
+                    kwargs,
+                    observation_id,
+                )
             self._finish_model_observation(observation_id, "done")
             return result
 
         payload["return_message"] = True
+        message = self._non_streaming_call(payload, observation_id)
+
+        result = ChatResult(
+            generations=[ChatGeneration(message=message)],
+            llm_output={"usage": message.response_metadata.get("usage")},
+        )
+        if self._should_retry_length_capped(result):
+            retry_payload = self._build_length_retry_payload(payload)
+            message = self._non_streaming_call(retry_payload, observation_id)
+            if not (
+                message.response_metadata or {}
+            ).get("model_length_capped"):
+                with self._usage_lock:
+                    self._stop_reason = None
+            result = ChatResult(
+                generations=[ChatGeneration(message=message)],
+                llm_output={"usage": message.response_metadata.get("usage")},
+            )
+        self._finish_model_observation(observation_id, "done")
+        return result
+
+    def _non_streaming_call(self, payload, observation_id):
+        """POST a return_message payload and build its AIMessage.
+
+        Runs the same non-streaming HTTP + message pipeline the primary
+        call does, so a capped retry inherits usage accounting, loop
+        detection, and guardrail bookkeeping. The caller owns the
+        observation start/finish lifecycle.
+        """
+
         start = time.monotonic()
         try:
             with _http_client_context(
@@ -517,7 +578,6 @@ class LensGatewayChatModel(BaseChatModel):
                 exc,
             )
             raise
-
         message = _message_from_gateway(data.get("message") or {})
         message.response_metadata["usage"] = data.get("usage") or {}
         message.response_metadata["latency_ms"] = int(
@@ -526,11 +586,7 @@ class LensGatewayChatModel(BaseChatModel):
         message = self._apply_token_budget(message, data.get("usage") or {})
         message = self._apply_loop_detection(message)
         self._notify_runtime_state_change()
-        self._finish_model_observation(observation_id, "done")
-        return ChatResult(
-            generations=[ChatGeneration(message=message)],
-            llm_output={"usage": data.get("usage") or {}},
-        )
+        return message
 
     def _model_observation_name(self, kwargs):
         """Return the bounded model transport span name for one call."""
@@ -587,6 +643,7 @@ class LensGatewayChatModel(BaseChatModel):
         *,
         publish_tokens=False,
         suppress_output=False,
+        on_reasoning_delta=None,
     ):
         """Consume a gateway stream and publish only a final answer turn."""
 
@@ -594,6 +651,7 @@ class LensGatewayChatModel(BaseChatModel):
         tool_calls = []
         usage = {}
         finish_reason = None
+        reasoning_cb = on_reasoning_delta or self.on_reasoning_delta
         # Subagent output must not reach the user-facing answer stream.
         # deepagents tags subagent runs via the langsmith tracing context;
         # when set, collect content and tool calls normally but stay silent.
@@ -645,6 +703,12 @@ class LensGatewayChatModel(BaseChatModel):
                                         and not silent
                                     ):
                                         self.emit_output(text)
+                                elif (
+                                    text
+                                    and kind == "reasoning"
+                                    and reasoning_cb is not None
+                                ):
+                                    reasoning_cb(text)
                             elif data.get("type") == "done":
                                 done_received = True
                                 usage = data.get("usage") or {}
@@ -704,6 +768,87 @@ class LensGatewayChatModel(BaseChatModel):
             generations=[ChatGeneration(message=message)],
             llm_output={"usage": usage},
         )
+
+    def _should_retry_length_capped(self, result):
+        """Return whether a capped response is worth one recovery attempt.
+
+        Retry only when the provider hit the output length limit and the
+        turn produced nothing actionable (no tool call and no real text) —
+        otherwise the capped turn still moved the conversation forward.
+        """
+
+        if not isinstance(result, ChatResult):
+            return False
+        generations = result.generations
+        if not generations:
+            return False
+        message = generations[0].message
+        metadata = getattr(message, "response_metadata", None) or {}
+        if not metadata.get("model_length_capped"):
+            return False
+        if getattr(message, "tool_calls", None):
+            return False
+        content = _message_text(message)
+        stripped = " ".join(str(content or "").split())
+        if not stripped:
+            return True
+        # A capped turn with no real content surfaces only the fixed
+        # "incomplete" notice; treat that as empty and worth a retry.
+        return stripped == _LENGTH_NOTICE_NORMALIZED
+
+    def _build_length_retry_payload(self, payload):
+        """Return a payload that steers a capped retry to act concisely."""
+
+        retry_payload = dict(payload)
+        retry_payload["messages"] = [
+            *retry_payload["messages"],
+            {"role": "user", "content": _LENGTH_CAPPED_RETRY_PROMPT},
+        ]
+        if (
+            not retry_payload.get("reasoning_effort")
+            or retry_payload["reasoning_effort"] != "low"
+        ):
+            retry_payload["reasoning_effort"] = "low"
+        return retry_payload
+
+    def _retry_length_capped(self, payload, kwargs, observation_id):
+        """Retry a capped turn once with a concise-action instruction.
+
+        The instruction is appended as a user turn so the retry shares the
+        model context of the capped attempt but steers it to act (tool call
+        or short answer) instead of reasoning past the output budget.
+        """
+
+        retry_payload = self._build_length_retry_payload(payload)
+        if self.emit_observation is not None and observation_id is not None:
+            self.emit_observation(
+                {
+                    "action": "start",
+                    "id": observation_id,
+                    "parent_observation_id": (
+                        self.trace_context or {}
+                    ).get("root_observation_id"),
+                    "name": "model.retry",
+                    "started_at": _utc_timestamp(),
+                }
+            )
+        try:
+            result = self._generate_streaming(
+                retry_payload,
+                publish_tokens=False,
+                suppress_output=bool(kwargs.get("runtime_structured_output")),
+            )
+            if result and result.generations:
+                recovered = result.generations[0].message
+                if not (
+                    recovered.response_metadata or {}
+                ).get("model_length_capped"):
+                    with self._usage_lock:
+                        self._stop_reason = None
+            return result
+        except Exception as exc:
+            self._finish_model_observation(observation_id, "failed", exc)
+            raise
 
     def _consume_runtime_warnings(self):
         """Consume pending guardrail warnings for one model request."""
@@ -1227,11 +1372,7 @@ def _message_from_gateway(payload):
                 "suppressed_tool_call_count": suppressed,
             }
         )
-        content = _append_runtime_notice(
-            content,
-            "This response is incomplete because the provider reached its "
-            "output length limit. Any unfinished tool calls were suppressed.",
-        )
+        content = _append_runtime_notice(content, _LENGTH_NOTICE)
 
     additional_kwargs = {}
     if raw_valid_calls:
@@ -1266,6 +1407,23 @@ def _append_runtime_notice(content, notice):
     if not text:
         return notice
     return f"{text}\n\n{notice}"
+
+
+def _message_text(message):
+    """Return the plain-text content of an AIMessage."""
+
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or ""))
+            else:
+                parts.append(str(block))
+        return " ".join(parts)
+    return str(content or "")
 
 
 def _usage_int(usage, key, fallback_key=None):

--- a/lensnode/tests/test_gateway_model.py
+++ b/lensnode/tests/test_gateway_model.py
@@ -8,6 +8,9 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from lensnode.agent_runtime import _build_summarization_middleware
+from lensnode.agent_runtime.summarization import (
+    build_summarization_middleware,
+)
 from lensnode.gateway_model import (
     LensGatewayChatModel,
     RunCancelledError,
@@ -441,6 +444,37 @@ def test_runtime_control_call_is_non_streaming_and_hidden(monkeypatch):
     assert outputs == []
     assert "stream" not in captured["payload"]
     assert "tools" not in captured["payload"]
+
+
+def test_streaming_structured_output_surfaces_reasoning_delta(monkeypatch):
+    captured = {}
+    outputs = []
+    reasoning = []
+
+    def handler(request):
+        captured["payload"] = request.read()
+        return httpx.Response(200, content=SSE_BODY.encode("utf-8"))
+
+    _install_transport(monkeypatch, handler)
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        emit_output=outputs.append,
+    )
+
+    result = model._generate(
+        [HumanMessage(content="plan")],
+        runtime_structured_output=True,
+        on_reasoning_delta=reasoning.append,
+    )
+
+    # The gateway streamed reasoning before content; the callback saw it.
+    assert reasoning == ["thinking"]
+    # Structured output stays hidden from the user-facing stream.
+    assert outputs == []
+    # The completed content is still returned to the caller.
+    assert result.generations[0].message.content.startswith("Hello")
 
 
 def test_https_gateway_request_uses_configured_tls_context(monkeypatch):
@@ -1218,3 +1252,171 @@ def test_summarization_model_receives_gateway_client_and_tls_configuration():
         assert middleware.model.tls_ca_file == "/ignored/ca.crt"
     finally:
         shared_client.close()
+
+
+def test_summarization_window_ratio_caps_trigger_below_absolute(
+    monkeypatch,
+):
+    """When the window ratio is lower, it wins over the absolute trigger."""
+
+    config = SimpleNamespace(
+        summary_trigger_tokens=48000,
+        summary_keep_tokens=16000,
+        context_window_tokens=32000,
+        summary_trigger_ratio=0.75,
+        ai_gateway_url="https://gateway.example/ai/",
+        token="token",
+        request_timeout_s=30,
+    )
+    captured = {}
+
+    def fake_model_class(*args, **kwargs):
+        return SimpleNamespace()
+
+    middleware = build_summarization_middleware(
+        config,
+        "summary-model",
+        lambda *args: None,
+        model_class=fake_model_class,
+        middleware_class=type(
+            "SpyMiddleware",
+            (object,),
+            {
+                "trigger": ("tokens", 0),
+                "keep": ("tokens", 0),
+                "trim_tokens_to_summarize": 32000,
+                "summary_prompt": "",
+                "__init__": lambda self, **kw: captured.update(kw),
+            },
+        ),
+    )
+
+    assert middleware is not None
+    assert captured["trigger"] == ("tokens", 24000)
+    assert captured["keep"] == ("tokens", 16000)
+
+
+def test_summarization_absolute_trigger_wins_when_below_window(monkeypatch):
+    """The absolute trigger stays when it is below the window ratio."""
+
+    config = SimpleNamespace(
+        summary_trigger_tokens=48000,
+        summary_keep_tokens=16000,
+        context_window_tokens=128000,
+        summary_trigger_ratio=0.75,
+        ai_gateway_url="https://gateway.example/ai/",
+        token="token",
+        request_timeout_s=30,
+    )
+    captured = {}
+
+    def fake_model_class(*args, **kwargs):
+        return SimpleNamespace()
+
+    middleware = build_summarization_middleware(
+        config,
+        "summary-model",
+        lambda *args: None,
+        model_class=fake_model_class,
+        middleware_class=type(
+            "SpyMiddleware",
+            (object,),
+            {
+                "trigger": ("tokens", 0),
+                "keep": ("tokens", 0),
+                "trim_tokens_to_summarize": 32000,
+                "summary_prompt": "",
+                "__init__": lambda self, **kw: captured.update(kw),
+            },
+        ),
+    )
+
+    assert middleware is not None
+    assert captured["trigger"] == ("tokens", 48000)
+
+
+def _sse_stream(parts):
+    """Encode a list of gateway stream events into an SSE body."""
+
+    return "".join(
+        f"data: {json.dumps(event)}\n\n" for event in parts
+    )
+
+
+def test_empty_capped_stream_retries_once_with_directive(monkeypatch):
+    requests = []
+
+    capped_body = _sse_stream(
+        [
+            {"type": "done", "usage": {"total_tokens": 10},
+             "tool_calls": [], "finish_reason": "length"},
+        ]
+    )
+    answer_body = _sse_stream(
+        [
+            {"type": "token", "kind": "content", "content": "42"},
+            {"type": "done", "usage": {"total_tokens": 10},
+             "tool_calls": [], "finish_reason": "stop"},
+        ]
+    )
+
+    def handler(request):
+        requests.append(request)
+        body = request.read()
+        if len(requests) == 1:
+            return httpx.Response(200, content=capped_body.encode("utf-8"))
+        payload = json.loads(body)
+        assert b"output length limit" in body
+        assert payload.get("reasoning_effort") == "low"
+        return httpx.Response(200, content=answer_body.encode("utf-8"))
+
+    _install_transport(monkeypatch, handler)
+    outputs = []
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        run_uuid="00000000-0000-0000-0000-000000000010",
+        emit_output=outputs.append,
+    )
+
+    result = model._generate([HumanMessage(content="what is 6*7?")])
+
+    assert len(requests) == 2
+    message = result.generations[0].message
+    assert "42" in message.content
+    assert message.response_metadata.get("model_length_capped") is None
+    assert model.stop_reason is None
+
+
+def test_capped_stream_with_real_content_does_not_retry(monkeypatch):
+    requests = []
+
+    body = _sse_stream(
+        [
+            {"type": "token", "kind": "content", "content": "partial answer"},
+            {"type": "done", "usage": {"total_tokens": 10},
+             "tool_calls": [], "finish_reason": "length"},
+        ]
+    )
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, content=body.encode("utf-8"))
+
+    _install_transport(monkeypatch, handler)
+    outputs = []
+    model = LensGatewayChatModel(
+        model_ref="model-ref",
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        run_uuid="00000000-0000-0000-0000-000000000011",
+        emit_output=outputs.append,
+    )
+
+    result = model._generate([HumanMessage(content="hi")])
+
+    assert len(requests) == 1
+    message = result.generations[0].message
+    assert "partial answer" in message.content
+    assert message.response_metadata.get("model_length_capped") is True

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -1112,6 +1112,8 @@ def test_route_selection_matches_intent_against_skill_and_tool_capabilities():
     assert "run_skill_artifact" in prompt
     assert "creating an order" in prompt
     assert model.options["temperature"] == 0
+    # Route classification is a control call: light reasoning budget only.
+    assert model.options["reasoning_effort"] == "none"
 
 
 def test_route_selection_includes_current_images_in_classifier_input():

--- a/lensnode/tests/test_planned_runtime.py
+++ b/lensnode/tests/test_planned_runtime.py
@@ -182,6 +182,67 @@ def test_planned_code_analysis_returns_awaiting_user_input_for_clarification(
     )
 
 
+def test_planned_planner_emits_planning_phase_and_reasoning_pulse(
+    tmp_path,
+):
+    clarification_plan = {
+        "objective": "Inspect the deployment path",
+        "clarification": {
+            "question": "Which deployment environment should I inspect?",
+            "reason": "ambiguous_scope",
+            "answer_type": "text",
+        },
+    }
+    events = []
+    invoke_kwargs = []
+
+    class Model:
+        stop_reason = "stop"
+        token_usage = {}
+
+        def invoke(self, _messages, **kwargs):
+            invoke_kwargs.append(kwargs)
+            return SimpleNamespace(content=json.dumps(clarification_plan))
+
+    model = Model()
+    agent_runtime._run_planned_code_analysis(
+        model=model,
+        command={"question": "Why did deployment fail?"},
+        tools=_workspace_tools(),
+        mcp_tools=[],
+        emit_agent_event=lambda *args: events.append(args),
+        workspace_root=tmp_path,
+    )
+
+    # The planner call went streaming with a reasoning pulse callback.
+    assert invoke_kwargs[0]["runtime_structured_output"] is True
+    assert callable(invoke_kwargs[0]["on_reasoning_delta"])
+    # A planning phase event was emitted before the planner call.
+    planning_events = [
+        detail
+        for (_event, detail) in events
+        if detail.get("event_type") == "phase.changed"
+        and detail.get("payload", {}).get("phase") == "planning"
+    ]
+    assert planning_events, "expected a planning phase event"
+
+
+def test_planned_reasoning_pulse_throttles_phase_events(tmp_path):
+    events = []
+
+    def emit(*args):
+        events.append(args)
+
+    callback = agent_runtime._planned_reasoning_pulse(emit, throttle_s=60.0)
+    # Two reasoning deltas inside the throttle window -> one pulse.
+    callback("token-a")
+    callback("token-b")
+    assert len(events) == 1
+    _event, detail = events[0]
+    assert detail["event_type"] == "phase.changed"
+    assert detail["payload"] == {"phase": "planning"}
+
+
 def test_planned_code_analysis_resume_replays_planned_pipeline(
     monkeypatch,
     tmp_path,

--- a/release-notes/296.yaml
+++ b/release-notes/296.yaml
@@ -1,0 +1,8 @@
+type: improvement
+audience: user
+en: >-
+  Faster first response on assistant chats and a clearer "planning" pulse
+  while multi-step work is being prepared, with tunable chat-history budgets.
+zh-CN: >-
+  助手对话首条回复更快，多步任务准备阶段有更清晰的"规划中"进度提示，
+  并支持调整聊天历史预算。


### PR DESCRIPTION
### **User description**
## Summary
- **Route classification `reasoning_effort=none`**: cuts classifier latency
  ~40% on DeepSeek (low/medium/high all map to thinking enabled; none
  disables it) with identical route decisions. Gateway now forwards the
  hint via `LLMTracker` (agentcore-metering #17).
- **Planner reasoning pulse**: planner/repair/fallback control calls stream
  and emit a throttled `phase.changed: planning` pulse from reasoning
  tokens, so the frontend shows liveness during long planning without
  leaking the chain of thought. Reuses existing phase/elapsed UI.
- **History budget tuning**: `lens.history_budget` GlobalSetting
  (pairs/message_chars/total_chars) with serializer validation and
  clamped fallbacks.
- **Length-capped recovery** (#267): retry once with a concise directive
  when a capped turn produced nothing actionable, sharing usage and
  guardrail bookkeeping via `_non_streaming_call`.
- **Summarization trigger**: capped by context-window ratio
  (`LENSNODE_CONTEXT_WINDOW_TOKENS` / `LENSNODE_SUMMARY_TRIGGER_RATIO`).
- **Checkpoint seeding**: shared `_seed_run_checkpoint` across planned,
  route-classified, and deep-agent paths.

Closes #296

## Test plan
- [x] lensnode: 500 passed / 2 pre-existing failures (image-classifier tests)
- [x] backend: test_services 113 passed; test_api global_setting/clarification/retry 13 passed
- [x] agentcore-metering #17 merged
- [x] New tests: reasoning_effort=none assertion, reasoning-delta streaming,
      planner planning-phase pulse + throttling, history_budget override/clamp,
      length-capped retry


___

### **PR Type**
Enhancement


___

### **Description**
- Route classifier uses reasoning_effort=none, saving ~40% latency

- Planner reasoning pulse and shared checkpoint seeding

- History budget tunable via GlobalSetting with clamping

- Length-capped recovery and context-window summarization trigger


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Route classifier"] --> B["reasoning_effort=none"]
  C["Planner pipeline"] --> D["reasoning pulse & shared checkpoint"]
  E["History budget"] --> F["GlobalSetting lens.history_budget"]
  G["Length-capped turn"] --> H["Retry once with concise directive"]
  I["Summarization trigger"] --> J["Min(absolute, context-window ratio)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Validate history budget JSON object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add get_history_budget with clamped fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+57/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gateway.py</strong><dd><code>Forward reasoning_effort to LLMTracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-7a38a41d1d2cc8239be8f186a349fee86254f97ad1ad16b566c0bacdc0d4fb4d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routing.py</strong><dd><code>Route classifier uses reasoning_effort=none</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-4ecc565e7d9f142f7b43f6c72106b1f44d3abfacbacb0b49355805e875f9a60e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Refactor checkpoint seeding, add planner reasoning pulse</code>&nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+89/-44</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>summarization.py</strong><dd><code>Cap summarization trigger by context-window ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-83db17daec3cb4bac98f2631398d79a892a55b97d6deda638556afdcb097bdc2">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway_model.py</strong><dd><code>Add length-capped retry, reasoning delta, and non-streaming call</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+169/-11</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Test history budget acceptance and rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Test history budget override and clamping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+74/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gateway_model.py</strong><dd><code>Test reasoning delta, window ratio, capped retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-4f2240ffca586ca8e4445e4c8f3ec15e34867e0bbdda207c78bc3cc1f28af586">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Assert reasoning_effort=none in route selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_planned_runtime.py</strong><dd><code>Test planning phase event and reasoning pulse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-79e1634cca7781e7914aaf562aba435aef0bae4993a973b4925f200f3f619949">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Add context_window, trigger_ratio, reasoning_effort config</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>agentcore-metering</strong><dd><code>Update submodule for reasoning_effort support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-6526bad06cb84f460e39dbe67971544b06e0e7b4cd6e09b06e22aed0987b9982">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>296.yaml</strong><dd><code>Add release note for routing efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/356/files#diff-799eee6a37ef21b361c8b25a9547f078093c5074d942bff4006e668fbf274bb0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

