### PR TITLE
Improve Office preview fidelity and fullscreen behavior

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "chart.js": "^4.5.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "docx-preview": "^0.4.0",
         "dompurify": "^3.0.9",
         "highlight.js": "^11.11.1",
         "mammoth": "1.9.1",
@@ -1951,6 +1952,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docx-preview": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/docx-preview/-/docx-preview-0.4.0.tgz",
+      "integrity": "sha512-OdKtE/uj3M4RfGarLkGjahUzRg8/kBp0Sraj1r1NAY1tp/sTpHOBqDrzVf9onMBt9vxP6SdQ6bpLCUCsFwjgcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": ">=3.0.0"
       }
     },
     "node_modules/dompurify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "chart.js": "^4.5.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "docx-preview": "^0.4.0",
     "dompurify": "^3.0.9",
     "highlight.js": "^11.11.1",
     "mammoth": "1.9.1",

--- a/frontend/src/components/lens/FilePreviewModal.vue
+++ b/frontend/src/components/lens/FilePreviewModal.vue
@@ -5,7 +5,7 @@ import { Download, Maximize2, Minimize2, X } from '@lucide/vue'
 
 import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
 import { fetchDeliverableBlob, previewKind } from '@/utils/filePreview'
-import { escapeHtml, sanitizeHtml } from '@/utils/sanitize'
+import { escapeHtml } from '@/utils/sanitize'
 
 const props = defineProps({
   // The delivered file to preview, or null when the modal is closed.
@@ -19,7 +19,7 @@ const { t } = useI18n()
 const kind = ref('')
 const objectUrl = ref('')
 const textContent = ref('')
-const docxContent = ref('')
+const docxHost = ref(null)
 const workbook = ref(null)
 const sheetNames = ref([])
 const selectedSheet = ref('')
@@ -31,6 +31,46 @@ const failed = ref(false)
 let currentUrl = ''
 let loadSeq = 0
 let pptxPreviewer = null
+let pptxBuffer = null
+
+function getPptxPreviewSize() {
+  if (!isFullscreen.value || !previewPanel.value) {
+    return { width: 900, height: 620 }
+  }
+
+  const header = previewPanel.value.querySelector('.preview-header')
+  return {
+    width: previewPanel.value.clientWidth,
+    height: Math.max(
+      previewPanel.value.clientHeight - (header?.offsetHeight || 0),
+      1
+    )
+  }
+}
+
+function waitForPptxLayout() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  })
+}
+
+async function renderPptx(buffer, seq) {
+  await nextTick()
+  await waitForPptxLayout()
+  if (seq !== loadSeq || !pptxHost.value) {
+    return
+  }
+  if (pptxPreviewer) {
+    pptxPreviewer.destroy()
+  }
+  pptxHost.value.innerHTML = ''
+  const { init: initPptxPreview } = await import('pptx-preview')
+  pptxPreviewer = initPptxPreview(pptxHost.value, {
+    ...getPptxPreviewSize(),
+    mode: 'slide'
+  })
+  await pptxPreviewer.preview(buffer)
+}
 
 function renderSheet(name) {
   if (!workbook.value || !name) return ''
@@ -61,7 +101,7 @@ function cleanup() {
   }
   objectUrl.value = ''
   textContent.value = ''
-  docxContent.value = ''
+  pptxBuffer = null
   workbook.value = null
   sheetNames.value = []
   selectedSheet.value = ''
@@ -71,6 +111,9 @@ function cleanup() {
   }
   if (pptxHost.value) {
     pptxHost.value.innerHTML = ''
+  }
+  if (docxHost.value) {
+    docxHost.value.innerHTML = ''
   }
 }
 
@@ -97,25 +140,25 @@ async function load(file) {
       return
     }
     if (kind.value === 'pptx') {
-      const { init: initPptxPreview } = await import('pptx-preview')
-      const buffer = await blob.arrayBuffer()
+      pptxBuffer = await blob.arrayBuffer()
+      await renderPptx(pptxBuffer, seq)
+    } else if (kind.value === 'docx') {
+      const { renderAsync } = await import('docx-preview')
       await nextTick()
-      if (seq !== loadSeq || !pptxHost.value) {
+      if (seq !== loadSeq || !docxHost.value) {
         return
       }
-      pptxPreviewer = initPptxPreview(pptxHost.value, {
-        width: 900,
-        height: 620,
-        mode: 'list'
+      await renderAsync(blob, docxHost.value, docxHost.value, {
+        breakPages: true,
+        ignoreHeight: false,
+        ignoreWidth: false,
+        inWrapper: true,
+        renderComments: false,
+        renderEndnotes: true,
+        renderFooters: true,
+        renderFootnotes: true,
+        renderHeaders: true
       })
-      await pptxPreviewer.preview(buffer)
-    } else if (kind.value === 'docx') {
-      const { default: mammoth } = await import('mammoth')
-      const result = await mammoth.convertToHtml({
-        arrayBuffer: await blob.arrayBuffer()
-      })
-      if (seq !== loadSeq) return
-      docxContent.value = sanitizeHtml(result.value)
     } else if (kind.value === 'xlsx') {
       const XLSX = await import('xlsx')
       const parsed = XLSX.read(await blob.arrayBuffer(), {
@@ -171,13 +214,19 @@ async function enterFullscreen() {
       // Keep the CSS fallback when the browser denies fullscreen access.
     }
   }
+  if (kind.value === 'pptx' && pptxBuffer) {
+    await renderPptx(pptxBuffer, loadSeq)
+  }
 }
 
-function exitFullscreen() {
+async function exitFullscreen() {
   if (document.fullscreenElement && document.exitFullscreen) {
-    document.exitFullscreen().catch(() => {})
+    await document.exitFullscreen().catch(() => {})
   }
   isFullscreen.value = false
+  if (kind.value === 'pptx' && pptxBuffer) {
+    await renderPptx(pptxBuffer, loadSeq)
+  }
 }
 
 function toggleFullscreen() {
@@ -190,11 +239,25 @@ function toggleFullscreen() {
 
 function onFullscreenChange() {
   isFullscreen.value = Boolean(document.fullscreenElement)
+  if (kind.value === 'pptx' && pptxBuffer) {
+    renderPptx(pptxBuffer, loadSeq)
+  }
 }
 
 function onDownload() {
   if (props.file) {
     emit('download', props.file)
+  }
+}
+
+function turnPptxPage(direction) {
+  if (!pptxPreviewer || kind.value !== 'pptx') {
+    return
+  }
+  if (direction > 0 && pptxPreviewer.renderNextSlide) {
+    pptxPreviewer.renderNextSlide()
+  } else if (direction < 0 && pptxPreviewer.renderPreSlide) {
+    pptxPreviewer.renderPreSlide()
   }
 }
 
@@ -205,6 +268,15 @@ function onKeydown(event) {
       return
     }
     close()
+    return
+  }
+  if (
+    kind.value === 'pptx' &&
+    [' ', 'ArrowRight', 'ArrowLeft'].includes(event.key)
+  ) {
+    event.preventDefault()
+    event.stopPropagation()
+    turnPptxPage(event.key === 'ArrowLeft' ? -1 : 1)
   }
 }
 
@@ -309,6 +381,9 @@ onUnmounted(() => {
         </header>
 
         <div class="preview-body">
+          <div v-if="kind === 'pptx'" ref="pptxHost" class="preview-pptx"></div>
+          <div v-if="kind === 'docx'" ref="docxHost" class="preview-docx"></div>
+
           <div v-if="loading" class="preview-status">
             {{ t('lens.chat.previewLoading') }}
           </div>
@@ -337,18 +412,6 @@ onUnmounted(() => {
             class="preview-frame"
             sandbox=""
           ></iframe>
-
-          <div
-            v-else-if="kind === 'pptx'"
-            ref="pptxHost"
-            class="preview-pptx"
-          ></div>
-
-          <article
-            v-else-if="kind === 'docx'"
-            class="preview-docx"
-            v-html="docxContent"
-          ></article>
 
           <div v-else-if="kind === 'xlsx'" class="preview-xlsx">
             <div class="preview-sheet-tabs" role="tablist">
@@ -506,6 +569,86 @@ onUnmounted(() => {
 }
 .preview-docx :deep(img) {
   max-width: 100%;
+}
+.preview-docx :deep(h1),
+.preview-docx :deep(h2),
+.preview-docx :deep(h3),
+.preview-docx :deep(h4),
+.preview-docx :deep(h5),
+.preview-docx :deep(h6) {
+  margin: 1.4em 0 0.6em;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--sl-text-primary);
+}
+.preview-docx :deep(h1) {
+  margin-top: 0;
+  font-size: 1.8rem;
+}
+.preview-docx :deep(h2) {
+  font-size: 1.45rem;
+}
+.preview-docx :deep(h3) {
+  font-size: 1.2rem;
+}
+.preview-docx :deep(p) {
+  margin: 0 0 0.9em;
+  line-height: 1.75;
+}
+.preview-docx :deep(ul),
+.preview-docx :deep(ol) {
+  padding-left: 1.6em;
+  margin: 0 0 1em;
+  line-height: 1.7;
+}
+.preview-docx :deep(li) {
+  padding-left: 0.25em;
+  margin: 0.2em 0;
+}
+.preview-docx :deep(blockquote) {
+  padding: 0.7em 1em;
+  margin: 1em 0;
+  color: var(--sl-text-secondary);
+  background: var(--sl-bg-canvas);
+  border-left: 3px solid var(--sl-border-strong);
+}
+.preview-docx :deep(table) {
+  width: 100%;
+  margin: 1.2em 0;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+.preview-docx :deep(th),
+.preview-docx :deep(td) {
+  padding: 0.55em 0.7em;
+  text-align: left;
+  vertical-align: top;
+  border: 1px solid var(--sl-border-default);
+}
+.preview-docx :deep(th) {
+  font-weight: 600;
+  background: var(--sl-bg-canvas);
+}
+.preview-docx :deep(a) {
+  color: var(--sl-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.preview-docx :deep(hr) {
+  margin: 1.5em 0;
+  border: 0;
+  border-top: 1px solid var(--sl-border-default);
+}
+.preview-docx :deep(pre) {
+  padding: 12px 14px;
+  margin: 1em 0;
+  overflow-x: auto;
+  color: var(--sl-code-text);
+  background: var(--sl-code-bg);
+  border-radius: 6px;
+}
+.preview-docx :deep(code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .preview-xlsx {
   min-width: max-content;

--- a/frontend/tests/filePreviewModalTheme.test.js
+++ b/frontend/tests/filePreviewModalTheme.test.js
@@ -41,3 +41,53 @@ test('preview text chrome follows theme foreground tokens', () => {
   assert.match(status, /color:\s*var\(--sl-text-muted\)/)
   assert.match(text, /color:\s*var\(--sl-text-primary\)/)
 })
+
+test('PPTX host mounts while the preview is loading', () => {
+  const modalSource = readFileSync(
+    new URL('../src/components/lens/FilePreviewModal.vue', import.meta.url),
+    'utf8'
+  )
+  const pptxHostIndex = modalSource.indexOf('ref="pptxHost"')
+  const loadingIndex = modalSource.indexOf('class="preview-status"')
+
+  assert.ok(pptxHostIndex > -1, 'PPTX preview host must exist')
+  assert.ok(loadingIndex > -1, 'preview loading state must exist')
+  assert.ok(
+    pptxHostIndex < loadingIndex,
+    'PPTX host must be declared before the loading branch'
+  )
+  assert.match(
+    modalSource.slice(pptxHostIndex - 120, pptxHostIndex + 80),
+    /v-if="kind === 'pptx'"/
+  )
+})
+
+test('PPTX preview recalculates its viewport after fullscreen changes', () => {
+  assert.match(modalSource, /function getPptxPreviewSize\(\)/)
+  assert.match(modalSource, /previewPanel\.value\.clientWidth/)
+  assert.match(modalSource, /pptxHost\.value\.innerHTML = ''/)
+  assert.match(modalSource, /function waitForPptxLayout\(\)/)
+  assert.match(modalSource, /await renderPptx\(pptxBuffer, loadSeq\)/)
+  assert.match(modalSource, /renderPptx\(pptxBuffer, loadSeq\)/)
+})
+
+test('PPTX keyboard navigation keeps Space from closing the preview', () => {
+  assert.match(modalSource, /mode: 'slide'/)
+  assert.match(modalSource, /event\.preventDefault\(\)/)
+  assert.match(modalSource, /event\.key === 'ArrowLeft' \? -1 : 1/)
+  assert.match(modalSource, /turnPptxPage\(direction\)/)
+})
+
+test('DOCX preview restores document typography and table layout', () => {
+  assert.match(styleSource, /\.preview-docx :deep\(h1\)/)
+  assert.match(styleSource, /\.preview-docx :deep\(p\)/)
+  assert.match(styleSource, /\.preview-docx :deep\(table\)/)
+  assert.match(styleSource, /\.preview-docx :deep\(li\)/)
+})
+
+test('DOCX preview uses the browser renderer for document styles', () => {
+  assert.match(modalSource, /import\('docx-preview'\)/)
+  assert.match(modalSource, /renderAsync\(blob, docxHost\.value/)
+  assert.match(modalSource, /ref="docxHost"/)
+  assert.doesNotMatch(modalSource, /mammoth\.convertToHtml/)
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -127,7 +127,10 @@ export default defineConfig({
     },
     proxy: {
       '/api': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+        target:
+          process.env.API_PROXY_TARGET ||
+          process.env.VITE_API_BASE_URL ||
+          'http://localhost:8000',
         changeOrigin: true,
         secure: false,
         configure:
@@ -146,7 +149,10 @@ export default defineConfig({
             : undefined
       },
       '/accounts': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+        target:
+          process.env.API_PROXY_TARGET ||
+          process.env.VITE_API_BASE_URL ||
+          'http://localhost:8000',
         changeOrigin: true,
         secure: false
       }

--- a/release-notes/412.yaml
+++ b/release-notes/412.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: Improved DOCX styling and pagination, and fixed PPTX fullscreen rendering and keyboard slide navigation.
+zh-CN: 优化 DOCX 字体、颜色和分页样式，并修复 PPTX 全屏渲染及键盘翻页问题。


### PR DESCRIPTION
### **User description**
## Summary

- Upgrade DOCX rendering from Mammoth HTML conversion to `docx-preview` with page breaks, headers, footers, footnotes, endnotes, and document-oriented typography/table/list styling.
- Keep PPTX preview hosts mounted during loading, clear stale render output, and re-render against the actual panel size across fullscreen transitions.
- Add PPTX Space/ArrowRight/ArrowLeft navigation while preventing Space from triggering preview close behavior.
- Add configurable `API_PROXY_TARGET` support for local Vite development against the online backend and preserve Turnstile configuration.

Closes #412

## Test plan

- [x] Frontend unit tests: 392/392 passed
- [x] ESLint passed for modified frontend files
- [x] `git diff --check` passed
- [x] Production `npm run build` passed
- [x] Browser verification with ego-browser: localhost frontend, online API proxy, Turnstile, and preview flows


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade DOCX rendering from Mammoth to docx-preview

- Re-render PPTX preview on fullscreen transitions

- Add PPTX keyboard slide navigation (Space, ArrowRight, ArrowLeft)

- Support local Vite development with configurable API proxy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FilePreviewModal.vue"] --> B["DOCX: docx-preview (typography, pagination)"]
  A --> C["PPTX: re-render on fullscreen, keyboard nav"]
  C --> D["pptBuffer held, renderPptx on fullscreen change"]
  D --> E["turnPptxPage for Space/Arrow keys"]
  F["vite.config.js"] --> G["API_PROXY_TARGET env var"]
  G --> H["Proxy /api and /accounts"]
  I["frontend/package.json"] --> J["Add docx-preview dependency"]
  K["release-notes/412.yaml"] --> L["Changelog entry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FilePreviewModal.vue</strong><dd><code>Reworked DOCX/PPTX preview rendering and navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/lens/FilePreviewModal.vue

<ul><li>Replaced Mammoth HTML conversion with <code>docx-preview</code> for better DOCX <br>rendering (headers, footers, footnotes, endnotes, tables, lists)<br> <li> Added <code>docxHost</code> ref and <code>renderPptx</code> function for re-rendering PPTX on <br>fullscreen changes<br> <li> Implemented <code>turnPptxPage</code> for keyboard slide navigation (Space, <br>ArrowRight, ArrowLeft)<br> <li> Updated CSS for DOCX document typography, tables, blockquotes, code <br>blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/413/files#diff-5877269b3f6b5f20f5c1c0b908ee8d40929fdca3a7f23c65338e8f1bde92833f">+175/-32</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filePreviewModalTheme.test.js</strong><dd><code>Unit tests for improved preview behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/filePreviewModalTheme.test.js

<ul><li>Added tests for PPTX host mount order relative to loading state<br> <li> Added tests for PPTX viewport recalculation on fullscreen changes<br> <li> Added tests for PPTX keyboard navigation preventing Space close<br> <li> Added tests for DOCX typography and docx-preview usage</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/413/files#diff-cdaccb7f9b09b64efab8ca607ce354b532f501d4a8ea66240b12ca8655b78319">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.js</strong><dd><code>Configurable API proxy target for local dev</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/vite.config.js

<ul><li>Added <code>API_PROXY_TARGET</code> environment variable as fallback proxy target<br> <li> Applied to both <code>/api</code> and <code>/accounts</code> proxy configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/413/files#diff-3ab42a14055f455cac92d192b5dfc9b850cd36f1ea3410d1694a602f6d4b83c1">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add docx-preview dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/package.json

- Added `docx-preview` dependency (^0.4.0) for DOCX rendering


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/413/files#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>412.yaml</strong><dd><code>Release note for preview improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/412.yaml

<ul><li>Added release note for DOCX styling/pagination and PPTX <br>fullscreen/keyboard navigation fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/413/files#diff-ec2c4b7a92256fdc0528623bedd55a0e3ee2435b3f50e2e708e8873a196e730a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

