### PR TITLE
Fix multimodal model selection for configured vision inputs

### DIFF
--- a/frontend/e2e/chat-image-upload-layout.spec.js
+++ b/frontend/e2e/chat-image-upload-layout.spec.js
@@ -38,7 +38,8 @@ async function mockChat(page) {
           slug: 'image-layout-test',
           name: 'Image Layout Test',
           status: 'active',
-          multimodal_model_ref: 'model-1'
+          multimodal_model_ref: 'model-1',
+          can_process_images: true
         }
       ],
       '/api/lens/shares/': [],

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -1110,10 +1110,7 @@ const wizardStep = ref(1)
 const visionModelOptions = computed(() => {
   const selected = props.form.multimodal_model_ref
   const eligible = props.llmConfigOptions.filter(
-    (config) =>
-      config.is_active !== false &&
-      (config.vision_capability === 'supported' ||
-        config.capabilities?.includes?.('vision'))
+    (config) => isVisionModelEligible(config)
   )
   const historical = props.llmConfigOptions.find(
     (config) => config.uuid === selected

--- a/release-notes/398.yaml
+++ b/release-notes/398.yaml
@@ -1,0 +1,7 @@
+type: fix
+audience: admin
+en: >-
+  Fixed the Assistant Multimodal Model selector so active models explicitly
+  configured to support image input can be selected.
+zh-CN: >-
+  修复助手多模态模型选择器问题，现在可以选择已明确配置为支持图片输入的启用模型。


### PR DESCRIPTION
### **User description**
## Summary

- Reuse the complete vision eligibility check when populating the Assistant Multimodal Model selector.
- Allow active models explicitly configured with vision or supports_vision to be selected.
- Update the image upload E2E fixture to reflect image-capable assistants.

## Verification

- Targeted ESLint passed.
- Frontend unit tests passed.
- Image upload Playwright test passed.
- Manual ego-browser verification confirmed the configured Vision models appear and are selectable in the Create Assistant dialog.

Fixes #398


___

### **PR Type**
Bug fix


___

### **Description**
- Reuse vision eligibility check in model selector

- Add image capability to E2E mock assistant

- Add release note for issue 398 fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration: vision enabled"] --> B["isVisionModelEligible check"]
  B --> C["Assistant Multimodal Model dropdown"]
  C --> D["User selects enabled model"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AssistantFormDrawerDirectEnvironment.vue</strong><dd><code>Use shared vision eligibility in assistant form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue

<ul><li>Replaced inline vision filter with reusable isVisionModelEligible <br>function<br> <li> Ensures active models with vision_capability or supports_vision are <br>selectable</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/421/files#diff-1bbf22475c1d3e7a28848d3821a473ca289b3ce9c70ed901042e503be4fbc9ff">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-image-upload-layout.spec.js</strong><dd><code>Update E2E fixture with image capability flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-image-upload-layout.spec.js

<ul><li>Added can_process_images: true to mock assistant data<br> <li> Reflects image-capable assistant for E2E image upload test</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/421/files#diff-8f20d8d9ef25cc4b3b5046c255c2f7b5c7b82438ebf2615c59ab611ef4c78db8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>398.yaml</strong><dd><code>Add release note for issue 398</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/398.yaml

<ul><li>Added release note for fix in English and Chinese<br> <li> Describes the fix for multimodal model selection</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/421/files#diff-dcb62352b36aba0840cb1cd4d39d3f91c562afc7122d1fbb87090fd01476956b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

