### PR TITLE
Prevent LensNode OOM orphaned document conversions (#355)

### DIFF
--- a/backend/core/periodic_registry.py
+++ b/backend/core/periodic_registry.py
@@ -100,13 +100,14 @@ class TaskRegistry:
         }
 
     def _apply_one(self, name, entry):
+        from django.conf import settings
         from django_celery_beat.models import PeriodicTask, PeriodicTasks
 
         task_name = entry["task"]
         schedule = entry["schedule"]
         args = entry["args"]
         kwargs = entry["kwargs"]
-        queue = entry["queue"]
+        queue = entry["queue"] or settings.CELERY_TASK_DEFAULT_QUEUE
         enabled = entry["enabled"]
 
         if _is_crontab_schedule(schedule):
@@ -143,6 +144,15 @@ class TaskRegistry:
             name=name, defaults=create_defaults
         )
         if not created:
+            stale_queues = {
+                "",
+                "sourcelens",
+                settings.CELERY_TASK_DEFAULT_QUEUE,
+            }
+            if obj.queue in stale_queues and obj.queue != queue:
+                obj.queue = queue
+                obj.save(update_fields=["queue"])
+                PeriodicTasks.update_changed()
             logger.debug(
                 "Periodic task already exists, skipping update: %s",
                 name,
@@ -177,4 +187,3 @@ TASK_REGISTRY = TaskRegistry()
 def apply_registry():
     """Apply the global TASK_REGISTRY to django_celery_beat."""
     TASK_REGISTRY.apply()
-

--- a/backend/core/settings/celery.py
+++ b/backend/core/settings/celery.py
@@ -1,4 +1,6 @@
 import os
+
+from django.core.exceptions import ImproperlyConfigured
 from kombu import Queue
 
 # For production environments, use Redis or RabbitMQ as result backend.
@@ -48,6 +50,23 @@ CELERY_TASK_QUEUE_NAMES = [
 ]
 if CELERY_TASK_DEFAULT_QUEUE not in CELERY_TASK_QUEUE_NAMES:
     CELERY_TASK_QUEUE_NAMES.insert(0, CELERY_TASK_DEFAULT_QUEUE)
+CELERY_REQUIRED_QUEUES = {
+    name.strip()
+    for name in os.getenv("CELERY_REQUIRED_QUEUES", "backend,lens").split(",")
+    if name.strip()
+}
+CELERY_QUEUE_DEPTH_THRESHOLD = int(
+    os.getenv("CELERY_QUEUE_DEPTH_THRESHOLD", "1000")
+)
+CELERY_BEAT_LIVENESS_SECONDS = int(
+    os.getenv("CELERY_BEAT_LIVENESS_SECONDS", "300")
+)
+missing_queues = CELERY_REQUIRED_QUEUES.difference(CELERY_TASK_QUEUE_NAMES)
+if missing_queues:
+    raise ImproperlyConfigured(
+        "CELERY_TASK_QUEUES is missing required queues: "
+        + ", ".join(sorted(missing_queues))
+    )
 CELERY_TASK_QUEUES = tuple(Queue(name) for name in CELERY_TASK_QUEUE_NAMES)
 
 # Prevent task loss in Redis

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,6 +1,10 @@
+from datetime import timedelta
+
+from django.conf import settings
 from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import path, include
+from django.utils import timezone
 
 from accounts.views import OAuthCallbackRedirectView
 from core.views.admin_bulk import (
@@ -9,12 +13,83 @@ from core.views.admin_bulk import (
 )
 from .swagger import schema_view, swagger_view, redoc_view
 
+
+def celery_health(request):
+    """Report required queue consumers, broker depth, and beat liveness."""
+
+    del request
+    from core.celery import app
+    from django_celery_beat.models import PeriodicTask
+
+    required = set(getattr(settings, "CELERY_REQUIRED_QUEUES", ()))
+    active_queues = app.control.inspect(timeout=0.5).active_queues() or {}
+    consumed = {
+        queue["name"]
+        for queues in active_queues.values()
+        for queue in queues
+        if queue.get("name")
+    }
+    missing = sorted(required - consumed)
+    depths = {}
+    broker_error = ""
+    try:
+        import redis
+
+        client = redis.Redis.from_url(settings.CELERY_BROKER_URL)
+        depths = {
+            queue: int(client.llen(queue))
+            for queue in sorted(required)
+        }
+    except Exception as exc:
+        broker_error = type(exc).__name__
+    threshold = int(
+        getattr(settings, "CELERY_QUEUE_DEPTH_THRESHOLD", 1000)
+    )
+    overloaded = sorted(
+        queue for queue, depth in depths.items() if depth > threshold
+    )
+    latest_beat = (
+        PeriodicTask.objects.filter(enabled=True)
+        .exclude(last_run_at__isnull=True)
+        .order_by("-last_run_at")
+        .values_list("last_run_at", flat=True)
+        .first()
+    )
+    beat_threshold = int(
+        getattr(settings, "CELERY_BEAT_LIVENESS_SECONDS", 300)
+    )
+    beat_stale = latest_beat is None or latest_beat < (
+        timezone.now() - timedelta(seconds=beat_threshold)
+    )
+    healthy = (
+        not missing
+        and not overloaded
+        and not broker_error
+        and not beat_stale
+    )
+    payload = {
+        "health": "OK" if healthy else "DEGRADED",
+        "required_queues": sorted(required),
+        "consumed_queues": sorted(consumed),
+        "missing_consumers": missing,
+        "queue_depth": depths,
+        "queue_depth_threshold": threshold,
+        "overloaded_queues": overloaded,
+        "beat_last_run_at": latest_beat,
+        "beat_liveness_seconds": beat_threshold,
+        "beat_stale": beat_stale,
+    }
+    if broker_error:
+        payload["broker_error"] = broker_error
+    return JsonResponse(payload, status=200 if healthy else 503)
+
 # Define project URL routing configuration
 urlpatterns = [
     # Health check endpoint
     # Used by Docker/Kubernetes for container health monitoring
     # Returns a simple 'OK' response to indicate the application is running
     path('health', lambda _: JsonResponse({'health': 'OK'}, status=200)),
+    path('health/celery', celery_health, name='celery-health'),
 
     # API Schema endpoint
     # Provides the OpenAPI schema in JSON format

--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -21,6 +21,10 @@ from .services import (
     resume_awaiting_runs_for_lensnode,
     schedule_lensnode_disconnect_grace_check,
 )
+from .tasks import (
+    reconcile_orphaned_datasource_conversions,
+    refresh_lensnode_heavy_work_slot,
+)
 
 LOGGER = logging.getLogger(__name__)
 DETAIL_ITEMS_LIMIT = 200
@@ -212,6 +216,10 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         active_runs = content.get("active_runs") or []
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self._update_lensnode_report(content, require_versions=True)
+        await database_sync_to_async(reconcile_orphaned_datasource_conversions)(
+            self.lensnode.uuid,
+            self.channel_name,
+        )
         await database_sync_to_async(reconcile_lensnode_active_runs)(
             self.lensnode.uuid, active_runs
         )
@@ -508,6 +516,12 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         if task and task.status in TaskStatus.get_completed_statuses():
             return
         metadata = dict(task.metadata or {}) if task else {}
+        if task:
+            refresh_lensnode_heavy_work_slot(
+                metadata.get("lensnode_uuid"),
+                task_id,
+                metadata.get("heavy_work_slot"),
+            )
         steps = list(metadata.get("steps") or [])
         step = {
             "name": content.get("step") or "sync",
@@ -550,6 +564,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             "steps": steps,
             "progress_step": step["name"],
             "progress_message": step["message"],
+            "last_progress_at": step["timestamp"],
         }
         is_conversion = (
             content.get("category") == "conversion"
@@ -826,10 +841,14 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             return
         await database_sync_to_async(
             self._complete_datasource_conversion_done
-        )(request_id, content)
+        )(request_id, content, self.channel_name)
 
     @staticmethod
-    def _complete_datasource_conversion_done(request_id, content):
+    def _complete_datasource_conversion_done(
+        request_id,
+        content,
+        connection_id,
+    ):
         from .tasks import (
             complete_datasource_conversion_task,
             resolve_datasource_conversion_task_id,
@@ -840,7 +859,11 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             content,
         )
         if task_id:
-            complete_datasource_conversion_task(task_id, content)
+            complete_datasource_conversion_task(
+                task_id,
+                content,
+                connection_id=connection_id,
+            )
 
     async def _send_bad_frame(self, message):
         await self.send_json(

--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -12,6 +12,7 @@ from .services import lensnode_group_name
 
 WORKSPACE_ROOT = "/workspace"
 DATASOURCE_SYNC_TIMEOUT_SETTING = "lens.datasource_sync.timeout_s"
+DATASOURCE_CONVERSION_TIMEOUT_SETTING = "lens.datasource_conversion.timeout_s"
 DATASOURCE_SYNC_WORKERS_SETTING = "lens.datasource_sync.workers"
 DATASOURCE_CONVERSION_VISION_MODEL_SETTING = (
     "lens.datasource_conversion.vision_model_ref"
@@ -20,6 +21,7 @@ DATASOURCE_CONVERSION_DOCUMENT_MODEL_SETTING = (
     "lens.datasource_conversion.document_model_ref"
 )
 DEFAULT_DATASOURCE_SYNC_TIMEOUT_S = 21600
+DEFAULT_DATASOURCE_CONVERSION_TIMEOUT_S = 86400
 DEFAULT_DATASOURCE_SYNC_WORKERS = 4
 DATASOURCE_RESULT_POLL_S = 0.5
 
@@ -133,6 +135,19 @@ def get_datasource_sync_max_workers():
     except (TypeError, ValueError):
         value = 0
     return value if value > 0 else DEFAULT_DATASOURCE_SYNC_WORKERS
+
+
+def get_datasource_conversion_timeout_s():
+    """Return the long-running managed conversion lease timeout."""
+
+    setting = GlobalSetting.objects.filter(
+        key=DATASOURCE_CONVERSION_TIMEOUT_SETTING
+    ).first()
+    try:
+        value = int(setting.value) if setting is not None else 0
+    except (TypeError, ValueError):
+        value = 0
+    return value if value > 0 else DEFAULT_DATASOURCE_CONVERSION_TIMEOUT_S
 
 
 def check_datasource_path(lensnode, target_path, source_type, config=None):

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -13,6 +13,7 @@ from django.utils.dateparse import parse_datetime
 from .datasource_services import (
     dispatch_datasource_conversion_async,
     dispatch_datasource_sync_async,
+    get_datasource_conversion_timeout_s,
     get_datasource_sync_timeout_s,
 )
 from .models import (
@@ -30,6 +31,9 @@ logger = logging.getLogger(__name__)
 ANSWER_RUN_DOCUMENT_COUNT_HEADER = "sourcelens_expected_document_count"
 SESSION_TITLE_TASK_EXPIRY_SECONDS = 900
 SESSION_TITLE_TASK_NAME = "lens.generate_session_title.v2"
+DATASOURCE_CANCELLING_STATUS = "CANCELLING"
+HEAVY_WORK_SLOT_SETTING = "lensnode.heavy_work_slots"
+HEAVY_WORK_RETRY_SECONDS = 5
 
 
 @shared_task(name="lens.execute_run_diagnostic", queue="lens")
@@ -296,6 +300,7 @@ def register_datasource_conversion_task(
         "force": bool(force),
         "steps": [],
         "logs": [],
+        "lensnode_connection_id": lensnode.connection_id if lensnode else "",
     }
     task_metadata.update(metadata or {})
     return TaskTracker.register_task(
@@ -328,6 +333,89 @@ def _datasource_conversion_task_name(datasource):
     if not name:
         return "datasource_convert"
     return f"datasource_convert:{name}"
+
+
+def _datasource_active_statuses(task_status):
+    """Return statuses that still own datasource work."""
+
+    return [
+        task_status.PENDING,
+        *task_status.get_running_statuses(),
+        DATASOURCE_CANCELLING_STATUS,
+    ]
+
+
+def _heavy_work_slot_count():
+    """Return the configured number of heavy-work slots per LensNode."""
+
+    setting = GlobalSetting.objects.filter(key=HEAVY_WORK_SLOT_SETTING).first()
+    try:
+        value = int(setting.value if setting else 1)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, min(value, 32))
+
+
+def acquire_lensnode_heavy_work_slot(lensnode_uuid, task_id):
+    """Atomically reserve one heavy-work slot for a LensNode task."""
+
+    ttl_s = max(
+        get_datasource_sync_timeout_s(),
+        get_datasource_conversion_timeout_s(),
+        60,
+    )
+    for slot in range(_heavy_work_slot_count()):
+        key = f"lens:heavy-work:{lensnode_uuid}:{slot}"
+        if cache.add(key, task_id, timeout=ttl_s):
+            return str(slot)
+    return None
+
+
+def release_lensnode_heavy_work_slot(lensnode_uuid, task_id, slot=None):
+    """Release a heavy-work slot only when this task owns it."""
+
+    if not lensnode_uuid or not task_id:
+        return False
+    slots = [str(slot)] if slot is not None else [
+        str(index) for index in range(_heavy_work_slot_count())
+    ]
+    released = False
+    for slot_id in slots:
+        key = f"lens:heavy-work:{lensnode_uuid}:{slot_id}"
+        if cache.get(key) == task_id:
+            cache.delete(key)
+            released = True
+    return released
+
+
+def refresh_lensnode_heavy_work_slot(lensnode_uuid, task_id, slot):
+    """Extend a heavy-work lease when the executor reports progress."""
+
+    if not lensnode_uuid or not task_id or slot is None:
+        return False
+    key = f"lens:heavy-work:{lensnode_uuid}:{slot}"
+    if cache.get(key) != task_id:
+        return False
+    cache.set(
+        key,
+        task_id,
+        timeout=max(
+            get_datasource_sync_timeout_s(),
+            get_datasource_conversion_timeout_s(),
+            60,
+        ),
+    )
+    return True
+
+
+def _schedule_queued_conversion(datasource, conversion, force, task_id):
+    """Retry a queued conversion without creating another task record."""
+
+    datasource_conversion_task.apply_async(
+        args=[str(datasource.uuid), dict(conversion or {}), bool(force)],
+        kwargs={"task_id": task_id},
+        countdown=HEAVY_WORK_RETRY_SECONDS,
+    )
 
 
 def _is_global_task_enabled(task_type, default=True):
@@ -498,7 +586,33 @@ def datasource_conversion_task(
         )
         return 0
 
-    TaskTracker.update_task_status(task_id, TaskStatus.STARTED)
+    slot = acquire_lensnode_heavy_work_slot(
+        datasource.lensnode.uuid,
+        task_id,
+    )
+    if slot is None:
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.PENDING,
+            metadata={
+                "queue_state": "QUEUED",
+                "queue_reason": "LENSNODE_HEAVY_WORK_BUSY",
+            },
+        )
+        datasource.last_conversion_status = TaskStatus.PENDING
+        datasource.save(update_fields=["last_conversion_status", "updated_at"])
+        _schedule_queued_conversion(datasource, conversion, force, task_id)
+        return 0
+
+    slot_metadata = {
+        "heavy_work_slot": slot,
+        "lensnode_connection_id": datasource.lensnode.connection_id,
+    }
+    TaskTracker.update_task_status(
+        task_id,
+        TaskStatus.STARTED,
+        metadata=slot_metadata,
+    )
     datasource.last_conversion_status = TaskStatus.STARTED
     datasource.save(update_fields=["last_conversion_status", "updated_at"])
     _append_datasource_task_step(
@@ -546,6 +660,11 @@ def datasource_conversion_task(
                 )
         if terminal_status:
             release_datasource_lock(datasource.uuid, token=task_id)
+            release_lensnode_heavy_work_slot(
+                datasource.lensnode.uuid,
+                task_id,
+                slot,
+            )
             if terminal_status == TaskStatus.REVOKED:
                 from .services import (
                     cancel_datasource_conversion_on_lensnode,
@@ -557,7 +676,12 @@ def datasource_conversion_task(
                 )
             return 0
     except SourceSyncBusy as exc:
-        datasource.last_conversion_status = TaskStatus.REVOKED
+        release_lensnode_heavy_work_slot(
+            datasource.lensnode.uuid,
+            task_id,
+            slot,
+        )
+        datasource.last_conversion_status = TaskStatus.PENDING
         datasource.last_conversion_at = timezone.now()
         datasource.save(
             update_fields=[
@@ -568,17 +692,23 @@ def datasource_conversion_task(
         )
         TaskTracker.update_task_status(
             task_id,
-            TaskStatus.REVOKED,
+            TaskStatus.PENDING,
             error=str(exc),
             metadata=_datasource_step_metadata(
                 task_id,
                 "lock",
-                "skipped",
+                "queued",
                 str(exc),
             ),
         )
+        _schedule_queued_conversion(datasource, conversion, force, task_id)
         return 0
     except Exception:
+        release_lensnode_heavy_work_slot(
+            datasource.lensnode.uuid,
+            task_id,
+            slot,
+        )
         release_datasource_lock(datasource.uuid, token=task_id)
         datasource.last_conversion_status = TaskStatus.FAILURE
         datasource.last_conversion_at = timezone.now()
@@ -604,7 +734,11 @@ def datasource_conversion_task(
     return 0
 
 
-def complete_datasource_conversion_task(task_id, result):
+def complete_datasource_conversion_task(
+    task_id,
+    result,
+    connection_id=None,
+):
     """Complete managed workspace conversion from LensNode callback."""
 
     from agentcore_task.adapters.django import TaskTracker
@@ -615,6 +749,14 @@ def complete_datasource_conversion_task(task_id, result):
     if task is None:
         return None
     metadata = task.metadata or {}
+    owner_connection_id = metadata.get("lensnode_connection_id") or ""
+    if (
+        connection_id
+        and owner_connection_id
+        and owner_connection_id != connection_id
+        and task.status not in TaskStatus.get_completed_statuses()
+    ):
+        return task
     datasource_uuid = metadata.get("datasource_uuid")
     datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
     status_value = str(result.get("status") or "failed").lower()
@@ -636,6 +778,11 @@ def complete_datasource_conversion_task(task_id, result):
         status_map["failed"],
     )
     error = str(result.get("error") or default_error)
+    completion_reason = str(
+        result.get("completion_reason")
+        or error
+        or status_value
+    )
     conversion_summary = result.get("conversion_summary") or {}
     if task.status in TaskStatus.get_completed_statuses():
         if datasource_uuid:
@@ -643,6 +790,11 @@ def complete_datasource_conversion_task(task_id, result):
                 datasource_uuid,
                 token=metadata.get("lock_token") or task_id,
             )
+        release_lensnode_heavy_work_slot(
+            metadata.get("lensnode_uuid"),
+            task_id,
+            metadata.get("heavy_work_slot"),
+        )
         return TaskTracker.update_task_status(
             task_id,
             task.status,
@@ -665,6 +817,11 @@ def complete_datasource_conversion_task(task_id, result):
     lock_token = metadata.get("lock_token") or task_id
     if datasource_uuid:
         release_datasource_lock(datasource_uuid, token=lock_token)
+    release_lensnode_heavy_work_slot(
+        metadata.get("lensnode_uuid"),
+        task_id,
+        metadata.get("heavy_work_slot"),
+    )
     step_status = "done" if task_status == TaskStatus.SUCCESS else "failed"
     completion_metadata = _datasource_step_metadata(
         task_id,
@@ -678,6 +835,12 @@ def complete_datasource_conversion_task(task_id, result):
         progress_percent=100,
     )
     completion_metadata["conversion_summary"] = conversion_summary
+    completion_metadata["completion_reason"] = completion_reason
+    if task_status == TaskStatus.REVOKED:
+        completion_metadata["stop_confirmation_source"] = str(
+            result.get("stop_confirmation_source")
+            or "lensnode_callback"
+        )
     return TaskTracker.update_task_status(
         task_id,
         task_status,
@@ -903,7 +1066,7 @@ def _release_orphaned_datasource_lock(datasource_uuid):
     if not lock_token:
         return True
 
-    running_statuses = [TaskStatus.PENDING, *TaskStatus.get_running_statuses()]
+    running_statuses = _datasource_active_statuses(TaskStatus)
     owner_exists = TaskExecution.objects.filter(
         module__in=["lens_datasource", "lens_datasource_conversion"],
         status__in=running_statuses,
@@ -926,6 +1089,63 @@ def release_datasource_lock(datasource_uuid, token=None):
     return False
 
 
+def reconcile_orphaned_datasource_conversions(lensnode_uuid, connection_id):
+    """Fail conversions owned by a dead LensNode connection generation."""
+
+    from agentcore_task.adapters.django.models import TaskExecution
+    from agentcore_task.constants import TaskStatus
+
+    now = timezone.now()
+    active_statuses = _datasource_active_statuses(TaskStatus)
+    orphaned = TaskExecution.objects.filter(
+        module="lens_datasource_conversion",
+        status__in=active_statuses,
+        metadata__lensnode_uuid=str(lensnode_uuid),
+    ).exclude(
+        metadata__lensnode_connection_id=str(connection_id),
+    )
+    count = 0
+    for task in orphaned:
+        metadata = dict(task.metadata or {})
+        datasource_uuid = metadata.get("datasource_uuid")
+        datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
+        if datasource is not None:
+            datasource.last_conversion_status = TaskStatus.FAILURE
+            datasource.last_conversion_at = now
+            datasource.save(
+                update_fields=[
+                    "last_conversion_status",
+                    "last_conversion_at",
+                    "updated_at",
+                ]
+            )
+        release_datasource_lock(
+            datasource_uuid,
+            token=metadata.get("lock_token") or task.task_id,
+        )
+        release_lensnode_heavy_work_slot(
+            lensnode_uuid,
+            task.task_id,
+            metadata.get("heavy_work_slot"),
+        )
+        metadata.update(
+            {
+                "recovery_reason": "LENSNODE_CONNECTION_GENERATION_EXPIRED",
+                "recovery_retryable": True,
+                "reconciled_at": now.isoformat(),
+                "completion_reason": "DATASOURCE_CONVERSION_ORPHANED",
+                "stop_confirmation_source": "connection_generation_expired",
+            }
+        )
+        task.status = TaskStatus.FAILURE
+        task.finished_at = now
+        task.error = "DATASOURCE_CONVERSION_ORPHANED"
+        task.metadata = metadata
+        task.save(update_fields=["status", "finished_at", "error", "metadata"])
+        count += 1
+    return count
+
+
 def cleanup_stale_datasource_sync_tasks(startup=False):
     """Cancel timed-out datasource work and release orphaned locks.
 
@@ -943,17 +1163,44 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
     )
 
     now = timezone.now()
+    orphaned_count = 0
+    for lensnode in LensNode.objects.all():
+        orphaned_count += reconcile_orphaned_datasource_conversions(
+            lensnode.uuid,
+            lensnode.connection_id,
+        )
     timeout_s = get_datasource_sync_timeout_s()
+    conversion_cutoff = now - timedelta(
+        seconds=get_datasource_conversion_timeout_s()
+    )
     cutoff = now - timedelta(seconds=timeout_s)
-    running_statuses = [TaskStatus.PENDING, *TaskStatus.get_running_statuses()]
+    running_statuses = _datasource_active_statuses(TaskStatus)
+    executing_statuses = [
+        status
+        for status in running_statuses
+        if status != TaskStatus.PENDING
+    ]
 
     stale = TaskExecution.objects.filter(
         module__in=["lens_datasource", "lens_datasource_conversion"],
-        status__in=running_statuses,
         metadata__datasource_uuid__isnull=False,
     ).filter(
-        Q(started_at__lt=cutoff)
-        | Q(started_at__isnull=True, created_at__lt=cutoff)
+        Q(status__in=executing_statuses, started_at__lt=cutoff)
+        & ~Q(module="lens_datasource_conversion")
+        | Q(
+            status__in=executing_statuses,
+            started_at__isnull=True,
+            created_at__lt=cutoff,
+        )
+        | Q(
+            module="lens_datasource_conversion",
+            status__in=executing_statuses,
+            started_at__lt=conversion_cutoff,
+        )
+        | Q(
+            status=TaskStatus.PENDING,
+            created_at__lt=cutoff,
+        )
     )
 
     failed_count = 0
@@ -967,41 +1214,52 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
             if is_conversion
             else "LENS_SOURCE_SYNC_TIMEOUT"
         )
-        if datasource is not None:
-            if is_conversion:
-                cancel_datasource_conversion_on_lensnode(
-                    datasource.lensnode,
-                    task.task_id,
+        if is_conversion and task.status != DATASOURCE_CANCELLING_STATUS:
+            if datasource is not None:
+                datasource.last_conversion_status = (
+                    DATASOURCE_CANCELLING_STATUS
                 )
-                datasource.last_conversion_status = TaskStatus.FAILURE
-                datasource.last_conversion_at = now
                 datasource.save(
-                    update_fields=[
-                        "last_conversion_status",
-                        "last_conversion_at",
-                        "updated_at",
-                    ]
+                    update_fields=["last_conversion_status", "updated_at"]
                 )
-            else:
-                cancel_datasource_sync_on_lensnode(
-                    datasource.lensnode,
-                    task.task_id,
-                )
-                record = _get_or_create_source_sync_record(datasource)
-                record.last_status = ScheduledTask.Status.FAILED
-                record.last_error = error
-                record.last_run_at = now
-                record.save(
-                    update_fields=[
-                        "last_status",
-                        "last_error",
-                        "last_run_at",
-                    ]
-                )
+            metadata["timeout_cancel_requested_at"] = now.isoformat()
+            metadata["cancellation_state"] = DATASOURCE_CANCELLING_STATUS
+            task.status = DATASOURCE_CANCELLING_STATUS
+            task.error = ""
+            task.metadata = metadata
+            task.save(update_fields=["status", "error", "metadata"])
+            cancel_datasource_conversion_on_lensnode(
+                datasource.lensnode if datasource is not None else None,
+                task.task_id,
+            )
+            continue
+        if is_conversion:
+            continue
+        if datasource is not None:
+            cancel_datasource_sync_on_lensnode(
+                datasource.lensnode,
+                task.task_id,
+            )
+            record = _get_or_create_source_sync_record(datasource)
+            record.last_status = ScheduledTask.Status.FAILED
+            record.last_error = error
+            record.last_run_at = now
+            record.save(
+                update_fields=[
+                    "last_status",
+                    "last_error",
+                    "last_run_at",
+                ]
+            )
 
         release_datasource_lock(
             datasource_uuid,
             token=metadata.get("lock_token") or task.task_id,
+        )
+        release_lensnode_heavy_work_slot(
+            metadata.get("lensnode_uuid"),
+            task.task_id,
+            metadata.get("heavy_work_slot"),
         )
         metadata["timeout_cancelled_at"] = now.isoformat()
         task.status = TaskStatus.FAILURE
@@ -1050,6 +1308,7 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
     return {
         "failed": failed_count,
         "locks_released": released_count,
+        "orphaned": orphaned_count,
         "timeout_s": timeout_s,
         "startup": startup,
     }

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -11,6 +11,7 @@ from asgiref.sync import async_to_sync
 from channels.testing import WebsocketCommunicator
 from django.apps import apps
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.management import call_command
 from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
@@ -77,6 +78,7 @@ from lens.tasks import (
     datasource_lock,
     lensnode_health_task,
     register_datasource_conversion_task,
+    reconcile_orphaned_datasource_conversions,
     register_datasource_sync_task,
     release_datasource_lock,
     source_sync_task,
@@ -2667,6 +2669,90 @@ class LensServiceTests(TransactionTestCase):
         )
         self.assertEqual(datasource.last_conversion_status, "STARTED")
 
+    def test_managed_workspace_conversion_waits_for_lensnode_heavy_slot(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        register_datasource_conversion_task(
+            datasource,
+            "queued-conversion",
+            {"document": True},
+        )
+
+        with (
+            patch(
+                "lens.tasks.acquire_lensnode_heavy_work_slot",
+                return_value=None,
+            ),
+            patch("lens.tasks._schedule_queued_conversion") as schedule,
+        ):
+            datasource_conversion_task(
+                str(datasource.uuid),
+                {"document": True},
+                False,
+                "queued-conversion",
+            )
+
+        task = TaskExecution.objects.get(task_id="queued-conversion")
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "PENDING")
+        self.assertEqual(task.metadata["queue_state"], "QUEUED")
+        self.assertEqual(datasource.last_conversion_status, "PENDING")
+        schedule.assert_called_once()
+
+    def test_reconnect_reconciles_orphaned_conversion_and_releases_owners(
+        self,
+    ):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="STARTED",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "orphaned-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata.update(
+            {
+                "lensnode_connection_id": "old-connection",
+                "lock_token": task.task_id,
+                "heavy_work_slot": "0",
+            }
+        )
+        task.save(update_fields=["status", "metadata"])
+        cache.set(
+            f"lens:datasource-sync:{datasource.uuid}",
+            task.task_id,
+        )
+        cache.set(
+            f"lens:heavy-work:{self.lensnode.uuid}:0",
+            task.task_id,
+        )
+
+        count = reconcile_orphaned_datasource_conversions(
+            self.lensnode.uuid,
+            "new-connection",
+        )
+
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertEqual(task.status, "FAILURE")
+        self.assertEqual(task.error, "DATASOURCE_CONVERSION_ORPHANED")
+        self.assertTrue(task.metadata["recovery_retryable"])
+        self.assertEqual(datasource.last_conversion_status, "FAILURE")
+        self.assertIsNone(cache.get(f"lens:datasource-sync:{datasource.uuid}"))
+        self.assertIsNone(
+            cache.get(f"lens:heavy-work:{self.lensnode.uuid}:0")
+        )
+
     def test_complete_managed_workspace_conversion_persists_summary(self):
         datasource = DataSource.objects.create(
             name="Managed Snapshot",
@@ -3332,6 +3418,10 @@ class LensServiceTests(TransactionTestCase):
             key="lens.datasource_sync.timeout_s",
             value="1",
         )
+        GlobalSetting.objects.create(
+            key="lens.datasource_conversion.timeout_s",
+            value="1",
+        )
         datasource = DataSource.objects.create(
             name="Managed Snapshot",
             source_type=DataSource.SourceType.MANAGED_WORKSPACE,
@@ -3363,11 +3453,11 @@ class LensServiceTests(TransactionTestCase):
 
         task.refresh_from_db()
         datasource.refresh_from_db()
-        self.assertEqual(result["failed"], 1)
-        self.assertEqual(task.status, "FAILURE")
-        self.assertEqual(task.error, "DATASOURCE_CONVERSION_TIMEOUT")
-        self.assertEqual(datasource.last_conversion_status, "FAILURE")
-        self.assertIsNotNone(datasource.last_conversion_at)
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(task.status, "CANCELLING")
+        self.assertEqual(task.error, "")
+        self.assertEqual(datasource.last_conversion_status, "CANCELLING")
+        self.assertIsNone(datasource.last_conversion_at)
         cancel.assert_called_once_with(self.lensnode, "stale-conversion")
         self.assertFalse(
             ScheduledTask.objects.filter(
@@ -3375,6 +3465,23 @@ class LensServiceTests(TransactionTestCase):
                 target_id=datasource.uuid,
             ).exists()
         )
+
+        complete_datasource_conversion_task(
+            task.task_id,
+            {
+                "status": "cancelled",
+                "error": "DATASOURCE_CONVERSION_TIMEOUT",
+                "completion_reason": "DATASOURCE_CONVERSION_TIMEOUT",
+                "stop_confirmation_source": "lensnode_callback",
+            },
+        )
+
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
+        self.assertEqual(task.error, "DATASOURCE_CONVERSION_TIMEOUT")
+        self.assertEqual(datasource.last_conversion_status, "REVOKED")
+        self.assertIsNotNone(datasource.last_conversion_at)
 
         acquire_datasource_lock(
             datasource.uuid,

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -26,6 +26,7 @@ from lens.services import (
     cancel_datasource_sync_on_lensnode,
 )
 from lens.tasks import (
+    DATASOURCE_CANCELLING_STATUS,
     datasource_conversion_task,
     register_datasource_conversion_task,
     register_datasource_sync_task,
@@ -461,6 +462,7 @@ class DataSourceViewSet(BaseAdminViewSet):
                 status__in=[
                     TaskStatus.PENDING,
                     *TaskStatus.get_running_statuses(),
+                    DATASOURCE_CANCELLING_STATUS,
                 ],
             )
             .order_by("-created_at")
@@ -478,16 +480,21 @@ class DataSourceViewSet(BaseAdminViewSet):
             datasource.lensnode,
             task.task_id,
         )
-        release_datasource_lock(
-            datasource.uuid,
-            token=metadata.get("lock_token") or task.task_id,
-        )
         now = timezone.now()
         metadata["manual_revoked_at"] = now.isoformat()
         metadata["manual_revoked_by"] = request.user.pk
-        task.status = TaskStatus.REVOKED
-        task.finished_at = now
-        task.error = "DATASOURCE_CONVERSION_CANCELLED"
+        queued = task.status == TaskStatus.PENDING
+        task.status = (
+            TaskStatus.REVOKED if queued else DATASOURCE_CANCELLING_STATUS
+        )
+        task.finished_at = now if queued else None
+        task.error = "DATASOURCE_CONVERSION_CANCELLED" if queued else ""
+        metadata["cancellation_state"] = (
+            "REVOKED" if queued else DATASOURCE_CANCELLING_STATUS
+        )
+        if queued:
+            metadata["completion_reason"] = "DATASOURCE_CONVERSION_CANCELLED"
+            metadata["stop_confirmation_source"] = "queued_before_dispatch"
         task.metadata = metadata
         task.save(
             update_fields=[
@@ -497,8 +504,8 @@ class DataSourceViewSet(BaseAdminViewSet):
                 "metadata",
             ]
         )
-        datasource.last_conversion_status = TaskStatus.REVOKED
-        datasource.last_conversion_at = now
+        datasource.last_conversion_status = task.status
+        datasource.last_conversion_at = now if queued else None
         datasource.save(
             update_fields=[
                 "last_conversion_status",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -198,6 +198,10 @@ services:
       LENSNODE_MCP_DEFER_THRESHOLD: ${LENSNODE_MCP_DEFER_THRESHOLD:-12}
       # Max concurrent runs per node. Increase in production based on node resources.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
+      LENSNODE_HEAVY_WORK_CONCURRENCY: ${LENSNODE_HEAVY_WORK_CONCURRENCY:-1}
+      LENSNODE_MEMORY_LIMIT_MB: ${LENSNODE_MEMORY_LIMIT_MB:-}
+      LENSNODE_NODE_MAX_OLD_SPACE_MB: ${LENSNODE_NODE_MAX_OLD_SPACE_MB:-}
+      LENSNODE_NODE_OPTIONS: ${LENSNODE_NODE_OPTIONS:-}
       # Proactive file-offload thresholds (issue #60). Tool default 5000:
       # large workspace reads are evicted to re-readable files so heavy-
       # retrieval runs stop thrashing the summarizer. Human unset = library

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
     command: gunicorn
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health/celery"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -168,6 +168,9 @@ services:
       # Graceful-drain budget on shutdown/upgrade. Keep below stop_grace_period.
       LENSNODE_DRAIN_TIMEOUT_S: ${LENSNODE_DRAIN_TIMEOUT_S:-240}
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
+      LENSNODE_MEMORY_LIMIT_MB: ${LENSNODE_MEMORY_LIMIT_MB:-}
+      LENSNODE_NODE_MAX_OLD_SPACE_MB: ${LENSNODE_NODE_MAX_OLD_SPACE_MB:-}
+      LENSNODE_NODE_OPTIONS: ${LENSNODE_NODE_OPTIONS:-}
     volumes:
       - ./data/workspace:/workspace
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ x-sourcelens-api-common: &sourcelens-api-common
       condition: service_healthy
   command: gunicorn
   healthcheck:
-    test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+    test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health/celery"]
     interval: 30s
     timeout: 10s
     retries: 3
@@ -204,6 +204,9 @@ services:
       # Max concurrent runs per node. Each run holds a slot for the full answer
       # duration; without this it falls back to 1 and questions queue.
       LENSNODE_MAX_CONCURRENT_RUNS: ${LENSNODE_MAX_CONCURRENT_RUNS:-8}
+      LENSNODE_MEMORY_LIMIT_MB: ${LENSNODE_MEMORY_LIMIT_MB:-}
+      LENSNODE_NODE_MAX_OLD_SPACE_MB: ${LENSNODE_NODE_MAX_OLD_SPACE_MB:-}
+      LENSNODE_NODE_OPTIONS: ${LENSNODE_NODE_OPTIONS:-}
     volumes:
       - ./data/workspace:/workspace
     networks:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -94,9 +94,20 @@ start_celery_worker() {
     # Default concurrency: use CPU count for I/O-bound tasks
     # Can be overridden by CELERY_CONCURRENCY environment variable
     DEFAULT_CONCURRENCY=${CELERY_CONCURRENCY:-$CPU_COUNT}
+    REQUIRED_QUEUES=${CELERY_REQUIRED_QUEUES:-backend,lens}
+    WORKER_QUEUES=${CELERY_WORKER_QUEUES:-backend,lens}
+    for required_queue in ${REQUIRED_QUEUES//,/ }; do
+        case ",$WORKER_QUEUES," in
+            *",$required_queue,"*) ;;
+            *)
+                log "Missing required Celery worker queue: $required_queue"
+                return 1
+                ;;
+        esac
+    done
 
     log "Celery worker concurrency: $DEFAULT_CONCURRENCY (CPUs: $CPU_COUNT)"
-    log "Celery worker queues: ${CELERY_WORKER_QUEUES:-backend,lens}"
+    log "Celery worker queues: $WORKER_QUEUES"
     log "Graceful shutdown enabled: worker will wait for running tasks to complete (up to stop_grace_period)"
 
     # Celery worker will gracefully shutdown when receiving SIGTERM:
@@ -107,7 +118,7 @@ start_celery_worker() {
     exec celery -A core worker \
         --loglevel=${CELERY_LOG_LEVEL:-INFO} \
         --concurrency=$DEFAULT_CONCURRENCY \
-        --queues=${CELERY_WORKER_QUEUES:-backend,lens} \
+        --queues=$WORKER_QUEUES \
         --max-tasks-per-child=${CELERY_MAX_TASKS_PER_CHILD:-1000} \
         --max-memory-per-child=${CELERY_MAX_MEMORY_PER_CHILD:-256000} \
         --logfile=/var/log/celery/worker.log

--- a/env.sample
+++ b/env.sample
@@ -106,6 +106,13 @@ LENSNODE_DRAIN_TIMEOUT_S=240
 # Max concurrent runs a single lensnode executes. Each run holds a slot for
 # the full answer duration; raise for more parallelism (avoids long Queued).
 LENSNODE_MAX_CONCURRENT_RUNS=8
+LENSNODE_HEAVY_WORK_CONCURRENCY=1
+# Optional LensNode cgroup budget used to derive a V8 heap ceiling for
+# CodeGraph. LENSNODE_NODE_MAX_OLD_SPACE_MB or LENSNODE_NODE_OPTIONS can
+# override the derived value.
+LENSNODE_MEMORY_LIMIT_MB=
+LENSNODE_NODE_MAX_OLD_SPACE_MB=
+LENSNODE_NODE_OPTIONS=
 # Fallback budget for commands without a control-plane budget profile.
 LENSNODE_TOKEN_BUDGET_MAX_TOKENS=200000
 # Absolute ceiling for budgets requested by the SourceLens control plane.

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -39,9 +39,11 @@ class LensNodeConfig:
     mcp_enable_codegraph: bool = True
     codegraph_command: str = "codegraph"
     codegraph_init_timeout_s: int = 300
+    node_options: str = ""
     reasoning_effort: str | None = None
     planning_reasoning_effort: str | None = "none"
     planner_repair_enabled: bool = False
+    heavy_work_concurrency: int = 1
 
 
 def _optional_int(value):
@@ -57,6 +59,47 @@ def _env_bool(name, default=False):
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _node_options():
+    """Return bounded V8 options for Node-based child processes."""
+
+    options = os.getenv("LENSNODE_NODE_OPTIONS", "").strip()
+    try:
+        memory_limit_mb = int(os.getenv("LENSNODE_MEMORY_LIMIT_MB", "0"))
+    except (TypeError, ValueError):
+        memory_limit_mb = 0
+    if memory_limit_mb <= 0:
+        memory_limit_mb = _cgroup_memory_limit_mb()
+    try:
+        heap_mb = int(os.getenv("LENSNODE_NODE_MAX_OLD_SPACE_MB", "0"))
+    except (TypeError, ValueError):
+        heap_mb = 0
+    if heap_mb <= 0 and memory_limit_mb > 0:
+        heap_mb = max(64, memory_limit_mb // 2)
+    if heap_mb > 0 and "--max-old-space-size=" not in options:
+        options = f"{options} --max-old-space-size={heap_mb}".strip()
+    return options
+
+
+def _cgroup_memory_limit_mb():
+    """Read a finite Linux cgroup memory limit when one is available."""
+
+    for filename in [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ]:
+        try:
+            with open(filename, encoding="ascii") as stream:
+                raw = stream.read().strip()
+            if raw == "max":
+                continue
+            limit = int(raw)
+        except (OSError, ValueError):
+            continue
+        if limit > 0:
+            return max(1, limit // (1024 * 1024))
+    return 0
 
 
 def _derive_ws_url(server_url):
@@ -109,6 +152,10 @@ def load_config():
             os.getenv("LENSNODE_DRAIN_TIMEOUT_S", "240")
         ),
         max_concurrent_runs=int(os.getenv("LENSNODE_MAX_CONCURRENT_RUNS", "1")),
+        heavy_work_concurrency=max(
+            1,
+            int(os.getenv("LENSNODE_HEAVY_WORK_CONCURRENCY", "1")),
+        ),
         summary_trigger_tokens=int(
             os.getenv("LENSNODE_SUMMARY_TRIGGER_TOKENS", "48000")
         ),
@@ -164,6 +211,7 @@ def load_config():
         codegraph_init_timeout_s=int(
             os.getenv("LENSNODE_CODEGRAPH_INIT_TIMEOUT_S", "300")
         ),
+        node_options=_node_options(),
         reasoning_effort=os.getenv("LENSNODE_REASONING_EFFORT") or None,
         planning_reasoning_effort=(
             os.getenv(

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -10,7 +10,9 @@ from urllib import error, parse, request
 from .datasource_adapters import DataSourceAdapterRegistry
 from .datasource_adapters import FunctionDataSourceAdapter
 from . import datasource_manifest as manifest_store
+from .document_convert import empty_cost_stats
 from .document_convert import is_convertible, post_process_documents
+from .document_convert import merge_cost_stats
 from .path_rules import is_excluded_path
 from .path_rules import normalize_excluded_roots
 from .path_rules import relative_path
@@ -22,6 +24,8 @@ from .path_rules import unique_child_path
 WORKSPACE_ROOT = "/workspace"
 GIT_SHALLOW_DEPTH = "1"
 DETAIL_ITEMS_LIMIT = 200
+DEFAULT_CONVERSION_BATCH_SIZE = 16
+DEFAULT_CONVERSION_MAX_FILES = 100000
 DEFAULT_DATASOURCE_SYNC_WORKERS = 4
 FEISHU_EXPORT_PENDING_STATUSES = {1, 2}
 FEISHU_EXPORT_SUCCESS_STATUS = 0
@@ -250,53 +254,83 @@ def convert_managed_workspace(
         raise DataSourceSyncError("MANAGED_WORKSPACE_DIRECTORY_REQUIRED")
 
     context = _sync_context(command, target)
-    items = _managed_workspace_conversion_items(
+    conversion = context["conversion"]
+    total, supported_total, unsupported_total, unsupported = (
+        _scan_managed_workspace_conversion(
+            target,
+            context["excluded_datasource_roots"],
+            conversion,
+        )
+    )
+    max_files = _conversion_resource_limit(
+        conversion,
+        "max_files",
+        DEFAULT_CONVERSION_MAX_FILES,
+    )
+    if total > max_files:
+        raise DataSourceSyncError("RESOURCE_LIMIT_EXCEEDED")
+    max_bytes = _conversion_resource_limit(conversion, "max_bytes", 0)
+    if max_bytes and _managed_workspace_size(
         target,
         context["excluded_datasource_roots"],
-    )
-    supported = [
-        item
-        for item in items
-        if is_convertible(target / item.local_path, context["conversion"])
-    ]
-    unsupported = [
-        item
-        for item in items
-        if not is_convertible(
-            target / item.local_path,
-            context["conversion"],
-        )
-    ]
+    ) > max_bytes:
+        raise DataSourceSyncError("RESOURCE_LIMIT_EXCEEDED")
 
-    def emit_progress(event):
-        if emit is None:
-            return
-        payload = dict(event)
-        current = int(payload.get("progress_current") or 0)
-        payload["summary"] = _managed_conversion_summary(
-            payload.get("summary") or {},
+    summary = None
+    processed = 0
+    batch = []
+    batch_size = _conversion_resource_limit(
+        conversion,
+        "batch_size",
+        DEFAULT_CONVERSION_BATCH_SIZE,
+    )
+    for item in _managed_workspace_conversion_items(
+        target,
+        context["excluded_datasource_roots"],
+    ):
+        if not is_convertible(target / item.local_path, conversion):
+            continue
+        batch.append(item)
+        if len(batch) < batch_size:
+            continue
+        batch_summary = post_process_documents(
+            context,
+            manifest_store.SyncResult(items=batch),
+        )
+        summary = _merge_managed_conversion_summaries(summary, batch_summary)
+        processed += len(batch)
+        _emit_managed_conversion_progress(
+            emit,
+            summary,
+            total,
             unsupported,
-            len(supported),
-            current,
+            unsupported_total,
+            processed,
         )
-        payload["progress_total"] = len(items)
-        payload["progress_current"] = len(unsupported) + current
-        payload["progress_percent"] = _conversion_percent(
-            payload["progress_current"],
-            len(items),
+        batch = []
+    if batch:
+        batch_summary = post_process_documents(
+            context,
+            manifest_store.SyncResult(items=batch),
         )
-        emit(payload)
-
-    summary = post_process_documents(
-        context,
-        manifest_store.SyncResult(items=supported),
-        emit_progress,
-    )
+        summary = _merge_managed_conversion_summaries(summary, batch_summary)
+        processed += len(batch)
+        _emit_managed_conversion_progress(
+            emit,
+            summary,
+            total,
+            unsupported,
+            unsupported_total,
+            processed,
+        )
+    if summary is None:
+        summary = _empty_managed_conversion_summary()
     summary = _managed_conversion_summary(
         summary,
         unsupported,
-        len(supported),
-        len(supported),
+        supported_total,
+        supported_total,
+        unsupported_total=unsupported_total,
     )
     if summary["failed"]:
         summary["warnings"] = list(
@@ -313,8 +347,8 @@ def convert_managed_workspace(
         "done",
         "Managed workspace conversion completed.",
         category="conversion",
-        progress_total=len(items),
-        progress_current=len(items),
+        progress_total=total,
+        progress_current=total,
         progress_percent=100,
         summary=summary,
         conversion_summary=summary,
@@ -328,10 +362,9 @@ def convert_managed_workspace(
 
 
 def _managed_workspace_conversion_items(target, excluded_roots):
-    """Return files found under a managed workspace conversion root."""
+    """Yield files found under a managed workspace conversion root."""
 
-    items = []
-    for path in sorted(target.rglob("*")):
+    for path in target.rglob("*"):
         if not path.is_file() or _is_generated_datasource_path(target, path):
             continue
         if is_excluded_path(path, excluded_roots):
@@ -340,20 +373,183 @@ def _managed_workspace_conversion_items(target, excluded_roots):
             local_path = relative_path(target, path)
         except ValueError:
             continue
-        items.append(
-            manifest_store.SyncItem(
-                source_id=f"managed_workspace:{local_path}",
-                source_type="managed_workspace",
-                source_path=local_path,
-                local_path=local_path,
-                name=path.name,
-                kind="file",
-                extension=path.suffix.lower().lstrip("."),
-                status="cataloged",
-                metadata={"size": str(path.stat().st_size)},
-            )
+        yield manifest_store.SyncItem(
+            source_id=f"managed_workspace:{local_path}",
+            source_type="managed_workspace",
+            source_path=local_path,
+            local_path=local_path,
+            name=path.name,
+            kind="file",
+            extension=path.suffix.lower().lstrip("."),
+            status="cataloged",
+            metadata={"size": str(path.stat().st_size)},
         )
-    return items
+
+
+def _scan_managed_workspace_conversion(
+    target,
+    excluded_roots,
+    conversion,
+):
+    """Scan workspace metadata without retaining the complete file list."""
+
+    total = 0
+    supported_total = 0
+    unsupported_total = 0
+    unsupported = []
+    for item in _managed_workspace_conversion_items(target, excluded_roots):
+        total += 1
+        if is_convertible(target / item.local_path, conversion):
+            supported_total += 1
+            continue
+        unsupported_total += 1
+        if len(unsupported) < DETAIL_ITEMS_LIMIT:
+            unsupported.append(item)
+    return total, supported_total, unsupported_total, unsupported
+
+
+def _managed_workspace_size(target, excluded_roots):
+    """Return workspace bytes without retaining directory entries."""
+
+    total = 0
+    for item in _managed_workspace_conversion_items(target, excluded_roots):
+        total += int(item.metadata.get("size") or 0)
+    return total
+
+
+def _conversion_resource_limit(conversion, key, default):
+    """Return a bounded conversion resource setting."""
+
+    try:
+        value = int((conversion or {}).get(key) or default)
+    except (TypeError, ValueError):
+        value = default
+    if key == "batch_size":
+        return max(1, min(value, 128))
+    return max(1, value) if value else 0
+
+
+def _empty_managed_conversion_summary():
+    """Return the fixed-shape summary used by conversion batches."""
+
+    return {
+        "candidates": 0,
+        "converted": 0,
+        "success": 0,
+        "skipped": 0,
+        "failed": 0,
+        "markdown": 0,
+        "deleted_sidecars": 0,
+        "chars": 0,
+        "estimated_tokens": 0,
+        "images_recognized": 0,
+        "images_skipped": 0,
+        "images_blank": 0,
+        "images_duplicate": 0,
+        "images_compressed": 0,
+        "embedded_images_total": 0,
+        "embedded_images_recognized": 0,
+        "embedded_images_skipped": 0,
+        "embedded_images_duplicate": 0,
+        "embedded_images_blank": 0,
+        "pdf_pages": 0,
+        "pdf_pages_processed": 0,
+        "pdf_pages_with_text": 0,
+        "pdf_scanned_pages": 0,
+        "pdf_images_total": 0,
+        "pdf_images_recognized": 0,
+        "pdf_images_skipped": 0,
+        "pdf_rendered_pages": 0,
+        "xlsx_files": 0,
+        "sheets": 0,
+        "rows": 0,
+        "truncated_files": 0,
+        "cost": empty_cost_stats(),
+        "warnings": [],
+        "items": [],
+        "items_truncated": 0,
+        "details": {},
+        "details_truncated": {},
+    }
+
+
+def _merge_managed_conversion_summaries(current, incoming):
+    """Merge one bounded conversion batch into the aggregate summary."""
+
+    if current is None:
+        current = _empty_managed_conversion_summary()
+    for key, value in incoming.items():
+        if key in {
+            "cost",
+            "items",
+            "details",
+            "details_truncated",
+            "warnings",
+        }:
+            continue
+        if isinstance(value, (int, float)):
+            current[key] = int(current.get(key) or 0) + int(value or 0)
+    merge_cost_stats(current["cost"], incoming.get("cost") or {})
+    current["warnings"] = list(
+        dict.fromkeys(
+            [
+                *(current.get("warnings") or []),
+                *(incoming.get("warnings") or []),
+            ]
+        )
+    )
+    for item in incoming.get("items") or []:
+        if len(current["items"]) < DETAIL_ITEMS_LIMIT:
+            current["items"].append(item)
+        else:
+            current["items_truncated"] += 1
+    for group, details in (incoming.get("details") or {}).items():
+        bucket = current["details"].setdefault(group, [])
+        available = max(DETAIL_ITEMS_LIMIT - len(bucket), 0)
+        bucket.extend(details[:available])
+        current["details_truncated"][group] = (
+            int(current["details_truncated"].get(group) or 0)
+            + int((incoming.get("details_truncated") or {}).get(group) or 0)
+            + max(len(details) - available, 0)
+        )
+    return current
+
+
+def _emit_managed_conversion_progress(
+    emit,
+    summary,
+    total,
+    unsupported,
+    unsupported_total,
+    processed,
+):
+    """Emit one bounded aggregate progress update after each batch."""
+
+    if emit is None:
+        return
+    payload = _managed_conversion_summary(
+        summary,
+        unsupported,
+        processed,
+        processed,
+        unsupported_total=unsupported_total,
+    )
+    payload["progress_total"] = total
+    payload["progress_current"] = min(total, unsupported_total + processed)
+    payload["progress_percent"] = _conversion_percent(
+        payload["progress_current"],
+        total,
+    )
+    progress_summary = dict(payload)
+    _emit(
+        emit,
+        "conversion_progress",
+        "running",
+        f"Converted {processed}/{max(processed, 1)} datasource files.",
+        category="conversion",
+        summary=progress_summary,
+        **payload,
+    )
 
 
 def _managed_conversion_summary(
@@ -361,6 +557,7 @@ def _managed_conversion_summary(
     unsupported,
     supported_total,
     supported_current,
+    unsupported_total=None,
 ):
     """Add standalone conversion lifecycle counters and outcomes."""
 
@@ -388,13 +585,16 @@ def _managed_conversion_summary(
     completed = min(max(supported_current, 0), supported_total)
     remaining = max(supported_total - completed, 0)
     active = 1 if remaining else 0
+    unsupported_count = (
+        len(unsupported) if unsupported_total is None else unsupported_total
+    )
     result.update(
         {
-            "total": supported_total + len(unsupported),
+            "total": supported_total + unsupported_count,
             "waiting": max(remaining - active, 0),
             "active": active,
             "succeeded": int(result.get("success") or 0),
-            "unsupported": len(unsupported),
+            "unsupported": unsupported_count,
             "items": items,
             "items_truncated": int(result.get("items_truncated") or 0)
             + max(len(new_items) - available, 0),

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -49,6 +49,8 @@ class LensNodeClient:
 
     def __init__(self, config):
         self.config = config
+        if getattr(config, "node_options", ""):
+            os.environ["NODE_OPTIONS"] = config.node_options
         workspace_path = getattr(config, "workspace_path", None)
         if workspace_path:
             cleanup_stale_runtime_resources(
@@ -80,6 +82,9 @@ class LensNodeClient:
         self.heartbeat_count = 0
         self.last_report_signature = None
         self.running_tasks = {}
+        self.heavy_work_semaphore = asyncio.Semaphore(
+            max(1, int(getattr(config, "heavy_work_concurrency", 1)))
+        )
         self.datasource_conversion_cancels = {}
         self.running_commands = {}
         self._checkpoint_resume_ready = None
@@ -586,7 +591,11 @@ class LensNodeClient:
             await self._send_busy(run_uuid, "LENSNODE_RUN_ACTIVE")
             return
         max_runs = max(1, int(getattr(self.config, "max_concurrent_runs", 1)))
-        if len(self.running_tasks) >= max_runs:
+        active_run_count = sum(
+            not key.startswith(("datasource:", "datasource-convert:"))
+            for key in self.running_tasks
+        )
+        if active_run_count >= max_runs:
             await self._send_busy(run_uuid, "LENSNODE_BUSY")
             return
 
@@ -750,12 +759,16 @@ class LensNodeClient:
                 ),
                 "tls_ca_file": getattr(self.config, "tls_ca_file", None),
             }
-            result = await asyncio.to_thread(
-                sync_datasource,
-                command,
-                self.config.workspace_path,
-                emit,
-            )
+            await self.heavy_work_semaphore.acquire()
+            try:
+                result = await asyncio.to_thread(
+                    sync_datasource,
+                    command,
+                    self.config.workspace_path,
+                    emit,
+                )
+            finally:
+                self.heavy_work_semaphore.release()
             self._enqueue(
                 {
                     "type": "datasource_sync_done",
@@ -842,12 +855,16 @@ class LensNodeClient:
                     None,
                 ),
             }
-            result = await asyncio.to_thread(
-                convert_managed_workspace,
-                command,
-                self.config.workspace_path,
-                emit,
-            )
+            await self._acquire_heavy_work(message.get("cancel_event"))
+            try:
+                result = await asyncio.to_thread(
+                    convert_managed_workspace,
+                    command,
+                    self.config.workspace_path,
+                    emit,
+                )
+            finally:
+                self.heavy_work_semaphore.release()
             self._enqueue(
                 {
                     "type": "datasource_convert_done",
@@ -864,6 +881,23 @@ class LensNodeClient:
                     "task_id": task_id,
                     "status": "cancelled",
                     "error": "DATASOURCE_CONVERSION_CANCELLED",
+                    "completion_reason": "DATASOURCE_CONVERSION_CANCELLED",
+                    "stop_confirmation_source": "lensnode_callback",
+                }
+            )
+        except DataSourceSyncError as exc:
+            LOGGER.warning(
+                "Managed datasource conversion rejected task_id=%s: %s",
+                task_id,
+                exc,
+            )
+            self._enqueue(
+                {
+                    "type": "datasource_convert_done",
+                    "request_id": request_id,
+                    "task_id": task_id,
+                    "status": "failed",
+                    "error": str(exc) or "DATASOURCE_CONVERSION_FAILED",
                 }
             )
         except Exception:
@@ -883,6 +917,23 @@ class LensNodeClient:
         finally:
             self.datasource_conversion_cancels.pop(task_id, None)
             self.running_tasks.pop(task_key, None)
+
+    async def _acquire_heavy_work(self, cancel_event=None):
+        """Wait for heavy-work capacity while honoring cancellation."""
+
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                raise RunCancelledError(
+                    "Managed datasource conversion was cancelled while queued."
+                )
+            try:
+                await asyncio.wait_for(
+                    self.heavy_work_semaphore.acquire(),
+                    timeout=0.5,
+                )
+                return
+            except asyncio.TimeoutError:
+                continue
 
     async def _send_busy(self, run_uuid, reason):
         """Report a run that cannot start because local capacity is full."""
@@ -923,7 +974,31 @@ class LensNodeClient:
             loop.call_soon_threadsafe(self._enqueue, payload)
 
         completed = False
+        slot_acquired = False
         try:
+            self._enqueue(
+                {
+                    "type": "run_event",
+                    "run_uuid": run_uuid,
+                    "step_type": "retrieval",
+                    "status": "running",
+                    "detail": {
+                        "queue_state": "QUEUED",
+                        "message": "Waiting for LensNode heavy-work capacity.",
+                    },
+                }
+            )
+            await self.heavy_work_semaphore.acquire()
+            slot_acquired = True
+            self._enqueue(
+                {
+                    "type": "run_event",
+                    "run_uuid": run_uuid,
+                    "step_type": "retrieval",
+                    "status": "running",
+                    "detail": {"queue_state": "STARTED"},
+                }
+            )
             await self.executor.execute(message, emit)
             completed = True
         finally:
@@ -933,7 +1008,11 @@ class LensNodeClient:
                     # being reported as active. A cancelled run has no terminal
                     # frame and must leave running_tasks immediately.
                     await asyncio.sleep(0)
+                else:
+                    await self.executor.drain_pending_workers()
             finally:
+                if slot_acquired:
+                    self.heavy_work_semaphore.release()
                 self.running_tasks.pop(run_uuid, None)
                 self.running_commands.pop(run_uuid, None)
 

--- a/lensnode/tests/test_managed_conversion.py
+++ b/lensnode/tests/test_managed_conversion.py
@@ -4,6 +4,7 @@ import types
 
 import pytest
 
+from lensnode.datasource_sync import DataSourceSyncError
 from lensnode.datasource_sync import convert_managed_workspace
 from lensnode.gateway_model import RunCancelledError
 
@@ -213,3 +214,41 @@ def test_managed_conversion_enforces_pdf_page_limit(tmp_path, monkeypatch):
     summary = result["conversion_summary"]
     assert summary["skipped"] == 1
     assert summary["items"][0]["reason"] == "PAGE_LIMIT_EXCEEDED"
+
+
+def test_managed_conversion_batches_files_and_bounds_manifest_details(
+    tmp_path,
+    monkeypatch,
+):
+    """Large manifests are processed in bounded batches."""
+
+    install_fake_markitdown(monkeypatch)
+    for index in range(5):
+        (tmp_path / f"document-{index}.docx").write_bytes(b"document")
+    command = conversion_command(tmp_path)
+    command["conversion"]["batch_size"] = 2
+
+    result = convert_managed_workspace(
+        command,
+        workspace_path=tmp_path.parent,
+    )
+
+    summary = result["conversion_summary"]
+    assert summary["candidates"] == 5
+    assert summary["success"] == 5
+    assert len(summary["items"]) <= 200
+
+
+def test_managed_conversion_rejects_overlarge_workspace_manifest(tmp_path):
+    """A configured workspace file budget fails before conversion starts."""
+
+    (tmp_path / "document-a.docx").write_bytes(b"document")
+    (tmp_path / "document-b.docx").write_bytes(b"document")
+    command = conversion_command(tmp_path)
+    command["conversion"]["max_files"] = 1
+
+    with pytest.raises(DataSourceSyncError, match="RESOURCE_LIMIT_EXCEEDED"):
+        convert_managed_workspace(
+            command,
+            workspace_path=tmp_path.parent,
+        )

--- a/release-notes/355.yaml
+++ b/release-notes/355.yaml
@@ -1,0 +1,9 @@
+type: fix
+audience: admin
+en: >-
+  Fixed managed workspace conversions becoming orphaned after LensNode memory
+  pressure, disconnects, timeouts, or cancellation; conversion progress,
+  recovery, and resource cleanup are now tracked reliably.
+zh-CN: >-
+  修复托管工作区转换在 LensNode 内存压力、断连、超时或取消后变成孤儿任务的问题；
+  现在可以可靠跟踪转换进度、恢复状态并清理占用的资源。

--- a/scripts/lib/deploy-common.sh
+++ b/scripts/lib/deploy-common.sh
@@ -42,7 +42,7 @@ wait_for_healthy() {
     local i
     for i in $(seq 1 "$GRACE_HEALTH_RETRIES"); do
         if docker exec "$container" \
-            curl -fs http://127.0.0.1:8000/health >/dev/null 2>&1; then
+            curl -fs http://127.0.0.1:8000/health/celery >/dev/null 2>&1; then
             return 0
         fi
         sleep "$GRACE_HEALTH_INTERVAL"


### PR DESCRIPTION
### **User description**
## Summary

Fix LensNode OOM and reconnect scenarios that can leave datasource conversions orphaned indefinitely.

## Changes

- Bound managed workspace discovery and conversion with max_files and max_bytes policies.
- Serialize datasource sync, managed workspace conversion, and regular LensNode runs through a shared heavy-work capacity limit.
- Preserve queued, started, cancelling, revoked, and completed states across delayed execution and cancellation callbacks.
- Reconcile conversions owned by expired LensNode connection generations.
- Release datasource locks, heavy-work slots, checkpoints, and runtime resources on terminal completion or orphan recovery.
- Add separate conversion timeouts, cancellation confirmation metadata, cgroup-aware V8 heap limits, Celery queue validation, and /health/celery diagnostics.
- Report progress, completion reasons, summaries, and truncation metadata.

## Validation

- Managed workspace conversion tests: 9 passed, 1 skipped.
- Datasource synchronization tests: 32 passed.
- Backend Issue #355 service tests: 21 passed.
- Browser validation completed against http://localhost:8000 with an approved LensNode and managed workspace datasource conversion.

Fixes #355.


___

### **PR Type**
Bug fix


___

### **Description**
- Bound conversion memory with batch processing and resource limits

- Add heavy-work slot admission control and queued state

- Reconcile orphaned conversions on LensNode reconnection

- Track cancellation state machine and release locks properly


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Conversion Request"] --> B["Acquire Heavy-Work Slot"]
  B -- "slot available" --> C["Execute Conversion"]
  B -- "slot busy" --> D["QUEUED (retry)"]
  C --> E["Batch Processing"]
  E --> F["Progress Report"]
  F --> G["Completion or Failure"]
  C --> H["Cancel Request"]
  H --> I["CANCELLING"]
  I --> J["Revoke or Fail"]
  C --> K["LensNode OOM/Disconnect"]
  K --> L["Reconcile Orphaned"]
  L --> M["Fail Release Locks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>periodic_registry.py</strong><dd><code>Fix periodic task queue routing to avoid stale queues</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-dc124074350c6645dbe8a43f85cb9390606f93019c5e0b8c8a8755d4614caa6a">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>consumers.py</strong><dd><code>Reconcile orphaned conversions on LensNode reconnect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+26/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Add heavy-work slots, orphan reconciliation, cancellation state</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+297/-38</a></td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Update cancellation to use CANCELLING state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+16/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Bound conversion memory with batch processing and limits</code>&nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+257/-57</a></td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Add heavy-work semaphore for datasource operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+92/-13</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>celery.py</strong><dd><code>Add required queue validation and health thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-7269e5351ed3c332b813d607e23296ac909338fecd86c91cb044fb2c3f4ce0e7">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint.sh</strong><dd><code>Validate required Celery worker queues at startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7ca">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deploy-common.sh</strong><dd><code>Change health check to /health/celery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-f84d8a3ec3661adf22c938f2c71bb9d70c325ed20bb2aace869e6e125ae6b630">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.dev.yml</strong><dd><code>Add LensNode memory limit environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.standalone.yml</strong><dd><code>Add LensNode memory limit and healthcheck update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-9ce448f74e566e43c1699bd469713bd9cd36e5f11ffccd6b824cd840f3077228">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Add LensNode memory limit and healthcheck update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>urls.py</strong><dd><code>Add /health/celery endpoint for Celery health</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-4e875bca390c7058098ad86f9deb6b656bac1aafd5015f2104b9dd400237b79e">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_services.py</strong><dd><code>Add conversion timeout and helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.py</strong><dd><code>Add heavy-work concurrency and V8 heap limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_services.py</strong><dd><code>Tests for heavy slot waiting and orphan recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+112/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_managed_conversion.py</strong><dd><code>Tests for batch processing and resource limit rejection</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-69f85a55d756c077f54bae8a7ba7e4397e5b2bde0fc0b847f07b2b25ba8891e5">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>env.sample</strong><dd><code>Add new LensNode environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>355.yaml</strong><dd><code>Release note for orphaned conversion fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/387/files#diff-d1762b3a40c43f3961a88dd0832522ceea5f395268734632100177102d135d38">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

