### PR TITLE
Accept detailed planner objectives

### DIFF
--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -41,6 +41,7 @@ from ..plugins import collect_agent_runtime_contributions
 from ..planned_evidence import (
     ALLOWED_CODEGRAPH_OPERATIONS,
     EvidenceExecutor,
+    MAX_OBJECTIVE_CHARS,
     build_evidence_bundle,
     assess_code_analysis_capabilities,
     parse_retrieval_plan,
@@ -1951,7 +1952,8 @@ def _planned_planner_prompt(
         "tools. The backend will execute every bounded operation. Include "
         "objective, project, repository, revision, question_type, "
         "evidence_requirements, codegraph_queries, literal_queries, "
-        "clarification, max_files, max_fallback_rounds, and budgets. If a "
+        "clarification, max_files, max_fallback_rounds, and budgets. Keep "
+        f"objective under {MAX_OBJECTIVE_CHARS} characters. If a "
         "critical input is missing or the target is materially ambiguous, "
         "set clarification to an object with a plain-text question, reason, "
         "and answer_type=text; do not guess or retrieve until the answer "
@@ -2006,6 +2008,7 @@ def _planned_planner_repair_prompt(
         "retrieval plan. Required fields are objective, question_type, "
         "evidence_requirements, codegraph_queries, literal_queries, "
         "source_windows, max_files, max_fallback_rounds, and budgets. "
+        f"Keep objective under {MAX_OBJECTIVE_CHARS} characters. "
         "Use path, start_line, and end_line for source window fields. "
         f"{codegraph_contract} literal_queries must be an array of plain "
         "strings, never objects. Keep all searches bounded and set "

--- a/lensnode/lensnode/planned_evidence.py
+++ b/lensnode/lensnode/planned_evidence.py
@@ -14,6 +14,7 @@ from pathlib import Path
 MAX_FILES = 15
 MAX_SOURCE_WINDOW_LINES = 250
 MAX_EVIDENCE_TOKENS = 20000
+MAX_OBJECTIVE_CHARS = 2000
 MAX_QUERY_CHARS = 500
 MAX_CODEGRAPH_QUERIES = 16
 MAX_LITERAL_QUERIES = 32
@@ -259,7 +260,11 @@ def parse_retrieval_plan(raw):
     if not isinstance(raw, dict):
         raise PlanValidationError("retrieval plan must be an object")
 
-    objective = _required_text(raw.get("objective"), "objective")
+    objective = _required_text(
+        raw.get("objective"),
+        "objective",
+        max_chars=MAX_OBJECTIVE_CHARS,
+    )
     codegraph_queries = []
     codegraph_items = _list_value(raw.get("codegraph_queries"))[
         :MAX_CODEGRAPH_QUERIES
@@ -978,9 +983,9 @@ def _requirement_category(requirement):
     return "structural"
 
 
-def _required_text(value, label):
+def _required_text(value, label, max_chars=MAX_QUERY_CHARS):
     text = str(value or "").strip()
-    if not text or len(text) > MAX_QUERY_CHARS:
+    if not text or len(text) > max_chars:
         raise PlanValidationError(f"{label} is missing or too long")
     return text
 

--- a/lensnode/tests/test_planned_evidence.py
+++ b/lensnode/tests/test_planned_evidence.py
@@ -92,6 +92,30 @@ def test_retrieval_plan_accepts_planner_source_window_field_names():
     assert plan.source_windows[0].end_line == 195
 
 
+def test_retrieval_plan_accepts_detailed_bounded_objective():
+    objective = (
+        "Investigate the agent-syncer invalid block number failure and "
+        "trace the call path from SyncManager.StartSync through "
+        "Syncer.Start into NewBlockDeviceSyncer. Identify the exact "
+        "validation logic, determine how the device size and block count "
+        "are derived, distinguish device-mapper behavior from ordinary "
+        "block devices, and find related error handling, retries, tests, "
+        "or fixes. "
+        + "Preserve this relevant retrieval detail. " * 8
+    ).strip()
+
+    assert len(objective) > 500
+
+    plan = parse_retrieval_plan({"objective": objective})
+
+    assert plan.objective == objective
+
+
+def test_retrieval_plan_rejects_objective_over_its_dedicated_limit():
+    with pytest.raises(PlanValidationError):
+        parse_retrieval_plan({"objective": "x" * 2001})
+
+
 def test_retrieval_plan_rejects_missing_objective_and_invalid_operation():
     with pytest.raises(PlanValidationError):
         parse_retrieval_plan({"literal_queries": ["error"]})

--- a/release-notes/417.yaml
+++ b/release-notes/417.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: user
+en: >-
+  Fixed detailed Code Analysis plans falling back to unrelated searches when
+  their objective description exceeded the search-query length limit.
+zh-CN: >-
+  修复代码分析的详细规划目标超过检索词长度限制时，错误降级为无关搜索的问题。


### PR DESCRIPTION
### **User description**
## Summary
- give retrieval-plan objectives a dedicated 2,000-character bound
- keep literal and CodeGraph query limits unchanged
- tell initial and repair planners about the objective bound
- add regression coverage for valid detailed objectives and the upper bound

Closes #417

## Production evidence
Run `a035ea2d-9754-449e-a800-a85973bf295f` produced a valid detailed plan but was rejected with `objective is missing or too long`, then fell back to irrelevant searches for `ssue` and `Unknown`.

## Test plan
- [x] `lensnode/.venv/bin/pytest -q lensnode/tests/test_planned_evidence.py lensnode/tests/test_planned_runtime.py`
- [x] Python compilation check for changed Python files
- [x] `git diff --check`


___

### **PR Type**
Bug fix


___

### **Description**
- Add dedicated 2000-character limit for planner objectives

- Keep literal and CodeGraph query limits unchanged

- Inform planners about the new objective bound

- Add regression tests for valid and exceeding objectives


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planned_evidence.py</strong><dd><code>Add dedicated objective length limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/planned_evidence.py

<ul><li>Added MAX_OBJECTIVE_CHARS = 2000 constant<br> <li> Modified _required_text to accept max_chars parameter<br> <li> Updated parse_retrieval_plan to use new limit for objective</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/418/files#diff-df5cfbc677e6c1298ba0474c2b12b2f2c7bc36baf496b3a6a4ef1d7f4d1a00a9">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Inform planners about objective length limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Imported MAX_OBJECTIVE_CHARS from planned_evidence<br> <li> Updated planner prompts to include objective length constraint</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/418/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_planned_evidence.py</strong><dd><code>Add regression tests for objective length limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_planned_evidence.py

<ul><li>Added test for accepting objectives > 500 characters<br> <li> Added test for rejecting objectives at 2001 characters</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/418/files#diff-ec43276f76831d47098d0deabf5c13edd4f09221ffbf404ebeb0eac5f75e8641">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>417.yaml</strong><dd><code>Add release note for objective length fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/417.yaml

- Added release note entry for the fix in English and Chinese


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/418/files#diff-fd736ac9cafc586770027746d5b4872eff0cb9121cb85e1abc872fead3f70597">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

