### PR TITLE
Document Docker Compose V2 requirement and add standalone installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,76 @@ done
 
 ## Production
 
-```bash
-cp env.sample .env
-# Configure SECRET_KEY, DJANGO_DEBUG=false, ALLOWED_HOSTS, database, etc.
-docker-compose up -d
-```
+SourceLens has two production shapes — pick **ONE** per host (both share the
+`sourcelens` compose project):
+
+- **Standalone single instance** (one backend-api, one frontend, no blue/green).
+  One-command installer: fetches the release config files from the tag,
+  generates a `.env` with random secrets, pulls images, starts the stack and
+  health-checks it. GitHub unreachable? `-c cn` pulls images from Aliyun ACR and
+  release files from Gitee.
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
+      -o install.sh && chmod +x install.sh && sudo ./install.sh <tag>
+  ```
+
+- **Zero-downtime blue/green** (docker-compose.yml): `scripts/install.sh <tag>`.
 
 Default ports: HTTP 10080, HTTPS 10443 (configurable via `NGINX_HTTP_PORT` / `NGINX_HTTPS_PORT`).
+
+### Automated Deployment (standalone installer)
+
+The standalone stack installs and upgrades with a single command: it downloads
+the release config files (`docker-compose.standalone.yml`, nginx/postgres
+config, `env.sample`) from the repository tag, generates a production `.env`
+with random secrets, pulls the container images, starts the stack and
+health-checks it.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
+    -o install.sh && chmod +x install.sh && sudo ./install.sh <tag>
+```
+
+- **Requirements**: Docker + Docker Compose V2 (`docker compose`). Legacy
+  Compose v1 is rejected — the compose files use V2-only features.
+- **Idempotent upgrades**: re-running the same command with a newer tag upgrades
+  in place. An existing `.env` is never overwritten; only known insecure
+  placeholder values (`change-me`, `postgres`, `adminpassword`,
+  `change-me-lensnode-token`) are replaced with random secrets. The initial
+  admin username/password are printed at the end and stored in
+  `install-info.env`.
+- **Channels**: release files come from GitHub and application images from
+  Docker Hub (`oneprolabs/*`) by default. When GitHub is unreachable, pass
+  `-c cn` to fetch release files from Gitee and pull application images from
+  Aliyun ACR (`registry.cn-beijing.aliyuncs.com/oneprolabs`). Infrastructure
+  images (postgres/redis/nginx) always come from Docker Hub.
+- **Ports**: HTTP port defaults to 10080, HTTPS to 10443. Busy ports are
+  detected and the next free port is used automatically.
+
+Common options:
+
+| Option | Description |
+|---|---|
+| `-d, --dir DIR` | Install directory (default `/opt/sourcelens`) |
+| `-p, --port PORT` | HTTP port (default 10080) |
+| `-v, --version VER` | Release version (default: latest tag) |
+| `-c, --channel github\|cn` | Distribution channel (default: auto-detect) |
+| `--download-source github\|gitee` | Release-file source; also selects the image registry |
+| `--source DIR` | Use a local repository checkout instead of downloading (testing/offline) |
+| `--domain HOST` | Public hostname/IP (default: auto-detect) |
+| `-y, --yes` | Non-interactive: accept defaults, no prompts |
+
+Run `install.sh --help` for the full list, including environment overrides
+(`SOURCELENS_INSTALL_DIR`, `SOURCELENS_HTTP_PORT`, `SOURCELENS_HTTPS_PORT`,
+`SOURCELENS_VERSION`, `SOURCELENS_REGISTRY`, `SOURCELENS_DOMAIN`, ...).
+
+> **Cloudflare Turnstile**: `env.sample` keeps `TURNSTILE_ENABLED=true` and
+> requires a real `TURNSTILE_SECRET_KEY` in production — the backend refuses to
+> start without one (a deliberate fail-fast guard). The one-command installer
+> cannot mint real keys, so it sets `TURNSTILE_ENABLED=false` on a fresh install
+> so login works without the widget. To enable Turnstile later, set a real
+> secret (and frontend site key), then flip `TURNSTILE_ENABLED=true` in `.env`.
 
 ### Capacity & Concurrency Tuning
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@ git submodule update --init --recursive
 
 ### 2. Docker dev
 
+> **Prerequisite:** Docker Compose **V2** (`docker compose`) is required. The dev
+> stack relies on Compose V2 features — the top-level `name` field (dev/prod
+> project isolation), `pull_policy`, and `depends_on.condition` health gating —
+> that legacy Docker Compose v1 (`docker-compose`, e.g. 1.29.x) rejects with a
+> schema error on `up -d`. Verify your version with `docker compose version`.
+
 ```bash
 cp env.sample .env.dev
 # Edit .env.dev — database, AI service keys, etc.
-docker-compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml up -d
 ```
 
 ### 3. Services

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,13 +158,69 @@ done
 
 ## 生产部署
 
-```bash
-cp env.sample .env
-# 配置 SECRET_KEY、DJANGO_DEBUG=false、ALLOWED_HOSTS、数据库等
-docker-compose up -d
-```
+SourceLens 有两种生产形态——每台主机**只选一种**（两者共享 `sourcelens` compose 项目名）：
+
+- **Standalone 单实例**（一个 backend-api、一个 frontend，无蓝绿切换）。
+  一键安装器：从 tag 拉取 release 配置文件、生成带随机密钥的 `.env`、拉取镜像、
+  启动栈并做健康检查。GitHub 不可达时用 `-c cn`，镜像改从阿里云 ACR 拉取、
+  配置文件从 Gitee 下载。
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
+      -o install.sh && chmod +x install.sh && sudo ./install.sh <tag>
+  ```
+
+- **零停机蓝绿**（docker-compose.yml）：`scripts/install.sh <tag>`。
 
 默认端口：HTTP 10080, HTTPS 10443（可通过 `NGINX_HTTP_PORT`、`NGINX_HTTPS_PORT` 调整）。
+
+### 自动化部署（standalone 安装器）
+
+standalone 栈可用一条命令完成安装与升级：从仓库 tag 下载 release 配置文件
+（`docker-compose.standalone.yml`、nginx/postgres 配置、`env.sample`），生成带
+随机密钥的生产 `.env`，拉取容器镜像，启动栈并做健康检查。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
+    -o install.sh && chmod +x install.sh && sudo ./install.sh <tag>
+```
+
+- **前置要求**：Docker + Docker Compose **V2**（`docker compose`）。旧版
+  Compose v1 会被拒绝——compose 文件使用了 V2 专属特性。
+- **幂等升级**：用更新的 tag 重跑同一条命令即可原地升级。已有 `.env` 绝不
+  覆盖，只会把已知的不安全占位值（`change-me`、`postgres`、`adminpassword`、
+  `change-me-lensnode-token`）替换为随机密钥。初始管理员用户名/密码会在结束
+  时打印并保存在 `install-info.env`。
+- **通道**：默认 release 文件来自 GitHub、应用镜像来自 Docker Hub
+  （`oneprolabs/*`）。GitHub 不可达时加 `-c cn`，release 文件改从 Gitee 下载、
+  应用镜像改从阿里云 ACR（`registry.cn-beijing.aliyuncs.com/oneprolabs`）拉取。
+  基础设施镜像（postgres/redis/nginx）始终来自 Docker Hub。
+- **端口**：HTTP 默认 10080、HTTPS 默认 10443。检测到端口被占用时会自动
+  使用下一个空闲端口。
+
+常用选项：
+
+| 选项 | 说明 |
+|---|---|
+| `-d, --dir DIR` | 安装目录（默认 `/opt/sourcelens`） |
+| `-p, --port PORT` | HTTP 端口（默认 10080） |
+| `-v, --version VER` | 发布版本（默认：最新 tag） |
+| `-c, --channel github\|cn` | 分发通道（默认：自动探测） |
+| `--download-source github\|gitee` | release 文件来源；同时决定镜像仓库 |
+| `--source DIR` | 使用本地仓库代码而非下载（测试/离线） |
+| `--domain HOST` | 公网主机名/IP（默认：自动探测） |
+| `-y, --yes` | 非交互：接受默认值，不提问 |
+
+完整选项及环境变量覆盖（`SOURCELENS_INSTALL_DIR`、`SOURCELENS_HTTP_PORT`、
+`SOURCELENS_HTTPS_PORT`、`SOURCELENS_VERSION`、`SOURCELENS_REGISTRY`、
+`SOURCELENS_DOMAIN` 等）见 `install.sh --help`。
+
+> **Cloudflare Turnstile**：`env.sample` 保持 `TURNSTILE_ENABLED=true`，生产
+> 环境要求配置真实的 `TURNSTILE_SECRET_KEY`——否则后端拒绝启动（这是刻意的
+> fail-fast 守卫）。一键安装器无法生成真实密钥，因此在全新安装时会把
+> `TURNSTILE_ENABLED` 设为 `false`，让登录在无验证组件下可用。之后要启用
+> Turnstile，请在 `.env` 中配置真实密钥（及前端 site key），再把
+> `TURNSTILE_ENABLED` 翻回 `true`。
 
 ### 容量与并发调优
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,10 +89,16 @@ git submodule update --init --recursive
 
 ### 2. Docker 本地开发
 
+> **前置要求**：必须使用 Docker Compose **V2**（`docker compose`）。开发栈依赖
+> Compose V2 特性——顶层 `name` 字段（dev/prod 项目隔离）、`pull_policy` 和
+> `depends_on.condition` 健康门控——旧版 Docker Compose v1（`docker-compose`，
+> 如 1.29.x）会在 `up -d` 时因 schema 校验报错而拒绝。可用
+> `docker compose version` 确认版本。
+
 ```bash
 cp env.sample .env.dev
 # 按需编辑 .env.dev，配置数据库、AI 服务密钥等
-docker-compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml up -d
 ```
 
 ### 3. 访问服务

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,1121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# SourceLens one-command installer (standalone single-instance deployment)
+#
+# Drives docker-compose.standalone.yml — the simple production shape (one
+# backend-api, one frontend, plain `up -d`, no blue/green). This is a SEPARATE
+# path from scripts/install.sh, which does zero-downtime blue/green against
+# docker-compose.yml. Pick ONE production shape per host: both share the
+# "sourcelens" compose project.
+#
+#   curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
+#       -o install.sh && chmod +x install.sh && ./install.sh <tag>
+#
+# What it does, every single run (idempotent; re-running upgrades):
+#   1. Fetches the small set of declarative deploy files (docker-compose
+#      .standalone.yml, nginx/postgres config, env.sample) straight from the
+#      repository at the given tag — not the whole repo.
+#   2. Generates a production .env with random secrets (never overwrites an
+#      existing .env; known placeholder values are replaced).
+#   3. Patches the compose file: pins the release version tag and, for the
+#      cn/gitee channel, rewrites the image registry to Aliyun ACR.
+#   4. Generates a self-signed TLS certificate if missing, creates the data
+#      directory layout, pulls images, starts the stack and health-checks it.
+#
+# Channels: the download source (github/gitee) selects where release files come
+# from AND which registry the application images are pulled from:
+#   github -> release files from GitHub, images from Docker Hub (oneprolabs/*)
+#   gitee  -> release files from Gitee,  images from Aliyun ACR
+# Docker Hub is always used for the infrastructure images (postgres/redis/nginx).
+#
+# Requirements: Docker + Docker Compose V2 (`docker compose`). Compose V1
+# (docker-compose 1.x) is NOT supported — the compose files use V2-only features
+# (top-level `name`, `depends_on.condition`).
+#
+# --source mode — for testing this script itself, or running the whole flow from
+# a local checkout without touching GitHub/Gitee:
+#
+#   ./install.sh --source /path/to/sourcelens-repo [tag]
+# =============================================================================
+
+set -Eeuo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+APP_NAME="sourcelens"
+GITHUB_REPO="oneprolabs/sourcelens"
+GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}"
+GITHUB_RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPO}"
+GITEE_REPO="oneprolabs/sourcelens"
+GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
+GITEE_RAW_BASE="https://gitee.com/${GITEE_REPO}/raw"
+DEFAULT_INSTALL_DIR="/opt/${APP_NAME}"
+DEFAULT_HTTP_PORT=10080
+DEFAULT_HTTPS_PORT=10443
+# Image registry prefixes. Docker Hub uses just the namespace; Aliyun ACR uses
+# host/namespace. Both carry sourcelens-{backend,frontend,lensnode}.
+REGISTRY_GITHUB="oneprolabs"
+REGISTRY_CN="registry.cn-beijing.aliyuncs.com/oneprolabs"
+COMPOSE_FILE="docker-compose.standalone.yml"
+INSTALLER_VERSION="0.1.0"
+HEALTH_TIMEOUT=240
+
+# Release files fetched directly from the repository tag. Only what
+# docker-compose.standalone.yml actually mounts/needs is included.
+RELEASE_FILES=(
+  docker-compose.standalone.yml
+  env.sample
+  docker/nginx/default.standalone.conf
+  docker/nginx/certs/README.md
+  docker/postgresql/etc/postgresql.conf
+  docker/postgresql/initdb.d/000-create-databases.sql
+  docker/postgresql/initdb.d/001-grant-schema-privileges.sh
+  docker/postgresql/initdb.d/002-setup-log-permissions.sh
+)
+
+# Detect host platform early: macOS and Linux differ in memory detection and
+# networking helpers.
+case "$(uname -s)" in
+  Darwin)                PLATFORM="macos" ;;
+  Linux)                 PLATFORM="linux" ;;
+  MINGW*|MSYS*|CYGWIN*)  PLATFORM="windows" ;;
+  *)                     PLATFORM="unknown" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via SOURCELENS_* environment variables / CLI flags)
+# ---------------------------------------------------------------------------
+INSTALL_DIR="${SOURCELENS_INSTALL_DIR:-${DEFAULT_INSTALL_DIR}}"
+INSTALL_DIR_OVERRIDE=0
+[[ -n "${SOURCELENS_INSTALL_DIR:-}" ]] && INSTALL_DIR_OVERRIDE=1
+
+HTTP_PORT=""
+HTTP_PORT_OVERRIDE=0
+[[ -n "${SOURCELENS_HTTP_PORT:-}" ]] && { HTTP_PORT="${SOURCELENS_HTTP_PORT}"; HTTP_PORT_OVERRIDE=1; }
+HTTPS_PORT="${SOURCELENS_HTTPS_PORT:-${DEFAULT_HTTPS_PORT}}"
+CHANNEL="${SOURCELENS_CHANNEL:-}"
+GITHUB_REACHABLE_PENDING=1
+GITHUB_REACHABLE=0
+DOWNLOAD_SOURCE="${SOURCELENS_DOWNLOAD_SOURCE:-}"
+VERSION="${SOURCELENS_VERSION:-}"
+REGISTRY="${SOURCELENS_REGISTRY:-}"
+DOMAIN="${SOURCELENS_DOMAIN:-}"
+DOMAIN_OVERRIDE=0
+[[ -n "${SOURCELENS_DOMAIN:-}" ]] && DOMAIN_OVERRIDE=1
+DOCKER_MIRROR="${SOURCELENS_DOCKER_MIRROR:-}"
+
+HTTPS="${SOURCELENS_HTTPS:-false}"
+ADMIN_USERNAME="${SOURCELENS_ADMIN_USER:-admin}"
+ADMIN_EMAIL="${SOURCELENS_ADMIN_EMAIL:-}"
+ASSUME_YES=0
+[[ "${SOURCELENS_YES:-}" == "1" ]] && ASSUME_YES=1
+FORCE=0
+SOURCE_DIR=""
+INSTALL_ARGS=()
+
+SCHEME="http"
+PORT_SUFFIX=""
+LOG_FILE=""
+COMPOSE_CMD=()
+EXISTING=0
+INSTALLED_VERSION=""
+PORTS_FROM_EXISTING=0
+ENV_EXISTS=0
+ADMIN_PASSWORD=""
+
+# ---------------------------------------------------------------------------
+# Colored logging helpers
+# ---------------------------------------------------------------------------
+c_red=$'\033[31m'; c_green=$'\033[32m'; c_yellow=$'\033[33m'
+c_cyan=$'\033[34m'; c_bold=$'\033[1m'; c_reset=$'\033[0m'
+if [[ ! -t 1 || "${NO_COLOR:-}" == "1" || "${TERM:-}" == "dumb" ]]; then
+  c_red=""; c_green=""; c_yellow=""; c_cyan=""; c_bold=""; c_reset=""
+fi
+
+log_line() {
+  [[ -n "${LOG_FILE}" ]] || return 0
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >>"${LOG_FILE}"
+}
+
+log_info()  { printf '%s%s%s\n' "${c_cyan}" "$1" "${c_reset}"; log_line "[INFO]  $1"; }
+log_ok()    { printf '%s%s%s\n' "${c_green}" "$1" "${c_reset}"; log_line "[OK]    $1"; }
+log_warn()  { printf '%sWARN: %s%s\n' "${c_yellow}" "$1" "${c_reset}"; log_line "[WARN]  $1"; }
+log_error() { printf '%sERROR: %s%s\n' "${c_red}" "$1" "${c_reset}" >&2; log_line "[ERROR] $1"; }
+log_step()  { printf '\n%s=== %s ===%s\n' "${c_bold}${c_cyan}" "$1" "${c_reset}"; log_line "[STEP]  $1"; }
+
+abort() {
+  log_error "$1"
+  log_line "install aborted"
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: install.sh [options] [tag]
+
+Installs/upgrades the standalone (single-instance) SourceLens stack by driving
+docker-compose.standalone.yml. Supported platforms: Linux, macOS. Requires
+Docker and Docker Compose V2 (\`docker compose\`).
+
+Options:
+  -d, --dir DIR            Install directory (default: ${DEFAULT_INSTALL_DIR})
+  -p, --port PORT          HTTP port (default: ${DEFAULT_HTTP_PORT})
+      --https-port PORT    HTTPS port (default: ${DEFAULT_HTTPS_PORT})
+  -c, --channel CH         Distribution channel: github | cn (default: auto)
+      --download-source SRC  Release-file download source: github | gitee
+                             (default: auto; also selects the image registry:
+                             github -> Docker Hub, gitee -> Aliyun ACR)
+  -v, --version VER        Release version to install (default: latest tag)
+      --source DIR         Use a local repository directory instead of
+                           downloading release files (testing/offline)
+  -r, --registry REG       Override the application image registry prefix
+      --domain HOST        Public hostname / IP (default: auto-detect)
+      --admin-user USER    Initial admin username (default: admin)
+      --admin-email EMAIL  Initial admin email (default: admin@<domain>)
+      --https              Configure URLs for HTTPS behind a TLS proxy
+      --docker-mirror URL  Configure a Docker Hub registry mirror (linux)
+  -y, --yes                Non-interactive: accept defaults, no prompts
+      --force              Upgrade without confirmation
+  -h, --help               Show this help
+
+Environment overrides: SOURCELENS_INSTALL_DIR, SOURCELENS_HTTP_PORT,
+SOURCELENS_HTTPS_PORT, SOURCELENS_VERSION, SOURCELENS_REGISTRY,
+SOURCELENS_DOMAIN, SOURCELENS_CHANNEL, SOURCELENS_DOWNLOAD_SOURCE,
+SOURCELENS_DOCKER_MIRROR, SOURCELENS_ADMIN_USER, SOURCELENS_ADMIN_EMAIL,
+SOURCELENS_YES=1, SOURCELENS_HTTPS=true
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Interaction helpers
+# ---------------------------------------------------------------------------
+confirm() {
+  local prompt="$1" answer=""
+  [[ "${ASSUME_YES}" == "1" ]] && return 0
+  if [[ ! -t 0 ]]; then
+    if [[ -e /dev/tty ]]; then
+      printf '%s [y/N] ' "${prompt}" >/dev/tty
+      read -r answer </dev/tty || answer="n"
+    else
+      return 0 # fully non-interactive: proceed with defaults
+    fi
+  else
+    printf '%s [y/N] ' "${prompt}"
+    read -r answer || answer="n"
+  fi
+  answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${answer}" == "y" || "${answer}" == "yes" ]]
+}
+
+prompt_value() {
+  local var_name="$1" label="$2" default="$3" answer=""
+  if [[ "${ASSUME_YES}" == "1" || ! -t 0 ]]; then
+    printf -v "${var_name}" '%s' "${default}"
+    return 0
+  fi
+  printf '%s [%s]: ' "${label}" "${default}"
+  read -r answer || true
+  printf -v "${var_name}" '%s' "${answer:-${default}}"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+require_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then return 0; fi
+  if command -v sudo >/dev/null 2>&1 && [[ -f "$0" && "$0" != "bash" && "$0" != "-bash" ]]; then
+    log_warn "not running as root, re-executing with sudo"
+    exec sudo -E bash "$0" "${INSTALL_ARGS[@]}"
+  fi
+  abort "install.sh must run as root (or via sudo). e.g. sudo bash install.sh"
+}
+
+detect_os() {
+  OS_ID="unknown"; OS_NAME="unknown"
+  if [[ "${PLATFORM}" == "macos" ]]; then
+    OS_ID="macos"; OS_NAME="macOS $(sw_vers -productVersion 2>/dev/null)"
+  elif [[ -r /etc/os-release ]]; then
+    OS_ID=$(. /etc/os-release; printf '%s' "${ID:-unknown}")
+    OS_NAME=$(. /etc/os-release; printf '%s' "${PRETTY_NAME:-unknown}")
+  fi
+  log_info "OS: ${OS_NAME} (${OS_ID})"
+  if [[ "${PLATFORM}" != "macos" && "${PLATFORM}" != "linux" ]]; then
+    abort "unsupported platform '${PLATFORM}'; supported: Linux, macOS"
+  fi
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)   ARCH="amd64" ;;
+    aarch64|arm64)  ARCH="arm64" ;;
+    *) abort "unsupported CPU architecture: $(uname -m) (supported: amd64, arm64)" ;;
+  esac
+  log_info "Architecture: ${ARCH}"
+}
+
+check_memory() {
+  local mem_kb=0 mem_gb=0
+  if [[ "${PLATFORM}" == "macos" ]]; then
+    local pagesize=0 pf=0 pi=0 ps=0
+    pagesize="$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)"
+    pf="$(vm_stat 2>/dev/null | awk '/Pages free/ {print $3}' | tr -d '.')"
+    pi="$(vm_stat 2>/dev/null | awk '/Pages inactive/ {print $3}' | tr -d '.')"
+    ps="$(vm_stat 2>/dev/null | awk '/Pages speculative/ {print $3}' | tr -d '.')"
+    pf="${pf:-0}"; pi="${pi:-0}"; ps="${ps:-0}"
+    mem_kb="$(( (pf + pi + ps) * pagesize / 1024 ))"
+  else
+    mem_kb="$(awk '/MemAvailable/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)"
+  fi
+  mem_kb="${mem_kb:-0}"
+  [[ "${mem_kb}" =~ ^[0-9]+$ ]] || mem_kb=0
+  mem_gb=$((mem_kb / 1024 / 1024))
+  log_info "Memory: ${mem_gb} GB available"
+  if ((mem_gb < 2)); then
+    abort "available memory is too low (${mem_gb} GB); at least 2 GB required (4 GB recommended)"
+  elif ((mem_gb < 4)); then
+    log_warn "memory below the 4 GB recommendation (${mem_gb} GB)"
+  fi
+}
+
+check_disk() {
+  local check_dir="${INSTALL_DIR}" free_kb=0 free_gb=0
+  while [[ ! -d "${check_dir}" && "${check_dir}" != "/" ]]; do
+    check_dir="$(dirname "${check_dir}")"
+  done
+  free_kb="$(df -Pk "${check_dir}" 2>/dev/null | awk 'NR==2 {print $4}')"
+  free_kb="${free_kb:-0}"
+  free_gb=$((free_kb / 1024 / 1024))
+  log_info "Disk space on ${check_dir} (target ${INSTALL_DIR}): ${free_gb} GB free"
+  if ((free_gb < 5)); then
+    abort "insufficient disk space (${free_gb} GB free); at least 5 GB required (20 GB recommended)"
+  elif ((free_gb < 20)); then
+    log_warn "disk space below the 20 GB recommendation (${free_gb} GB free)"
+  fi
+}
+
+check_tools() {
+  local tool
+  for tool in curl tar gzip openssl; do
+    command -v "${tool}" >/dev/null 2>&1 || abort "required tool not found: ${tool}"
+  done
+  log_ok "Required tools present (curl, tar, gzip, openssl)"
+}
+
+prompt_install_dir() {
+  if [[ "${INSTALL_DIR_OVERRIDE}" != "1" && "${ASSUME_YES}" != "1" && -t 0 ]]; then
+    prompt_value INSTALL_DIR "Install directory" "${INSTALL_DIR}"
+  fi
+  INSTALL_DIR="${INSTALL_DIR%/}"
+}
+
+# ---------------------------------------------------------------------------
+# Channel detection & network connectivity
+# ---------------------------------------------------------------------------
+probe_github_reachable() {
+  if [[ "${GITHUB_REACHABLE_PENDING}" == "1" ]]; then
+    if curl -fsSI --max-time 8 -o /dev/null https://github.com >/dev/null 2>&1; then
+      GITHUB_REACHABLE=1
+    else
+      GITHUB_REACHABLE=0
+    fi
+    GITHUB_REACHABLE_PENDING=0
+  fi
+}
+
+detect_channel() {
+  if [[ -z "${CHANNEL}" ]]; then
+    probe_github_reachable
+    if [[ "${GITHUB_REACHABLE}" == "1" ]]; then
+      CHANNEL="github"
+    else
+      CHANNEL="cn"
+    fi
+  fi
+  CHANNEL="$(printf '%s' "${CHANNEL}" | tr '[:upper:]' '[:lower:]')"
+  case "${CHANNEL}" in
+    github|cn) ;;
+    *) abort "invalid channel '${CHANNEL}' (supported: github, cn)" ;;
+  esac
+}
+
+detect_download_source() {
+  if [[ -z "${DOWNLOAD_SOURCE}" ]]; then
+    if [[ "${CHANNEL}" == "cn" ]]; then
+      DOWNLOAD_SOURCE="gitee"
+    else
+      probe_github_reachable
+      if [[ "${GITHUB_REACHABLE}" == "1" ]]; then
+        DOWNLOAD_SOURCE="github"
+      elif curl -fsSI --max-time 8 -o /dev/null https://gitee.com >/dev/null 2>&1; then
+        DOWNLOAD_SOURCE="gitee"
+      else
+        DOWNLOAD_SOURCE="github"
+        log_warn "could not reach github.com or gitee.com; assuming github"
+      fi
+    fi
+  fi
+  DOWNLOAD_SOURCE="$(printf '%s' "${DOWNLOAD_SOURCE}" | tr '[:upper:]' '[:lower:]')"
+  case "${DOWNLOAD_SOURCE}" in
+    github|gitee) ;;
+    *) abort "invalid download source '${DOWNLOAD_SOURCE}' (supported: github, gitee)" ;;
+  esac
+  # The download source selects the application image registry: github -> Docker
+  # Hub, gitee -> Aliyun ACR. An explicit --channel cn also forces the CN path.
+  if [[ -z "${REGISTRY}" ]]; then
+    if [[ "${DOWNLOAD_SOURCE}" == "gitee" || "${CHANNEL}" == "cn" ]]; then
+      REGISTRY="${REGISTRY_CN}"
+    else
+      REGISTRY="${REGISTRY_GITHUB}"
+    fi
+  fi
+  REGISTRY="${REGISTRY%/}"
+}
+
+# ---------------------------------------------------------------------------
+# Docker & Docker Compose
+# ---------------------------------------------------------------------------
+check_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    abort "Docker is not installed. Install Docker (https://docs.docker.com/engine/install/) or Docker Desktop, then re-run this installer."
+  fi
+  DOCKER_VERSION="$(docker --version 2>/dev/null | sed -n 's/^Docker version \([0-9][0-9.]*\).*/\1/p')"
+  log_info "Docker: ${DOCKER_VERSION:-unknown}"
+  docker info >/dev/null 2>&1 \
+    || abort "docker daemon is not running; start it (Docker Desktop on ${OS_NAME}) and re-run the installer"
+  log_ok "Docker daemon is running"
+  configure_docker_mirror
+}
+
+configure_docker_mirror() {
+  [[ -n "${DOCKER_MIRROR}" ]] || return 0
+  log_info "Configuring Docker Hub mirror: ${DOCKER_MIRROR}"
+  if [[ "${PLATFORM}" != "linux" ]]; then
+    log_warn "Docker Desktop does not read /etc/docker/daemon.json; configure the mirror in Docker Desktop settings (registry-mirrors) manually"
+    return 0
+  fi
+  mkdir -p /etc/docker
+  if [[ -f /etc/docker/daemon.json ]]; then
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c 'import json, sys
+p = "/etc/docker/daemon.json"
+d = json.load(open(p))
+m = d.setdefault("registry-mirrors", [])
+for x in sys.argv[1:]:
+    if x not in m:
+        m.append(x)
+json.dump(d, open(p, "w"), indent=2)' "${DOCKER_MIRROR}"
+    else
+      log_warn "daemon.json exists but python3 is unavailable; mirror config not merged"
+      return 0
+    fi
+  else
+    printf '{\n  "registry-mirrors": ["%s"]\n}\n' "${DOCKER_MIRROR}" >/etc/docker/daemon.json
+  fi
+  systemctl restart docker >/dev/null 2>&1 || service docker restart >/dev/null 2>&1 || true
+  sleep 3
+  docker info >/dev/null 2>&1 || log_warn "docker daemon did not come back after mirror configuration"
+  log_ok "Docker Hub mirror configured"
+}
+
+check_compose() {
+  COMPOSE_CMD=()
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    abort "Docker Compose v1 (docker-compose) is installed, but Docker Compose V2 (docker compose) is required: the compose files use V2-only features (top-level 'name' field, 'depends_on.condition' health gating). Install the Compose V2 plugin and re-run."
+  else
+    abort "Docker Compose is not installed. Docker Compose V2 (docker compose) is required; install the plugin and re-run."
+  fi
+  "${COMPOSE_CMD[@]}" version >/dev/null 2>&1 || abort "Docker Compose is not usable"
+  log_ok "Compose: $("${COMPOSE_CMD[@]}" version | head -n 1)"
+}
+
+# The standalone stack shares project name "sourcelens" with the blue/green
+# stack; refuse to run on a host where blue/green is already active.
+check_no_bluegreen() {
+  local c=""
+  for c in sourcelens-api-blue sourcelens-api-green; do
+    if [[ "$(docker inspect -f '{{.State.Running}}' "${c}" 2>/dev/null)" == "true" ]]; then
+      abort "blue/green stack is active on this host (${c} is running). The standalone installer shares project 'sourcelens' with it; use scripts/install.sh instead, or install on a separate host."
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Interactive configuration
+# ---------------------------------------------------------------------------
+configure() {
+  if [[ -z "${DOMAIN}" ]]; then
+    if [[ "${PLATFORM}" == "linux" ]]; then
+      DOMAIN="$(ip route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}' | head -n1)"
+      [[ -z "${DOMAIN}" ]] && DOMAIN="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+    else
+      DOMAIN="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)"
+    fi
+    [[ -z "${DOMAIN}" ]] && DOMAIN="$(hostname -f 2>/dev/null || hostname)"
+    [[ -z "${DOMAIN}" ]] && DOMAIN="127.0.0.1"
+  fi
+  [[ "${DOMAIN}" =~ ^[A-Za-z0-9._:-]+$ ]] || abort "invalid domain/host: ${DOMAIN}"
+  if [[ -z "${ADMIN_EMAIL}" ]]; then ADMIN_EMAIL="admin@${DOMAIN}"; fi
+  if [[ "${HTTPS}" == "true" ]]; then SCHEME="https"; fi
+}
+
+# ---------------------------------------------------------------------------
+# Port conflict detection
+# ---------------------------------------------------------------------------
+port_in_use() {
+  local port="$1"
+  if [[ "${PLATFORM}" == "macos" ]] && command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnH 2>/dev/null | awk -v p=":${port}$" '$4 ~ p { found=1 } END { exit !found }'
+  elif command -v netstat >/dev/null 2>&1; then
+    netstat -ltn 2>/dev/null | awk -v p=":${port}$" '$4 ~ p { found=1 } END { exit !found }'
+  else
+    return 1
+  fi
+}
+
+next_free_port() {
+  local port="$1"
+  while port_in_use "${port}"; do port=$((port + 1)); done
+  printf '%s' "${port}"
+}
+
+validate_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && ((10#$1 >= 1 && 10#$1 <= 65535))
+}
+
+resolve_ports() {
+  [[ -n "${HTTP_PORT}" ]] || HTTP_PORT="${DEFAULT_HTTP_PORT}"
+  [[ -n "${HTTPS_PORT}" ]] || HTTPS_PORT="${DEFAULT_HTTPS_PORT}"
+  validate_port "${HTTP_PORT}" || abort "invalid HTTP port: ${HTTP_PORT}"
+  validate_port "${HTTPS_PORT}" || abort "invalid HTTPS port: ${HTTPS_PORT}"
+  if [[ "${PORTS_FROM_EXISTING}" != "1" ]] && port_in_use "${HTTP_PORT}"; then
+    if [[ "${ASSUME_YES}" != "1" && -t 0 ]]; then
+      while port_in_use "${HTTP_PORT}"; do
+        prompt_value HTTP_PORT "Port ${HTTP_PORT} is in use; enter a free port" "$((HTTP_PORT + 1))"
+        validate_port "${HTTP_PORT}" || HTTP_PORT="$((HTTP_PORT + 1))"
+      done
+    else
+      local old_http="${HTTP_PORT}"
+      HTTP_PORT="$(next_free_port "$((old_http + 1))")"
+      log_warn "port ${old_http} is in use; using ${HTTP_PORT} instead"
+    fi
+  fi
+  if [[ "${PORTS_FROM_EXISTING}" != "1" ]] && port_in_use "${HTTPS_PORT}"; then
+    local old_https="${HTTPS_PORT}"
+    HTTPS_PORT="$(next_free_port "$((old_https + 1))")"
+    log_warn "port ${old_https} is in use; using ${HTTPS_PORT} instead"
+  fi
+  PORT_SUFFIX=""
+  if [[ "${SCHEME}" == "https" ]]; then
+    [[ "${HTTP_PORT}" != "443" ]] && PORT_SUFFIX=":${HTTP_PORT}"
+  else
+    [[ "${HTTP_PORT}" != "80" ]] && PORT_SUFFIX=":${HTTP_PORT}"
+  fi
+  log_info "Ports: HTTP=${HTTP_PORT} HTTPS=${HTTPS_PORT}"
+}
+
+# ---------------------------------------------------------------------------
+# Existing installation detection
+# ---------------------------------------------------------------------------
+detect_existing() {
+  EXISTING=0; INSTALLED_VERSION=""; PORTS_FROM_EXISTING=0
+  [[ -f "${INSTALL_DIR}/docker-compose.standalone.yml" ]] || return 0
+  EXISTING=1
+  log_warn "Existing standalone installation detected at ${INSTALL_DIR}"
+  if [[ -f "${INSTALL_DIR}/install-info.env" ]]; then
+    INSTALLED_VERSION="$(info_key "${INSTALL_DIR}/install-info.env" SOURCELENS_VERSION)"
+    [[ -n "${INSTALLED_VERSION}" ]] && log_info "Installed version: ${INSTALLED_VERSION}"
+    local ports_found=0
+    if [[ "${HTTP_PORT_OVERRIDE}" == "0" ]]; then
+      HTTP_PORT="$(info_key "${INSTALL_DIR}/install-info.env" SOURCELENS_HTTP_PORT)"
+      [[ -n "${HTTP_PORT}" ]] && ports_found=1
+    fi
+    if [[ "${DOMAIN_OVERRIDE}" == "0" ]]; then
+      DOMAIN="$(info_key "${INSTALL_DIR}/install-info.env" SOURCELENS_DOMAIN)"
+      [[ -n "${DOMAIN}" ]] && DOMAIN_OVERRIDE=1
+    fi
+    if ((ports_found)); then PORTS_FROM_EXISTING=1; fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Release version resolution & artifact download
+# ---------------------------------------------------------------------------
+resolve_version() {
+  if [[ -z "${VERSION}" ]]; then
+    if [[ -n "${SOURCE_DIR}" ]]; then
+      local v=""
+      v="$(git -C "${SOURCE_DIR}" describe --tags --abbrev=0 2>/dev/null || true)"
+      v="${v#v}"
+      if [[ -n "${v}" ]]; then
+        VERSION="${v}"
+        log_info "Using version v${VERSION} from local repository ${SOURCE_DIR}"
+      fi
+    fi
+    if [[ -z "${VERSION}" && "${EXISTING}" == "1" && -n "${INSTALLED_VERSION}" ]]; then
+      VERSION="${INSTALLED_VERSION#v}"
+      log_info "Reusing installed version v${VERSION} (rerun)"
+    elif [[ -z "${VERSION}" ]]; then
+      log_info "Resolving latest release version..."
+      local api="" url
+      for url in "${GITHUB_API}/tags?per_page=1" "${GITEE_API}/tags?per_page=1&sort=updated&direction=desc"; do
+        api="$(curl -fsSL --max-time 20 "${url}" 2>/dev/null \
+          | grep -oE '"name": *"[^"]*"' | head -n 1 | sed -E 's/.*"name": *"([^"]*)".*/\1/' || true)"
+        [[ -n "${api}" ]] && { VERSION="${api#v}"; break; }
+      done
+      [[ -z "${VERSION}" ]] && abort "could not resolve the latest release tag; pass --version explicitly"
+      log_info "Latest release: v${VERSION}"
+    fi
+  fi
+  VERSION="${VERSION#v}"
+  [[ "${VERSION}" =~ ^[0-9a-zA-Z][0-9a-zA-Z._-]*$ ]] || abort "invalid version: ${VERSION}"
+  TAG="v${VERSION}"
+  if [[ "${INSTALLER_VERSION}" != "${VERSION}" ]]; then
+    log_warn "installer v${INSTALLER_VERSION} is installing release v${VERSION}"
+  fi
+}
+
+release_raw_url() {
+  local rel="$1"
+  if [[ "${DOWNLOAD_SOURCE}" == "gitee" ]]; then
+    printf '%s/%s/%s' "${GITEE_RAW_BASE}" "${TAG}" "${rel}"
+  else
+    printf '%s/%s/%s' "${GITHUB_RAW_BASE}" "${TAG}" "${rel}"
+  fi
+}
+
+# Download a single release file, transparently falling back to gitee when the
+# github transfer is slow or fails. Sets LAST_HTTP to the winning attempt's
+# code. Returns 0 once a source either succeeds (200) or reports 404.
+download_release_file() {
+  local rel="$1" url="" code=""
+  url="$(release_raw_url "${rel}")"
+  code="$(curl -sSL --retry 2 --retry-delay 2 \
+    --speed-limit 409600 --speed-time 15 --max-time 600 \
+    -o "${INSTALL_DIR}/${rel}" -w '%{http_code}' "${url}" 2>/dev/null || true)"
+  if [[ "${code}" == "200" ]] || [[ "${code}" == "404" ]]; then
+    LAST_HTTP="${code}"
+    return 0
+  fi
+  if [[ "${DOWNLOAD_SOURCE}" != "gitee" ]]; then
+    log_warn "github download of ${rel} is slow/failed (HTTP ${code:-timeout}); switching to gitee"
+    DOWNLOAD_SOURCE="gitee"
+    rm -f "${INSTALL_DIR}/${rel}"
+    url="${GITEE_RAW_BASE}/${TAG}/${rel}"
+    code="$(curl -sSL --retry 2 --retry-delay 2 \
+      --speed-limit 409600 --speed-time 15 --max-time 120 \
+      -o "${INSTALL_DIR}/${rel}" -w '%{http_code}' "${url}" 2>/dev/null || true)"
+    LAST_HTTP="${code}"
+    return 0
+  fi
+  LAST_HTTP="${code}"; return 1
+}
+
+fetch_release_files() {
+  log_step "Installing release files (source: ${DOWNLOAD_SOURCE})"
+  local rel="" src="" dir="" http="" done=0
+  local total="${#RELEASE_FILES[@]}"
+  for rel in "${RELEASE_FILES[@]}"; do
+    dir="${INSTALL_DIR}/$(dirname "${rel}")"
+    mkdir -p "${dir}"
+    if [[ -n "${SOURCE_DIR}" ]]; then
+      src="${SOURCE_DIR%/}/${rel}"
+      [[ -f "${src}" ]] || abort "source directory ${SOURCE_DIR} is missing ${rel}"
+      cp -f "${src}" "${INSTALL_DIR}/${rel}"
+      done=$((done + 1))
+    else
+      download_release_file "${rel}" || true
+      http="${LAST_HTTP}"
+      if [[ "${http}" != "200" ]]; then
+        rm -f "${INSTALL_DIR}/${rel}"
+        if [[ "${http}" == "404" ]]; then
+          if [[ "${rel}" == "docker-compose.standalone.yml" ]]; then
+            if [[ "${DOWNLOAD_SOURCE}" == "gitee" ]]; then
+              abort "failed to download ${rel} (${url}): tag ${TAG} not found on gitee — the mirror has not synced version ${VERSION}; sync it from GitHub or use --download-source github / an available --version"
+            fi
+            abort "failed to download ${rel} (${url}): tag ${TAG} does not contain ${rel} (HTTP 404)"
+          fi
+          if [[ "${DOWNLOAD_SOURCE}" == "gitee" ]]; then
+            log_warn "skipping ${rel}: not present in tag ${TAG} on gitee (the mirror may not have synced version ${VERSION})"
+          else
+            log_warn "skipping ${rel}: not present in tag ${TAG} (HTTP 404)"
+          fi
+        elif [[ "${rel}" == "docker-compose.standalone.yml" ]]; then
+          abort "failed to download ${rel} (${url}): network error (HTTP ${http:-timeout}); check the version and network"
+        else
+          log_warn "skipping ${rel}: network error while downloading (HTTP ${http:-timeout})"
+        fi
+      else
+        done=$((done + 1))
+      fi
+    fi
+    if [[ -t 1 ]]; then
+      printf '\r%sDownloading config files: %s/%s%s' "${c_cyan}" "${done}" "${total}" "${c_reset}"
+    fi
+  done
+  [[ -t 1 ]] && printf '\n'
+  # Postgres initdb shell scripts must stay executable for the official image.
+  chmod +x "${INSTALL_DIR}/docker/postgresql/initdb.d"/*.sh 2>/dev/null || true
+  log_ok "Release files installed"
+}
+
+# ---------------------------------------------------------------------------
+# Configuration generation (secrets are never prompted for)
+# ---------------------------------------------------------------------------
+gen_secret()   { openssl rand -hex 48; }
+gen_password() { openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 20; }
+
+sed_inplace() {
+  local file="$1"; shift
+  sed -i.bak "$@" "${file}" && rm -f "${file}.bak"
+}
+
+set_env_key() {
+  local file="$1" key="$2" value="$3"
+  if grep -qE "^${key}=" "${file}"; then
+    sed_inplace "${file}" -E "s|^${key}=.*|${key}=${value}|"
+  else
+    printf '%s=%s\n' "${key}" "${value}" >>"${file}"
+  fi
+}
+
+read_env_key() {
+  grep -E "^$2=" "$1" | tail -n1 | cut -d= -f2- | tr -d "'\"" || true
+}
+
+info_key() {
+  grep -E "^$2=" "$1" | tail -n1 | cut -d= -f2- || true
+}
+
+# Replace known insecure placeholder values left over from env.sample so a
+# seeded .env is never deployed with default credentials.
+secure_placeholder() {
+  local env_file="$1" key="$2" placeholder="$3"
+  local current=""
+  current="$(read_env_key "${env_file}" "${key}")"
+  if [[ -n "${current}" && "${current}" == "${placeholder}" ]]; then
+    set_env_key "${env_file}" "${key}" "$(gen_password)"
+    log_info "Replaced placeholder ${key}"
+  fi
+}
+
+generate_env() {
+  log_step "Generating configuration"
+  local env_file="${INSTALL_DIR}/.env"
+  if [[ -f "${env_file}" ]]; then
+    ENV_EXISTS=1
+    log_warn ".env exists — preserving it (the installer never overwrites .env)"
+    secure_placeholder "${env_file}" SECRET_KEY "change-me"
+    secure_placeholder "${env_file}" POSTGRES_PASSWORD "postgres"
+    secure_placeholder "${env_file}" LENSNODE_TOKEN "change-me-lensnode-token"
+    secure_placeholder "${env_file}" DJANGO_SUPERUSER_PASSWORD "adminpassword"
+    set_env_key "${env_file}" NGINX_HTTP_PORT "${HTTP_PORT}"
+    set_env_key "${env_file}" NGINX_HTTPS_PORT "${HTTPS_PORT}"
+    ensure_turnstile_boots "${env_file}"
+    ADMIN_PASSWORD="$(read_env_key "${env_file}" DJANGO_SUPERUSER_PASSWORD)"
+    return 0
+  fi
+
+  [[ -f "${INSTALL_DIR}/env.sample" ]] || abort "env.sample not found at ${INSTALL_DIR}/env.sample"
+  cp "${INSTALL_DIR}/env.sample" "${env_file}"
+  chmod 600 "${env_file}"
+
+  set_env_key "${env_file}" SECRET_KEY "$(gen_secret)"
+  set_env_key "${env_file}" DJANGO_DEBUG false
+  set_env_key "${env_file}" ALLOWED_HOSTS "${DOMAIN},localhost,127.0.0.1"
+  set_env_key "${env_file}" CSRF_TRUSTED_ORIGINS "${SCHEME}://${DOMAIN}${PORT_SUFFIX},${SCHEME}://127.0.0.1${PORT_SUFFIX}"
+  set_env_key "${env_file}" CORS_ALLOWED_ORIGINS "${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
+  set_env_key "${env_file}" SITE_DOMAIN "${DOMAIN}${PORT_SUFFIX}"
+  set_env_key "${env_file}" FRONTEND_URL "${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
+  set_env_key "${env_file}" ACCOUNT_DEFAULT_HTTP_PROTOCOL "${SCHEME}"
+  set_env_key "${env_file}" NGINX_HTTP_PORT "${HTTP_PORT}"
+  set_env_key "${env_file}" NGINX_HTTPS_PORT "${HTTPS_PORT}"
+  set_env_key "${env_file}" POSTGRES_PASSWORD "$(gen_password)"
+  set_env_key "${env_file}" LENSNODE_NAME "${DOMAIN}"
+  set_env_key "${env_file}" LENSNODE_TOKEN "$(gen_password)"
+  set_env_key "${env_file}" DJANGO_SUPERUSER_USERNAME "${ADMIN_USERNAME}"
+  set_env_key "${env_file}" DJANGO_SUPERUSER_EMAIL "${ADMIN_EMAIL}"
+  ADMIN_PASSWORD="$(gen_password)"
+  set_env_key "${env_file}" DJANGO_SUPERUSER_PASSWORD "${ADMIN_PASSWORD}"
+  ensure_turnstile_boots "${env_file}"
+  log_ok ".env generated from env.sample with random secrets (chmod 600)"
+}
+
+# Turnstile needs real Cloudflare keys; with an empty secret and DJANGO_DEBUG
+# false the backend refuses to start (fail-fast guard in
+# core/settings/accounts.py). The one-command installer cannot mint real keys,
+# so disable the check unless the operator has already configured a secret —
+# login then works without the Turnstile widget, and they can enable it later.
+ensure_turnstile_boots() {
+  local env_file="$1" ts_secret=""
+  ts_secret="$(read_env_key "${env_file}" TURNSTILE_SECRET_KEY)"
+  if [[ -z "${ts_secret}" ]]; then
+    set_env_key "${env_file}" TURNSTILE_ENABLED false
+    log_warn "TURNSTILE_SECRET_KEY is empty — set TURNSTILE_ENABLED=false so the backend can start (login runs without Cloudflare Turnstile). To enable it later, set a real secret and frontend site key, then flip TURNSTILE_ENABLED=true."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Compose patching per channel & install parameters
+# ---------------------------------------------------------------------------
+patch_compose() {
+  log_step "Patching compose file (channel: ${CHANNEL}, source: ${DOWNLOAD_SOURCE})"
+  local compose="${INSTALL_DIR}/${COMPOSE_FILE}"
+  [[ -f "${compose}" ]] || abort "compose file missing at ${compose}"
+  # Pin version-consistent image tags and rewrite the registry prefix.
+  # github -> REGISTRY_GITHUB ("oneprolabs", a no-op rewrite);
+  # gitee/cn -> Aliyun ACR host/namespace.
+  # Delimiter is '#' (not '|'): '|' is the ERE alternation operator inside the
+  # pattern and would close the expression early on BSD sed.
+  sed_inplace "${compose}" -E \
+    "s#image:[[:space:]]*oneprolabs/(sourcelens-(backend|frontend|lensnode)):.*\$#image: ${REGISTRY}/\1:${VERSION}#"
+  if ! grep -q "image: ${REGISTRY}/sourcelens-backend:${VERSION}" "${compose}"; then
+    abort "failed to pin image references in ${compose}"
+  fi
+  log_ok "Compose patched (registry: ${REGISTRY}, images tagged :${VERSION})"
+}
+
+# ---------------------------------------------------------------------------
+# TLS certificate (self-signed for the nginx HTTPS server block)
+# ---------------------------------------------------------------------------
+generate_certs() {
+  log_step "Ensuring TLS certificate"
+  local certs_dir="${INSTALL_DIR}/docker/nginx/certs"
+  mkdir -p "${certs_dir}"
+  if [[ ! -f "${certs_dir}/nginx-selfsigned.crt" || ! -f "${certs_dir}/nginx-selfsigned.key" ]]; then
+    log_info "Generating self-signed certificate for ${DOMAIN} (replace with a real certificate for production)"
+    docker run --rm -v "${certs_dir}:/certs" alpine/openssl req -x509 \
+      -newkey rsa:2048 -nodes -days 3650 \
+      -keyout /certs/nginx-selfsigned.key -out /certs/nginx-selfsigned.crt \
+      -subj "/CN=${DOMAIN}" \
+      -addext "subjectAltName=DNS:${DOMAIN},DNS:localhost,IP:127.0.0.1" 2>/dev/null \
+      || docker run --rm -v "${certs_dir}:/certs" alpine/openssl req -x509 \
+           -newkey rsa:2048 -nodes -days 3650 \
+           -keyout /certs/nginx-selfsigned.key -out /certs/nginx-selfsigned.crt \
+           -subj "/CN=${DOMAIN}"
+    chmod 600 "${certs_dir}/nginx-selfsigned.key"
+  fi
+  log_ok "TLS certificate ready"
+}
+
+# ---------------------------------------------------------------------------
+# Directory layout
+# ---------------------------------------------------------------------------
+create_dirs() {
+  log_step "Creating directories"
+  mkdir -p "${INSTALL_DIR}"/{data,logs}
+  mkdir -p "${INSTALL_DIR}/data"/{django/staticfiles,storage,document-attachments,deliverables,workspace,postgresql/data,redis}
+  mkdir -p "${INSTALL_DIR}/data"/logs/{api,worker,scheduler,nginx,postgresql,redis}
+  log_ok "Directories created under ${INSTALL_DIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Docker Compose lifecycle
+# ---------------------------------------------------------------------------
+run_compose() {
+  "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
+    -f "${INSTALL_DIR}/${COMPOSE_FILE}" "$@" 2>&1 | tee -a "${LOG_FILE}"
+}
+
+run_compose_quiet() {
+  "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
+    -f "${INSTALL_DIR}/${COMPOSE_FILE}" "$@"
+}
+
+pull_one() {
+  local img="$1" rc=0
+  if [[ -t 1 ]]; then
+    docker pull "${img}" 2>&1 | tee -a "${LOG_FILE:-/dev/null}" | docker_pull_progress "${img}" || rc=$?
+  else
+    docker pull "${img}" >>"${LOG_FILE:-/dev/null}" 2>&1 || rc=$?
+  fi
+  return "${rc}"
+}
+
+docker_pull_progress() {
+  local img="${1##*/}" line="" frac="" msg="" prev=""
+  local total=0 ready=0 done=0
+  [[ -t 1 ]] || { cat >/dev/null 2>&1 || true; return 0; }
+  while IFS= read -r line; do
+    line="${line//$'\r'/}"
+    case "${line}" in
+      *": Pulling fs layer") total=$((total + 1));;
+      *": Layer already exists") total=$((total + 1)); ready=$((ready + 1));;
+      *": Download complete") ready=$((ready + 1));;
+      *": Pull complete") done=$((done + 1));;
+    esac
+    frac=""
+    if [[ "${line}" =~ \:[[:space:]]*(Downloading|Extracting)[[:space:]]*\[[^]]*\][[:space:]]*([0-9][0-9.]*[kMG]?B/[0-9][0-9.]*[kMG]?B) ]]; then
+      frac="${BASH_REMATCH[2]}"
+    fi
+    msg="${img}: ${ready}/${total} layers ready"
+    ((done > 0)) && msg+=", ${done} complete"
+    [[ -n "${frac}" ]] && msg+=" (${frac})"
+    printf '\r\033[K%s' "${msg}"
+    prev=1
+  done
+  [[ -n "${prev}" ]] && printf '\r\033[K'
+  return 0
+}
+
+pull_images() {
+  log_step "Pulling container images (registry: ${REGISTRY})"
+  run_compose config --quiet || abort "invalid docker-compose configuration; see ${LOG_FILE}"
+
+  local -a images=() img=""
+  while IFS= read -r img; do
+    [[ -n "${img}" ]] && images+=("${img}")
+  done < <(run_compose_quiet config --images 2>/dev/null | sort -u)
+
+  local total="${#images[@]}" idx=1 attempt=1 max_attempts=3
+  if ((total == 0)); then
+    log_warn "no container images to pull"
+    return 0
+  fi
+  for img in "${images[@]}"; do
+    attempt=1
+    while :; do
+      if pull_one "${img}"; then
+        break
+      fi
+      if ((attempt >= max_attempts)); then
+        abort "failed to pull ${img} after ${max_attempts} attempts; check network access to the registry (see ${LOG_FILE})"
+      fi
+      log_warn "pull of ${img} failed (attempt ${attempt}/${max_attempts}); retrying in 10s"
+      sleep 10
+      attempt=$((attempt + 1))
+    done
+    log_ok "[${idx}/${total}] pulled ${img}"
+    idx=$((idx + 1))
+  done
+  log_ok "All ${total} images pulled"
+}
+
+_spinner_pid=""
+_spinner_on=0
+
+spinner_start() {
+  [[ -t 1 ]] || return 0
+  _spinner_on=1
+  (
+    local label="$1" chars='/-\|' i=0 c=""
+    while :; do
+      c="${chars:$((i % 4)):1}"
+      printf '\r\033[K%s %s' "${label}" "${c}"
+      i=$((i + 1))
+      sleep 0.2
+    done
+  ) &
+  _spinner_pid=$!
+}
+
+spinner_stop() {
+  [[ "${_spinner_on}" == "1" ]] || return 0
+  kill "${_spinner_pid}" 2>/dev/null || true
+  wait "${_spinner_pid}" 2>/dev/null || true
+  printf '\r\033[K'
+  _spinner_on=0
+}
+
+start_stack() {
+  log_step "Starting Docker Compose stack"
+  local attempt=1 max_attempts=5 backoff=20
+  if [[ -t 1 ]]; then
+    log_info "Starting stack (details logged to ${LOG_FILE})"
+    spinner_start "Starting Docker Compose stack"
+  fi
+  until run_compose_quiet up -d --no-build --remove-orphans >>"${LOG_FILE}" 2>&1; do
+    spinner_stop
+    if ((attempt >= max_attempts)); then
+      log_error "docker compose up failed after ${max_attempts} attempts"
+      log_error "container status:"
+      run_compose ps || true
+      log_error "recent container logs:"
+      run_compose logs --tail=100 --no-color || true
+      abort "docker compose up failed; see ${LOG_FILE} and the container logs above"
+    fi
+    log_info "dependencies still warming up; retrying in ${backoff}s (attempt ${attempt}/${max_attempts})"
+    sleep "${backoff}"
+    ((backoff < 120)) && backoff=$((backoff * 2))
+    attempt=$((attempt + 1))
+    spinner_start "Starting Docker Compose stack"
+  done
+  spinner_stop
+  log_ok "Stack started"
+  log_info "Container status:"
+  run_compose_quiet ps --format 'table {{.Name}}\t{{.Status}}' || true
+}
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+health_check() {
+  log_step "Waiting for health endpoint (timeout: ${HEALTH_TIMEOUT}s)"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local url="http://127.0.0.1:${HTTP_PORT}/health"
+  until curl -fsS --max-time 5 "${url}" >/dev/null 2>&1; do
+    if ((SECONDS >= deadline)); then
+      log_error "health check timed out after ${HEALTH_TIMEOUT}s"
+      log_error "container status:"
+      run_compose ps || true
+      log_error "recent container logs:"
+      run_compose logs --tail=100 --no-color || true
+      abort "health check failed — see ${LOG_FILE} and the container logs above"
+    fi
+    sleep 5
+  done
+  log_ok "Health check passed: ${url}"
+}
+
+# ---------------------------------------------------------------------------
+# Installation metadata & summary
+# ---------------------------------------------------------------------------
+write_install_info() {
+  local info="${INSTALL_DIR}/install-info.env"
+  {
+    printf '# SourceLens installation metadata — generated by install.sh v%s\n' "${INSTALLER_VERSION}"
+    printf 'SOURCELENS_VERSION=%s\n' "${VERSION}"
+    printf 'SOURCELENS_INSTALL_TIME=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'SOURCELENS_CHANNEL=%s\n' "${CHANNEL}"
+    printf 'SOURCELENS_DOWNLOAD_SOURCE=%s\n' "${DOWNLOAD_SOURCE}"
+    printf 'SOURCELENS_INSTALL_DIR=%s\n' "${INSTALL_DIR}"
+    printf 'SOURCELENS_URL=%s\n' "${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
+    printf 'SOURCELENS_USERNAME=%s\n' "${ADMIN_USERNAME}"
+    printf 'SOURCELENS_INITIAL_PASSWORD=%s\n' "${ADMIN_PASSWORD}"
+    printf 'SOURCELENS_REGISTRY=%s\n' "${REGISTRY}"
+    printf 'SOURCELENS_HTTP_PORT=%s\n' "${HTTP_PORT}"
+    printf 'SOURCELENS_HTTPS_PORT=%s\n' "${HTTPS_PORT}"
+    printf 'SOURCELENS_DOMAIN=%s\n' "${DOMAIN}"
+    printf 'SOURCELENS_HTTPS=%s\n' "${HTTPS}"
+    printf 'SOURCELENS_INSTALLER_VERSION=%s\n' "${INSTALLER_VERSION}"
+  } >"${info}"
+  chmod 600 "${info}"
+  log_ok "Installation metadata saved (${info}, chmod 600)"
+}
+
+show_summary() {
+  log_step "Installation summary"
+  log_info "  Platform:     ${OS_NAME} (${PLATFORM}/${ARCH})"
+  log_info "  Version:      v${VERSION}"
+  log_info "  Channel:      ${CHANNEL} (source: ${DOWNLOAD_SOURCE}, registry: ${REGISTRY})"
+  log_info "  Install dir:  ${INSTALL_DIR}"
+  log_info "  URL:          ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
+  log_info "  HTTP port:    ${HTTP_PORT}"
+  if [[ "${EXISTING}" == "1" ]]; then
+    log_info "  Mode:         rerun/upgrade (existing installation, .env preserved)"
+  fi
+}
+
+final_summary() {
+  log_step "Installation complete"
+  log_ok "SourceLens v${VERSION} installed at ${INSTALL_DIR}"
+  log_info "URL:              ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
+  log_info "Username:         ${ADMIN_USERNAME}"
+  log_info "Initial password: ${ADMIN_PASSWORD}"
+  log_info "Install dir:      ${INSTALL_DIR}"
+  log_info "Config file:      ${INSTALL_DIR}/.env"
+  log_info "Install info:     ${INSTALL_DIR}/install-info.env"
+  log_info "Install log:      ${LOG_FILE}"
+  if [[ "${ENV_EXISTS}" == "1" ]]; then
+    log_warn "An existing .env was preserved; the admin password above is the one stored in it"
+  fi
+  if [[ "${HTTPS}" != "true" ]]; then
+    log_warn "HTTPS is not enabled; put a TLS-terminating reverse proxy in front for production, or set --https"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  INSTALL_ARGS=("$@")
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -d|--dir) INSTALL_DIR="${2:?--dir requires an argument}"; INSTALL_DIR_OVERRIDE=1; shift 2 ;;
+      -p|--port) HTTP_PORT="${2:?--port requires an argument}"; HTTP_PORT_OVERRIDE=1; shift 2 ;;
+      --https-port) HTTPS_PORT="${2:?--https-port requires an argument}"; shift 2 ;;
+      -c|--channel) CHANNEL="$2"; shift 2 ;;
+      --download-source) DOWNLOAD_SOURCE="$2"; shift 2 ;;
+      -v|--version) VERSION="$2"; shift 2 ;;
+      --source) SOURCE_DIR="$2"; shift 2 ;;
+      -r|--registry) REGISTRY="$2"; shift 2 ;;
+      --domain) DOMAIN="$2"; DOMAIN_OVERRIDE=1; shift 2 ;;
+      --admin-user) ADMIN_USERNAME="$2"; shift 2 ;;
+      --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
+      --https) HTTPS="true"; shift ;;
+      --docker-mirror) DOCKER_MIRROR="$2"; shift 2 ;;
+      -y|--yes) ASSUME_YES=1; shift ;;
+      --force) FORCE=1; shift ;;
+      --) shift; break ;;
+      -*)
+        if [[ "${1#-}" =~ ^[0-9] ]]; then
+          VERSION="${1#-}"; shift
+        else
+          log_error "unknown option: $1"; usage; exit 1
+        fi
+        ;;
+      *) VERSION="${1#v}"; shift ;;
+    esac
+  done
+
+  trap 'log_line "=== install failed at line ${LINENO} (exit $?) ==="' ERR
+
+  # Preflight
+  require_root
+  detect_os
+  detect_arch
+  check_memory
+  prompt_install_dir
+
+  mkdir -p "${INSTALL_DIR}/logs"
+  LOG_FILE="${INSTALL_DIR}/logs/install.log"
+  log_line "=== install.sh v${INSTALLER_VERSION} started ($(date -u '+%Y-%m-%dT%H:%M:%SZ')) ==="
+  log_line "argv: $*"
+
+  check_disk
+  check_tools
+
+  detect_existing
+  detect_channel
+  detect_download_source
+  check_docker
+  check_compose
+  check_no_bluegreen
+
+  configure
+  resolve_version
+  resolve_ports
+  show_summary
+  if [[ "${EXISTING}" == "1" && -n "${INSTALLED_VERSION}" && "${INSTALLED_VERSION#v}" != "${VERSION}" && "${FORCE}" != "1" ]]; then
+    log_warn "upgrade: installed v${INSTALLED_VERSION#v} -> v${VERSION}"
+  fi
+  confirm "Proceed?" || abort "installation cancelled"
+
+  create_dirs
+  if [[ -n "${SOURCE_DIR}" ]]; then
+    log_info "Using local release files from ${SOURCE_DIR%/}"
+  fi
+  fetch_release_files
+  generate_env
+  patch_compose
+  generate_certs
+  pull_images
+  start_stack
+  health_check
+  write_install_info
+  final_summary
+}
+
+if [[ "${BASH_SOURCE[0]:-}" == "$0" || -z "${BASH_SOURCE[0]:-}" ]]; then
+  main "$@"
+fi

--- a/release-notes/381.yaml
+++ b/release-notes/381.yaml
@@ -1,0 +1,11 @@
+type: feature
+audience: admin
+en: >-
+  Added a one-command installer (install.sh) for the standalone single-instance
+  deployment: it downloads the release config files, generates a production
+  .env with random secrets, pulls images, and health-checks the stack. Supports
+  GitHub/Gitee release sources and Docker Hub / Aliyun ACR image registries.
+zh-CN: >-
+  新增 standalone 单实例部署的一键安装器（install.sh）：自动下载发布配置、生成带随机密钥的
+  生产 .env、拉取镜像并启动栈做健康检查。支持 GitHub/Gitee 发布源与
+  Docker Hub / 阿里云 ACR 镜像仓库。


### PR DESCRIPTION
### **User description**
## Summary
- **#381 fix**: Quick Start now states Docker Compose **V2** is required and uses `docker compose` commands. `docker-compose.dev.yml` relies on V2-only syntax (top-level `name`, `pull_policy`, `depends_on.condition`) that Compose 1.29.x rejects with a schema error; the requirement was only mentioned in the Production section, not the install guide.
- **New `install.sh`**: one-command standalone installer driving `docker-compose.standalone.yml` — fetches release config files from a tag (GitHub/Gitee), generates a production `.env` with random secrets (never overwrites, replaces insecure placeholders), pins image tags, selects the image registry per channel (Docker Hub `oneprolabs/*` vs Aliyun ACR), generates a self-signed TLS cert, pulls images, starts the stack and health-checks it. Idempotent — re-running with a newer tag upgrades in place. Requires Docker Compose V2.
- **Docs**: READMEs describe the two production shapes (standalone vs blue/green) and the installer.

Closes #381

## Test plan
- [x] `bash -n` + shellcheck clean
- [x] Local unit checks: .env generation/preservation, compose registry+tag patching (both channels), arg parsing, port-conflict bump
- [x] Full install on a real Ubuntu 24.04 host: both `cn`→Aliyun ACR and `github`→Docker Hub channels, HTTPS port auto-bumped off a busy port, Turnstile-empty-key default handled (login works), health check passed, superuser login returns JWT


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Document Docker Compose V2 requirement and update dev commands

- Add standalone one-command installer (install.sh)

- Update READMEs with production deployment options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DevDocs["Dev: Document Compose V2 requirement"]
  Installer["New: install.sh standalone installer"]
  DevDocs --> UpdateDev["Update 'docker compose' commands"]
  Installer --> Preflight["Preflight checks (OS, Docker, Compose V2)"]
  Installer --> Fetch["Fetch release files from tag"]
  Installer --> Env["Generate .env with random secrets"]
  Installer --> Pull["Pull images (Docker Hub / Aliyun ACR)"]
  Installer --> Start["Start stack and health check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Add standalone one-command installer script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

install.sh

<ul><li>Added standalone one-command installer for production deployment, <br>driving docker-compose.standalone.yml<br> <li> Includes preflight checks (OS, memory, disk, tools), release file <br>download, .env generation, compose patching, image pulling, stack <br>startup, health check, and idempotent upgrades<br> <li> Supports GitHub/Gitee release sources and Docker Hub / Aliyun ACR <br>image registries<br> <li> Generates random secrets, replaces insecure placeholders, and <br>configures TLS certificate</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/384/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+1121/-0</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Docker Compose V2 requirement and production deployment</code></dd></summary>
<hr>

README.md

<ul><li>Updated Quick Start to require Docker Compose V2 and use 'docker <br>compose' commands<br> <li> Added production deployment section describing standalone installer <br>and blue/green options<br> <li> Documented installer usage, channels, port handling, and Turnstile <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/384/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+74/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>Chinese documentation for Docker Compose V2 and production deployment</code></dd></summary>
<hr>

README.zh-CN.md

<ul><li>Updated Chinese Quick Start to require Docker Compose V2 and use <br>'docker compose' commands<br> <li> Added Chinese production deployment section with standalone installer <br>documentation<br> <li> Documented installer usage, channels, and Turnstile configuration in <br>Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/384/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+67/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>381.yaml</strong><dd><code>Add release note for standalone installer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/381.yaml

<ul><li>Added release note fragment for the standalone installer feature<br> <li> Describes the installer in English and Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/384/files#diff-1e5f8d657fa8d196b4a8f069cadab93a8840f1a36389a0bd4eac6bc0896850d5">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

