### PR TITLE
Accept planner source window field aliases

### DIFF
--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -1958,7 +1958,8 @@ def _planned_planner_prompt(
         "arrives. Otherwise set clarification to null. Leave "
         "source_windows empty unless exact file paths and line ranges are "
         "already known; the executor derives source windows from retrieval "
-        "results. "
+        "results. If source_windows are provided, use path, start_line, and "
+        "end_line as the field names. "
         f"{codegraph_contract} literal_queries must be an array of plain "
         'strings (never objects), for example ["153301", "Sysconfig.ini"]. '
         "Use CodeGraph for structural questions and exact search for logs "
@@ -2005,6 +2006,7 @@ def _planned_planner_repair_prompt(
         "retrieval plan. Required fields are objective, question_type, "
         "evidence_requirements, codegraph_queries, literal_queries, "
         "source_windows, max_files, max_fallback_rounds, and budgets. "
+        "Use path, start_line, and end_line for source window fields. "
         f"{codegraph_contract} literal_queries must be an array of plain "
         "strings, never objects. Keep all searches bounded and set "
         "max_fallback_rounds to 1 or less. Do not answer the question."

--- a/lensnode/lensnode/planned_evidence.py
+++ b/lensnode/lensnode/planned_evidence.py
@@ -280,9 +280,17 @@ def parse_retrieval_plan(raw):
     for item in _list_value(raw.get("source_windows"))[:MAX_SOURCE_WINDOWS]:
         if not isinstance(item, dict):
             raise PlanValidationError("source window must be an object")
-        path = _required_text(item.get("path"), "source window path")
-        start = _positive_int(item.get("start_line"), 1)
+        path = _required_text(
+            item.get("path") or item.get("file_path"),
+            "source window path",
+        )
+        start = _positive_int(
+            item.get("start_line") or item.get("line_start"),
+            1,
+        )
         end = item.get("end_line")
+        if end is None:
+            end = item.get("line_end")
         if end is not None:
             end = _positive_int(end, start)
             if end < start:

--- a/lensnode/tests/test_planned_evidence.py
+++ b/lensnode/tests/test_planned_evidence.py
@@ -69,6 +69,29 @@ def test_retrieval_plan_normalizes_bounded_limits():
     assert plan.literal_queries == ("raise None",)
 
 
+def test_retrieval_plan_accepts_planner_source_window_field_names():
+    plan = parse_retrieval_plan(
+        {
+            "objective": "inspect the failing block device path",
+            "source_windows": [
+                {
+                    "repository": "linux-agent-syncer",
+                    "file_path": "internal/service/block_device_syncer.go",
+                    "line_start": 160,
+                    "line_end": 195,
+                }
+            ],
+        }
+    )
+
+    assert len(plan.source_windows) == 1
+    assert plan.source_windows[0].path == (
+        "internal/service/block_device_syncer.go"
+    )
+    assert plan.source_windows[0].start_line == 160
+    assert plan.source_windows[0].end_line == 195
+
+
 def test_retrieval_plan_rejects_missing_objective_and_invalid_operation():
     with pytest.raises(PlanValidationError):
         parse_retrieval_plan({"literal_queries": ["error"]})

--- a/release-notes/415.yaml
+++ b/release-notes/415.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed Code Analysis source-window plans falling back to broad searches when
+  the planner used compatible alternate field names.
+zh-CN: >-
+  修复代码分析规划器使用兼容字段名时，源码窗口计划错误降级为宽泛检索的问题。


### PR DESCRIPTION
### **User description**
## Summary
- accept `file_path`, `line_start`, and `line_end` as bounded source-window aliases
- keep `path`, `start_line`, and `end_line` as the canonical planner contract
- add regression coverage for the production plan shape
- add a bilingual user-facing release note

Closes #415

## Test plan
- [x] `cd lensnode && ./.venv/bin/pytest -q tests/test_planned_evidence.py tests/test_planned_runtime.py` (45 passed)
- [x] `PYTHONPATH=. ./.venv/bin/python scripts/test_release_notes.py` (6 passed)
- [x] LensNode full suite: 543 passed; 3 pre-existing unrelated failures in image messages, external deliverables, and outbox ordering


___

### **PR Type**
Bug fix


___

### **Description**
- Accept planner source window field aliases

- Update prompts to document canonical names

- Add regression test for aliases

- Add release note


___

### Diagram Walkthrough


```mermaid
flowchart LR
  planner["Planner"] --> source_windows["source_windows<br/>(file_path/line_start/line_end)"]
  source_windows --> parse["parse_retrieval_plan"]
  parse --> accepted["Accepted: path/start_line/end_line"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Document canonical source window field names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Updated planner prompts to document canonical source window field <br>names (path, start_line, end_line).<br> <li> Added note in repair prompt as well.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/416/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>415.yaml</strong><dd><code>Add release note for alias fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/415.yaml

- Added bilingual release note for the fix.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/416/files#diff-a3259b340ab172f2a464e7682b368debe4179629c3656923a9547068fa0698fa">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planned_evidence.py</strong><dd><code>Accept planner source window field aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/planned_evidence.py

<ul><li>Accept file_path, line_start, line_end as aliases for path, <br>start_line, end_line.<br> <li> Fallback to canonical fields if alias not present.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/416/files#diff-df5cfbc677e6c1298ba0474c2b12b2f2c7bc36baf496b3a6a4ef1d7f4d1a00a9">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_planned_evidence.py</strong><dd><code>Add regression test for alias parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_planned_evidence.py

<ul><li>Added regression test <br>test_retrieval_plan_accepts_planner_source_window_field_names.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/416/files#diff-ec43276f76831d47098d0deabf5c13edd4f09221ffbf404ebeb0eac5f75e8641">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

