### PR TITLE
Harden Code Analysis planner and trim duplicate run-stream I/O

### DIFF
--- a/backend/lens/citations.py
+++ b/backend/lens/citations.py
@@ -69,6 +69,9 @@ def sanitize_planned_evidence(value):
     planner_status = value.get("planner_status")
     if planner_status in PLANNER_STATUSES:
         output["planner_status"] = planner_status
+    reason = value.get("planner_rejection_reason")
+    if isinstance(reason, str) and reason:
+        output["planner_rejection_reason"] = reason[:500]
     return output
 
 

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -2084,20 +2084,6 @@ def dispatch_run_to_lensnode(
         raise LensNodeDispatchError(
             "DOCUMENT_ATTACHMENTS_UNSUPPORTED_BY_LENSNODE"
         )
-    image_data_urls = []
-    if run.input_message_id:
-        for attachment in run.input_message.attachments.all():
-            data_url = attachment_data_url(attachment)
-            if not data_url:
-                raise LensNodeDispatchError("ATTACHMENT_UNREADABLE")
-            image_data_urls.append(data_url)
-    agent_model_ref = (
-        model_refs.get("multimodal")
-        or str(run.session.assistant.multimodal_model_ref or "")
-        if image_data_urls
-        else model_refs.get("agent")
-        or str(run.session.assistant.agent_model_ref or "")
-    )
     channel_layer = get_channel_layer()
     if channel_layer is None:
         raise LensNodeDispatchError("LENS_CHANNEL_LAYER_UNAVAILABLE")
@@ -2138,11 +2124,12 @@ def dispatch_run_to_lensnode(
         image_attachments = run.input_message.attachments.filter(
             kind=MessageAttachment.Kind.IMAGE
         )
-    image_data_urls = [
-        data_url
-        for attachment in image_attachments.order_by("created_at", "pk")
-        if (data_url := attachment_data_url(attachment))
-    ]
+    image_data_urls = []
+    for attachment in image_attachments.order_by("created_at", "pk"):
+        data_url = attachment_data_url(attachment)
+        if not data_url:
+            raise LensNodeDispatchError("ATTACHMENT_UNREADABLE")
+        image_data_urls.append(data_url)
     agent_model_ref = (
         model_refs.get("multimodal")
         or str(run.session.assistant.multimodal_model_ref or "")
@@ -2863,12 +2850,18 @@ async def stream_run_events_async(run):
 
     run = await sync_to_async(_load_run_stream_state)(run_pk)
     yield _build_sync_event(run)
-    # the sync event already carries the current content; seed emitted_content
-    # so the loop streams only new deltas (avoids resending it on reconnect)
+    # The sync event already carries the current status, resume_by, all
+    # steps, and content. Seed the dedup cursors so the loop below emits
+    # only genuine deltas instead of replaying the snapshot.
     emitted_content = _run_content(run)
+    last_status = run.status
+    last_resume_by = run.resume_by.isoformat() if run.resume_by else None
+    emitted_steps = {
+        (step.sequence, step.status, step.updated_at)
+        for step in run.steps.all()
+    }
 
     while True:
-        run = await sync_to_async(_load_run_stream_state)(run_pk)
         content = _run_content(run)
 
         resume_by = run.resume_by.isoformat() if run.resume_by else None
@@ -2938,6 +2931,7 @@ async def stream_run_events_async(run):
             }
 
         await asyncio.sleep(STREAM_POLL_INTERVAL_SECONDS)
+        run = await sync_to_async(_load_run_stream_state)(run_pk)
 
 
 def _load_run_stream_state(run_pk):

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -3418,6 +3418,45 @@ class LensApiTests(TestCase):
         self.assertIn('"type": "sync"', body)
         self.assertIn('"type": "done"', body)
 
+    def test_stream_does_not_replay_snapshot_steps_after_sync(self):
+        session = Session.objects.create(
+            assistant=self.assistant,
+            user=self.user,
+        )
+        run = create_execution_run(
+            session=session,
+            question="Explain the event pipeline",
+            enqueue=False,
+        )
+        run.status = Run.Status.DONE
+        run.outcome = Run.Outcome.COMPLETED
+        run.termination_detail = {}
+        run.save(update_fields=["status", "outcome", "termination_detail"])
+        run.execution.status = RunExecution.Status.COMPLETED
+        run.execution.save(update_fields=["status"])
+        for sequence in (1, 2):
+            RunStep.objects.create(
+                run=run,
+                step_type=RunStep.StepType.GENERAL_CHAT,
+                status=RunStep.Status.DONE,
+                sequence=sequence,
+                detail={"events": [{"agent_event": f"step.{sequence}"}]},
+            )
+
+        stream_response = self.client.get(
+            f"/api/lens/runs/{run.uuid}/stream/",
+            HTTP_AUTHORIZATION=bearer_header(self.user),
+        )
+        self.assertEqual(stream_response.status_code, 200)
+        body = collect_stream(stream_response.streaming_content).decode()
+
+        # The sync snapshot already carries every persisted step; the loop
+        # must not replay them as duplicate standalone step events.
+        self.assertIn('"type": "sync"', body)
+        self.assertIn("step.1", body)
+        self.assertIn("step.2", body)
+        self.assertNotIn('"type": "step"', body)
+
     def test_clarification_answer_creates_one_continuation_run(self):
         session = Session.objects.create(
             assistant=self.assistant,
@@ -3978,7 +4017,7 @@ class LensApiTests(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
-    def test_running_run_stream_returns_sync_and_status(self):
+    def test_running_run_stream_returns_sync_without_replaying_status(self):
         session_response = self.client.post(
             "/api/lens/sessions/",
             {"assistant_uuid": str(self.assistant.uuid)},
@@ -4002,7 +4041,9 @@ class LensApiTests(TestCase):
         body = collect_stream(stream_response.streaming_content, limit=2).decode()
 
         self.assertIn('"type": "sync"', body)
-        self.assertIn('"type": "status"', body)
+        # The sync snapshot already carries the current status; a duplicate
+        # status event is only emitted when the run status actually changes.
+        self.assertNotIn('"type": "status"', body)
 
     def test_datasource_create_uses_target_path(self):
         payload = {

--- a/backend/lens/tests/test_planned_evidence_sanitizer.py
+++ b/backend/lens/tests/test_planned_evidence_sanitizer.py
@@ -1,0 +1,51 @@
+from django.test import SimpleTestCase
+
+from lens.citations import sanitize_planned_evidence
+
+
+class SanitizePlannedEvidenceTest(SimpleTestCase):
+    """Bound the public planned-evidence summary surface."""
+
+    def test_keeps_sufficient_and_gap_categories(self):
+        output = sanitize_planned_evidence(
+            {
+                "sufficient": True,
+                "gap_categories": ["source", "unexpected"],
+                "internal_secret": "x",
+            }
+        )
+
+        self.assertEqual(output["sufficient"], True)
+        self.assertEqual(output["gap_categories"], ["source"])
+        self.assertNotIn("internal_secret", output)
+
+    def test_keeps_planner_status_and_bounded_rejection_reason(self):
+        output = sanitize_planned_evidence(
+            {
+                "planner_status": "fallback",
+                "planner_rejection_reason": (
+                    "unsupported CodeGraph operation: symbol_search | "
+                    "codegraph query must be an object"
+                ),
+            }
+        )
+
+        self.assertEqual(output["planner_status"], "fallback")
+        self.assertIn(
+            "unsupported CodeGraph operation: symbol_search",
+            output["planner_rejection_reason"],
+        )
+
+    def test_rejects_unknown_planner_status_and_non_string_reason(self):
+        output = sanitize_planned_evidence(
+            {
+                "planner_status": "exploded",
+                "planner_rejection_reason": {"nested": "secret"},
+            }
+        )
+
+        self.assertNotIn("planner_status", output)
+        self.assertNotIn("planner_rejection_reason", output)
+
+    def test_non_dict_input_returns_empty(self):
+        self.assertEqual(sanitize_planned_evidence("oops"), {})

--- a/env.sample
+++ b/env.sample
@@ -129,6 +129,10 @@ LENSNODE_MCP_STDIO_ALLOWLIST=codegraph
 LENSNODE_MCP_ENABLE_CODEGRAPH=true
 LENSNODE_CODEGRAPH_COMMAND=codegraph
 LENSNODE_CODEGRAPH_INIT_TIMEOUT_S=300
+# Re-run the planner with a repair prompt after an invalid retrieval plan
+# instead of falling back to bounded keyword search immediately. The repair
+# costs one extra model call per invalid plan; the fallback is fast.
+LENSNODE_PLANNER_REPAIR_ENABLED=false
 
 # -----------------------------------------------------------------------------
 # Admin bootstrap

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -55,6 +55,11 @@
     "overviewTiming": "Timing",
     "overviewResources": "Runtime resources",
     "plannedEvidence": "Planned evidence",
+    "plannedEvidencePlannerStatus": "Planner",
+    "plannedEvidencePlannerStatus.valid": "Valid",
+    "plannedEvidencePlannerStatus.repaired": "Repaired",
+    "plannedEvidencePlannerStatus.fallback": "Fallback",
+    "plannedEvidenceFallback": "Retrieval plan was rejected and fell back to keyword search",
     "plannedEvidenceModelCalls": "Model calls",
     "plannedEvidenceRetrievalCalls": "Retrieval calls",
     "plannedEvidenceTokens": "Evidence tokens",
@@ -1608,7 +1613,7 @@
       "deep": "Deep",
       "deepHint": "500K total · 75K reserved for the final answer",
       "unlimited": "Unlimited",
-      "unlimitedHint": "No cumulative token cap · other run safety limits still apply",
+      "unlimitedHint": "No cumulative token cap; other run safety limits still apply",
       "nodeLimitHint": "Unlimited only disables the cumulative token cap. Run time, maximum rounds, and other safety limits still apply."
     },
     "messages": {

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -55,6 +55,11 @@
     "overviewTiming": "时间信息",
     "overviewResources": "运行资源",
     "plannedEvidence": "计划证据检索",
+    "plannedEvidencePlannerStatus": "计划器状态",
+    "plannedEvidencePlannerStatus.valid": "有效",
+    "plannedEvidencePlannerStatus.repaired": "已修复",
+    "plannedEvidencePlannerStatus.fallback": "已降级",
+    "plannedEvidenceFallback": "检索计划被拒绝，已降级为关键词搜索",
     "plannedEvidenceModelCalls": "模型调用",
     "plannedEvidenceRetrievalCalls": "检索调用",
     "plannedEvidenceTokens": "证据 Token",
@@ -1608,7 +1613,7 @@
       "deep": "深度",
       "deepHint": "总计 50 万 · 为最终回答预留 7.5 万",
       "unlimited": "无限制",
-      "unlimitedHint": "不设置累计 Token 预算 · 其他运行安全限制仍然生效",
+      "unlimitedHint": "不设置累计 Token 预算；其他运行安全限制仍然生效",
       "nodeLimitHint": "无限制仅关闭累计 Token 门禁；运行时间、最大轮次和其他安全限制仍然生效。"
     },
     "messages": {

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -814,7 +814,32 @@
                   <h3 class="overview-title">
                     {{ t('lensRuns.plannedEvidence') }}
                   </h3>
+                  <p
+                    v-if="plannedEvidence.planner_status === 'fallback'"
+                    data-testid="planned-evidence-fallback"
+                    class="mb-2 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
+                  >
+                    {{ t('lensRuns.plannedEvidenceFallback') }}
+                    <span
+                      v-if="plannedEvidence.planner_rejection_reason"
+                      class="mt-0.5 block font-mono"
+                      :title="plannedEvidence.planner_rejection_reason"
+                    >
+                      {{ plannedEvidence.planner_rejection_reason }}
+                    </span>
+                  </p>
                   <dl class="overview-grid">
+                    <div>
+                      <dt class="overview-label">
+                        {{ t('lensRuns.plannedEvidencePlannerStatus') }}
+                      </dt>
+                      <dd
+                        class="overview-value"
+                        :data-testid="`planner-status-${plannedEvidence.planner_status || 'none'}`"
+                      >
+                        {{ plannerStatusLabel }}
+                      </dd>
+                    </div>
                     <div>
                       <dt class="overview-label">
                         {{ t('lensRuns.plannedEvidenceModelCalls') }}
@@ -1270,6 +1295,14 @@ const plannedEvidence = computed(() => detail.value?.planned_evidence || {})
 const hasPlannedEvidence = computed(
   () => Object.keys(plannedEvidence.value).length > 0
 )
+const plannerStatusLabel = computed(() => {
+  const status = plannedEvidence.value.planner_status
+  if (!status) return '-'
+  const key = { valid: 'valid', repaired: 'repaired', fallback: 'fallback' }[
+    status
+  ]
+  return key ? t(`lensRuns.plannedEvidencePlannerStatus.${key}`) : status
+})
 
 const AGENT_ROUNDS_KEYS = {
   flash: 'flash',

--- a/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
+++ b/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
@@ -49,7 +49,7 @@
                 v-for="step in lane.steps"
                 :key="`overview-${lane.key}-${step.event.event_id}`"
                 type="button"
-                class="absolute top-0 h-full rounded-sm"
+                class="absolute top-0 h-full"
                 :class="[
                   categoryColor(eventCategory(step.event)),
                   step.subagent ? 'ring-1 ring-amber-400' : ''
@@ -58,7 +58,7 @@
                   left: `${step.left}%`,
                   width: `${step.width}%`
                 }"
-                :title="`${step.event.sequence} · ${step.event.event_type}`"
+                :title="stepTooltip(step)"
                 @click="selectedEvent = step.event"
               />
             </div>
@@ -106,64 +106,85 @@
           data-testid="trajectory-ledger"
           class="max-h-[42rem] overflow-y-auto divide-y divide-gray-100 bg-white"
         >
-          <li v-for="row in rows" :key="row.event.event_id">
-            <div
-              role="button"
-              tabindex="0"
-              class="group flex w-full items-start gap-2 px-3 py-2.5 text-left hover:bg-gray-50"
-              :class="
-                selectedEvent?.event_id === row.event.event_id
-                  ? 'bg-primary-50/70'
-                  : ''
-              "
-              :style="{ paddingLeft: `${12 + row.depth * 18}px` }"
-              @click="selectedEvent = row.event"
-              @keydown.enter="selectedEvent = row.event"
+          <template v-for="group in groupedRows" :key="group.key">
+            <li
+              v-if="group.rows.length > 1"
+              class="sticky top-0 z-10 flex items-center gap-2 border-y border-gray-200 bg-gray-100/95 px-3 py-1.5 backdrop-blur-sm"
             >
-              <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center">
-                <button
-                  v-if="row.hasChildren"
-                  type="button"
-                  class="rounded text-gray-400 hover:bg-gray-200"
-                  :aria-label="t('lensRuns.trajectoryToggle')"
-                  @click.stop="toggleCall(row.event.call_id)"
-                >
-                  <ChevronRight
-                    v-if="collapsed.has(row.event.call_id)"
-                    :size="15"
+              <span
+                class="h-2 w-2 rounded-full"
+                :class="categoryColor(group.category)"
+              />
+              <span
+                class="text-[11px] font-semibold uppercase tracking-wide text-gray-600"
+              >
+                {{ group.label }}
+              </span>
+              <span class="ml-auto text-[10px] tabular-nums text-gray-400">
+                {{ group.rows.length }}
+              </span>
+            </li>
+            <li v-for="row in group.rows" :key="row.event.event_id">
+              <div
+                role="button"
+                tabindex="0"
+                class="group flex w-full items-start gap-2 px-3 py-2.5 text-left hover:bg-gray-50"
+                :class="
+                  selectedEvent?.event_id === row.event.event_id
+                    ? 'bg-primary-50/70'
+                    : ''
+                "
+                :style="{ paddingLeft: `${12 + row.depth * 18}px` }"
+                @click="selectedEvent = row.event"
+                @keydown.enter="selectedEvent = row.event"
+              >
+                <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center">
+                  <button
+                    v-if="row.hasChildren"
+                    type="button"
+                    class="rounded text-gray-400 hover:bg-gray-200"
+                    :aria-label="t('lensRuns.trajectoryToggle')"
+                    @click.stop="toggleCall(row.event.call_id)"
+                  >
+                    <ChevronRight
+                      v-if="collapsed.has(row.event.call_id)"
+                      :size="15"
+                    />
+                    <ChevronDown v-else :size="15" />
+                  </button>
+                  <span
+                    v-else
+                    class="mx-auto h-2 w-2 rounded-full"
+                    :class="categoryColor(eventCategory(row.event))"
                   />
-                  <ChevronDown v-else :size="15" />
-                </button>
-                <span
-                  v-else
-                  class="mx-auto h-2 w-2 rounded-full"
-                  :class="categoryColor(eventCategory(row.event))"
-                />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="flex items-center justify-between gap-3">
-                  <span class="truncate text-sm font-medium text-gray-800">
-                    {{ eventTitle(row.event) }}
-                  </span>
-                  <time class="shrink-0 text-[11px] tabular-nums text-gray-400">
-                    #{{ row.event.sequence }} ·
-                    {{ timeText(row.event.timestamp) }}
-                  </time>
                 </span>
-                <span
-                  class="mt-0.5 flex flex-wrap gap-x-3 text-xs text-gray-500"
-                >
-                  <span>{{ row.event.event_type }}</span>
-                  <span v-if="eventMetric(row.event)">
-                    {{ eventMetric(row.event) }}
+                <span class="min-w-0 flex-1">
+                  <span class="flex items-center justify-between gap-3">
+                    <span class="truncate text-sm font-medium text-gray-800">
+                      {{ eventTitle(row.event) }}
+                    </span>
+                    <time
+                      class="shrink-0 text-[11px] tabular-nums text-gray-400"
+                    >
+                      #{{ row.event.sequence }} ·
+                      {{ timeText(row.event.timestamp) }}
+                    </time>
                   </span>
-                  <span v-if="row.event.attempt > 1">
-                    attempt {{ row.event.attempt }}
+                  <span
+                    class="mt-0.5 flex flex-wrap gap-x-3 text-xs text-gray-500"
+                  >
+                    <span>{{ row.event.event_type }}</span>
+                    <span v-if="eventMetric(row.event)">
+                      {{ eventMetric(row.event) }}
+                    </span>
+                    <span v-if="row.event.attempt > 1">
+                      attempt {{ row.event.attempt }}
+                    </span>
                   </span>
                 </span>
-              </span>
-            </div>
-          </li>
+              </div>
+            </li>
+          </template>
         </ol>
 
         <aside
@@ -263,7 +284,8 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import {
   buildTimelineLanes,
   buildTrajectoryRows,
-  eventCategory
+  eventCategory,
+  groupTrajectoryRows
 } from './runTrajectory'
 
 const props = defineProps({
@@ -308,6 +330,8 @@ const filteredEvents = computed(() => events.value)
 const rows = computed(() =>
   buildTrajectoryRows(filteredEvents.value, collapsed.value)
 )
+
+const groupedRows = computed(() => groupTrajectoryRows(rows.value))
 
 const timelineLanes = computed(() =>
   buildTimelineLanes(events.value, summary.value)
@@ -420,6 +444,18 @@ function durationText(value) {
   if (value === null || value === undefined) return '-'
   if (value < 1000) return `${value}ms`
   return `${(value / 1000).toFixed(1)}s`
+}
+
+function stepTooltip(step) {
+  const event = step.event || {}
+  const parts = [`${event.sequence ?? '?'} · ${event.event_type}`]
+  if (step.startMs != null) {
+    parts.push(timeText(new Date(step.startMs).toISOString()))
+  }
+  if (step.durationMs != null) {
+    parts.push(durationText(step.durationMs))
+  }
+  return parts.join('\n')
 }
 
 function timeText(value) {

--- a/frontend/src/admin/pages/lens/runTrajectory.js
+++ b/frontend/src/admin/pages/lens/runTrajectory.js
@@ -46,7 +46,9 @@ export function buildTimelineLanes(events, summary) {
       event,
       left,
       width: Math.min(width, 100 - left),
-      subagent
+      subagent,
+      startMs,
+      durationMs: endMs - startMs
     })
   }
 
@@ -121,4 +123,33 @@ export function buildTrajectoryRows(events, collapsed) {
       }
     ]
   })
+}
+
+const STEP_STATUS_SUFFIX = /\.(start|started|done|completed|failed|stopped)$/
+
+function stepGroupName(event) {
+  const name = String(event?.payload?.name || '')
+  if (!name) return 'step'
+  return name.replace(STEP_STATUS_SUFFIX, '')
+}
+
+export function groupTrajectoryRows(rows) {
+  const groups = []
+  const index = new Map()
+  for (const row of rows) {
+    const category = eventCategory(row.event)
+    let key = category
+    let label = category
+    if (category === 'step') {
+      key = `step:${stepGroupName(row.event)}`
+      label = stepGroupName(row.event)
+    }
+    if (!index.has(key)) {
+      const group = { key, category, label, rows: [] }
+      index.set(key, group)
+      groups.push(group)
+    }
+    index.get(key).rows.push(row)
+  }
+  return groups
 }

--- a/frontend/tests/runTrajectory.test.js
+++ b/frontend/tests/runTrajectory.test.js
@@ -5,6 +5,7 @@ import {
   buildTimelineLanes,
   buildTrajectoryRows,
   eventCategory,
+  groupTrajectoryRows,
   isSubagentEvent,
   timelineLane
 } from '../src/admin/pages/lens/runTrajectory.js'
@@ -56,6 +57,48 @@ test('collapsing a call hides every descendant event', () => {
     rows.map((row) => row.event.sequence),
     [1]
   )
+})
+
+test('trajectory rows group by category and step base name', () => {
+  const grouped = groupTrajectoryRows(
+    buildTrajectoryRows(
+      [
+        {
+          event_id: 'stage-start',
+          sequence: 1,
+          event_type: 'step.event',
+          payload: { name: 'deepagents.runtime.stage.start' }
+        },
+        {
+          event_id: 'stage-done',
+          sequence: 2,
+          event_type: 'step.event',
+          payload: { name: 'deepagents.runtime.stage.done' }
+        },
+        {
+          event_id: 'model-start',
+          sequence: 3,
+          event_type: 'model.started',
+          call_id: 'model-1'
+        },
+        {
+          event_id: 'resource',
+          sequence: 4,
+          event_type: 'step.event',
+          payload: { name: 'resources.materialized' }
+        }
+      ],
+      new Set()
+    )
+  )
+
+  assert.deepEqual(
+    grouped.map((group) => group.label),
+    ['deepagents.runtime.stage', 'model', 'resources.materialized']
+  )
+  assert.equal(grouped[0].rows.length, 2)
+  assert.equal(grouped[1].category, 'model')
+  assert.equal(grouped[2].rows.length, 1)
 })
 
 test('trajectory events expose their filter category', () => {
@@ -143,12 +186,16 @@ test('timeline lanes fill per-call duration and keep events on lanes', () => {
   assert.equal(modelStep.left, 10)
   assert.equal(modelStep.width, 30)
   assert.equal(modelStep.subagent, false)
+  assert.equal(modelStep.startMs, 1000)
+  assert.equal(modelStep.durationMs, 3000)
 
   const toolStep = lanes[2].steps[0]
   assert.equal(toolStep.event.event_id, 'tool-start')
   assert.equal(toolStep.left, 50)
   assert.equal(toolStep.width, 30)
   assert.equal(toolStep.subagent, true)
+  assert.equal(toolStep.startMs, 5000)
+  assert.equal(toolStep.durationMs, 3000)
 })
 
 test('timeline lanes treat single events as minimal markers', () => {

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -38,6 +38,7 @@ from ..logging_utils import elapsed_since, task_log, utc_now
 from ..mcp_tools import build_deferred_mcp_tools, load_mcp_tools
 from ..plugins import collect_agent_runtime_contributions
 from ..planned_evidence import (
+    ALLOWED_CODEGRAPH_OPERATIONS,
     EvidenceExecutor,
     build_evidence_bundle,
     assess_code_analysis_capabilities,
@@ -233,6 +234,13 @@ class LensDeepAgentRuntime:
                         state.resources,
                         "context_skill_contents",
                         None,
+                    ),
+                    planner_repair_enabled=(
+                        getattr(
+                            self.config,
+                            "planner_repair_enabled",
+                            False,
+                        )
                     ),
                 )
             route_result = self._route_runtime(state)
@@ -1224,6 +1232,7 @@ def _run_planned_code_analysis(
     workspace_root,
     context_skill_contents=None,
     trajectory=None,
+    planner_repair_enabled=False,
 ):
     """Run Code Analysis through one plan and one compact evidence bundle."""
 
@@ -1277,6 +1286,7 @@ def _run_planned_code_analysis(
     planner_prompt = _planned_planner_prompt(
         command,
         context_skill_contents=context_skill_contents,
+        codegraph_operations=sorted(codegraph_adapters),
     )
     emit_agent_event(
         "workflow.phase.changed",
@@ -1297,34 +1307,54 @@ def _run_planned_code_analysis(
     )
     planner_status = "valid"
     planner_retry_count = 0
+    planner_rejection_reason = ""
     try:
         plan = parse_retrieval_plan(_message_content(planner_response))
-    except Exception:
-        planner_retry_count = 1
-        repair_response = model.invoke(
-            [
-                SystemMessage(content=_planned_planner_repair_prompt()),
-                HumanMessage(
-                    content=json.dumps(
-                        {
-                            "question": question,
-                            "invalid_plan": _message_content(
-                                planner_response
-                            )[:4000],
-                        },
-                        ensure_ascii=False,
-                    )
-                ),
-            ],
-            runtime_structured_output=True,
-            on_reasoning_delta=pulse_callback,
-        )
-        try:
-            plan = parse_retrieval_plan(_message_content(repair_response))
-            planner_status = "repaired"
-        except Exception:
+    except Exception as exc:
+        planner_rejection_reason = str(exc)
+        if planner_repair_enabled:
+            planner_retry_count = 1
+            repair_response = model.invoke(
+                [
+                    SystemMessage(
+                        content=_planned_planner_repair_prompt(
+                            validation_error=str(exc),
+                            codegraph_operations=sorted(codegraph_adapters),
+                        )
+                    ),
+                    HumanMessage(
+                        content=json.dumps(
+                            {
+                                "question": question,
+                                "invalid_plan": _message_content(
+                                    planner_response
+                                )[:4000],
+                            },
+                            ensure_ascii=False,
+                        )
+                    ),
+                ],
+                runtime_structured_output=True,
+                on_reasoning_delta=pulse_callback,
+            )
+            try:
+                plan = parse_retrieval_plan(
+                    _message_content(repair_response)
+                )
+                planner_status = "repaired"
+            except Exception as repair_exc:
+                planner_rejection_reason = (
+                    f"{planner_rejection_reason} | {repair_exc}"
+                )
+                plan = _parse_planner_response(
+                    repair_response,
+                    question,
+                    command,
+                )
+                planner_status = "fallback"
+        else:
             plan = _parse_planner_response(
-                repair_response,
+                planner_response,
                 question,
                 command,
             )
@@ -1365,6 +1395,7 @@ def _run_planned_code_analysis(
                 "model_call_count": 1 + planner_retry_count,
                 "planner_status": planner_status,
                 "planner_retry_count": planner_retry_count,
+                "planner_rejection_reason": planner_rejection_reason,
             },
             "citations": [],
         }
@@ -1428,6 +1459,7 @@ def _run_planned_code_analysis(
     )
     bundle.metrics["planner_status"] = planner_status
     bundle.metrics["planner_retry_count"] = planner_retry_count
+    bundle.metrics["planner_rejection_reason"] = planner_rejection_reason
     bundle.metrics["planned_operation_count"] = (
         len(plan.codegraph_queries) + len(plan.literal_queries)
     )
@@ -1841,9 +1873,41 @@ def _looks_like_planned_answer_envelope(content):
     return len(keys) >= 2
 
 
-def _planned_planner_prompt(command, context_skill_contents=None):
-    """Build the compact initial planner contract."""
+def _planned_planner_prompt(
+    command,
+    context_skill_contents=None,
+    codegraph_operations=None,
+):
+    """Build the compact initial planner contract.
 
+    Enumerates the allowed CodeGraph operations and shows concrete JSON so
+    the model does not invent operation names that validation rejects. When
+    only a subset is available (no dedicated adapter), the model is told
+    which ones can actually run.
+    """
+
+    if codegraph_operations is None:
+        operations = ALLOWED_CODEGRAPH_OPERATIONS
+    else:
+        operations = set(codegraph_operations)
+    if operations:
+        operation_text = ", ".join(
+            f'"{name}"' for name in sorted(operations)
+        )
+        example_operation = (
+            "search" if "search" in operations else sorted(operations)[0]
+        )
+        codegraph_contract = (
+            "Each codegraph_queries item must be an object with an "
+            f"operation from [{operation_text}] and a query or symbol; for "
+            f'example {{"operation": "{example_operation}", "symbol": '
+            '"VSSMode"}.'
+        )
+    else:
+        codegraph_contract = (
+            "CodeGraph is not available in this run; set codegraph_queries "
+            "to []."
+        )
     prompt = (
         "Return only one JSON retrieval plan. Do not inspect files or call "
         "tools. The backend will execute every bounded operation. Include "
@@ -1857,6 +1921,8 @@ def _planned_planner_prompt(command, context_skill_contents=None):
         "source_windows empty unless exact file paths and line ranges are "
         "already known; the executor derives source windows from retrieval "
         "results. "
+        f"{codegraph_contract} literal_queries must be an array of plain "
+        'strings (never objects), for example ["153301", "Sysconfig.ini"]. '
         "Use CodeGraph for structural questions and exact search for logs "
         "or traceback text. Keep max_fallback_rounds at 1 or less. The "
         "workspace is "
@@ -1865,18 +1931,52 @@ def _planned_planner_prompt(command, context_skill_contents=None):
     return prompt + _context_guidance(context_skill_contents)
 
 
-def _planned_planner_repair_prompt():
-    """Build the single repair prompt for an invalid retrieval plan."""
+def _planned_planner_repair_prompt(
+    validation_error=None,
+    codegraph_operations=None,
+):
+    """Build the repair prompt for an invalid retrieval plan.
 
-    return (
+    Passes the concrete rejection reason and the allowed operations back so
+    the model can fix the specific violation instead of guessing again.
+    """
+
+    if codegraph_operations is None:
+        operations = ALLOWED_CODEGRAPH_OPERATIONS
+    else:
+        operations = set(codegraph_operations)
+    if operations:
+        operation_text = ", ".join(
+            f'"{name}"' for name in sorted(operations)
+        )
+        example_operation = (
+            "search" if "search" in operations else sorted(operations)[0]
+        )
+        codegraph_contract = (
+            "Each CodeGraph query must be an object with an operation from "
+            f"[{operation_text}] and a query or symbol, for example "
+            f'{{"operation": "{example_operation}", "symbol": "VSSMode"}}.'
+        )
+    else:
+        codegraph_contract = (
+            "CodeGraph is not available in this run; set codegraph_queries "
+            "to []."
+        )
+    prompt = (
         "Repair the invalid retrieval plan and return only one valid JSON "
         "retrieval plan. Required fields are objective, question_type, "
         "evidence_requirements, codegraph_queries, literal_queries, "
         "source_windows, max_files, max_fallback_rounds, and budgets. "
-        "Each CodeGraph query must be an object with an allowed operation "
-        "and query or symbol. Keep all searches bounded and set "
+        f"{codegraph_contract} literal_queries must be an array of plain "
+        "strings, never objects. Keep all searches bounded and set "
         "max_fallback_rounds to 1 or less. Do not answer the question."
     )
+    if validation_error:
+        prompt += (
+            "\nThe previous plan was rejected with this reason: "
+            f"{validation_error}"
+        )
+    return prompt
 
 
 def _planned_fallback_prompt():

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -41,6 +41,7 @@ class LensNodeConfig:
     codegraph_init_timeout_s: int = 300
     reasoning_effort: str | None = None
     planning_reasoning_effort: str | None = "none"
+    planner_repair_enabled: bool = False
 
 
 def _optional_int(value):
@@ -170,6 +171,9 @@ def load_config():
                 "none",
             )
             or None
+        ),
+        planner_repair_enabled=_env_bool(
+            "LENSNODE_PLANNER_REPAIR_ENABLED", default=False
         ),
         offload_tool_tokens=int(
             os.getenv("LENSNODE_OFFLOAD_TOOL_TOKENS") or "5000"

--- a/lensnode/lensnode/planned_evidence.py
+++ b/lensnode/lensnode/planned_evidence.py
@@ -28,10 +28,41 @@ ALLOWED_CODEGRAPH_OPERATIONS = {
     "search",
     "trace",
 }
+OPERATION_ALIASES = {
+    "symbol_search": "search",
+    "code_search": "search",
+    "search_symbol": "search",
+    "search_code": "search",
+    "symbol_lookup": "node",
+    "callers_of": "callers",
+    "callees_of": "callees",
+    "dependency_graph": "impact",
+    "subgraph": "explore",
+    "code_analysis": "explore",
+}
 
 
 class PlanValidationError(ValueError):
     """Raised when a model-generated retrieval plan is not safe to run."""
+
+
+def _normalize_codegraph_operation(item):
+    """Resolve a model-supplied operation to the allowed set.
+
+    Tolerates missing or aliased operation names so a substantively good
+    plan is not discarded wholesale, while still rejecting unknown values.
+    """
+
+    raw = item.get("operation")
+    operation = raw.strip().lower() if isinstance(raw, str) else ""
+    if not operation:
+        operation = "search" if item.get("symbol") else "explore"
+    operation = OPERATION_ALIASES.get(operation, operation)
+    if operation not in ALLOWED_CODEGRAPH_OPERATIONS:
+        raise PlanValidationError(
+            f"unsupported CodeGraph operation: {operation}"
+        )
+    return operation
 
 
 @dataclass(frozen=True)
@@ -236,11 +267,7 @@ def parse_retrieval_plan(raw):
     for item in codegraph_items:
         if not isinstance(item, dict):
             raise PlanValidationError("codegraph query must be an object")
-        operation = _required_text(item.get("operation"), "operation")
-        if operation not in ALLOWED_CODEGRAPH_OPERATIONS:
-            raise PlanValidationError(
-                f"unsupported CodeGraph operation: {operation}"
-            )
+        operation = _normalize_codegraph_operation(item)
         query = _bounded_query(item.get("query"))
         symbol = _bounded_query(item.get("symbol"))
         if not query and not symbol:
@@ -427,9 +454,19 @@ class EvidenceExecutor:
         requests = []
         for query in plan.codegraph_queries:
             adapter = self.codegraph_tools.get(query.operation)
+            args = query.as_args()
+            if adapter is None:
+                # The generic explore adapter covers structural questions
+                # when a specific operation is unavailable; keep the query
+                # alive rather than silently dropping the evidence request.
+                adapter = self.codegraph_tools.get("explore")
+                if adapter is not None:
+                    args = {"query": " ".join(
+                        filter(None, (args.get("query"), args.get("symbol")))
+                    )}
             if adapter is not None:
                 requests.append(
-                    ("codegraph", query.operation, adapter, query.as_args())
+                    ("codegraph", query.operation, adapter, args)
                 )
         search = self.workspace_tools.get("search_workspace")
         if search is not None:
@@ -986,10 +1023,18 @@ def _list_value(value):
 def _unique_queries(value):
     queries = []
     for item in _list_value(value):
-        query = _bounded_query(item)
+        query = _bounded_query(_literal_query_value(item))
         if query:
             queries.append(query)
     return tuple(dict.fromkeys(queries))
+
+
+def _literal_query_value(item):
+    """Accept either a plain string or an object with a pattern field."""
+
+    if isinstance(item, dict):
+        return item.get("pattern") or item.get("query") or ""
+    return item
 
 
 def _unique_texts(value):

--- a/lensnode/tests/test_config.py
+++ b/lensnode/tests/test_config.py
@@ -140,6 +140,25 @@ def test_load_config_uses_light_reasoning_for_initial_planning(monkeypatch):
     assert config.planning_reasoning_effort == "none"
 
 
+def test_load_config_disables_planner_repair_by_default(monkeypatch):
+    monkeypatch.delenv(
+        "LENSNODE_PLANNER_REPAIR_ENABLED",
+        raising=False,
+    )
+
+    config = load_config()
+
+    assert config.planner_repair_enabled is False
+
+
+def test_load_config_can_enable_planner_repair(monkeypatch):
+    monkeypatch.setenv("LENSNODE_PLANNER_REPAIR_ENABLED", "true")
+
+    config = load_config()
+
+    assert config.planner_repair_enabled is True
+
+
 def test_load_config_allows_mcp_discovery_and_cleanup_headroom(monkeypatch):
     monkeypatch.delenv(
         "LENSNODE_MCP_DISCOVERY_TIMEOUT_S",

--- a/lensnode/tests/test_planned_evidence.py
+++ b/lensnode/tests/test_planned_evidence.py
@@ -84,6 +84,62 @@ def test_retrieval_plan_rejects_missing_objective_and_invalid_operation():
         )
 
 
+def test_retrieval_plan_aliases_common_codegraph_operations():
+    plan = parse_retrieval_plan(
+        {
+            "objective": "trace the exception",
+            "codegraph_queries": [
+                {"operation": "symbol_search", "symbol": "VSSMode"},
+                {"operation": "code_search", "query": "VSSMode is conflict"},
+            ],
+        }
+    )
+
+    assert [query.operation for query in plan.codegraph_queries] == [
+        "search",
+        "search",
+    ]
+    assert plan.codegraph_queries[0].symbol == "VSSMode"
+
+
+def test_retrieval_plan_infers_missing_codegraph_operation():
+    plan = parse_retrieval_plan(
+        {
+            "objective": "trace the exception",
+            "codegraph_queries": [
+                {"query": "VSSMode symbols", "reason": "structural"},
+                {"symbol": "InitializeVSS_Model"},
+            ],
+        }
+    )
+
+    assert [query.operation for query in plan.codegraph_queries] == [
+        "explore",
+        "search",
+    ]
+
+
+def test_retrieval_plan_accepts_literal_query_objects_with_pattern():
+    plan = parse_retrieval_plan(
+        {
+            "objective": "trace the exception",
+            "codegraph_queries": [],
+            "literal_queries": [
+                {"pattern": "153301", "scope": "agent", "reason": "code"},
+                {"pattern": "VSSMode is conflict"},
+                "Sysconfig.ini",
+                {"pattern": "153301", "reason": "duplicate"},
+            ],
+        }
+    )
+
+    assert plan.literal_queries == (
+        "153301",
+        "VSSMode is conflict",
+        "Sysconfig.ini",
+    )
+
+
 def test_retrieval_plan_parses_bounded_text_clarification():
     plan = parse_retrieval_plan(
         {
@@ -159,6 +215,33 @@ def test_executor_runs_independent_retrievals_in_parallel_and_deduplicates():
     assert len(bundle.items) == 2
     assert bundle.metrics["retrieval_call_count"] == 2
     assert bundle.metrics["deduplicated_item_count"] == 0
+
+
+def test_executor_falls_back_to_explore_for_missing_codegraph_operation():
+    explored = []
+
+    def graph(query, **kwargs):
+        del kwargs
+        explored.append(query)
+        return {"exploration": query}
+
+    plan = parse_retrieval_plan(
+        {
+            "objective": "trace flow",
+            "codegraph_queries": [
+                {"operation": "search", "symbol": "VSSMode"},
+                {"operation": "callers", "symbol": "InitializeVSS_Model"},
+            ],
+        }
+    )
+    executor = EvidenceExecutor(
+        codegraph_tools={"explore": graph},
+    )
+
+    bundle = executor.execute(plan)
+
+    assert set(explored) == {"VSSMode", "InitializeVSS_Model"}
+    assert bundle.metrics["retrieval_call_count"] == 2
 
 
 def test_executor_records_nested_subtool_arguments_and_results():

--- a/lensnode/tests/test_planned_runtime.py
+++ b/lensnode/tests/test_planned_runtime.py
@@ -471,10 +471,6 @@ def test_planned_code_analysis_uses_bounded_fallback_for_invalid_plan(
             )
         ),
         SimpleNamespace(
-            content='{"objective":"still invalid",'
-            '"codegraph_queries":["bad"]}'
-        ),
-        SimpleNamespace(
             content=json.dumps(
                 {
                     "answer": "Fallback planner answer.",
@@ -507,9 +503,12 @@ def test_planned_code_analysis_uses_bounded_fallback_for_invalid_plan(
     )
 
     assert result["planned_evidence"]["planner_status"] == "fallback"
-    assert result["planned_evidence"]["planner_retry_count"] == 1
-    assert result["planned_evidence"]["model_call_count"] == 3
-    assert len(model.calls) == 3
+    assert result["planned_evidence"]["planner_retry_count"] == 0
+    assert result["planned_evidence"]["model_call_count"] == 2
+    assert "codegraph query must be an object" in result["planned_evidence"][
+        "planner_rejection_reason"
+    ]
+    assert len(model.calls) == 2
 
 
 def test_planner_repairs_invalid_plan_once_before_fallback(tmp_path):
@@ -558,12 +557,58 @@ def test_planner_repairs_invalid_plan_once_before_fallback(tmp_path):
         mcp_tools=[],
         emit_agent_event=lambda *_args: None,
         workspace_root=tmp_path,
+        planner_repair_enabled=True,
     )
 
     assert result["planned_evidence"]["planner_status"] == "repaired"
     assert result["planned_evidence"]["planner_retry_count"] == 1
     assert result["planned_evidence"]["model_call_count"] == 3
     assert len(model.calls) == 3
+
+
+def test_planned_code_analysis_falls_back_without_repair_when_disabled(
+    tmp_path,
+):
+    responses = [
+        SimpleNamespace(
+            content='{"objective":"still invalid",'
+            '"codegraph_queries":["bad"]}'
+        ),
+        SimpleNamespace(
+            content=json.dumps(
+                {
+                    "answer": "No repair was attempted.",
+                    "citations": [],
+                    "unsupported_claims": [],
+                }
+            )
+        ),
+    ]
+
+    class Model:
+        stop_reason = "stop"
+        token_usage = {}
+
+        def __init__(self):
+            self.calls = []
+
+        def invoke(self, messages, **kwargs):
+            self.calls.append((messages, kwargs))
+            return responses[len(self.calls) - 1]
+
+    model = Model()
+    result = agent_runtime._run_planned_code_analysis(
+        model=model,
+        command={"question": "Where is it implemented?"},
+        tools=_workspace_tools(),
+        mcp_tools=[],
+        emit_agent_event=lambda *_args: None,
+        workspace_root=tmp_path,
+    )
+
+    assert result["planned_evidence"]["planner_status"] == "fallback"
+    assert result["planned_evidence"]["planner_retry_count"] == 0
+    assert len(model.calls) == 2
 
 
 def test_invalid_plan_fallback_uses_decomposed_queries():
@@ -848,7 +893,7 @@ def test_planner_fallback_keeps_question_and_workspace_guidance(tmp_path):
     planner_text = "\n".join(message.content for message in planner_messages)
     assert question in planner_text
     assert guidance in planner_text
-    assert len(model.calls) == 3
+    assert len(model.calls) == 2
 
 
 def test_citations_use_trusted_workspace_provenance(tmp_path):
@@ -941,3 +986,44 @@ def test_planned_prompts_include_bound_workspace_guidance():
         planner_prompt
     )
     assert guidance in final_prompt
+
+
+def test_planner_prompt_enumerates_allowed_operations_and_json_contract():
+    planner_prompt = agent_runtime._planned_planner_prompt(
+        {"workspace_path": "/workspace"},
+    )
+
+    assert '"callers"' in planner_prompt
+    assert '"explore"' in planner_prompt
+    assert '"search"' in planner_prompt
+    assert '"operation": "search"' in planner_prompt
+    assert "literal_queries must be an array of plain strings" in (
+        planner_prompt
+    )
+
+
+def test_planner_prompt_honors_available_codegraph_operations():
+    planner_prompt = agent_runtime._planned_planner_prompt(
+        {"workspace_path": "/workspace"},
+        codegraph_operations=["explore"],
+    )
+
+    assert '"explore"' in planner_prompt
+    assert '"callers"' not in planner_prompt
+
+    unavailable_prompt = agent_runtime._planned_planner_prompt(
+        {"workspace_path": "/workspace"},
+        codegraph_operations=[],
+    )
+    assert "CodeGraph is not available" in unavailable_prompt
+
+
+def test_repair_prompt_includes_validation_error_and_allowed_operations():
+    repair_prompt = agent_runtime._planned_planner_repair_prompt(
+        validation_error="unsupported CodeGraph operation: symbol_search",
+        codegraph_operations=["explore", "search"],
+    )
+
+    assert "unsupported CodeGraph operation: symbol_search" in repair_prompt
+    assert '"explore"' in repair_prompt
+    assert '"search"' in repair_prompt

--- a/release-notes/371.yaml
+++ b/release-notes/371.yaml
@@ -1,0 +1,11 @@
+type: improvement
+audience: admin
+en: >-
+  Reduced Code Analysis latency by dropping the planner repair retry when the
+  initial retrieval plan is invalid: the run now falls back to bounded keyword
+  search immediately instead of spending a second model call on repair. The
+  legacy repair path stays available behind LENSNODE_PLANNER_REPAIR_ENABLED.
+zh-CN: >-
+  降低代码分析的延迟：当首次检索计划无效时不再进行计划修复重试，而是直接
+  降级为有界的关键词搜索，省去一次额外的模型调用。如需保留旧的修复路径，
+  可设置 LENSNODE_PLANNER_REPAIR_ENABLED。


### PR DESCRIPTION
### **User description**
## Summary
- Normalize planner operation aliases, infer missing `operation`, accept `literal_queries` objects; executor falls back to the generic `explore` adapter when a specific operation is unavailable.
- Planner/repair prompts enumerate available CodeGraph operations with JSON examples so the model stops inventing names validation rejects.
- Repair gets the concrete `PlanValidationError`; `planner_rejection_reason` recorded and surfaced in the admin run overview on fallback.
- Invalid plans fall back to bounded keyword search immediately by default; old repair path behind `LENSNODE_PLANNER_REPAIR_ENABLED`.
- SSE sync no longer replays status/steps it already carries; dispatch reads image attachments once instead of twice.
- Trajectory timeline bars drop rounded corners, show start time + duration on hover; event ledger groups by category and step base name.

Closes #376

## Test plan
- [x] lensnode: 98 planned-evidence/config/executor/trajectory tests
- [x] backend: stream/sync + dispatch/image/attachment tests (Docker)
- [x] frontend: runTrajectory unit tests, lint, build


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Harden planner contract and trim duplicate I/O
  - Normalize operation aliases, infer missing operation, accept literal_queries objects
  - Repair prompt receives validation error; fallback skips repair by default

- Remove duplicate SSE snapshot replay and image attachment reads
  - Stream dedup cursors for status, steps, and content
  - Dispatch reads image attachments once

- Add planner rejection reason to metrics and admin UI
  - Sanitized and surfaced in run overview with fallback warning

- Improve trajectory timeline and ledger grouping
  - Timeline bars show start time and duration on hover
  - Ledger groups rows by category and step base name


___

### Diagram Walkthrough


```mermaid
flowchart TD
  start["Model generates plan"] --> validate["parse_retrieval_plan"]
  validate -->|valid| execute["Execute plan"]
  validate -->|invalid| fallback["Fallback to keyword search"]
  validate -->|invalid + repair enabled| repair["Repair with validation error"]
  repair -->|valid| execute
  repair -->|invalid| fallback
  execute --> bundle["Evidence bundle"]
  bundle --> metrics["planner_rejection_reason recorded"]
  sse["SSE stream"] --> sync["Sync event seeds dedup cursors"]
  sync --> delta["Only delta events emitted"]
  timeline["Trajectory timeline"] --> tooltip["Start time + duration on hover"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>citations.py</strong><dd><code>Add planner_rejection_reason to sanitized output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-09dc464f7844578a1e94a8cfaf35d1e74af9a8e78a349862c2ca52b9f50878f8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Update planner prompts and fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+132/-32</a></td>

</tr>

<tr>
  <td><strong>planned_evidence.py</strong><dd><code>Normalize operations and infer missing fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-df5cfbc677e6c1298ba0474c2b12b2f2c7bc36baf496b3a6a4ef1d7f4d1a00a9">+52/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RunObservation.vue</strong><dd><code>Show planner status and fallback warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RunTrajectoryPanel.vue</strong><dd><code>Add timeline tooltip and ledger grouping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-acd33a4919f80bdd229fb22f29fdc24d30cc85dce17d6d94170ef474014fb797">+91/-55</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runTrajectory.js</strong><dd><code>Add groupTrajectoryRows and timeline duration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-798120b5a90f954a7675c56abbcdbe64bd863f6e63edc46fa74aa066491b9264">+32/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Remove duplicate snapshot replay and image reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+16/-22</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for SSE dedup and no replay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+43/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_planned_evidence_sanitizer.py</strong><dd><code>Add sanitizer tests for planner metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-ec9e67dc05ee4de4c2b41ec37489c926cf20bbda1d441e5fffccc27ac537c1be">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_config.py</strong><dd><code>Add tests for planner_repair_enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-fe4181ec6e0283de70ef882d03ccbe78488c22434fb88d7f599b174dd0a0b1a8">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_planned_evidence.py</strong><dd><code>Add tests for aliases, inference, and fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-ec43276f76831d47098d0deabf5c13edd4f09221ffbf404ebeb0eac5f75e8641">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_planned_runtime.py</strong><dd><code>Add tests for repair disabled and fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-79e1634cca7781e7914aaf562aba435aef0bae4993a973b4925f200f3f619949">+94/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runTrajectory.test.js</strong><dd><code>Add tests for grouping and timeline metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-c2a93eb2418728a6f9b1fa0002488177dcf0dffba0ceb06c6cf0afe7e27515f3">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Add planner_repair_enabled config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.sample</strong><dd><code>Add LENSNODE_PLANNER_REPAIR_ENABLED sample</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add planner status and fallback translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese translations for planner UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>371.yaml</strong><dd><code>Add release note for planner improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/377/files#diff-541c3d685fce71b98558549eb52493f9cacc5305c1f3aee917f77fffdbfa4be8">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

