### PR TITLE
Show loading indicator on the active pending plan step

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1064,7 +1064,10 @@
                           <span
                             class="runtime-plan-status"
                             :class="[
-                              `is-${task.status}`,
+                              `is-${livePlanStatus(
+                                task,
+                                liveStructuredProgress.tasks
+                              )}`,
                               {
                                 'is-active-ancestor': isActiveProgressAncestor(
                                   task,
@@ -1074,7 +1077,14 @@
                             ]"
                             aria-hidden="true"
                           >
-                            {{ progressStatusIcon(task.status) }}
+                            {{
+                              progressStatusIcon(
+                                livePlanStatus(
+                                  task,
+                                  liveStructuredProgress.tasks
+                                )
+                              )
+                            }}
                           </span>
                           <span>{{ workflowTaskTitle(task) }}</span>
                         </div>
@@ -1180,10 +1190,20 @@
                       <div class="runtime-plan-step">
                         <span
                           class="runtime-plan-status"
-                          :class="`is-${item.status}`"
+                          :class="`is-${livePlanStatus(
+                            item,
+                            liveStructuredProgress.items
+                          )}`"
                           aria-hidden="true"
                         >
-                          {{ progressStatusIcon(item.status) }}
+                          {{
+                            progressStatusIcon(
+                              livePlanStatus(
+                                item,
+                                liveStructuredProgress.items
+                              )
+                            )
+                          }}
                         </span>
                         <span class="runtime-step-content">
                           <span>{{ item.title }}</span>
@@ -1681,6 +1701,7 @@ import {
   formatDuration,
   getMessageTimestamp,
   isActiveProgressAncestor,
+  planStepDisplayStatus,
   scrollConversationToBottomAfterRender,
   selectLiveProgressText,
   selectStructuredProgress,
@@ -2155,6 +2176,10 @@ const liveStructuredProgress = computed(() =>
   structuredProgress(runtimeState.value)
 )
 
+function livePlanStatus(item, items) {
+  return planStepDisplayStatus(item, items, { active: isRunActive.value })
+}
+
 function nodeActivities(state, nodeId) {
   return activitiesForNode(state, nodeId)
 }
@@ -2176,7 +2201,11 @@ function activityLabel(kind) {
 
 function isCurrentActivity(activity, item) {
   const latest = runtimeState.value.activities.at(-1)
-  return item.status === 'in_progress' && latest?.id === activity.id
+  const items = liveStructuredProgress.value.items
+  return (
+    livePlanStatus(item, items) === 'in_progress' &&
+    latest?.id === activity.id
+  )
 }
 
 function isCurrentStandaloneActivity(activity, items) {

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -572,6 +572,18 @@ export function summarizePlanProgress(steps, { terminal = false } = {}) {
   }
 }
 
+export function planStepDisplayStatus(step, steps, { active = false } = {}) {
+  if (!active) return step?.status
+  if (['completed', 'failed', 'skipped'].includes(step?.status)) {
+    return step.status
+  }
+  if (!Array.isArray(steps) || steps.length === 0) return step?.status
+  const current =
+    steps.find((item) => item.status === 'in_progress') ||
+    steps.find((item) => item.status === 'pending')
+  return current?.id === step?.id ? 'in_progress' : step?.status
+}
+
 export function summarizeStageProgress(stages, { terminal = false } = {}) {
   if (!Array.isArray(stages) || stages.length === 0) return null
   const completed = stages.filter(

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -14,6 +14,7 @@ import {
   isActiveProgressAncestor,
   normalizePlanSteps,
   normalizeStages,
+  planStepDisplayStatus,
   scrollConversationToBottomAfterRender,
   selectCurrentWorkflowStage,
   selectLiveProgressText,
@@ -309,6 +310,54 @@ test('marks incomplete plan progress as terminal after the run ends', () => {
       isComplete: false,
       isTerminal: true
     }
+  )
+})
+
+test('promotes the current pending plan step while the run is active', () => {
+  const steps = [
+    { id: 'one', title: 'Inspect', status: 'completed' },
+    { id: 'two', title: 'Implement', status: 'completed' },
+    { id: 'three', title: 'Verify', status: 'pending' },
+    { id: 'four', title: 'Release', status: 'pending' }
+  ]
+  assert.equal(
+    planStepDisplayStatus(steps[0], steps, { active: true }),
+    'completed'
+  )
+  assert.equal(
+    planStepDisplayStatus(steps[2], steps, { active: true }),
+    'in_progress'
+  )
+  assert.equal(
+    planStepDisplayStatus(steps[3], steps, { active: true }),
+    'pending'
+  )
+})
+
+test('keeps the reported status when the run is not active', () => {
+  const steps = [
+    { id: 'one', status: 'completed' },
+    { id: 'two', status: 'pending' }
+  ]
+  assert.equal(planStepDisplayStatus(steps[1], steps), 'pending')
+  assert.equal(
+    planStepDisplayStatus(steps[1], steps, { active: false }),
+    'pending'
+  )
+})
+
+test('does not promote a step past an earlier in_progress step', () => {
+  const steps = [
+    { id: 'one', status: 'in_progress' },
+    { id: 'two', status: 'pending' }
+  ]
+  assert.equal(
+    planStepDisplayStatus(steps[0], steps, { active: true }),
+    'in_progress'
+  )
+  assert.equal(
+    planStepDisplayStatus(steps[1], steps, { active: true }),
+    'pending'
   )
 })
 

--- a/release-notes/367.yaml
+++ b/release-notes/367.yaml
@@ -1,0 +1,8 @@
+type: fix
+audience: user
+en: >-
+  Fixed the live execution plan looking stuck while the current subtask ran:
+  the active pending step now shows a loading indicator during the run.
+zh-CN: >-
+  修复执行计划在当前子任务运行期间看起来卡住的问题：进行中的待执行步骤现在
+  会在运行期间显示加载指示器。


### PR DESCRIPTION
### **User description**
## Summary
- While a run is active, the current plan step (first non-completed) can
  stay `pending` because `write_todos` is not advanced while the agent
  delegates a heavy subtask to a subagent via the `task` tool
- The live progress card only animated `in_progress` steps, so the active
  step rendered as a hollow `○` with no loading indicator and looked stuck
- Add `planStepDisplayStatus` helper in `runtimeEvents.js` that promotes
  the current step to `in_progress` for display while the run is active
- Use it in the live workflow task rows and plan node rows in `Chat.vue`;
  terminal messages keep the reported status so a finished run still shows
  a stuck step as pending
- Add unit tests for promotion while active, no promotion when inactive,
  and no promotion past an earlier `in_progress` step

Closes #367

## Test plan
- [x] `node --test tests/runtimeEvents.test.js` — 65/65 pass
- [x] `npm run test:unit` — 296 pass, 4 pre-existing failures unchanged


___

### **PR Type**
Bug fix


___

### **Description**
- Show loading indicator on active pending plan step during run.

- Add `planStepDisplayStatus` helper to promote pending step to `in_progress`.

- Use helper in live workflow task rows and plan node rows.

- Add unit tests and release note.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  step["Step Status"] --> check{"Run Active?"}
  check -- "No" --> keep["Keep Reported Status"]
  check -- "Yes" --> pending{"Step is Pending?"}
  pending -- "No" --> keep
  pending -- "Yes" --> promote["Promote to in_progress"]
  promote --> display["Show Loading Indicator"]
  keep --> display
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Use live plan status in plan step rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Import and use <code>planStepDisplayStatus</code> helper.<br> <li> Replace direct <code>task.status</code> with <code>livePlanStatus</code> computed from helper.<br> <li> Apply promoted status to CSS class and icon in plan node rows.<br> <li> Update <code>isCurrentActivity</code> to use promoted status.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/368/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+34/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtimeEvents.js</strong><dd><code>Add planStepDisplayStatus helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/runtimeEvents.js

<ul><li>Add <code>planStepDisplayStatus</code> function that promotes the current pending <br>step to <code>in_progress</code> when the run is active.<br> <li> Logic: if active and step is not terminal, find first <code>in_progress</code> or <br><code>pending</code> step; if it matches the given step, return <code>in_progress</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/368/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeEvents.test.js</strong><dd><code>Add tests for planStepDisplayStatus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/runtimeEvents.test.js

<ul><li>Add three test cases for <code>planStepDisplayStatus</code>: promotion while <br>active, no promotion when inactive, and no promotion past an earlier <br><code>in_progress</code> step.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/368/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>367.yaml</strong><dd><code>Add release note for loading indicator fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/367.yaml

<ul><li>Add release note fragment documenting the fix for the stuck loading <br>indicator.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/368/files#diff-a4590b344a38ff5793bfc8e15981658f84244186bedafb2e4d05ecd9d82b1e28">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

