### PR TITLE
Fix deleted Skills remaining in LensNode cache

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -187,6 +187,42 @@ def lensnode_group_name(lensnode_uuid):
     return f"lens.lensnode.{lensnode_uuid}"
 
 
+def invalidate_skill_cache(skill_uuid):
+    """Ask every online LensNode to remove one Skill cache directory."""
+
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        logger.warning(
+            "Cannot invalidate Skill cache %s without a channel layer.",
+            skill_uuid,
+        )
+        return
+
+    nodes = LensNode.objects.filter(
+        status=LensNode.Status.ONLINE,
+        enrollment_status=LensNode.EnrollmentStatus.APPROVED,
+        token_revoked=False,
+    ).values_list("uuid", flat=True)
+    for lensnode_uuid in nodes:
+        try:
+            async_to_sync(channel_layer.group_send)(
+                lensnode_group_name(lensnode_uuid),
+                {
+                    "type": "lensnode.command",
+                    "payload": {
+                        "type": "skill_cache_invalidate",
+                        "skill_uuid": str(skill_uuid),
+                    },
+                },
+            )
+        except Exception:
+            logger.exception(
+                "Failed to invalidate Skill cache %s on LensNode %s.",
+                skill_uuid,
+                lensnode_uuid,
+            )
+
+
 LENSNODE_DISCONNECT_GRACE_SECONDS_DEFAULT = 180
 
 

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -1219,13 +1219,16 @@ class LensApiTests(TestCase):
             self.assistant.name,
         )
 
-        delete_response = self.client.post(
-            f"/api/lens/admin/skills/{self.skill.uuid}/force-delete/",
-            {"confirmation_name": self.skill.name},
-            format="json",
-        )
+        with patch("lens.views.skills.invalidate_skill_cache") as invalidate:
+            with self.captureOnCommitCallbacks(execute=True):
+                delete_response = self.client.post(
+                    f"/api/lens/admin/skills/{self.skill.uuid}/force-delete/",
+                    {"confirmation_name": self.skill.name},
+                    format="json",
+                )
 
         self.assertEqual(delete_response.status_code, 204)
+        invalidate.assert_called_once_with(self.skill.uuid)
         self.assertFalse(Skill.objects.filter(pk=self.skill.pk).exists())
         self.assertFalse(
             AssistantSkill.objects.filter(assistant=self.assistant).exists()

--- a/backend/lens/views/skills.py
+++ b/backend/lens/views/skills.py
@@ -26,6 +26,7 @@ from lens.skill_packages import (
     update_skill_from_github,
     update_skill_zip,
 )
+from lens.services import invalidate_skill_cache
 from .base import BaseAdminViewSet
 
 
@@ -48,9 +49,10 @@ class SkillViewSet(BaseAdminViewSet):
         """Delete an unbound Skill and remove its package files."""
 
         package_path = instance.package_path
+        skill_uuid = instance.uuid
         instance.delete()
         transaction.on_commit(
-            lambda: self._remove_skill_package_path(package_path)
+            lambda: self._cleanup_deleted_skill(package_path, skill_uuid)
         )
 
     @action(detail=True, methods=["get"], url_path="delete-impact")
@@ -83,11 +85,15 @@ class SkillViewSet(BaseAdminViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         package_path = skill.package_path
+        skill_uuid = skill.uuid
         with transaction.atomic():
             AssistantSkill.objects.filter(skill=skill).delete()
             skill.delete()
             transaction.on_commit(
-                lambda: self._remove_skill_package_path(package_path)
+                lambda: self._cleanup_deleted_skill(
+                    package_path,
+                    skill_uuid,
+                )
             )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -169,6 +175,12 @@ class SkillViewSet(BaseAdminViewSet):
             return
 
         shutil.rmtree(package_path, ignore_errors=True)
+
+    def _cleanup_deleted_skill(self, package_path, skill_uuid):
+        """Remove control-plane files and notify LensNodes after commit."""
+
+        self._remove_skill_package_path(package_path)
+        invalidate_skill_cache(skill_uuid)
 
     @action(
         detail=False,

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -33,6 +33,7 @@ from .logging_utils import (
     utc_now,
 )
 from .runtime_resources import (
+    delete_skill_cache,
     cleanup_run_runtime_resources,
     cleanup_stale_runtime_resources,
 )
@@ -431,6 +432,12 @@ class LensNodeClient:
         message_type = message.get("type")
         if message_type == "run_start":
             await self._start_command(message)
+        elif message_type == "skill_cache_invalidate":
+            await asyncio.to_thread(
+                delete_skill_cache,
+                getattr(self.config, "workspace_path", None),
+                message.get("skill_uuid"),
+            )
         elif message_type == "list_dirs":
             await self._handle_list_dirs(message)
         elif message_type == "datasource_check_path":

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -10,6 +10,7 @@ import shutil
 import stat
 import tempfile
 import time
+import uuid
 import zipfile
 from dataclasses import dataclass, field, replace
 from pathlib import Path, PurePosixPath
@@ -668,6 +669,33 @@ def cleanup_run_runtime_resources(workspace_path, run_uuid):
         return False
     shutil.rmtree(runtime_root, ignore_errors=True)
     return not runtime_root.exists()
+
+
+def delete_skill_cache(workspace_path, skill_uuid):
+    """Remove one validated Skill cache directory from a workspace."""
+
+    if not workspace_path or not skill_uuid:
+        return False
+    try:
+        skill_identifier = str(uuid.UUID(str(skill_uuid)))
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+    cache_root = (
+        Path(workspace_path) / ".sourcelens" / "cache" / "skills"
+    ).resolve()
+    skill_root = cache_root / skill_identifier
+    if skill_root.is_symlink():
+        skill_root.unlink(missing_ok=True)
+        return True
+    try:
+        skill_root.resolve().relative_to(cache_root)
+    except ValueError:
+        return False
+    if not skill_root.exists():
+        return True
+    shutil.rmtree(skill_root, ignore_errors=True)
+    return not skill_root.exists()
 
 
 def _run_runtime_path(workspace_path, run_uuid):

--- a/lensnode/tests/test_subject_documents.py
+++ b/lensnode/tests/test_subject_documents.py
@@ -16,6 +16,7 @@ from lensnode.agent_runtime import (
 from lensnode.agent_runtime.scenarios import SCENARIOS
 from lensnode.gateway_model import RunCancelledError
 from lensnode.runtime_resources import (
+    delete_skill_cache,
     cleanup_run_runtime_resources,
     cleanup_runtime_resources,
     cleanup_stale_runtime_resources,
@@ -517,6 +518,25 @@ def test_cleanup_run_runtime_resources_removes_safe_run_directory(tmp_path):
 
     assert removed is True
     assert not run_root.exists()
+
+
+def test_delete_skill_cache_removes_only_the_requested_skill(tmp_path):
+    skill_uuid = "00000000-0000-0000-0000-000000000013"
+    cache_root = tmp_path / ".sourcelens" / "cache" / "skills"
+    target = cache_root / skill_uuid / "hash"
+    other = cache_root / "00000000-0000-0000-0000-000000000014" / "hash"
+    target.mkdir(parents=True)
+    other.mkdir(parents=True)
+    (target / "SKILL.md").write_text("remove", encoding="utf-8")
+    (other / "SKILL.md").write_text("keep", encoding="utf-8")
+
+    assert delete_skill_cache(tmp_path, skill_uuid) is True
+    assert not target.exists()
+    assert (other / "SKILL.md").exists()
+
+
+def test_delete_skill_cache_rejects_invalid_skill_uuid(tmp_path):
+    assert delete_skill_cache(tmp_path, "../../outside") is False
 
 
 def test_knowledge_prompt_separates_subject_from_reference_material():

--- a/release-notes/391.yaml
+++ b/release-notes/391.yaml
@@ -1,0 +1,8 @@
+type: fix
+audience: admin
+en: >-
+  Fixed deleted Skills remaining in the persistent cache of connected LensNodes.
+  Removing a Skill now also invalidates its corresponding LensNode cache.
+zh-CN: >-
+  修复了删除 Skill 后，已连接 LensNode 的持久化缓存中仍保留该 Skill 的问题。
+  删除 Skill 现在也会同步使对应的 LensNode 缓存失效。


### PR DESCRIPTION
### **User description**
## Summary
- Broadcast Skill cache invalidation after a Skill deletion transaction commits.
- Remove the corresponding validated Skill cache directory from online LensNodes.
- Cover backend deletion notification and LensNode path-safety behavior with regression tests.

## Validation
- Backend lens.test_api: 162 passed.
- LensNode targeted tests: 26 passed.
- Full LensNode suite: 534 passed, 2 pre-existing unrelated failures.
- Browser deletion flow verified against localhost:8000.
- git diff --check passed.

Closes #391


___

### **PR Type**
Bug fix


___

### **Description**
- Broadcast Skill cache invalidation after deletion

- Handle invalidation command on LensNode side

- Add tests for backend notification and path safety


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A[Skill deletion API] --> B[on_commit callback]
  B --> C[_cleanup_deleted_skill]
  C --> D[remove package files]
  C --> E[invalidate_skill_cache]
  E --> F[WebSocket group_send to online LensNodes]
  F --> G[LensNode: delete_skill_cache]
  G --> H[remove cache directory from workspace]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Add invalidate_skill_cache function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Test invalidation call on skill deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_subject_documents.py</strong><dd><code>Test delete_skill_cache for valid and invalid UUIDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-13e8a99ae6db55f17067bd5a4af36980fafd91af472f30a2e605c5decb52172b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>skills.py</strong><dd><code>Integrate cache invalidation in deletion flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-d8404fc248580fa728ddc95fac7bc3f679803524195df0dbba6773a2361e774b">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Handle skill_cache_invalidate WebSocket message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Add delete_skill_cache with path safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>391.yaml</strong><dd><code>Add release note for issue 391</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/392/files#diff-dc63c4ab817a19d290627ef22f9f5aca0edc792a7cd777415702d9a4c415b7f4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

