### PR TITLE
Redesign environment variable set management and add inline value viewing

### DIFF
--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -951,7 +951,20 @@
       "noValues": "No variables added yet.",
       "createTitle": "New environment variable set",
       "editTitle": "Edit environment variable set",
-      "deleteConfirm": "Delete this variable set? Variable sets currently in use cannot be deleted."
+      "deleteConfirm": "Delete this variable set? Variable sets currently in use cannot be deleted.",
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search by name, variable, or reference...",
+      "filteredCount": "Showing {filtered} of {total}",
+      "noResults": "No variable sets match the current filters.",
+      "moreUsages": "+{count}",
+      "deleteTitle": "Delete variable set",
+      "deleteMessage": "Delete variable set \"{name}\"? This action cannot be undone.",
+      "deleteBlocked": "This variable set is still used by {count} references. Unbind them before deleting it.",
+      "deleteAction": "Delete Variable Set",
+      "viewAction": "View details of \"{name}\"",
+      "viewTitle": "Variable Set Details",
+      "revealValues": "Reveal values",
+      "hideValues": "Hide values"
     },
     "skillDetail": {
       "title": "Skill Detail"
@@ -1558,6 +1571,7 @@
       "environmentSetName": "Variable set name (for example, Jira – Production)",
       "environmentConfigured": "Saved",
       "environmentMissing": "Not set",
+      "environmentSetValues": "Variable set values",
       "mcpSection": "MCP Servers",
       "mcpEnvironmentSectionHint": "These values apply only to this MCP Server. Configure every required variable before continuing.",
       "mcpEnvironmentConfigurationHint": "This MCP Server needs {count} environment variables. Choose an existing variable set or create a new one.",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -951,7 +951,20 @@
       "noValues": "请添加 Skill 所需的环境变量。",
       "createTitle": "新建环境配置",
       "editTitle": "编辑环境配置",
-      "deleteConfirm": "确定删除这个环境变量配置集吗？"
+      "deleteConfirm": "确定删除这个环境变量配置集吗？",
+      "searchLabel": "搜索",
+      "searchPlaceholder": "按名称、变量或引用方搜索...",
+      "filteredCount": "显示 {filtered} 条，共 {total} 条",
+      "noResults": "没有符合当前筛选条件的配置集。",
+      "moreUsages": "+{count}",
+      "deleteTitle": "删除环境变量配置集",
+      "deleteMessage": "确定删除配置集「{name}」吗？此操作无法撤销。",
+      "deleteBlocked": "该配置集仍被 {count} 个引用使用，请先解除关联。",
+      "deleteAction": "删除配置集",
+      "viewAction": "查看「{name}」的配置详情",
+      "viewTitle": "环境变量配置集详情",
+      "revealValues": "显示变量值",
+      "hideValues": "隐藏变量值"
     },
     "skillDetail": {
       "title": "Skill 详情"
@@ -1558,6 +1571,7 @@
       "environmentSetName": "配置集名称，例如 Jira - Production",
       "environmentConfigured": "已保存",
       "environmentMissing": "未配置",
+      "environmentSetValues": "配置集已配置值",
       "mcpSection": "MCP Servers",
       "mcpEnvironmentSectionHint": "这些配置仅对当前 MCP Server 生效；继续前需配置全部必填变量。",
       "mcpEnvironmentConfigurationHint": "该 MCP Server 声明了 {count} 个环境变量。请选择已有配置集，或在这里新建。",

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -502,6 +502,14 @@
                         {{ variableSet.name }}
                       </option>
                     </BaseSelect>
+                    <EnvironmentSetValues
+                      v-if="
+                        form.skill_environment_set_uuids[skill.uuid] &&
+                        form.skill_environment_set_uuids[skill.uuid] !==
+                          '__new__'
+                      "
+                      :variable-set="selectedEnvironmentSet(skill.uuid)"
+                    />
                     <input
                       v-if="
                         form.skill_environment_set_uuids[skill.uuid] ===
@@ -656,6 +664,13 @@
                       {{ variableSet.name }}
                     </option>
                   </BaseSelect>
+                  <EnvironmentSetValues
+                    v-if="
+                      form.mcp_environment_set_uuids[mcp.uuid] &&
+                      form.mcp_environment_set_uuids[mcp.uuid] !== '__new__'
+                    "
+                    :variable-set="selectedMcpEnvironmentSet(mcp.uuid)"
+                  />
                   <input
                     v-if="
                       form.mcp_environment_set_uuids[mcp.uuid] === '__new__'
@@ -1024,6 +1039,8 @@ import BaseDrawer from '@/components/ui/BaseDrawer.vue'
 import BaseSelect from '@/components/ui/BaseSelect.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
 import { useUserStore } from '@/store/user'
+
+import EnvironmentSetValues from './components/EnvironmentSetValues.vue'
 
 import {
   EMPTY_VALUE,

--- a/frontend/src/pages/lens/EnvironmentVariables.vue
+++ b/frontend/src/pages/lens/EnvironmentVariables.vue
@@ -5,98 +5,210 @@
         class="overflow-hidden rounded-lg border border-line bg-surface shadow-sm"
       >
         <div
-          class="flex flex-wrap items-start justify-between gap-4 border-b border-line px-5 py-4"
+          class="flex flex-col gap-4 border-b border-line px-5 py-4 lg:flex-row lg:items-start lg:justify-between"
         >
-          <div>
-            <h1 class="text-xl font-semibold text-ink-900">
-              {{ t('lensAdmin.pages.environmentVariables.title') }}
-            </h1>
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <h1 class="text-xl font-semibold text-ink-900">
+                {{ t('lensAdmin.pages.environmentVariables.title') }}
+              </h1>
+              <span
+                class="rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-500"
+              >
+                {{
+                  t('lensAdmin.total', {
+                    label: t('lensAdmin.pages.environmentVariables.label'),
+                    count: rows.length
+                  })
+                }}
+              </span>
+            </div>
           </div>
-          <BaseButton variant="primary" size="sm" @click="startCreate">
-            {{ t('lensAdmin.pages.environmentVariables.action') }}
-          </BaseButton>
+          <div class="flex flex-wrap items-center gap-2">
+            <BaseButton
+              variant="outline"
+              size="sm"
+              :loading="loading"
+              @click="load"
+            >
+              {{ t('common.refresh') }}
+            </BaseButton>
+            <BaseButton variant="primary" size="sm" @click="startCreate">
+              {{ t('lensAdmin.pages.environmentVariables.action') }}
+            </BaseButton>
+          </div>
         </div>
 
-        <BaseLoading v-if="loading" />
-        <div
-          v-else-if="!rows.length"
-          class="px-5 py-12 text-center text-sm text-ink-500"
-        >
-          {{ t('lensAdmin.environmentVariables.empty') }}
+        <div v-if="rows.length" class="border-b border-line px-5 py-4">
+          <label class="block max-w-md">
+            <span class="mb-1 block text-xs font-medium text-ink-600">
+              {{ t('lensAdmin.environmentVariables.searchLabel') }}
+            </span>
+            <input
+              v-model="searchQuery"
+              type="search"
+              class="form-input"
+              :placeholder="t('lensAdmin.environmentVariables.searchPlaceholder')"
+            />
+          </label>
+          <p class="mt-2 text-xs text-ink-500" role="status">
+            {{
+              t('lensAdmin.environmentVariables.filteredCount', {
+                filtered: filteredRows.length,
+                total: rows.length
+              })
+            }}
+          </p>
         </div>
-        <div v-else class="overflow-x-auto">
-          <table class="w-full text-left text-sm">
-            <thead
-              class="border-b border-line bg-surface-sunken text-xs text-ink-500"
+
+        <div class="px-5 py-4">
+          <BaseLoading v-if="loading && rows.length === 0" />
+
+          <div
+            v-else-if="rows.length === 0"
+            class="rounded-lg border border-line bg-surface-sunken py-16 text-center"
+          >
+            <p class="text-sm font-medium text-ink-500">
+              {{ t('lensAdmin.environmentVariables.empty') }}
+            </p>
+          </div>
+
+          <div
+            v-else-if="filteredRows.length === 0"
+            class="rounded-lg border border-line bg-surface-sunken py-12 text-center"
+          >
+            <p class="text-sm font-medium text-ink-500">
+              {{ t('lensAdmin.environmentVariables.noResults') }}
+            </p>
+          </div>
+
+          <div
+            v-else
+            class="env-list relative overflow-x-auto rounded-lg border border-line bg-surface"
+            data-testid="environment-variables-list"
+          >
+            <table
+              class="env-table w-full min-w-[62rem] table-fixed divide-y divide-line"
             >
-              <tr>
-                <th class="px-5 py-3">{{ t('lensAdmin.fields.name') }}</th>
-                <th class="px-5 py-3">
-                  {{ t('lensAdmin.environmentVariables.keys') }}
-                </th>
-                <th class="px-5 py-3">
-                  {{ t('lensAdmin.environmentVariables.usages') }}
-                </th>
-                <th class="px-5 py-3">{{ t('lensAdmin.fields.status') }}</th>
-                <th class="px-5 py-3 text-right">{{ t('common.actions') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="row in rows"
-                :key="row.uuid"
-                class="border-b border-line last:border-b-0"
-              >
-                <td class="px-5 py-4">
-                  <div class="font-medium text-ink-900">{{ row.name }}</div>
-                  <div v-if="row.description" class="mt-1 text-xs text-ink-500">
-                    {{ row.description }}
-                  </div>
-                </td>
-                <td class="px-5 py-4 font-mono text-xs text-ink-600">
-                  {{ (row.keys || []).join(', ') || '—' }}
-                </td>
-                <td class="px-5 py-4">
-                  <div v-if="row.usages?.length" class="flex flex-wrap gap-1.5">
-                    <span
-                      v-for="usage in row.usages"
-                      :key="usageKey(usage)"
-                      class="inline-flex max-w-72 items-center gap-1 rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-600"
-                      :title="usageTitle(usage)"
-                    >
-                      <span class="font-medium text-ink-700">
-                        {{ usageTypeLabel(usage.type) }}
+              <colgroup>
+                <col class="w-52" />
+                <col class="w-56" />
+                <col class="w-56" />
+                <col class="w-24" />
+                <col class="w-24" />
+              </colgroup>
+              <thead class="bg-surface-sunken">
+                <tr>
+                  <th
+                    v-for="column in activeColumns"
+                    :key="column"
+                    class="table-head"
+                  >
+                    {{ column }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-line bg-surface">
+                <tr
+                  v-for="row in pagedRows"
+                  :key="row.uuid"
+                  class="transition-colors hover:bg-line-soft"
+                >
+                  <td class="table-cell" :data-label="activeColumns[0]">
+                    <div class="font-medium text-ink-900">{{ row.name }}</div>
+                    <div v-if="row.description" class="mt-1 text-xs text-ink-500">
+                      {{ row.description }}
+                    </div>
+                  </td>
+                  <td class="table-cell" :data-label="activeColumns[1]">
+                    <div v-if="row.keys?.length" class="flex flex-wrap gap-1.5">
+                      <span
+                        v-for="key in row.keys"
+                        :key="key"
+                        class="inline-flex max-w-48 items-center gap-1 rounded-md border border-line bg-surface-sunken px-2 py-1 font-mono text-xs text-ink-600"
+                      >
+                        <span class="truncate">{{ key }}</span>
                       </span>
-                      <span aria-hidden="true">·</span>
-                      <span class="truncate">{{ usage.resource_name }}</span>
-                      <span aria-hidden="true">·</span>
-                      <span class="truncate text-ink-400">
-                        {{ usage.assistant_name }}
+                    </div>
+                    <span v-else class="text-xs text-ink-400">{{ emptyValue }}</span>
+                  </td>
+                  <td class="table-cell" :data-label="activeColumns[2]">
+                    <div v-if="row.usages?.length" class="flex flex-wrap gap-1.5">
+                      <span
+                        v-for="usage in visibleUsages(row)"
+                        :key="usageKey(usage)"
+                        class="inline-flex max-w-64 items-center gap-1 rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-600"
+                        :title="usageTitle(usage)"
+                      >
+                        <span class="font-medium text-ink-700">
+                          {{ usageTypeLabel(usage.type) }}
+                        </span>
+                        <span aria-hidden="true">·</span>
+                        <span class="truncate">{{ usage.resource_name }}</span>
+                        <span v-if="usage.assistant_name" aria-hidden="true">·</span>
+                        <span v-if="usage.assistant_name" class="truncate text-ink-400">
+                          {{ usage.assistant_name }}
+                        </span>
                       </span>
-                    </span>
-                  </div>
-                  <span v-else class="text-xs text-ink-400">—</span>
-                </td>
-                <td class="px-5 py-4">
-                  <StatusBadge :status="row.enabled ? 'enabled' : 'disabled'" />
-                </td>
-                <td class="px-5 py-4 text-right">
-                  <div class="flex justify-end gap-2">
-                    <BaseButton
-                      size="sm"
-                      variant="outline"
-                      @click="startEdit(row)"
+                      <span
+                        v-if="row.usages.length > VISIBLE_USAGE_LIMIT"
+                        class="inline-flex items-center rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-500"
+                        :title="row.usages.map(usageTitle).join('\n')"
+                      >
+                        {{
+                          t('lensAdmin.environmentVariables.moreUsages', {
+                            count: row.usages.length - VISIBLE_USAGE_LIMIT
+                          })
+                        }}
+                      </span>
+                    </div>
+                    <span v-else class="text-xs text-ink-400">{{ emptyValue }}</span>
+                  </td>
+                  <td class="table-cell" :data-label="activeColumns[3]">
+                    <StatusBadge :status="row.enabled ? 'enabled' : 'disabled'" />
+                  </td>
+                  <td class="table-cell !px-2" :data-label="activeColumns[4]">
+                    <div
+                      class="flex flex-nowrap items-center justify-end gap-1 whitespace-nowrap"
                     >
-                      {{ t('common.edit') }}
-                    </BaseButton>
-                    <BaseButton size="sm" variant="danger" @click="remove(row)">
-                      {{ t('common.delete') }}
-                    </BaseButton>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                      <button
+                        type="button"
+                        class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-transparent text-ink-500 transition-colors hover:border-line hover:bg-line-soft hover:text-ink-900 focus:outline-none focus:ring-2 focus:ring-brand-500/30 md:h-8 md:w-8"
+                        :aria-label="
+                          t('lensAdmin.environmentVariables.viewAction', {
+                            name: row.name
+                          })
+                        "
+                        :title="
+                          t('lensAdmin.environmentVariables.viewAction', {
+                            name: row.name
+                          })
+                        "
+                        @click="openView(row)"
+                      >
+                        <EyeIcon class="h-4 w-4" />
+                      </button>
+                      <RowActions
+                        :row="row"
+                        :confirm-inline="false"
+                        @edit="startEdit"
+                        @delete="requestDelete"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <PaginationBar
+            v-if="!loading"
+            v-model:page-size="pageSize"
+            :current-page="currentPage"
+            :total="filteredRows.length"
+            @page-size-change="handlePageSizeChange"
+            @prev="goPrevPage"
+            @next="goNextPage"
+          />
         </div>
       </section>
 
@@ -109,6 +221,8 @@
         <form
           id="environment-set-form"
           class="space-y-4"
+          novalidate
+          @input="formError = ''"
           @submit.prevent="save"
         >
           <FormRow :label="t('lensAdmin.fields.name')" required>
@@ -132,24 +246,28 @@
               <div
                 v-for="(item, index) in form.values"
                 :key="index"
-                class="grid gap-2 border-b border-line p-3 last:border-b-0 sm:grid-cols-[0.8fr_1.2fr_auto]"
+                class="grid gap-2 border-b border-line p-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
               >
                 <input
                   v-model.trim="item.key"
                   class="form-input font-mono"
                   :pattern="SHELL_ENVIRONMENT_NAME_PATTERN"
                   :placeholder="t('lensAdmin.skills.environmentKey')"
+                  :aria-label="t('lensAdmin.skills.environmentKey')"
                   required
                 />
                 <input
                   v-model="item.value"
                   class="form-input font-mono"
                   type="password"
+                  :autocomplete="'new-password'"
                   :placeholder="t('lensAdmin.environmentVariables.value')"
+                  :aria-label="t('lensAdmin.environmentVariables.value')"
                 />
                 <BaseButton
                   size="sm"
                   variant="outline"
+                  :aria-label="t('common.delete')"
                   @click="removeValue(index)"
                 >
                   {{ t('common.delete') }}
@@ -157,11 +275,12 @@
               </div>
             </div>
           </FormRow>
-          <label class="flex items-center gap-2 text-sm text-ink-700">
-            <input v-model="form.enabled" type="checkbox" />
-            {{ t('lensAdmin.fields.enabled') }}
-          </label>
-          <p v-if="formError" class="text-sm text-danger-700">
+          <BooleanRow v-model="form.enabled" />
+          <p
+            v-if="formError"
+            class="text-sm text-danger-700"
+            role="alert"
+          >
             {{ formError }}
           </p>
         </form>
@@ -180,11 +299,164 @@
           </div>
         </template>
       </BaseDrawer>
+
+      <BaseModal
+        :show="!!deleteTarget"
+        :title="t('lensAdmin.environmentVariables.deleteTitle')"
+        @close="deleteTarget = null"
+      >
+        <p class="text-sm text-ink-700">
+          {{
+            t('lensAdmin.environmentVariables.deleteMessage', {
+              name: deleteTarget?.name
+            })
+          }}
+        </p>
+        <div
+          v-if="deleteTarget?.usages?.length"
+          class="mt-4 rounded-lg border border-warning-200 bg-warning-50 p-3"
+          role="alert"
+        >
+          <p class="text-sm font-medium text-warning-800">
+            {{
+              t('lensAdmin.environmentVariables.deleteBlocked', {
+                count: deleteTarget.usages.length
+              })
+            }}
+          </p>
+          <ul class="mt-2 max-h-40 list-disc space-y-1 overflow-y-auto pl-5 text-sm text-warning-800">
+            <li v-for="usage in deleteTarget.usages" :key="usageKey(usage)">
+              {{ usageTitle(usage) }}
+            </li>
+          </ul>
+        </div>
+        <template #footer>
+          <div class="flex flex-row-reverse gap-2">
+            <BaseButton
+              variant="danger"
+              :loading="deleting"
+              :disabled="!!deleteTarget?.usages?.length"
+              @click="confirmDelete"
+            >
+              {{ t('lensAdmin.environmentVariables.deleteAction') }}
+            </BaseButton>
+            <BaseButton variant="outline" @click="deleteTarget = null">
+              {{ t('common.cancel') }}
+            </BaseButton>
+          </div>
+        </template>
+      </BaseModal>
+
+      <BaseDrawer
+        :show="!!viewTarget"
+        :title="t('lensAdmin.environmentVariables.viewTitle')"
+        :subtitle="viewTarget?.name || ''"
+        @close="closeView"
+      >
+        <template v-if="viewTarget">
+          <div class="space-y-6">
+            <section>
+              <dl class="grid grid-cols-1 gap-4">
+                <div v-if="viewTarget.description">
+                  <dt
+                    class="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-600"
+                  >
+                    {{ t('lensAdmin.fields.description') }}
+                  </dt>
+                  <dd class="break-words text-sm font-medium text-ink-900">
+                    {{ viewTarget.description }}
+                  </dd>
+                </div>
+                <div>
+                  <dt
+                    class="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-600"
+                  >
+                    {{ t('lensAdmin.fields.status') }}
+                  </dt>
+                  <dd>
+                    <StatusBadge
+                      :status="viewTarget.enabled ? 'enabled' : 'disabled'"
+                    />
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section class="border-t border-line pt-6">
+              <div class="mb-3 flex items-center justify-between gap-3">
+                <h3 class="text-sm font-semibold text-ink-900">
+                  {{ t('lensAdmin.environmentVariables.values') }}
+                </h3>
+                <BaseButton size="sm" variant="outline" @click="toggleViewReveal">
+                  {{
+                    viewRevealed
+                      ? t('lensAdmin.environmentVariables.hideValues')
+                      : t('lensAdmin.environmentVariables.revealValues')
+                  }}
+                </BaseButton>
+              </div>
+              <BaseLoading v-if="viewLoading" />
+              <div
+                v-else-if="!viewValues.length"
+                class="rounded-md border border-line bg-surface-sunken p-4 text-sm text-ink-400"
+              >
+                {{ t('lensAdmin.environmentVariables.noValues') }}
+              </div>
+              <div v-else class="overflow-hidden rounded-lg border border-line">
+                <div
+                  v-for="item in viewValues"
+                  :key="item.key"
+                  class="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-3 border-b border-line px-4 py-3 text-sm last:border-b-0"
+                >
+                  <span class="min-w-0 truncate font-mono text-xs font-medium text-ink-700">
+                    {{ item.key }}
+                  </span>
+                  <span
+                    class="min-w-0 truncate font-mono text-xs text-ink-500"
+                    :class="viewRevealed ? '' : 'select-none tracking-widest'"
+                  >
+                    {{ viewRevealed ? item.value : '••••••••' }}
+                  </span>
+                </div>
+              </div>
+            </section>
+
+            <section class="border-t border-line pt-6">
+              <h3 class="mb-3 text-sm font-semibold text-ink-900">
+                {{ t('lensAdmin.environmentVariables.usages') }}
+              </h3>
+              <div
+                v-if="viewTarget.usages?.length"
+                class="flex flex-wrap gap-1.5"
+              >
+                <span
+                  v-for="usage in viewTarget.usages"
+                  :key="usageKey(usage)"
+                  class="inline-flex max-w-64 items-center gap-1 rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-600"
+                  :title="usageTitle(usage)"
+                >
+                  <span class="font-medium text-ink-700">
+                    {{ usageTypeLabel(usage.type) }}
+                  </span>
+                  <span aria-hidden="true">·</span>
+                  <span class="truncate">{{ usage.resource_name }}</span>
+                  <span v-if="usage.assistant_name" aria-hidden="true">·</span>
+                  <span v-if="usage.assistant_name" class="truncate text-ink-400">
+                    {{ usage.assistant_name }}
+                  </span>
+                </span>
+              </div>
+              <p v-else class="text-sm text-ink-400">{{ emptyValue }}</p>
+            </section>
+          </div>
+        </template>
+      </BaseDrawer>
     </div>
   </AdminLayout>
 </template>
 
 <script setup>
+import { Eye as EyeIcon } from '@lucide/vue'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -199,29 +471,83 @@ import {
 import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseDrawer from '@/components/ui/BaseDrawer.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import PaginationBar from '@/components/ui/PaginationBar.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
 import { useToast } from '@/composables/useToast'
 import { extractErrorMessage } from '@/utils/api'
 
+import BooleanRow from './components/BooleanRow.vue'
 import FormRow from './components/FormRow.vue'
-import { normalizeList } from './adminHelpers'
+import RowActions from './components/RowActions.vue'
+import { EMPTY_VALUE as emptyValue, normalizeList } from './adminHelpers'
 import { SHELL_ENVIRONMENT_NAME_PATTERN } from './skillEnvironment'
+
+const VISIBLE_USAGE_LIMIT = 3
 
 const { t } = useI18n()
 const { showSuccess, showError } = useToast()
 const rows = ref([])
 const loading = ref(false)
 const saving = ref(false)
+const deleting = ref(false)
 const showDrawer = ref(false)
 const mode = ref('create')
 const form = ref(defaultForm())
 const formError = ref('')
+const deleteTarget = ref(null)
+const viewTarget = ref(null)
+const viewValues = ref([])
+const viewLoading = ref(false)
+const viewRevealed = ref(false)
+const searchQuery = ref('')
+const currentPage = ref(1)
+const pageSize = ref(20)
 
 const drawerTitle = computed(() =>
   mode.value === 'create'
     ? t('lensAdmin.environmentVariables.createTitle')
     : t('lensAdmin.environmentVariables.editTitle')
 )
+
+const activeColumns = computed(() => [
+  t('lensAdmin.fields.name'),
+  t('lensAdmin.environmentVariables.keys'),
+  t('lensAdmin.environmentVariables.usages'),
+  t('lensAdmin.columns.status'),
+  t('lensAdmin.columns.actions')
+])
+
+const filteredRows = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  if (!query) {
+    return rows.value
+  }
+  return rows.value.filter((row) => {
+    const haystack = [
+      row.name,
+      row.description,
+      (row.keys || []).join(' '),
+      ...(row.usages || []).flatMap((usage) => [
+        usage.resource_name,
+        usage.assistant_name
+      ])
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    return haystack.includes(query)
+  })
+})
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(filteredRows.value.length / pageSize.value))
+)
+
+const pagedRows = computed(() => {
+  const start = (currentPage.value - 1) * pageSize.value
+  return filteredRows.value.slice(start, start + pageSize.value)
+})
 
 function defaultForm() {
   return {
@@ -231,6 +557,24 @@ function defaultForm() {
     values: [],
     enabled: true
   }
+}
+
+function handlePageSizeChange() {
+  currentPage.value = 1
+}
+
+function goPrevPage() {
+  if (currentPage.value <= 1) return
+  currentPage.value -= 1
+}
+
+function goNextPage() {
+  if (currentPage.value >= totalPages.value) return
+  currentPage.value += 1
+}
+
+function visibleUsages(row) {
+  return (row.usages || []).slice(0, VISIBLE_USAGE_LIMIT)
 }
 
 async function load() {
@@ -283,6 +627,31 @@ function removeValue(index) {
   form.value.values.splice(index, 1)
 }
 
+async function openView(row) {
+  viewTarget.value = row
+  viewRevealed.value = false
+  viewValues.value = []
+  viewLoading.value = true
+  try {
+    const revealed = await revealEnvironmentVariableSet(row.uuid)
+    viewValues.value = (revealed.values || []).map((item) => ({ ...item }))
+  } catch (error) {
+    showError(extractErrorMessage(error, t('lensAdmin.messages.loadFailed')))
+  } finally {
+    viewLoading.value = false
+  }
+}
+
+function closeView() {
+  viewTarget.value = null
+  viewValues.value = []
+  viewRevealed.value = false
+}
+
+function toggleViewReveal() {
+  viewRevealed.value = !viewRevealed.value
+}
+
 function usageTypeLabel(type) {
   return type === 'mcp'
     ? t('lensAdmin.environmentVariables.mcpUsage')
@@ -294,10 +663,12 @@ function usageKey(usage) {
 }
 
 function usageTitle(usage) {
-  return `${usageTypeLabel(usage.type)} · ${usage.resource_name} · ${t(
-    'lensAdmin.environmentVariables.assistantUsage',
-    { name: usage.assistant_name }
-  )}`
+  const assistant = usage.assistant_name
+    ? ` · ${t('lensAdmin.environmentVariables.assistantUsage', {
+        name: usage.assistant_name
+      })}`
+    : ''
+  return `${usageTypeLabel(usage.type)} · ${usage.resource_name}${assistant}`
 }
 
 function payload() {
@@ -334,18 +705,97 @@ async function save() {
   }
 }
 
-async function remove(row) {
-  if (!window.confirm(t('lensAdmin.environmentVariables.deleteConfirm'))) {
+function requestDelete(row) {
+  deleteTarget.value = row
+}
+
+async function confirmDelete() {
+  const row = deleteTarget.value
+  if (!row?.uuid || row.usages?.length || deleting.value) {
     return
   }
+  deleting.value = true
   try {
     await deleteEnvironmentVariableSet(row.uuid)
     showSuccess(t('lensAdmin.messages.deleteSuccess'))
+    deleteTarget.value = null
     await load()
   } catch (error) {
     showError(extractErrorMessage(error, t('lensAdmin.messages.deleteFailed')))
+  } finally {
+    deleting.value = false
   }
 }
 
 onMounted(load)
 </script>
+
+<style scoped>
+.form-input {
+  @apply w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20;
+}
+
+.table-head {
+  @apply border-b border-line px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-ink-500;
+}
+
+.table-cell {
+  @apply px-4 py-3 text-sm text-ink-700;
+}
+
+@media (max-width: 767px) {
+  .env-list {
+    @apply overflow-x-hidden border-0 bg-transparent;
+  }
+
+  .env-table,
+  .env-table tbody {
+    display: block;
+    width: 100%;
+  }
+
+  .env-table {
+    min-width: 100% !important;
+    table-layout: auto;
+  }
+
+  .env-table colgroup {
+    display: none;
+  }
+
+  .env-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .env-table tbody {
+    @apply space-y-3;
+  }
+
+  .env-table tbody tr {
+    @apply block overflow-hidden rounded-lg border border-line bg-surface;
+  }
+
+  .env-table .table-cell {
+    display: grid;
+    grid-template-columns: minmax(6rem, 36%) minmax(0, 1fr);
+    @apply gap-3 border-b border-line px-3 py-3;
+  }
+
+  .env-table .table-cell::before {
+    content: attr(data-label);
+    @apply text-xs font-semibold uppercase tracking-wide text-ink-500;
+  }
+
+  .env-table .table-cell:last-child {
+    @apply border-b-0;
+  }
+}
+</style>

--- a/frontend/src/pages/lens/components/EnvironmentSetValues.vue
+++ b/frontend/src/pages/lens/components/EnvironmentSetValues.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="overflow-hidden rounded-md border border-line bg-surface">
+    <div class="flex items-center justify-between gap-2 border-b border-line px-3 py-2">
+      <span class="text-[11px] font-semibold text-ink-700">
+        {{ t('lensAdmin.wizard.environmentSetValues') }}
+      </span>
+      <BaseButton size="sm" variant="outline" @click="toggleReveal">
+        {{
+          revealed
+            ? t('lensAdmin.environmentVariables.hideValues')
+            : t('lensAdmin.environmentVariables.revealValues')
+        }}
+      </BaseButton>
+    </div>
+    <div v-if="loading" class="px-3 py-3 text-xs text-ink-500">
+      {{ t('common.loading') }}
+    </div>
+    <div
+      v-else-if="!items.length"
+      class="px-3 py-3 text-xs text-ink-400"
+    >
+      {{ t('lensAdmin.environmentVariables.noValues') }}
+    </div>
+    <div v-else class="divide-y divide-line">
+      <div
+        v-for="item in items"
+        :key="item.key"
+        class="flex items-center justify-between gap-3 px-3 py-2"
+      >
+        <span class="min-w-0 truncate font-mono text-[11px] font-medium text-ink-700">
+          {{ item.key }}
+        </span>
+        <span
+          class="min-w-0 truncate font-mono text-[11px] text-ink-500"
+          :class="revealed ? '' : 'select-none tracking-widest'"
+        >
+          {{ revealed ? item.value : '••••••••' }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { revealEnvironmentVariableSet } from '@/api/lens'
+import BaseButton from '@/components/ui/BaseButton.vue'
+import { useToast } from '@/composables/useToast'
+import { extractErrorMessage } from '@/utils/api'
+
+const props = defineProps({
+  variableSet: {
+    type: Object,
+    default: null
+  }
+})
+
+const { t } = useI18n()
+const { showError } = useToast()
+
+const items = ref([])
+const loading = ref(false)
+const revealed = ref(false)
+
+watch(
+  () => props.variableSet?.uuid,
+  (uuid) => {
+    revealed.value = false
+    if (!uuid) {
+      items.value = []
+      return
+    }
+    loadValues(uuid)
+  },
+  { immediate: true }
+)
+
+async function loadValues(uuid) {
+  loading.value = true
+  try {
+    const payload = await revealEnvironmentVariableSet(uuid)
+    items.value = (payload.values || []).map((item) => ({ ...item }))
+  } catch (error) {
+    showError(extractErrorMessage(error, t('lensAdmin.messages.loadFailed')))
+  } finally {
+    loading.value = false
+  }
+}
+
+function toggleReveal() {
+  revealed.value = !revealed.value
+}
+</script>

--- a/release-notes/359.yaml
+++ b/release-notes/359.yaml
@@ -1,0 +1,10 @@
+type: improvement
+audience: admin
+en: >-
+  Reworked the environment variable set page with search, filtering, and
+  pagination, and added the ability to view configured values (masked by
+  default) from the list and inside the assistant wizard when a set is
+  bound to a Skill or MCP.
+zh-CN: >-
+  重新设计了环境变量配置集页面，支持搜索、筛选与分页；并可在列表页及助手
+  向导中为 Skill/MCP 绑定已有配置集时查看已配置的值（默认掩码显示）。


### PR DESCRIPTION
### **User description**
## Summary
- Redesign the admin environment variable set page: count badge, refresh,
  search/filter, table with usages, delete confirmation (blocked while in
  use), pagination, and mobile-friendly card layout
- Add a per-row eye icon that opens a read-only detail drawer showing the
  set's masked values with a reveal/hide toggle
- Show configured variable-set values inline in the assistant wizard when
  an existing set is bound to a Skill or MCP, so admins can verify actual
  values without leaving the form
- Add i18n keys for all new strings (en + zh-CN)

Closes #359

## Test plan
- [x] Locale JSON parses
- [x] Regression test suite passes (286 ok; 3 pre-existing failures are
      unrelated vue/pinia import issues from missing node_modules)


___

### **PR Type**
Enhancement


___

### **Description**
- Redesigned environment variable set page with search, pagination, and delete confirmation

- Added inline value viewing in list and assistant wizard with reveal/hide toggle

- Added i18n keys for all new UI strings (en + zh-CN)

- Added release note fragment for the changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Admin"] --> B["EnvironmentVariables.vue"]
  B --> C["Search & Pagination"]
  B --> D["View Drawer (eye icon)"]
  B --> E["Delete Confirmation Modal"]
  B --> F["Refresh Button"]
  A --> G["AssistantFormDrawerDirectEnvironment.vue"]
  G --> H["EnvironmentSetValues.vue"]
  H --> I["Reveal/Hide toggle"]
  H --> J["API: revealEnvironmentVariableSet"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AssistantFormDrawerDirectEnvironment.vue</strong><dd><code>Add inline environment set values display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue

<ul><li>Imported and added EnvironmentSetValues component to display inline <br>variable set values when a set is selected for Skill or MCP.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-1bbf22475c1d3e7a28848d3821a473ca289b3ce9c70ed901042e503be4fbc9ff">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnvironmentVariables.vue</strong><dd><code>Major redesign of environment variable set list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/EnvironmentVariables.vue

<ul><li>Added search bar, count badge, and filtered count display.<br> <li> Added pagination bar with page size control.<br> <li> Replaced inline delete confirmation with a modal showing usages and <br>blocking delete when in use.<br> <li> Added view drawer with eye icon, reveal/hide toggle, and loading <br>state.<br> <li> Added refresh button and responsive table layout.<br> <li> Added BooleanRow and RowActions components.<br> <li> Added aria-labels and improved accessibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-93c362d6b5fa8972954c44d140b15162086df5a2b0cc8a01c2e293ec4e16bebd">+546/-96</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnvironmentSetValues.vue</strong><dd><code>New component for inline variable set values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/components/EnvironmentSetValues.vue

<ul><li>New component that fetches and displays variable set values inline.<br> <li> Includes a reveal/hide toggle for masking values.<br> <li> Watches variableSet prop to load values on change.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-0563471f5e72b7fb72d4b9ce51d8568e046e774210e807cc56f3472a32ddc458">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English i18n keys for new UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/en.json

<ul><li>Added i18n keys for search, filter, delete confirmation, view drawer, <br>reveal/hide, etc.<br> <li> Added key for wizard environment set values label.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese i18n keys for new UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/admin/locales/zh-CN.json

<ul><li>Added Chinese i18n keys for search, filter, delete confirmation, view <br>drawer, reveal/hide, etc.<br> <li> Added key for wizard environment set values label.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>359.yaml</strong><dd><code>Add release note for environment changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/359.yaml

<ul><li>Added release note fragment for the environment variable set <br>improvements.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/360/files#diff-0a53b48f372aed75a4766e382046522684420a9cce876cf8e0df3d4b20f16035">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

