### PR TITLE
Fix chat submission crash outside secure contexts

### DIFF
--- a/frontend/src/pages/lens/chatSubmission.js
+++ b/frontend/src/pages/lens/chatSubmission.js
@@ -1,3 +1,25 @@
+// crypto.randomUUID() throws "is not a function" outside secure contexts
+// (plain HTTP on a non-localhost host, e.g. LAN IP deployments without
+// TLS), because browsers only expose it on https:// or localhost origins.
+// crypto.getRandomValues() has no such restriction, so build a v4 UUID
+// from it manually when randomUUID is unavailable.
+function generateUUID() {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID()
+  }
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join('')
+  ].join('-')
+}
+
 function sameAttachmentUuids(left, right) {
   return (
     left.length === right.length &&
@@ -21,7 +43,7 @@ export function prepareRunSubmission({
   attachmentUuids = [],
   retryDraft = null,
   pendingSubmission = null,
-  randomUUID = () => globalThis.crypto.randomUUID()
+  randomUUID = generateUUID
 }) {
   const retryOfRunUuid =
     retryDraft?.question === question ? retryDraft.runUuid || '' : ''

--- a/release-notes/379.yaml
+++ b/release-notes/379.yaml
@@ -1,0 +1,9 @@
+type: fix
+audience: user
+en: >-
+  Fixed a crash ("crypto.randomUUID is not a function") that prevented
+  sending chat messages when SourceLens is accessed over plain HTTP on a
+  non-localhost host, such as a LAN IP without TLS.
+zh-CN: >-
+  修复了在通过局域网 IP 等非 HTTPS 地址访问 SourceLens 时，发送聊天消息会
+  因 "crypto.randomUUID is not a function" 而崩溃的问题。


### PR DESCRIPTION
### **User description**
## Summary
- `crypto.randomUUID()` is only exposed by browsers in secure contexts (`https://` or `localhost`), so building the run idempotency key with it threw `TypeError: ... crypto.randomUUID is not a function` whenever the app was reached over plain HTTP on a non-localhost host (e.g. a LAN IP such as `http://192.168.8.182:8000`), breaking chat submission entirely.
- Add a `generateUUID()` fallback in `chatSubmission.js` that uses `crypto.getRandomValues()` (not restricted to secure contexts) to build a v4 UUID manually when `randomUUID` is unavailable.

Fixes #379

## Test plan
- [x] `npx eslint src/pages/lens/chatSubmission.js` — no errors (pre-existing unrelated warnings only)
- [ ] Manually verify chat sends successfully when served over plain HTTP on a LAN IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix chat submission crash on insecure HTTP origins

- Add fallback UUID generation when crypto.randomUUID unavailable

- Add release notes for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser sends chat"] --> B["crypto.randomUUID available?"]
  B -- "Yes" --> C["Use randomUUID()"]
  B -- "No" --> D["Use getRandomValues() fallback"]
  C --> E["Idempotency key built"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatSubmission.js</strong><dd><code>Add secure-context UUID fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatSubmission.js

<ul><li>Added generateUUID function that falls back to crypto.getRandomValues <br>when randomUUID is unavailable<br> <li> Updated default randomUUID parameter to use generateUUID</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/380/files#diff-e73e7f06403bf2928592a1a33440d3294cbc8dae81ffe7e2c23e12ba28a437e5">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>379.yaml</strong><dd><code>Add release notes for crash fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/379.yaml

- Added release notes entry for the fix in English and Chinese


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/380/files#diff-9fe0c6b2d1ec9d1c00a0f4a36f3bd676f906803ccadc003a6247762259632f95">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

