### PR TITLE
Improve Assistant workspace guides and Skill management

### DIFF
--- a/backend/lens/admin.py
+++ b/backend/lens/admin.py
@@ -51,8 +51,8 @@ class DataSourceAdmin(admin.ModelAdmin):
 
 @admin.register(Skill)
 class SkillAdmin(admin.ModelAdmin):
-    list_display = ("name", "slug", "enabled")
-    search_fields = ("name", "slug")
+    list_display = ("name", "uuid", "kind", "enabled")
+    search_fields = ("name", "package_name", "uuid")
 
 
 @admin.register(MCPServer)

--- a/backend/lens/migrations/0044_skill_metadata_and_workspace_guide.py
+++ b/backend/lens/migrations/0044_skill_metadata_and_workspace_guide.py
@@ -1,0 +1,111 @@
+from django.db import migrations, models
+
+
+def migrate_skill_identity(apps, schema_editor):
+    """Preserve package names and classify legacy workspace guides."""
+
+    Skill = apps.get_model("lens", "Skill")
+    for skill in Skill.objects.all().iterator():
+        skill.package_name = skill.slug or ""
+        if (skill.slug or "").endswith("-workspace-guide"):
+            skill.kind = "workspace_guide"
+        skill.save(update_fields=["package_name", "kind"])
+
+
+def migrate_workspace_guides(apps, schema_editor):
+    """Move legacy Workspace Guide content onto its Assistant."""
+
+    Assistant = apps.get_model("lens", "Assistant")
+    AssistantSkill = apps.get_model("lens", "AssistantSkill")
+
+    for binding in AssistantSkill.objects.filter(
+        skill__kind="workspace_guide",
+        enabled=True,
+    ).select_related("assistant", "skill"):
+        definition = binding.skill.definition or {}
+        content = (
+            definition.get("content")
+            if isinstance(definition, dict)
+            else definition
+        )
+        content = str(content or "").strip()
+        if content and not binding.assistant.workspace_guide:
+            Assistant.objects.filter(pk=binding.assistant_id).update(
+                workspace_guide=content,
+            )
+        binding.enabled = False
+        binding.save(update_fields=["enabled"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("lens", "0043_runtraceevent")]
+
+    operations = [
+        migrations.AddField(
+            model_name="skill",
+            name="source_ref",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+            ),
+        ),
+        migrations.AddField(
+            model_name="skill",
+            name="source_path",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=500,
+            ),
+        ),
+        migrations.AddField(
+            model_name="skill",
+            name="latest_source_ref",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+            ),
+        ),
+        migrations.AddField(
+            model_name="skill",
+            name="source_checked_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="skill",
+            name="package_name",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=180,
+            ),
+        ),
+        migrations.AddField(
+            model_name="skill",
+            name="kind",
+            field=models.CharField(
+                default="standard",
+                max_length=32,
+            ),
+        ),
+        migrations.RunPython(
+            migrate_skill_identity,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RemoveField(
+            model_name="skill",
+            name="slug",
+        ),
+        migrations.AddField(
+            model_name="assistant",
+            name="workspace_guide",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.RunPython(
+            migrate_workspace_guides,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -155,6 +155,7 @@ class Assistant(TimestampedUUIDModel):
 
     selected_task = models.CharField(max_length=160)
     selected_dirs = models.JSONField(default=list, blank=True)
+    workspace_guide = models.TextField(blank=True, default="")
     preprocess_model_ref = models.UUIDField(null=True, blank=True)
     postprocess_model_ref = models.UUIDField(null=True, blank=True)
     multimodal_model_ref = models.UUIDField(null=True, blank=True)
@@ -280,7 +281,8 @@ class Skill(TimestampedUUIDModel):
     """Global skill resource."""
 
     name = models.CharField(max_length=160)
-    slug = models.SlugField(max_length=180, unique=True)
+    package_name = models.CharField(max_length=180, blank=True, default="")
+    kind = models.CharField(max_length=32, default="standard")
     definition = models.JSONField(default=dict, blank=True)
     version = models.CharField(max_length=64, blank=True, default="1")
     enabled = models.BooleanField(default=True)
@@ -290,6 +292,14 @@ class Skill(TimestampedUUIDModel):
     package_manifest = models.JSONField(default=dict, blank=True)
     source_type = models.CharField(max_length=32, blank=True, default="manual")
     source_url = models.CharField(max_length=1000, blank=True, default="")
+    source_ref = models.CharField(max_length=255, blank=True, default="")
+    source_path = models.CharField(max_length=500, blank=True, default="")
+    latest_source_ref = models.CharField(
+        max_length=255,
+        blank=True,
+        default="",
+    )
+    source_checked_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         ordering = ["name"]

--- a/backend/lens/runtime_events.py
+++ b/backend/lens/runtime_events.py
@@ -140,7 +140,7 @@ def sanitize_loaded_skills(items):
 
     fields = (
         "skill_uuid",
-        "skill_slug",
+        "skill_package_name",
         "skill_name",
         "version",
         "content_hash",

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -1884,12 +1884,15 @@ def _validate_feishu_config(config, instance=None, credential=None):
 class SkillSerializer(serializers.ModelSerializer):
     """Skill serializer."""
 
+    update_available = serializers.SerializerMethodField()
+
     class Meta:
         model = Skill
         fields = [
             "uuid",
             "name",
-            "slug",
+            "package_name",
+            "kind",
             "definition",
             "version",
             "enabled",
@@ -1898,19 +1901,39 @@ class SkillSerializer(serializers.ModelSerializer):
             "package_manifest",
             "source_type",
             "source_url",
+            "source_ref",
+            "source_path",
+            "latest_source_ref",
+            "source_checked_at",
+            "update_available",
             "created_at",
             "updated_at",
         ]
         read_only_fields = [
             "uuid",
+            "kind",
+            "package_name",
             "package_hash",
             "package_size",
             "package_manifest",
             "source_type",
             "source_url",
+            "source_ref",
+            "source_path",
+            "latest_source_ref",
+            "source_checked_at",
             "created_at",
             "updated_at",
         ]
+
+    def get_update_available(self, obj):
+        """Return whether a newer source tag is known for this Skill."""
+
+        return bool(
+            obj.source_type == "github"
+            and obj.latest_source_ref
+            and obj.latest_source_ref != obj.source_ref
+        )
 
     def validate_definition(self, value):
         """Validate and normalize the Skill environment declaration."""

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -1408,8 +1408,9 @@ def build_loaded_skills(assistant):
         loaded.append(
             {
                 "skill_uuid": str(skill.uuid),
-                "skill_slug": skill.slug,
+                "skill_package_name": skill.package_name,
                 "skill_name": skill.name,
+                "skill_kind": skill.kind,
                 "version": skill.version,
                 "content_hash": content_hash,
                 "definition": skill.definition,
@@ -1757,6 +1758,7 @@ def _build_run_runtime_snapshot(assistant, lensnode, answer_language):
         "model_config_hashes": model_config_hashes,
         "settings": settings_payload,
         "settings_hash": _canonical_hash(settings_payload),
+        "workspace_guide": assistant.workspace_guide,
     }
 
 
@@ -2295,6 +2297,9 @@ def dispatch_run_to_lensnode(
                 "history": build_run_history(run),
                 "history_artifacts": history_artifacts,
                 "target_dirs": execution.target_dirs,
+                "workspace_guide": runtime_snapshot.get(
+                    "workspace_guide", ""
+                ),
                 "loaded_skills": resolve_loaded_skill_environment(
                     execution.loaded_skills
                 ),

--- a/backend/lens/skill_generation.py
+++ b/backend/lens/skill_generation.py
@@ -4,7 +4,7 @@ from .llm import run_completion
 from .models import AssistantSkill, GlobalSetting, Skill
 
 BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
-WORKSPACE_GUIDE_SUFFIX = "workspace-guide"
+WORKSPACE_GUIDE_KIND = "workspace_guide"
 WORKSPACE_GUIDE_LOAD_CONFIG = {
     "mode": "context",
     "inject": True,
@@ -85,51 +85,18 @@ def beautify_skill_content(*, content, name="", user_id=None):
     return _strip_code_fence(result.content)
 
 
-def workspace_guide_slug(assistant):
-    """Return the deterministic Workspace Guide skill slug."""
-
-    return f"{assistant.slug}-{WORKSPACE_GUIDE_SUFFIX}"
-
-
 def sync_workspace_guide_skill(assistant, workspace_guide):
-    """Create, update, or disable an assistant Workspace Guide skill."""
+    """Persist an assistant Workspace Guide and disable legacy bindings."""
 
     if workspace_guide is None:
         return None
 
     enabled = bool(workspace_guide.get("enabled"))
     content = str(workspace_guide.get("content") or "").strip()
-    slug = workspace_guide_slug(assistant)
-
-    if not enabled or not content:
-        _disable_workspace_guide_binding(assistant, slug)
-        return None
-
-    skill_md = build_workspace_guide_skill_md(content=content)
-    skill, _ = Skill.objects.update_or_create(
-        slug=slug,
-        defaults={
-            "name": f"{assistant.name} Workspace Guide",
-            "definition": {
-                "content": skill_md,
-                "description": (
-                    "Workspace structure and search guidance for "
-                    f"{assistant.name}."
-                ),
-            },
-            "version": "1",
-            "enabled": True,
-        },
-    )
-    AssistantSkill.objects.update_or_create(
-        assistant=assistant,
-        skill=skill,
-        defaults={
-            "enabled": True,
-            "load_config": WORKSPACE_GUIDE_LOAD_CONFIG,
-        },
-    )
-    return skill
+    assistant.workspace_guide = content if enabled else ""
+    assistant.save(update_fields=["workspace_guide", "updated_at"])
+    _disable_workspace_guide_binding(assistant)
+    return content
 
 
 def build_workspace_guide_skill_md(*, content):
@@ -141,10 +108,15 @@ def build_workspace_guide_skill_md(*, content):
 def get_workspace_guide_payload(assistant):
     """Return the persisted Workspace Guide payload for an assistant."""
 
-    slug = workspace_guide_slug(assistant)
+    if assistant.workspace_guide:
+        return {
+            "enabled": True,
+            "content": assistant.workspace_guide,
+        }
+
     binding = (
         assistant.skill_bindings.select_related("skill")
-        .filter(skill__slug=slug)
+        .filter(skill__kind=WORKSPACE_GUIDE_KIND)
         .first()
     )
     if binding is None:
@@ -156,17 +128,16 @@ def get_workspace_guide_payload(assistant):
         "enabled": binding.enabled,
         "content": _workspace_guide_user_content(binding.skill.definition),
         "skill_uuid": str(binding.skill.uuid),
-        "skill_slug": binding.skill.slug,
         "load_config": binding.load_config,
     }
 
 
-def _disable_workspace_guide_binding(assistant, slug):
+def _disable_workspace_guide_binding(assistant):
     """Disable an existing Workspace Guide binding if one exists."""
 
     AssistantSkill.objects.filter(
         assistant=assistant,
-        skill__slug=slug,
+        skill__kind=WORKSPACE_GUIDE_KIND,
     ).update(enabled=False)
 
 

--- a/backend/lens/skill_packages.py
+++ b/backend/lens/skill_packages.py
@@ -9,9 +9,11 @@ import shutil
 import stat
 import tempfile
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from urllib import error as urlerror
 from urllib import parse, request
+from uuid import uuid4
 
 from django.conf import settings
 from django.db import transaction
@@ -30,6 +32,7 @@ MAX_SKILL_MD_SIZE = 256 * 1024
 MAX_FILE_COUNT = 300
 MAX_GITHUB_DOWNLOAD_SIZE = MAX_ZIP_SIZE
 GITHUB_TIMEOUT_SECONDS = 30
+GITHUB_API_URL = "https://api.github.com"
 BLOCKED_PARTS = {".git", ".ssh", "__pycache__", "node_modules", ".venv"}
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,179}$")
 SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -45,6 +48,9 @@ def import_skill_zip(
     original_name="",
     source_type="upload",
     source_url="",
+    source_ref="",
+    source_path="",
+    latest_source_ref="",
     environment_override=None,
 ):
     """Validate and persist a Skill zip package."""
@@ -67,17 +73,18 @@ def import_skill_zip(
         metadata = _parse_skill_md(skill_md)
         metadata.update(_parse_sourcelens_config(skill_root))
         _apply_environment_override(metadata, environment_override)
-        slug = _slug_from_metadata(metadata)
+        package_name = _package_name_from_metadata(metadata)
         manifest = _package_manifest(skill_root)
-        package_root = skill_package_root(slug, digest)
-        existing = Skill.objects.filter(slug=slug).first()
+        existing = _find_skill_by_package_name(package_name)
+        skill_uuid = existing.uuid if existing else uuid4()
+        package_root = skill_package_root(skill_uuid, digest)
         if existing and (
             existing.package_hash != digest
             or existing.source_type != source_type
         ):
             raise SkillPackageError(
-                f"Skill slug '{slug}' already exists. "
-                "Use a different name or update it explicitly."
+                f"Skill package '{package_name}' already exists. "
+                "Use the existing Skill update action."
             )
         staged_root = package_root.with_name(f".{digest}.tmp")
         if staged_root.exists():
@@ -92,28 +99,40 @@ def import_skill_zip(
                 staged_root.rename(package_root)
                 created_package_root = True
             with transaction.atomic():
-                skill, _created = Skill.objects.update_or_create(
-                    slug=slug,
-                    defaults={
-                        "name": metadata["name"],
-                        "definition": {
-                            "description": metadata["description"],
-                            "content": metadata["content"],
-                            "skill_md": metadata["skill_md"],
-                            "environment": metadata["environment"],
-                            "api": metadata["api"],
-                            "transforms": metadata["transforms"],
-                        },
-                        "version": digest[:12],
-                        "enabled": True,
-                        "package_path": str(package_root),
-                        "package_hash": digest,
-                        "package_size": len(data),
-                        "package_manifest": manifest,
-                        "source_type": source_type,
-                        "source_url": source_url,
-                    },
+                if existing:
+                    skill = existing
+                    created = False
+                else:
+                    skill = Skill(uuid=skill_uuid)
+                    created = True
+                skill.name = metadata["name"]
+                skill.package_name = package_name
+                skill.definition = {
+                    "package_name": package_name,
+                    "description": metadata["description"],
+                    "content": metadata["content"],
+                    "skill_md": metadata["skill_md"],
+                    "environment": metadata["environment"],
+                    "api": metadata["api"],
+                    "transforms": metadata["transforms"],
+                }
+                skill.version = source_ref or digest[:12]
+                skill.enabled = True
+                skill.package_path = str(package_root)
+                skill.package_hash = digest
+                skill.package_size = len(data)
+                skill.package_manifest = manifest
+                skill.source_type = source_type
+                skill.source_url = source_url
+                skill.source_ref = source_ref
+                skill.source_path = source_path
+                skill.latest_source_ref = latest_source_ref
+                skill.source_checked_at = (
+                    datetime.now(timezone.utc)
+                    if source_type == "github"
+                    else None
                 )
+                skill.save()
         except Exception:
             shutil.rmtree(staged_root, ignore_errors=True)
             if created_package_root:
@@ -129,6 +148,9 @@ def update_skill_zip(
     original_name="",
     source_type="upload",
     source_url="",
+    source_ref="",
+    source_path="",
+    latest_source_ref="",
     environment_override=None,
 ):
     """Validate a Skill zip package and replace an existing Skill snapshot."""
@@ -154,13 +176,13 @@ def update_skill_zip(
         metadata = _parse_skill_md(skill_root / "SKILL.md")
         metadata.update(_parse_sourcelens_config(skill_root))
         _apply_environment_override(metadata, environment_override)
-        slug = _slug_from_metadata(metadata)
-        if slug != skill.slug:
+        package_name = _package_name_from_metadata(metadata)
+        if package_name != skill.package_name:
             raise SkillPackageError(
                 "Updated package Skill name must match the existing Skill."
             )
         manifest = _package_manifest(skill_root)
-        package_root = skill_package_root(slug, digest)
+        package_root = skill_package_root(skill.uuid, digest)
         staged_root = package_root.with_name(f".{digest}.tmp")
         if staged_root.exists():
             shutil.rmtree(staged_root)
@@ -176,7 +198,9 @@ def update_skill_zip(
                 created_package_root = True
             with transaction.atomic():
                 skill.name = metadata["name"]
+                skill.package_name = package_name
                 skill.definition = {
+                    "package_name": package_name,
                     "description": metadata["description"],
                     "content": metadata["content"],
                     "skill_md": metadata["skill_md"],
@@ -184,16 +208,25 @@ def update_skill_zip(
                     "api": metadata["api"],
                     "transforms": metadata["transforms"],
                 }
-                skill.version = digest[:12]
+                skill.version = source_ref or digest[:12]
                 skill.enabled = True
                 skill.package_path = str(package_root)
                 skill.package_hash = digest
                 skill.package_size = len(data)
                 skill.package_manifest = manifest
                 skill.source_url = source_url
+                skill.source_ref = source_ref
+                skill.source_path = source_path
+                skill.latest_source_ref = latest_source_ref
+                skill.source_checked_at = (
+                    datetime.now(timezone.utc)
+                    if source_type == "github"
+                    else None
+                )
                 skill.save(
                     update_fields=[
                         "name",
+                        "package_name",
                         "definition",
                         "version",
                         "enabled",
@@ -202,6 +235,10 @@ def update_skill_zip(
                         "package_size",
                         "package_manifest",
                         "source_url",
+                        "source_ref",
+                        "source_path",
+                        "latest_source_ref",
+                        "source_checked_at",
                         "updated_at",
                     ]
                 )
@@ -220,24 +257,46 @@ def update_skill_zip(
 
 
 def import_skill_from_github(url):
-    """Download a public GitHub Skill zip and import it."""
+    """Download a public GitHub repository and import its Skills."""
 
-    return _github_skill_zip(url, import_skill_zip)
+    return _github_skills_zip(url, import_skill_zip)
 
 
 def update_skill_from_github(skill, url):
-    """Download a public GitHub Skill zip and update an existing Skill."""
+    """Download one GitHub Skill directory and update it."""
 
-    return _github_skill_zip(
+    return _github_skills_zip(
         url,
         lambda **kwargs: update_skill_zip(skill, **kwargs),
+        source_path=skill.source_path,
     )
 
 
-def _github_skill_zip(url, importer):
-    """Download a public GitHub Skill zip and pass it to an importer."""
+def check_skill_github_update(skill):
+    """Refresh the latest GitHub tag metadata for one Skill."""
 
-    zip_url = _github_zip_url(url)
+    if skill.source_type != "github" or not skill.source_url:
+        return skill
+    latest_ref = _github_latest_tag(skill.source_url)
+    if not latest_ref:
+        latest_ref = skill.source_ref
+    skill.latest_source_ref = latest_ref
+    skill.source_checked_at = datetime.now(timezone.utc)
+    skill.save(update_fields=["latest_source_ref", "source_checked_at"])
+    return skill
+
+
+def _github_skills_zip(url, importer, source_path=""):
+    """Download a GitHub repository and import one or more Skill roots."""
+
+    repo_url, requested_ref, requested_path = _github_repo_parts(url)
+    latest_ref = _github_latest_tag(repo_url)
+    ref = requested_ref or latest_ref
+    if not ref:
+        raise SkillPackageError(
+            "GitHub repository must publish a tag before it can be imported."
+        )
+    zip_url = _github_zip_url(repo_url, ref)
     opener = request.build_opener(_GitHubRedirectHandler)
     req = request.Request(
         zip_url,
@@ -255,12 +314,60 @@ def _github_skill_zip(url, importer):
         raise SkillPackageError(f"GitHub download failed: {exc.reason}")
     if len(data) > MAX_GITHUB_DOWNLOAD_SIZE:
         raise SkillPackageError("GitHub skill package exceeds 50 MB.")
-    return importer(
-        file_obj=io.BytesIO(data),
-        original_name="github-skill.zip",
-        source_type="github",
-        source_url=url,
+    return _import_github_roots(
+        data,
+        importer,
+        source_url=repo_url,
+        source_ref=ref,
+        latest_source_ref=latest_ref or ref,
+        requested_path=source_path or requested_path,
     )
+
+
+def _import_github_roots(
+    data,
+    importer,
+    *,
+    source_url,
+    source_ref,
+    latest_source_ref,
+    requested_path="",
+):
+    """Import each directory containing a SKILL.md independently."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        extract_root = Path(temp_dir) / "extract"
+        extract_root.mkdir()
+        _safe_extract_zip(data, extract_root, ignore_unsafe=True)
+        roots = _find_skill_roots(extract_root, requested_path)
+        if not roots:
+            raise SkillPackageError("GitHub repository contains no SKILL.md.")
+        results = []
+        for root in roots:
+            package = io.BytesIO()
+            with zipfile.ZipFile(
+                package,
+                "w",
+                zipfile.ZIP_DEFLATED,
+            ) as archive:
+                for path in root.rglob("*"):
+                    if path.is_file():
+                        archive.write(path, path.relative_to(root).as_posix())
+            package.seek(0)
+            relative_parts = root.relative_to(extract_root).parts
+            relative_path = Path(*relative_parts[1:])
+            results.append(
+                importer(
+                    file_obj=package,
+                    original_name="github-skill.zip",
+                    source_type="github",
+                    source_url=source_url,
+                    source_ref=source_ref,
+                    source_path=relative_path.as_posix(),
+                    latest_source_ref=latest_source_ref,
+                )
+            )
+        return results
 
 
 class _GitHubRedirectHandler(request.HTTPRedirectHandler):
@@ -271,14 +378,14 @@ class _GitHubRedirectHandler(request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
-def skill_package_root(slug, package_hash):
+def skill_package_root(skill_uuid, package_hash):
     """Return persistent storage path for one Skill package snapshot."""
 
     return (
         Path(settings.STORAGE_ROOT)
         / "lens"
         / "skills"
-        / slug
+        / str(skill_uuid)
         / package_hash
     )
 
@@ -287,6 +394,7 @@ def package_zip_bytes(skill):
     """Return a downloadable zip archive for a Skill."""
 
     buffer = io.BytesIO()
+    package_name = _package_name_for_skill(skill)
     package_path = Path(skill.package_path) if skill.package_path else None
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
         if (
@@ -299,13 +407,13 @@ def package_zip_bytes(skill):
                     archive.write(
                         path,
                         str(
-                            PurePosixPath(skill.slug)
+                            PurePosixPath(package_name)
                             / path.relative_to(package_path)
                         ),
                     )
         else:
             archive.writestr(
-                f"{skill.slug}/SKILL.md",
+                f"{package_name}/SKILL.md",
                 _skill_md_from_definition(skill),
             )
             definition = skill.definition or {}
@@ -326,7 +434,7 @@ def package_zip_bytes(skill):
                         for name, transform in transforms.items()
                     }
                 archive.writestr(
-                    f"{skill.slug}/sourcelens.json",
+                    f"{package_name}/sourcelens.json",
                     json.dumps(
                         config,
                         ensure_ascii=False,
@@ -336,6 +444,17 @@ def package_zip_bytes(skill):
                 )
     buffer.seek(0)
     return buffer
+
+
+def _package_name_for_skill(skill):
+    """Return a valid external package name for a Skill snapshot."""
+
+    package_name = str(skill.package_name or "").strip().lower()
+    if SLUG_RE.match(package_name):
+        return package_name
+    package_name = re.sub(r"[^a-z0-9_-]+", "-", skill.name.lower())
+    package_name = package_name.strip("-_")
+    return package_name or f"skill-{skill.uuid}"
 
 
 def _read_limited(file_obj, limit):
@@ -354,7 +473,7 @@ def _read_limited(file_obj, limit):
     return file_obj.read(limit)
 
 
-def _safe_extract_zip(data, destination):
+def _safe_extract_zip(data, destination, ignore_unsafe=False):
     """Extract a zip after checking file count, size, and paths."""
 
     total_size = 0
@@ -375,7 +494,13 @@ def _safe_extract_zip(data, destination):
             total_size += info.file_size
             if total_size > MAX_UNPACKED_SIZE:
                 raise SkillPackageError("Skill package unpacks over 100 MB.")
-            member_path = _validate_zip_member(info)
+            try:
+                member_path = _validate_zip_member(info)
+            except SkillPackageError:
+                mode = (info.external_attr >> 16) & 0o170000
+                if ignore_unsafe and mode == 0o120000:
+                    continue
+                raise
             target = destination / member_path
             target.parent.mkdir(parents=True, exist_ok=True)
             try:
@@ -389,6 +514,9 @@ def _safe_extract_zip(data, destination):
 
         for info in archive.infolist():
             if _zip_member_is_dir(info):
+                continue
+            source_mode = (info.external_attr >> 16) & 0o170000
+            if ignore_unsafe and source_mode == 0o120000:
                 continue
             relative_path = _zip_member_path(info.filename)
             target = destination / relative_path
@@ -440,6 +568,23 @@ def _find_skill_root(extract_root):
             "Skill package must contain one SKILL.md root."
         )
     return candidates[0]
+
+
+def _find_skill_roots(extract_root, requested_path=""):
+    """Find all Skill roots in an extracted GitHub repository."""
+
+    roots = []
+    requested = PurePosixPath(requested_path) if requested_path else None
+    for skill_md in sorted(extract_root.rglob("SKILL.md")):
+        root = skill_md.parent
+        relative_parts = root.relative_to(extract_root).parts
+        relative = PurePosixPath(*relative_parts[1:])
+        if requested and not (
+            relative == requested or requested in relative.parents
+        ):
+            continue
+        roots.append(root)
+    return roots
 
 
 def _parse_skill_md(path):
@@ -684,15 +829,21 @@ def _parse_simple_frontmatter(frontmatter):
     return fields
 
 
-def _slug_from_metadata(metadata):
-    """Return validated slug from Skill metadata name."""
+def _package_name_from_metadata(metadata):
+    """Return the validated external package name from Skill metadata."""
 
-    slug = str(metadata["name"]).strip()
-    if not SLUG_RE.match(slug):
+    package_name = str(metadata["name"]).strip()
+    if not SLUG_RE.match(package_name):
         raise SkillPackageError(
             "Skill name must use lowercase letters, numbers, '-' or '_'."
         )
-    return slug
+    return package_name
+
+
+def _find_skill_by_package_name(package_name):
+    """Return the existing Skill imported from the same package name."""
+
+    return Skill.objects.filter(package_name=package_name).first()
 
 
 def _package_manifest(skill_root):
@@ -718,7 +869,61 @@ def _package_manifest(skill_root):
     }
 
 
-def _github_zip_url(value):
+def _github_repo_parts(value):
+    """Return a canonical repository URL, ref, and optional Skill path."""
+
+    parsed = parse.urlsplit(str(value or "").strip())
+    if parsed.netloc not in {"github.com", "www.github.com"}:
+        raise SkillPackageError("Only public GitHub URLs are supported.")
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        raise SkillPackageError(
+            "GitHub URL must include owner and repository."
+        )
+    owner, repo = parts[:2]
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    ref = ""
+    path = ""
+    if len(parts) >= 4 and parts[2] in {"tree", "blob"}:
+        ref = parts[3]
+        path = "/".join(parts[4:])
+    return f"https://github.com/{owner}/{repo}", ref, path
+
+
+def _github_api_json(url):
+    """Fetch public GitHub metadata with a bounded request."""
+
+    req = request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "SourceLens Skill Importer",
+        },
+    )
+    try:
+        with request.urlopen(req, timeout=GITHUB_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read(512 * 1024).decode("utf-8"))
+    except (
+        urlerror.HTTPError,
+        urlerror.URLError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise SkillPackageError("GitHub metadata request failed.") from exc
+
+
+def _github_latest_tag(repo_url):
+    """Return the newest GitHub tag, or an empty string when none exists."""
+
+    parsed = parse.urlsplit(repo_url)
+    owner, repo = parsed.path.strip("/").split("/")
+    payload = _github_api_json(
+        f"{GITHUB_API_URL}/repos/{owner}/{repo}/tags?per_page=1"
+    )
+    return str(payload[0].get("name") or "") if payload else ""
+
+
+def _github_zip_url(value, ref="main"):
     """Return a codeload GitHub zip URL from supported GitHub inputs."""
 
     parsed = parse.urlsplit(str(value or "").strip())
@@ -733,12 +938,12 @@ def _github_zip_url(value):
             "GitHub URL must include owner and repository."
         )
     owner, repo = parts[0], parts[1]
-    ref = "main"
     if len(parts) >= 4 and parts[2] in {"tree", "blob"}:
         ref = parts[3]
     elif len(parts) >= 4 and parts[2] == "archive":
         return parse.urlunsplit(parsed)
-    return f"https://codeload.github.com/{owner}/{repo}/zip/{ref}"
+    encoded_ref = parse.quote(ref, safe="")
+    return f"https://codeload.github.com/{owner}/{repo}/zip/{encoded_ref}"
 
 
 def _validate_github_download_url(value):
@@ -779,7 +984,7 @@ def _skill_md_from_definition(skill):
     )
     return (
         "---\n"
-        f"name: {skill.slug}\n"
+        f"name: {_package_name_for_skill(skill)}\n"
         f"description: {description}\n"
         "---\n\n"
         f"{str(content).strip()}\n"

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -287,7 +287,7 @@ class LensApiTests(TestCase):
         )
         self.skill = Skill.objects.create(
             name="Code Search",
-            slug="code-search",
+            package_name="code-search",
             definition={"summary": "Search code"},
         )
         self.mcp = MCPServer.objects.create(
@@ -967,7 +967,7 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 405)
         self.assertTrue(Assistant.objects.filter(uuid=self.assistant.uuid).exists())
 
-    def test_assistant_create_saves_workspace_guide_skill(self):
+    def test_assistant_create_saves_workspace_guide_context(self):
         payload = {
             "name": "Workspace Aware",
             "slug": "workspace-aware",
@@ -988,22 +988,22 @@ class LensApiTests(TestCase):
 
         self.assertEqual(response.status_code, 201)
         assistant = Assistant.objects.get(slug="workspace-aware")
-        binding = AssistantSkill.objects.get(
-            assistant=assistant,
-            skill__slug="workspace-aware-workspace-guide",
-        )
-        self.assertTrue(binding.enabled)
         self.assertEqual(
-            binding.load_config,
-            {"mode": "context", "inject": True},
+            assistant.workspace_guide,
+            "- repo is the primary application repository.",
+        )
+        self.assertFalse(
+            assistant.skill_bindings.filter(
+                skill__kind="workspace_guide",
+            ).exists()
         )
         self.assertIn(
             "repo is the primary application repository",
-            binding.skill.definition["content"],
+            response.data["workspace_guide"]["content"],
         )
         self.assertTrue(response.data["workspace_guide"]["enabled"])
 
-    def test_assistant_update_disables_workspace_guide_binding(self):
+    def test_assistant_update_clears_workspace_guide_context(self):
         create_response = self.client.post(
             "/api/lens/assistants/",
             {
@@ -1033,11 +1033,44 @@ class LensApiTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        binding = AssistantSkill.objects.get(
-            assistant__uuid=create_response.data["uuid"],
-            skill__slug="workspace-aware-workspace-guide",
+        assistant = Assistant.objects.get(uuid=create_response.data["uuid"])
+        self.assertEqual(assistant.workspace_guide, "")
+
+    def test_assistant_saves_workspace_guide_as_assistant_context(self):
+        response = self.client.post(
+            "/api/lens/assistants/",
+            {
+                "name": "General Chat Guide",
+                "slug": "general-chat-guide",
+                "lensnode_uuid": str(self.lensnode.uuid),
+                "selected_task": "general_chat",
+                "skill_bindings": [
+                    {"skill_uuid": str(self.skill.uuid)},
+                ],
+                "workspace_guide": {
+                    "enabled": True,
+                    "content": "Use the engineering workspace guide.",
+                },
+            },
+            format="json",
         )
-        self.assertFalse(binding.enabled)
+
+        self.assertEqual(response.status_code, 201)
+        assistant = Assistant.objects.get(slug="general-chat-guide")
+        self.assertEqual(
+            assistant.workspace_guide,
+            "Use the engineering workspace guide.",
+        )
+        self.assertFalse(
+            assistant.skill_bindings.filter(
+                skill__kind="workspace_guide",
+                enabled=True,
+            ).exists()
+        )
+        self.assertEqual(
+            response.data["workspace_guide"]["content"],
+            "Use the engineering workspace guide.",
+        )
 
     def test_global_setting_accepts_skill_generator_model_ref(self):
         response = self.client.post(
@@ -1123,7 +1156,6 @@ class LensApiTests(TestCase):
             "/api/lens/admin/skills/",
             {
                 "name": "Jira Connector",
-                "slug": "jira-connector",
                 "definition": {"content": "Use Jira.", "environment": []},
             },
             format="json",
@@ -1140,7 +1172,7 @@ class LensApiTests(TestCase):
     ):
         legacy_skill = Skill.objects.create(
             name="Legacy Skill",
-            slug="legacy-skill",
+            package_name="legacy-skill",
             definition={"content": "Old instructions."},
         )
 
@@ -1292,7 +1324,7 @@ class LensApiTests(TestCase):
                 )
 
                 self.assertEqual(response.status_code, 200)
-                skill = Skill.objects.get(slug="winrar-skill")
+                skill = Skill.objects.get(package_name="winrar-skill")
                 self.assertTrue(
                     Path(skill.package_path)
                     .joinpath("scripts", "run.sh")
@@ -1390,7 +1422,7 @@ class LensApiTests(TestCase):
             response.data["detail"],
             "Environment variables must be valid JSON.",
         )
-        self.assertFalse(Skill.objects.filter(slug="jira-connector").exists())
+        self.assertFalse(Skill.objects.filter(package_name="jira-connector").exists())
 
     def test_uploaded_skill_reads_api_access_policy(self):
         environment = [
@@ -1448,7 +1480,7 @@ class LensApiTests(TestCase):
                 )
 
                 self.assertEqual(response.status_code, 200)
-                skill = Skill.objects.get(slug="script-permissions")
+                skill = Skill.objects.get(package_name="script-permissions")
                 package_root = Path(skill.package_path)
                 self.assertEqual(
                     (package_root / "scripts/nested/run").stat().st_mode & 0o777,
@@ -1499,7 +1531,7 @@ class LensApiTests(TestCase):
                     saved_transform["sha256"],
                     hashlib.sha256(b"import json, sys\n").hexdigest(),
                 )
-                skill = Skill.objects.get(slug="order-transform")
+                skill = Skill.objects.get(package_name="order-transform")
                 with zipfile.ZipFile(package_zip_bytes(skill)) as archive:
                     config = json.loads(
                         archive.read("order-transform/sourcelens.json").decode("utf-8")
@@ -1637,7 +1669,7 @@ class LensApiTests(TestCase):
     def test_uploaded_skill_update_preserves_assistant_binding(self):
         skill = Skill.objects.create(
             name="package-skill",
-            slug="package-skill",
+            package_name="package-skill",
             definition={"content": "old"},
             source_type="upload",
         )
@@ -1670,7 +1702,7 @@ class LensApiTests(TestCase):
     def test_uploaded_skill_update_accepts_environment_schema_override(self):
         skill = Skill.objects.create(
             name="package-skill",
-            slug="package-skill",
+            package_name="package-skill",
             definition={"content": "old", "environment": []},
             source_type="upload",
         )

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -915,7 +915,7 @@ class LensServiceTests(TransactionTestCase):
     def test_dispatch_refreshes_skill_package_snapshot(self):
         skill = Skill.objects.create(
             name="Packaged Skill",
-            slug="packaged-skill",
+            package_name="packaged-skill",
             package_hash="sha256:old",
         )
         AssistantSkill.objects.create(
@@ -1430,6 +1430,36 @@ class LensServiceTests(TransactionTestCase):
         )
         self.assertEqual(payload["answer_language"], "zh-CN")
         self.assertEqual(payload["settings"], {"runtime_mode": "original"})
+
+    @patch("lens.services.async_to_sync")
+    @patch("lens.services.get_channel_layer")
+    def test_dispatch_uses_workspace_guide_runtime_snapshot(
+        self,
+        get_channel_layer,
+        mock_async_to_sync,
+    ):
+        sender = mock_async_to_sync.return_value
+        self.assistant.workspace_guide = "Use the frozen workspace guide."
+        self.assistant.save(update_fields=["workspace_guide"])
+        run = create_execution_run(
+            session=self.session,
+            question="Use the guide",
+            enqueue=False,
+        )
+
+        self.assistant.workspace_guide = "This must not affect the Run."
+        self.assistant.save(update_fields=["workspace_guide"])
+        dispatch_run_to_lensnode(run, "Use the guide")
+
+        payload = sender.call_args.args[1]["payload"]
+        self.assertEqual(
+            run.execution.runtime_snapshot["workspace_guide"],
+            "Use the frozen workspace guide.",
+        )
+        self.assertEqual(
+            payload["workspace_guide"],
+            "Use the frozen workspace guide.",
+        )
 
     @patch("lens.services.async_to_sync")
     @patch("lens.services.get_channel_layer")

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -366,7 +366,7 @@ class LensNodeSkillPackageView(LensNodeAuthMixin, APIView):
         response = FileResponse(
             archive,
             as_attachment=True,
-            filename=f"{skill.slug or skill.uuid}.zip",
+            filename=f"{skill.uuid}.zip",
             content_type="application/zip",
         )
         response["X-Skill-Package-Hash"] = skill.package_hash

--- a/backend/lens/views/skills.py
+++ b/backend/lens/views/skills.py
@@ -1,7 +1,9 @@
 """Skill and MCP server management views."""
 
 import json
+import mimetypes
 import shutil
+from pathlib import Path, PurePosixPath
 
 from django.db import transaction
 from django.http import FileResponse
@@ -20,6 +22,7 @@ from lens.skill_generation import (
 )
 from lens.skill_packages import (
     SkillPackageError,
+    check_skill_github_update,
     import_skill_from_github,
     import_skill_zip,
     package_zip_bytes,
@@ -66,10 +69,91 @@ class SkillViewSet(BaseAdminViewSet):
                 "skill": {
                     "uuid": str(skill.uuid),
                     "name": skill.name,
-                    "slug": skill.slug,
+                    "kind": skill.kind,
                 },
                 "bound_count": len(assistants),
                 "bound_assistants": assistants,
+            }
+        )
+
+    @action(detail=True, methods=["get"], url_path="file-preview")
+    def file_preview(self, request, *args, **kwargs):
+        """Return a bounded UTF-8 preview for a package text file."""
+
+        skill = self.get_object()
+        relative_path = str(request.query_params.get("path") or "").strip()
+        try:
+            path = PurePosixPath(relative_path)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "A valid package file path is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not relative_path or path.is_absolute() or ".." in path.parts:
+            return Response(
+                {"detail": "A valid package file path is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        package_root = Path(skill.package_path or "").resolve()
+        file_path = (package_root / Path(*path.parts)).resolve()
+        if package_root not in file_path.parents or not file_path.is_file():
+            return Response(
+                {"detail": "Package file was not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if file_path.stat().st_size > 512 * 1024:
+            return Response(
+                {"detail": "This file is too large to preview."},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        content_type = mimetypes.guess_type(file_path.name)[0] or ""
+        text_types = {
+            "application/json",
+            "application/javascript",
+            "application/xml",
+            "application/yaml",
+            "text/css",
+            "text/csv",
+            "text/html",
+            "text/javascript",
+            "text/markdown",
+            "text/plain",
+            "text/xml",
+        }
+        if content_type not in text_types and file_path.suffix.lower() not in {
+            ".conf",
+            ".env",
+            ".ini",
+            ".js",
+            ".json",
+            ".md",
+            ".py",
+            ".sh",
+            ".sql",
+            ".toml",
+            ".ts",
+            ".tsx",
+            ".txt",
+            ".vue",
+            ".yaml",
+            ".yml",
+        }:
+            return Response(
+                {"detail": "This file type is not supported for preview."},
+                status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            )
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return Response(
+                {"detail": "This file cannot be decoded for preview."},
+                status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            )
+        return Response(
+            {
+                "path": relative_path,
+                "content": content,
+                "content_type": content_type or "text/plain",
             }
         )
 
@@ -147,6 +231,20 @@ class SkillViewSet(BaseAdminViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(self.get_serializer(skill).data)
+
+    @action(detail=False, methods=["post"], url_path="check-updates")
+    def check_updates(self, request):
+        """Refresh GitHub tag metadata for all imported Skills."""
+
+        skills = self.get_queryset().filter(source_type="github")
+        for skill in skills:
+            try:
+                check_skill_github_update(skill)
+            except SkillPackageError:
+                continue
+        return Response(
+            self.get_serializer(self.get_queryset(), many=True).data
+        )
 
     def _bound_assistants(self, skill):
         """Return compact assistant data for delete confirmation."""
@@ -247,7 +345,7 @@ class SkillViewSet(BaseAdminViewSet):
                 {"detail": str(exc)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        return Response(self.get_serializer(skill).data)
+        return Response(self.get_serializer(skill, many=True).data)
 
     @action(detail=True, methods=["get"], url_path="download")
     def download(self, request, *args, **kwargs):
@@ -258,7 +356,7 @@ class SkillViewSet(BaseAdminViewSet):
         return FileResponse(
             archive,
             as_attachment=True,
-            filename=f"{skill.slug}.zip",
+            filename=f"{skill.uuid}.zip",
         )
 
     @action(detail=False, methods=["post"])

--- a/frontend/src/admin/layout/AdminHeader.vue
+++ b/frontend/src/admin/layout/AdminHeader.vue
@@ -208,7 +208,6 @@ const pageTitle = computed(() => {
     LensNodes: t('lensAdmin.pages.lensnodes.title'),
     LensDataSources: t('lensAdmin.pages.datasources.title'),
     LensCredentials: t('lensAdmin.pages.credentials.title'),
-    LensEnvironmentVariables: t('lensAdmin.pages.environmentVariables.title'),
     LensSkills: t('lensAdmin.pages.skills.title'),
     LensMcp: t('lensAdmin.pages.mcp.title'),
     LensResourceSettings: t('lensAdmin.pages.resourceSettings.title'),

--- a/frontend/src/admin/layout/AdminSidebar.vue
+++ b/frontend/src/admin/layout/AdminSidebar.vue
@@ -371,38 +371,6 @@
                 <span>{{ t('lensAdmin.pages.credentials.title') }}</span>
               </router-link>
               <router-link
-                to="/management/lens/resources/environment-variables"
-                class="admin-nav-item admin-nav-item-child"
-                :class="
-                  isActive('/management/lens/resources/environment-variables')
-                    ? 'admin-nav-item-active'
-                    : ''
-                "
-                @click="isMobile && $emit('close')"
-                @mouseenter="
-                  preloadRoute(
-                    '/management/lens/resources/environment-variables'
-                  )
-                "
-              >
-                <svg
-                  class="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 6h16M4 12h16M4 18h10"
-                  />
-                </svg>
-                <span>{{
-                  t('lensAdmin.pages.environmentVariables.title')
-                }}</span>
-              </router-link>
-              <router-link
                 to="/management/lens/resources/skills"
                 class="admin-nav-item admin-nav-item-child"
                 :class="
@@ -1148,14 +1116,16 @@ const clearAssistantReturnPath = () => {
 
 const navigation = ref(null)
 const activeMenu = computed(() => getAdminSidebarMenu(route.path))
-const openMenu = ref(activeMenu.value)
-const userManagementMenuOpen = computed(() => openMenu.value === 'users')
-const lensMenuOpen = computed(() => openMenu.value === 'lens')
-const dataManagementMenuOpen = computed(() => openMenu.value === 'data')
-const llmMenuOpen = computed(() => openMenu.value === 'llm')
-const taskManagementMenuOpen = computed(() => openMenu.value === 'tasks')
-const notificationManagementMenuOpen = computed(
-  () => openMenu.value === 'notifications'
+const openMenus = ref(
+  activeMenu.value ? new Set([activeMenu.value]) : new Set()
+)
+const userManagementMenuOpen = computed(() => openMenus.value.has('users'))
+const lensMenuOpen = computed(() => openMenus.value.has('lens'))
+const dataManagementMenuOpen = computed(() => openMenus.value.has('data'))
+const llmMenuOpen = computed(() => openMenus.value.has('llm'))
+const taskManagementMenuOpen = computed(() => openMenus.value.has('tasks'))
+const notificationManagementMenuOpen = computed(() =>
+  openMenus.value.has('notifications')
 )
 
 const { isMobile } = useIsMobile()
@@ -1204,13 +1174,13 @@ const isActive = (path) => {
 }
 
 const parentActiveClass = (menu) => {
-  return activeMenu.value === menu && openMenu.value !== menu
+  return activeMenu.value === menu && !openMenus.value.has(menu)
     ? 'admin-nav-item-parent-active'
     : ''
 }
 
 const toggleMenu = (menu) => {
-  openMenu.value = toggleAdminSidebarMenu(openMenu.value, menu)
+  openMenus.value = new Set(toggleAdminSidebarMenu(openMenus.value, menu))
 }
 
 const toggleUserManagementMenu = () => toggleMenu('users')
@@ -1224,7 +1194,7 @@ watch(
   () => route.path,
   async (newPath) => {
     const routeMenu = getAdminSidebarMenu(newPath)
-    if (routeMenu) openMenu.value = routeMenu
+    if (routeMenu) openMenus.value = new Set([routeMenu])
 
     if (navigation.value) {
       await nextTick()

--- a/frontend/src/admin/layout/adminSidebarState.js
+++ b/frontend/src/admin/layout/adminSidebarState.js
@@ -25,6 +25,12 @@ export const getAdminSidebarMenu = (path) => {
   )
 }
 
-export const toggleAdminSidebarMenu = (openMenu, selectedMenu) => {
-  return openMenu === selectedMenu ? null : selectedMenu
+export const toggleAdminSidebarMenu = (openMenus, selectedMenu) => {
+  const nextMenus = new Set(openMenus || [])
+  if (nextMenus.has(selectedMenu)) {
+    nextMenus.delete(selectedMenu)
+  } else {
+    nextMenus.add(selectedMenu)
+  }
+  return [...nextMenus]
 }

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -915,7 +915,7 @@
       },
       "skills": {
         "title": "Skill Library",
-        "description": "Manage reusable Skill resources that Assistants can load.",
+        "description": "Manage reusable Skills that Assistants can load, with source, version, and status at a glance.",
         "label": "Skill",
         "action": "Create Skill"
       },
@@ -945,6 +945,14 @@
       "environmentPlaceholderHint": "Reference a declared variable in the endpoint or Config with {placeholder}. SourceLens expands it only in the private per-Run MCP configuration."
     },
     "skills": {
+      "searchPlaceholder": "Search name, slug, description, or source",
+      "allSources": "All sources",
+      "allStatuses": "All statuses",
+      "version": "Version",
+      "uuid": "Identifier",
+      "updatedAt": "Updated",
+      "noDescription": "No description",
+      "noFilterResults": "No Skills match the current filters",
       "beautify": "Beautify",
       "beautifyHint": "Polish or generate the SKILL.md with the configured generator model",
       "beautifySuccess": "Content beautified",
@@ -977,6 +985,7 @@
       "importGithubHelp": "Skill name, description, and content will be read from the repository SKILL.md.",
       "githubUrl": "GitHub URL",
       "githubUrlHelp": "Use a public GitHub repository URL that contains a standard SKILL.md package.",
+      "updateAvailable": "Update available",
       "updateGithubHelp": "Re-import this Skill from the same source type while keeping assistant bindings.",
       "importSuccess": "Skill imported",
       "importFailed": "Skill import failed",
@@ -1024,10 +1033,10 @@
         "githubUrlRequired": "Enter a GitHub URL.",
         "githubPublicOnly": "Only public GitHub URLs are supported.",
         "githubRepositoryRequired": "The GitHub URL must include an owner and repository.",
+        "githubTagRequired": "The GitHub repository must publish a tag before it can be imported.",
         "githubUnsafeRedirect": "The GitHub download redirected to an unsafe host.",
         "environmentInvalid": "The Skill environment variable configuration is invalid. Check variable names, formats, and duplicates.",
         "generatorNotConfigured": "Configure a Skill generator model in Settings first.",
-        "skillSlugExists": "A Skill with this name already exists.",
         "githubDownloadFailed": "Failed to download the Skill from GitHub.",
         "transformInvalid": "The Skill Transform configuration is invalid. Check entrypoints, input formats, and environment declarations in sourcelens.json.",
         "apiPolicyInvalid": "The Skill API policy is invalid. Check base_url_env, routes, and request methods.",
@@ -1065,7 +1074,21 @@
       "hideValues": "Hide values"
     },
     "skillDetail": {
-      "title": "Skill Detail"
+      "title": "Skill Detail",
+      "descriptionZh": "Chinese description",
+      "descriptionZhPlaceholder": "Describe in Chinese what this Skill is useful for",
+      "sourceInfo": "Source information",
+      "sourceInfoHint": "Review the Skill source, version, and import path.",
+      "openSource": "Open source",
+      "sourceRef": "Source version",
+      "sourcePath": "Source path",
+      "environment": "Environment declarations",
+      "files": "Files",
+      "filesHint": "Select a file to view the saved read-only preview.",
+      "fileUnit": "files",
+      "previewHint": "SKILL.md is rendered as Markdown.",
+      "readOnly": "Read-only preview",
+      "filePreviewUnavailable": "This file cannot be previewed online. Download the Skill package to inspect it."
     },
     "assistantTypes": {
       "knowledgeQa": "Knowledge Q&A",
@@ -1645,8 +1668,8 @@
       "step3Desc": "Bind Skills and MCP, and add workspace context — all optional",
       "step4Title": "Access",
       "step4Desc": "Set visibility and choose which groups or users can access it",
-      "contextLabel": "Workspace Context (optional)",
-      "contextHint": "Write what the model cannot infer from reading code alone: business background, team conventions, search priorities, and directories to avoid.",
+      "contextLabel": "Workspace Guide (optional)",
+      "contextHint": "Tell the Assistant about workspace structure, business context, team conventions, search priorities, and directories to avoid. It is injected as this Assistant's private context after saving.",
       "contextPlaceholder": "# Information the model can't know just from reading code — write it here.\n\n## Project overview\n# SourceLens is a self-hosted AI code Q&A platform.\n# backend/ is the Django REST API; lensnode/ is a separately deployed execution node\n# that runs Deep Agents and pushes results back to the main service via WebSocket.\n# frontend/ is the Vue 3 admin console; it only talks to backend/ REST APIs.\n\n## Search priorities\n# Business logic lives in backend/lens/. backend/agentcore/ is a git submodule — don't look for business code there.\n# Frontend pages: frontend/src/pages/lens/. Admin components: frontend/src/admin/.\n# Agent behavior: lensnode/lensnode/agent_runtime.py.\n\n## Avoid misreading\n# references/ contains reference documents, not source code — don't analyze it as code.\n# For current field structure, read the latest migration only, not historical ones.",
       "back": "Back",
       "next": "Next",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -915,7 +915,7 @@
       },
       "skills": {
         "title": "Skill 资源库",
-        "description": "维护可被 Assistant 加载的全局 Skill 资源。",
+        "description": "维护可被 Assistant 加载的全局 Skill 资源，按来源、版本和状态快速定位。",
         "label": "Skill",
         "action": "新建 Skill"
       },
@@ -945,6 +945,14 @@
       "environmentPlaceholderHint": "可在 Endpoint 或 Config 中使用 {placeholder} 引用已声明变量；SourceLens 只会在每次 Run 的私有 MCP 配置中解析。"
     },
     "skills": {
+      "searchPlaceholder": "搜索名称、Slug、描述或来源",
+      "allSources": "全部来源",
+      "allStatuses": "全部状态",
+      "version": "版本",
+      "uuid": "唯一标识",
+      "updatedAt": "最近更新",
+      "noDescription": "暂无描述",
+      "noFilterResults": "没有符合当前筛选条件的 Skill",
       "beautify": "一键美化",
       "beautifyHint": "使用已配置的 Skill 生成模型润色 / 生成 SKILL.md 内容",
       "beautifySuccess": "已生成美化内容",
@@ -977,6 +985,7 @@
       "importGithubHelp": "Skill 名称、描述和内容会从仓库内的 SKILL.md 读取。",
       "githubUrl": "GitHub URL",
       "githubUrlHelp": "请输入公开 GitHub 仓库 URL，仓库内需要包含标准 SKILL.md 包结构。",
+      "updateAvailable": "有可用更新",
       "updateGithubHelp": "从相同来源类型重新导入当前 Skill，并保留已有助手绑定。",
       "importSuccess": "Skill 导入成功",
       "importFailed": "Skill 导入失败",
@@ -1024,10 +1033,10 @@
         "githubUrlRequired": "请输入 GitHub URL。",
         "githubPublicOnly": "仅支持公开的 GitHub URL。",
         "githubRepositoryRequired": "GitHub URL 必须包含所有者和仓库名。",
+        "githubTagRequired": "GitHub 仓库必须先发布 tag 才能导入 Skill。",
         "githubUnsafeRedirect": "GitHub 下载被重定向到不安全的主机。",
         "environmentInvalid": "Skill 环境变量配置无效，请检查变量名称、格式和重复项。",
         "generatorNotConfigured": "请先在设置中配置 Skill 生成模型。",
-        "skillSlugExists": "已存在同名 Skill。",
         "githubDownloadFailed": "从 GitHub 下载 Skill 失败。",
         "transformInvalid": "Skill Transform 配置无效，请检查 sourcelens.json 中的入口、输入格式和环境变量声明。",
         "apiPolicyInvalid": "Skill API 策略无效，请检查 base_url_env、路由和请求方法。",
@@ -1065,7 +1074,21 @@
       "hideValues": "隐藏变量值"
     },
     "skillDetail": {
-      "title": "Skill 详情"
+      "title": "Skill 详情",
+      "descriptionZh": "中文描述",
+      "descriptionZhPlaceholder": "用中文说明这个 Skill 适合处理什么问题",
+      "sourceInfo": "来源信息",
+      "sourceInfoHint": "查看 Skill 的来源、版本和导入路径。",
+      "openSource": "打开来源",
+      "sourceRef": "来源版本",
+      "sourcePath": "来源路径",
+      "environment": "环境变量声明",
+      "files": "文件资源",
+      "filesHint": "选择文件查看当前已保存的只读预览。",
+      "fileUnit": "个文件",
+      "previewHint": "SKILL.md 以渲染后的 Markdown 形式展示。",
+      "readOnly": "只读预览",
+      "filePreviewUnavailable": "该文件暂不支持在线预览，请下载 Skill 包查看。"
     },
     "assistantTypes": {
       "knowledgeQa": "知识问答",
@@ -1645,8 +1668,8 @@
       "step3Desc": "绑定 Skills 与 MCP，并补充工作区背景，均为可选",
       "step4Title": "授权",
       "step4Desc": "设置可见性，并指定可访问该助手的组或用户",
-      "contextLabel": "工作区背景（可选）",
-      "contextHint": "把模型仅凭读代码无法知道的信息写在这里：业务背景、团队约定、检索优先级、禁止参考的目录。",
+      "contextLabel": "工作区指引（可选）",
+      "contextHint": "用于告诉 Assistant 工作区目录结构、业务背景、团队约定、检索优先级和需要避开的目录。保存后会作为该 Assistant 的专属上下文注入。",
       "contextPlaceholder": "# 模型不读代码就不知道的信息，写在这里能让它更快、更准。\n\n## 项目说明\n# SourceLens 是一个私有部署的 AI 代码问答平台。\n# backend/ 是 Django REST API 主服务；lensnode/ 是独立部署的执行节点，\n# 负责运行 Deep Agent 并通过 WebSocket 把结果推回主服务。\n# frontend/ 是 Vue 3 管理台，只和 backend/ 的 REST API 通信。\n\n## 检索优先级\n# 业务逻辑找 backend/lens/；backend/agentcore/ 是 git 子模块，不要在那里找业务代码。\n# 前端页面在 frontend/src/pages/lens/，管理台组件在 frontend/src/admin/。\n# lensnode 的 agent 行为看 lensnode/lensnode/agent_runtime.py。\n\n## 避免误判\n# references/ 是参考文档，不是源码，不要当作代码分析对象。\n# backend/lens/migrations/ 只看最新迁移文件，不要从历史迁移推断当前字段结构。",
       "back": "上一步",
       "next": "下一步",

--- a/frontend/src/admin/routes.js
+++ b/frontend/src/admin/routes.js
@@ -63,12 +63,6 @@ export const adminRoutes = [
     meta: { requiresAuth: true, requiredFeature: 'admin_console' }
   },
   {
-    path: '/management/lens/resources/environment-variables',
-    name: 'LensEnvironmentVariables',
-    component: () => import('@/pages/lens/EnvironmentVariables.vue'),
-    meta: { requiresAuth: true, requiredFeature: 'admin_console' }
-  },
-  {
     path: '/management/lens/resources/skills',
     name: 'LensSkills',
     component: () => import('@/pages/lens/Skills.vue'),

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -540,11 +540,23 @@ export async function updateGithubSkill(uuid, url) {
   return unwrapResponse(response)
 }
 
+export async function checkSkillUpdates() {
+  const response = await api.post('/lens/admin/skills/check-updates/')
+  return unwrapResponse(response)
+}
+
 export async function downloadSkill(uuid) {
   const response = await api.get(`/lens/admin/skills/${uuid}/download/`, {
     responseType: 'blob'
   })
   return response
+}
+
+export async function previewSkillFile(uuid, path) {
+  const response = await api.get(`/lens/admin/skills/${uuid}/file-preview/`, {
+    params: { path }
+  })
+  return unwrapResponse(response)
 }
 
 export async function beautifySkill(payload) {

--- a/frontend/src/assets/css/main.css
+++ b/frontend/src/assets/css/main.css
@@ -184,8 +184,8 @@
     position: relative;
   }
 
-  input[type='checkbox'],
-  input[type='radio'] {
+  input[type='checkbox']:not(.sr-only),
+  input[type='radio']:not(.sr-only) {
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
     appearance: none !important;
@@ -200,36 +200,22 @@
     accent-color: var(--sl-accent) !important;
   }
 
-  input[type='checkbox'] {
+  input[type='checkbox']:not(.sr-only) {
     border-radius: 0.25rem !important;
   }
 
-  input[type='radio'] {
+  input[type='radio']:not(.sr-only) {
     border-radius: 50% !important;
   }
 
-  input[type='checkbox']:checked,
-  input[type='radio']:checked {
+  input[type='checkbox']:not(.sr-only):checked,
+  input[type='radio']:not(.sr-only):checked {
     background-color: var(--sl-accent) !important;
     background-image: none !important;
     border-color: var(--sl-accent) !important;
   }
 
-  input[type='checkbox']:checked::before {
-    content: '' !important;
-    position: absolute !important;
-    left: 50% !important;
-    top: 50% !important;
-    box-sizing: border-box !important;
-    width: 5px !important;
-    height: 9px !important;
-    border: solid var(--sl-on-accent) !important;
-    border-width: 0 2px 2px 0 !important;
-    transform: translate(-50%, -58%) rotate(45deg) !important;
-    display: block !important;
-  }
-
-  input[type='radio']:checked::before {
+  input[type='radio']:not(.sr-only):checked::before {
     content: '' !important;
     position: absolute !important;
     left: 50% !important;
@@ -242,16 +228,16 @@
     display: block !important;
   }
 
-  input[type='checkbox']:disabled,
-  input[type='radio']:disabled {
+  input[type='checkbox']:not(.sr-only):disabled,
+  input[type='radio']:not(.sr-only):disabled {
     background-color: var(--sl-form-disabled-bg) !important;
     border-color: var(--sl-form-border) !important;
     opacity: 0.6 !important;
     cursor: not-allowed !important;
   }
 
-  input[type='checkbox']:disabled:checked,
-  input[type='radio']:disabled:checked {
+  input[type='checkbox']:not(.sr-only):disabled:checked,
+  input[type='radio']:not(.sr-only):disabled:checked {
     background-color: var(--sl-accent) !important;
     border-color: var(--sl-accent) !important;
     opacity: 0.7 !important;

--- a/frontend/src/components/ui/BaseDrawer.vue
+++ b/frontend/src/components/ui/BaseDrawer.vue
@@ -122,7 +122,8 @@ const widthClass = computed(() => {
     md: 'max-w-md',
     lg: 'max-w-lg',
     xl: 'max-w-xl',
-    '2xl': 'max-w-2xl'
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl'
   }
   return map[props.width] ?? 'max-w-2xl'
 })

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -3,6 +3,7 @@
     :show="show"
     :title="drawerTitle"
     :subtitle="drawerSubtitle"
+    width="3xl"
     @close="$emit('close')"
   >
     <!-- Wizard step indicator -->
@@ -308,7 +309,7 @@
     <!-- Wizard Step 3 — Workspace, Skills, Environment & MCP -->
     <div v-else-if="wizardStep === 3" class="space-y-5">
       <p class="text-sm text-ink-500">{{ t('lensAdmin.wizard.step3Desc') }}</p>
-      <div v-if="!isGeneralChatTask">
+      <div>
         <span class="text-sm font-medium text-ink-700">{{
           t('lensAdmin.wizard.contextLabel')
         }}</span>
@@ -410,12 +411,9 @@
                     >
                       {{ skill.name }}
                     </div>
-                    <StatusBadge
-                      :status="skill.enabled ? 'enabled' : 'disabled'"
-                    />
                   </div>
-                  <div class="truncate font-mono text-xs text-ink-400">
-                    {{ skill.slug }}
+                  <div class="truncate text-xs text-ink-400">
+                    {{ skill.package_name || skill.uuid }}
                   </div>
                   <p
                     v-if="skillDescription(skill)"
@@ -444,17 +442,7 @@
                       {{ t('lensAdmin.wizard.environmentRequired') }}
                     </span>
                   </div>
-                  <p class="mt-1 text-[11px] leading-4 text-ink-500">
-                    {{ t('lensAdmin.wizard.environmentSectionHint') }}
-                  </p>
                   <div class="mt-2 space-y-2.5">
-                    <p class="text-[11px] leading-4 text-ink-500">
-                      {{
-                        t('lensAdmin.wizard.environmentConfigurationHint', {
-                          count: skillEnvironment(skill).length
-                        })
-                      }}
-                    </p>
                     <BaseSelect
                       v-model="form.skill_environment_set_uuids[skill.uuid]"
                       class="text-xs"
@@ -474,17 +462,6 @@
                         {{ variableSet.name }}
                       </option>
                     </BaseSelect>
-                    <EnvironmentSetValues
-                      v-if="
-                        form.skill_environment_set_uuids[skill.uuid] &&
-                        form.skill_environment_set_uuids[skill.uuid] !==
-                          '__new__'
-                      "
-                      :variable-set="selectedEnvironmentSet(skill.uuid)"
-                      :allowed-keys="
-                        skillEnvironment(skill).map((item) => item.name)
-                      "
-                    />
                     <p
                       v-if="!form.skill_environment_set_uuids[skill.uuid]"
                       class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 text-[11px] leading-4 text-primary-700"
@@ -538,12 +515,6 @@
                               *</span
                             >
                           </label>
-                          <span
-                            v-if="environmentItemSaved(skill, item)"
-                            class="text-[11px] text-success-700"
-                          >
-                            {{ t('lensAdmin.wizard.environmentConfigured') }}
-                          </span>
                         </div>
                         <input
                           v-model="
@@ -1076,7 +1047,11 @@ import {
   environmentConfigurationComplete,
   mcpRequiredEnvironmentNames
 } from './assistantEnvironment'
-import { filterSelectableSkills, skillDescription } from './assistantSkills'
+import {
+  filterSelectableSkills,
+  skillDescription,
+  sortSkillsBySelection
+} from './assistantSkills'
 
 const props = defineProps({
   show: Boolean,
@@ -1565,7 +1540,10 @@ const selectableSkills = computed(() =>
 )
 
 const filteredSelectableSkills = computed(() =>
-  filterSelectableSkills(props.skills, skillSearch.value)
+  sortSkillsBySelection(
+    filterSelectableSkills(props.skills, skillSearch.value),
+    props.form.skill_uuids
+  )
 )
 
 const enabledEnvironmentVariableSets = computed(() =>
@@ -1599,10 +1577,6 @@ function selectedEnvironmentSet(skillUuid) {
   return props.environmentVariableSets.find(
     (variableSet) => variableSet.uuid === selectedUuid
   )
-}
-
-function environmentItemSaved(skill, item) {
-  return (selectedEnvironmentSet(skill.uuid)?.keys || []).includes(item.name)
 }
 
 function environmentInputPlaceholder(item) {

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -356,6 +356,7 @@ import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 import AssistantDetailDrawer from './AssistantDetailDrawer.vue'
 import AssistantFormDrawer from './AssistantFormDrawerDirectEnvironment.vue'
+import { buildWorkspaceGuidePayload } from './assistantWorkspaceGuide'
 import {
   buildMcpEnvironmentBinding,
   buildSkillEnvironmentBinding
@@ -616,11 +617,7 @@ function defaultForm() {
 
 function workspaceGuideSkillUuids() {
   return new Set(
-    skills.value
-      .filter(
-        (s) => typeof s.slug === 'string' && s.slug.endsWith('-workspace-guide')
-      )
-      .map((s) => s.uuid)
+    skills.value.filter((s) => s.kind === 'workspace_guide').map((s) => s.uuid)
   )
 }
 
@@ -746,8 +743,7 @@ function buildPayload() {
     multimodal_model_ref: form.value.multimodal_model_ref || null,
     settings: buildAssistantSettings(),
     workspace_guide: {
-      enabled: form.value.selected_task !== 'general_chat' && !!guideContent,
-      content: guideContent
+      ...buildWorkspaceGuidePayload({ content: guideContent })
     },
     skill_bindings: (form.value.skill_uuids || []).map((uuid) => {
       const skill = skills.value.find((item) => item.uuid === uuid) || {

--- a/frontend/src/pages/lens/Skills.vue
+++ b/frontend/src/pages/lens/Skills.vue
@@ -39,7 +39,7 @@
           </div>
         </div>
 
-        <div class="px-5 py-4">
+        <div class="space-y-4 px-5 py-4">
           <BaseLoading v-if="loading && skills.length === 0" />
 
           <div
@@ -51,103 +51,166 @@
             </p>
           </div>
 
-          <div
-            v-else
-            class="relative overflow-x-auto rounded-lg border border-line bg-surface"
-          >
-            <table
-              class="w-full min-w-[56rem] table-fixed divide-y divide-line"
+          <div v-else class="space-y-4">
+            <div
+              class="flex flex-col gap-3 rounded-lg border border-line bg-surface-sunken p-3 md:flex-row md:items-center"
             >
-              <colgroup>
-                <col />
-                <col class="w-44" />
-                <col class="w-28" />
-                <col class="w-24" />
-                <col class="w-52" />
-              </colgroup>
-              <thead class="bg-surface-sunken">
-                <tr>
-                  <th
-                    v-for="column in columns"
-                    :key="column"
-                    class="table-head"
-                    scope="col"
-                  >
-                    {{ column }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-line bg-surface">
-                <tr
-                  v-for="row in pagedSkills"
-                  :key="row.uuid"
-                  class="transition-colors hover:bg-line-soft"
+              <div class="relative min-w-0 flex-1">
+                <input
+                  v-model="searchQuery"
+                  class="form-input pl-9"
+                  type="search"
+                  :placeholder="t('lensAdmin.skills.searchPlaceholder')"
+                />
+                <span
+                  class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-400"
+                  aria-hidden="true"
+                  >⌕</span
                 >
-                  <td class="table-cell">
-                    <button
-                      type="button"
-                      class="block max-w-full truncate text-left font-medium text-ink-900 hover:text-primary-700 hover:underline"
-                      :title="row.name"
-                      @click="openDetail(row)"
-                    >
-                      {{ row.name }}
-                    </button>
-                    <div
-                      v-if="skillDescription(row)"
-                      class="mt-1 max-w-xl truncate text-xs text-ink-500"
-                    >
-                      {{ skillDescription(row) }}
-                    </div>
-                  </td>
-                  <td class="table-cell font-mono text-ink-500">
-                    <span class="block truncate" :title="row.slug">
-                      {{ row.slug }}
-                    </span>
-                  </td>
-                  <td class="table-cell text-center">
-                    <span
-                      v-if="isWorkspaceGuideSkill(row)"
-                      class="inline-block rounded-md border border-primary-200 bg-primary-50 px-1.5 py-0.5 text-xs font-medium text-primary-700"
-                      :title="t('lensAdmin.columns.workspaceGuideHint')"
-                    >
-                      {{ t('lensAdmin.columns.workspaceGuideTag') }}
-                    </span>
-                    <span v-else class="text-sm text-ink-400">
-                      {{ t('lensAdmin.pages.skills.label') }}
-                    </span>
-                  </td>
-                  <td class="table-cell text-center">
-                    <StatusBadge
-                      :status="row.enabled ? 'enabled' : 'disabled'"
-                    />
-                  </td>
-                  <td class="table-cell">
-                    <div
-                      class="flex flex-nowrap items-center justify-center gap-2"
-                    >
-                      <BaseButton
-                        size="sm"
-                        variant="outline"
-                        @click="download(row)"
+              </div>
+              <BaseSelect v-model="sourceFilter" class="md:w-44">
+                <option value="all">
+                  {{ t('lensAdmin.skills.allSources') }}
+                </option>
+                <option value="github">GitHub</option>
+                <option value="upload">
+                  {{ t('lensAdmin.skills.upload') }}
+                </option>
+                <option value="manual">
+                  {{ t('lensAdmin.skills.manualCreate') }}
+                </option>
+                <option value="workspace">
+                  {{ t('lensAdmin.columns.workspaceGuideTag') }}
+                </option>
+              </BaseSelect>
+              <BaseSelect v-model="statusFilter" class="md:w-36">
+                <option value="all">
+                  {{ t('lensAdmin.skills.allStatuses') }}
+                </option>
+                <option value="enabled">
+                  {{ t('common.status.enabled') }}
+                </option>
+                <option value="disabled">
+                  {{ t('common.status.disabled') }}
+                </option>
+                <option value="updates">
+                  {{ t('lensAdmin.skills.updateAvailable') }}
+                </option>
+              </BaseSelect>
+            </div>
+
+            <div
+              v-if="pagedSkills.length"
+              class="grid items-stretch gap-4 lg:grid-cols-2"
+            >
+              <article
+                v-for="row in pagedSkills"
+                :key="row.uuid"
+                class="group flex h-full min-w-0 flex-col rounded-xl border border-line bg-surface p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-md"
+              >
+                <div class="flex min-w-0 items-start justify-between gap-3">
+                  <div class="min-w-0">
+                    <div class="min-w-0">
+                      <button
+                        type="button"
+                        class="block max-w-full truncate text-left text-lg font-semibold text-ink-900 hover:text-primary-700"
+                        :title="row.name"
+                        @click="openDetail(row)"
                       >
-                        {{ t('lensAdmin.skills.download') }}
-                      </BaseButton>
-                      <RowActions
-                        :row="row"
-                        @edit="startEdit"
-                        @delete="remove"
-                      />
+                        {{ row.name }}
+                      </button>
                     </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                  </div>
+                  <StatusBadge :status="row.enabled ? 'enabled' : 'disabled'" />
+                </div>
+                <p
+                  class="mt-4 line-clamp-2 h-10 overflow-hidden text-sm leading-5 text-ink-600"
+                  :title="
+                    skillDescription(row) || t('lensAdmin.skills.noDescription')
+                  "
+                >
+                  {{
+                    skillDescription(row) || t('lensAdmin.skills.noDescription')
+                  }}
+                </p>
+                <div
+                  class="mt-4 grid grid-cols-2 gap-2 border-y border-line py-3 text-xs sm:grid-cols-4"
+                >
+                  <div class="min-w-0">
+                    <div class="truncate text-ink-400">
+                      {{ t('lensAdmin.skills.version') }}
+                    </div>
+                    <div
+                      class="mt-1 truncate font-medium text-ink-700"
+                      :title="skillVersion(row)"
+                    >
+                      {{ skillVersion(row) }}
+                    </div>
+                  </div>
+                  <div class="min-w-0">
+                    <div class="truncate text-ink-400">
+                      {{ t('lensAdmin.skills.files') }}
+                    </div>
+                    <div class="mt-1 truncate font-medium text-ink-700">
+                      {{ skillFileCount(row) }}
+                    </div>
+                  </div>
+                  <div class="min-w-0">
+                    <div class="truncate text-ink-400">
+                      {{ t('lensAdmin.skills.updatedAt') }}
+                    </div>
+                    <div
+                      class="mt-1 truncate font-medium text-ink-700"
+                      :title="formatDate(row.updated_at)"
+                    >
+                      {{ formatDate(row.updated_at) }}
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="mt-auto flex min-h-9 flex-wrap items-center justify-between gap-2 pt-3"
+                >
+                  <div class="flex min-w-0 flex-wrap items-center gap-2">
+                    <span
+                      class="flex items-center gap-1.5 rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-500"
+                      :title="skillSourceLabel(row)"
+                    >
+                      <component
+                        :is="skillSourceIcon(row)"
+                        class="h-4 w-4"
+                        aria-hidden="true"
+                      />
+                      <span>{{ skillSourceLabel(row) }}</span>
+                    </span>
+                    <span
+                      v-if="row.update_available"
+                      class="rounded-md border border-warning-200 bg-warning-50 px-2 py-1 text-xs font-medium text-warning-700"
+                      >{{ t('lensAdmin.skills.updateAvailable') }}</span
+                    >
+                  </div>
+                  <div class="flex shrink-0 items-center gap-1">
+                    <RowActions
+                      :row="row"
+                      @download="download"
+                      @edit="startEdit"
+                      @delete="remove"
+                    />
+                  </div>
+                </div>
+              </article>
+            </div>
+            <div
+              v-else
+              class="rounded-lg border border-line bg-surface-sunken py-12 text-center text-sm text-ink-500"
+            >
+              {{ t('lensAdmin.skills.noFilterResults') }}
+            </div>
           </div>
           <PaginationBar
-            v-if="!loading"
+            v-if="!loading && filteredSkills.length"
             v-model:page-size="pageSize"
             :current-page="currentPage"
-            :total="skills.length"
+            :total="filteredSkills.length"
             @page-size-change="handlePageSizeChange"
             @prev="goPrevPage"
             @next="goNextPage"
@@ -194,14 +257,20 @@
             <FormRow :label="t('lensAdmin.fields.name')" required>
               <input v-model="form.name" class="form-input" required />
             </FormRow>
-            <FormRow :label="t('lensAdmin.fields.slug')" required>
-              <input v-model="form.slug" class="form-input" required />
-            </FormRow>
             <FormRow :label="t('lensAdmin.fields.description')">
               <input
                 v-model="form.description"
                 class="form-input"
                 :placeholder="t('lensAdmin.placeholders.skillDescription')"
+              />
+            </FormRow>
+            <FormRow :label="t('lensAdmin.skillDetail.descriptionZh')">
+              <input
+                v-model="form.descriptionZh"
+                class="form-input"
+                :placeholder="
+                  t('lensAdmin.skillDetail.descriptionZhPlaceholder')
+                "
               />
             </FormRow>
             <SkillEnvironmentEditor
@@ -393,25 +462,56 @@
       <BaseDrawer
         :show="showDetail"
         :title="t('lensAdmin.skillDetail.title')"
+        :subtitle="detailRow?.package_name || detailRow?.name || ''"
+        width="3xl"
         @close="closeDetail"
       >
         <template #actions>
-          <BaseButton size="sm" variant="outline" @click="download(detailRow)">
+          <BaseButton
+            v-if="detailRow"
+            size="sm"
+            variant="outline"
+            @click="download(detailRow)"
+          >
             {{ t('lensAdmin.skills.download') }}
           </BaseButton>
-          <BaseButton size="sm" variant="outline" @click="editFromDetail">
+          <BaseButton
+            v-if="detailRow"
+            size="sm"
+            variant="outline"
+            @click="editFromDetail"
+          >
             {{ t('common.edit') }}
           </BaseButton>
         </template>
         <div v-if="detailRow" class="space-y-5">
-          <div class="space-y-2">
-            <div class="flex flex-wrap items-center gap-2">
-              <StatusBadge
-                :status="detailRow.enabled ? 'enabled' : 'disabled'"
-              />
-              <h3 class="text-base font-semibold text-ink-900">
-                {{ detailRow.name }}
-              </h3>
+          <div
+            class="rounded-xl border border-line bg-surface-sunken p-4 sm:p-5"
+          >
+            <div class="flex items-start gap-3">
+              <div
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary-100 text-base font-bold text-primary-700"
+              >
+                {{ skillInitial(detailRow) }}
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                  <h3 class="text-lg font-semibold text-ink-900">
+                    {{ detailRow.name }}
+                  </h3>
+                  <StatusBadge
+                    :status="detailRow.enabled ? 'enabled' : 'disabled'"
+                  />
+                </div>
+                <p class="mt-2 text-sm leading-6 text-ink-600">
+                  {{
+                    skillDescription(detailRow) ||
+                    t('lensAdmin.skills.noDescription')
+                  }}
+                </p>
+              </div>
+            </div>
+            <div class="mt-4 flex flex-wrap items-center gap-2 text-xs">
               <span
                 v-if="isWorkspaceGuideSkill(detailRow)"
                 class="inline-block rounded-md border border-primary-200 bg-primary-50 px-1.5 py-0.5 text-xs font-medium text-primary-700"
@@ -425,20 +525,16 @@
               >
                 {{ t('lensAdmin.pages.skills.label') }}
               </span>
+              <span
+                v-if="detailRow.update_available"
+                class="rounded-md border border-warning-200 bg-warning-50 px-1.5 py-0.5 font-medium text-warning-700"
+              >
+                {{ t('lensAdmin.skills.updateAvailable') }}
+              </span>
             </div>
-            <p class="font-mono text-xs text-ink-500">{{ detailRow.slug }}</p>
           </div>
 
-          <div v-if="skillDescription(detailRow)">
-            <div class="mb-1 text-sm font-medium text-ink-700">
-              {{ t('lensAdmin.fields.description') }}
-            </div>
-            <p class="text-sm leading-6 text-ink-600">
-              {{ skillDescription(detailRow) }}
-            </p>
-          </div>
-
-          <div class="grid gap-3 sm:grid-cols-2">
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <div class="rounded-lg border border-line bg-surface-sunken p-3">
               <div class="text-xs font-medium text-ink-400">
                 {{ t('lensAdmin.skills.sourceType') }}
@@ -455,20 +551,176 @@
                 {{ skillFileCount(detailRow) }}
               </div>
             </div>
+            <div class="rounded-lg border border-line bg-surface-sunken p-3">
+              <div class="text-xs font-medium text-ink-400">
+                {{ t('lensAdmin.skills.version') }}
+              </div>
+              <div
+                class="mt-1 truncate text-sm text-ink-700"
+                :title="skillVersion(detailRow)"
+              >
+                {{ skillVersion(detailRow) }}
+              </div>
+            </div>
+            <div class="rounded-lg border border-line bg-surface-sunken p-3">
+              <div class="text-xs font-medium text-ink-400">
+                {{ t('lensAdmin.skills.updatedAt') }}
+              </div>
+              <div
+                class="mt-1 truncate text-sm text-ink-700"
+                :title="formatDate(detailRow.updated_at)"
+              >
+                {{ formatDate(detailRow.updated_at) }}
+              </div>
+            </div>
           </div>
 
+          <div class="rounded-lg border border-line bg-surface-sunken p-4">
+            <div class="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <h4 class="text-sm font-semibold text-ink-800">
+                  {{ t('lensAdmin.skillDetail.sourceInfo') }}
+                </h4>
+                <p class="mt-1 text-xs text-ink-500">
+                  {{ t('lensAdmin.skillDetail.sourceInfoHint') }}
+                </p>
+              </div>
+              <a
+                v-if="detailRow.source_url"
+                class="shrink-0 text-xs font-medium text-primary-700 hover:text-primary-800"
+                :href="detailRow.source_url"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {{ t('lensAdmin.skillDetail.openSource') }}
+              </a>
+            </div>
+            <dl class="grid gap-x-4 gap-y-3 text-sm sm:grid-cols-2">
+              <div>
+                <dt class="text-xs text-ink-400">
+                  {{ t('lensAdmin.skills.uuid') }}
+                </dt>
+                <dd class="mt-1 break-all text-ink-700">
+                  {{ detailRow.uuid }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-ink-400">
+                  {{ t('lensAdmin.skillDetail.sourceRef') }}
+                </dt>
+                <dd class="mt-1 break-all text-ink-700">
+                  {{ detailRow.source_ref || '—' }}
+                </dd>
+              </div>
+              <div v-if="detailRow.source_path" class="sm:col-span-2">
+                <dt class="text-xs text-ink-400">
+                  {{ t('lensAdmin.skillDetail.sourcePath') }}
+                </dt>
+                <dd class="mt-1 break-all font-mono text-xs text-ink-700">
+                  {{ detailRow.source_path }}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div v-if="skillEnvironment(detailRow).length">
+            <h4 class="mb-2 text-sm font-semibold text-ink-800">
+              {{ t('lensAdmin.skillDetail.environment') }}
+            </h4>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="item in skillEnvironment(detailRow)"
+                :key="item.name"
+                class="rounded-md border border-line bg-surface-sunken px-2 py-1 font-mono text-xs text-ink-600"
+              >
+                {{ item.name
+                }}<span v-if="item.required" class="ml-1 text-danger-600"
+                  >*</span
+                >
+              </span>
+            </div>
+          </div>
+
+          <details class="overflow-hidden rounded-lg border border-line">
+            <summary
+              class="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-semibold text-ink-800 hover:bg-surface-sunken [&::-webkit-details-marker]:hidden"
+            >
+              <span>{{ t('lensAdmin.skillDetail.files') }}</span>
+              <span class="text-xs font-normal text-ink-400">
+                {{ skillFileCount(detailRow) }}
+                {{ t('lensAdmin.skillDetail.fileUnit') }}
+              </span>
+            </summary>
+            <div class="border-t border-line px-4 pb-4 pt-3">
+              <p class="mb-3 text-xs text-ink-500">
+                {{ t('lensAdmin.skillDetail.filesHint') }}
+              </p>
+              <div class="overflow-hidden rounded-lg border border-line">
+                <button
+                  v-for="file in skillFiles(detailRow)"
+                  :key="file.path"
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 border-b border-line px-3 py-2 text-left text-xs last:border-b-0 hover:bg-surface-sunken"
+                  :class="
+                    selectedDetailFile === file.path
+                      ? 'bg-primary-50 text-primary-800'
+                      : 'text-ink-600'
+                  "
+                  @click="selectDetailFile(file.path)"
+                >
+                  <span class="min-w-0 truncate font-mono">{{
+                    file.path
+                  }}</span>
+                  <span class="shrink-0 text-ink-400">{{
+                    formatFileSize(file.size)
+                  }}</span>
+                </button>
+              </div>
+            </div>
+          </details>
           <div>
-            <div class="mb-2 text-sm font-medium text-ink-700">
-              {{ t('lensAdmin.fields.content') }}
+            <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h4 class="text-sm font-semibold text-ink-800">
+                  {{ selectedDetailFile || 'SKILL.md' }}
+                </h4>
+                <p class="mt-1 text-xs text-ink-500">
+                  {{ t('lensAdmin.skillDetail.previewHint') }}
+                </p>
+              </div>
+              <span
+                class="rounded-md border border-line bg-surface-sunken px-2 py-1 text-xs text-ink-500"
+              >
+                {{ t('lensAdmin.skillDetail.readOnly') }}
+              </span>
             </div>
             <div
-              v-if="skillContent(detailRow)"
+              v-if="detailFilePreviewLoading"
+              class="rounded-lg border border-line bg-surface-sunken p-6"
+            >
+              <BaseLoading />
+            </div>
+            <div
+              v-else-if="
+                selectedDetailFile === 'SKILL.md' && skillContent(detailRow)
+              "
               class="rounded-lg border border-line bg-surface-sunken p-4"
             >
               <MarkdownRenderer :content="skillContent(detailRow)" />
             </div>
-            <p v-else class="text-sm text-ink-400">
-              {{ t('common.noData') }}
+            <pre
+              v-else-if="detailFilePreview"
+              class="max-h-[32rem] overflow-auto whitespace-pre-wrap break-words rounded-lg border border-line bg-surface-sunken p-4 font-mono text-xs leading-5 text-ink-700"
+              >{{ detailFilePreview }}</pre
+            >
+            <p
+              v-else
+              class="rounded-lg border border-line bg-surface-sunken p-4 text-sm text-ink-400"
+            >
+              {{
+                detailFilePreviewError ||
+                t('lensAdmin.skillDetail.filePreviewUnavailable')
+              }}
             </p>
           </div>
         </div>
@@ -551,12 +803,15 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   Bot as BotIcon,
   ChevronDown as ChevronDownIcon,
   Copy as CopyIcon,
+  GitBranch as GitIcon,
+  PencilLine as PencilLineIcon,
+  Upload as UploadIcon,
   UploadCloud as UploadCloudIcon,
   X as XIcon
 } from '@lucide/vue'
@@ -564,6 +819,7 @@ import {
 import AdminLayout from '@/admin/layout/AdminLayout.vue'
 import {
   beautifySkill,
+  checkSkillUpdates,
   createSkill,
   deleteSkill,
   downloadSkill,
@@ -571,6 +827,7 @@ import {
   getSkillDeleteImpact,
   importSkillFromGithub,
   listSkills,
+  previewSkillFile,
   updateGithubSkill,
   updateSkill,
   updateUploadedSkill,
@@ -613,12 +870,19 @@ const skills = ref([])
 const currentPage = ref(1)
 const pageSize = ref(20)
 const loading = ref(false)
+const searchQuery = ref('')
+const sourceFilter = ref('all')
+const statusFilter = ref('all')
 const saving = ref(false)
 const beautifying = ref(false)
 const showModal = ref(false)
 const showDetail = ref(false)
 const showDeleteModal = ref(false)
 const detailRow = ref(null)
+const selectedDetailFile = ref('SKILL.md')
+const detailFilePreview = ref('')
+const detailFilePreviewError = ref('')
+const detailFilePreviewLoading = ref(false)
 const mode = ref('create')
 const form = ref({})
 const formError = ref('')
@@ -653,18 +917,49 @@ const createMethodOptions = computed(() => [
 
 const createMethod = ref('manual')
 
-const columns = computed(() =>
-  ['skill', 'slug', 'type', 'status', 'actions'].map((column) =>
-    t(`lensAdmin.columns.${column}`)
-  )
-)
+const filteredSkills = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  return skills.value.filter((skill) => {
+    const matchesQuery =
+      !query ||
+      [
+        skill.name,
+        skill.package_name,
+        skillDescription(skill),
+        skill.source_ref,
+        skill.source_path
+      ].some((value) =>
+        String(value || '')
+          .toLowerCase()
+          .includes(query)
+      )
+    const matchesSource =
+      sourceFilter.value === 'all' ||
+      (sourceFilter.value === 'workspace'
+        ? isWorkspaceGuideSkill(skill)
+        : skill.source_type === sourceFilter.value &&
+          !isWorkspaceGuideSkill(skill))
+    const matchesStatus =
+      statusFilter.value === 'all' ||
+      (statusFilter.value === 'updates'
+        ? skill.update_available
+        : statusFilter.value === 'enabled'
+          ? skill.enabled
+          : !skill.enabled)
+    return matchesQuery && matchesSource && matchesStatus
+  })
+})
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(skills.value.length / pageSize.value))
+  Math.max(1, Math.ceil(filteredSkills.value.length / pageSize.value))
 )
 const pagedSkills = computed(() => {
   const start = (currentPage.value - 1) * pageSize.value
-  return skills.value.slice(start, start + pageSize.value)
+  return filteredSkills.value.slice(start, start + pageSize.value)
+})
+
+watch([searchQuery, sourceFilter, statusFilter], () => {
+  currentPage.value = 1
 })
 
 function handlePageSizeChange() {
@@ -679,6 +974,41 @@ function goPrevPage() {
 function goNextPage() {
   if (currentPage.value >= totalPages.value) return
   currentPage.value += 1
+}
+
+function skillInitial(row) {
+  return (row?.name || 'S').trim().charAt(0).toUpperCase()
+}
+
+function skillVersion(row) {
+  return row?.source_ref || row?.version || '—'
+}
+
+function skillSourceLabel(row) {
+  if (isWorkspaceGuideSkill(row)) {
+    return t('lensAdmin.columns.workspaceGuideTag')
+  }
+  const labels = {
+    github: 'GitHub',
+    upload: t('lensAdmin.skills.upload'),
+    manual: t('lensAdmin.skills.manualCreate')
+  }
+  return labels[row?.source_type] || row?.source_type || '—'
+}
+
+function skillSourceIcon(row) {
+  if (row?.source_type === 'github') return GitIcon
+  if (row?.source_type === 'upload') return UploadIcon
+  return PencilLineIcon
+}
+
+function formatDate(value) {
+  if (!value) return '—'
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  }).format(new Date(value))
 }
 
 const modalTitle = computed(() => {
@@ -746,15 +1076,37 @@ const packageFileSize = computed(() => {
 })
 
 function isWorkspaceGuideSkill(row) {
-  return typeof row?.slug === 'string' && row.slug.endsWith('-workspace-guide')
+  return row?.kind === 'workspace_guide'
 }
 
 function skillDescription(row) {
   const definition = row?.definition
   if (definition && typeof definition === 'object') {
-    return definition.description || ''
+    return definition.description_zh || definition.description || ''
   }
   return ''
+}
+
+function skillEnvironment(row) {
+  const environment = row?.definition?.environment
+  return Array.isArray(environment)
+    ? environment.filter((item) => item && item.name)
+    : []
+}
+
+function skillFiles(row) {
+  const files = row?.package_manifest?.files
+  if (Array.isArray(files) && files.length) {
+    return files
+  }
+  return [{ path: 'SKILL.md', size: 0 }]
+}
+
+function formatFileSize(value) {
+  const size = Number(value) || 0
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${Math.max(1, Math.round(size / 1024))} KB`
+  return `${(size / 1024 / 1024).toFixed(1)} MB`
 }
 
 function skillContent(row) {
@@ -770,6 +1122,24 @@ function skillContent(row) {
   return ''
 }
 
+async function selectDetailFile(path) {
+  selectedDetailFile.value = path
+  detailFilePreview.value = ''
+  detailFilePreviewError.value = ''
+  if (path === 'SKILL.md' || !detailRow.value?.uuid) return
+  detailFilePreviewLoading.value = true
+  try {
+    const result = await previewSkillFile(detailRow.value.uuid, path)
+    detailFilePreview.value = result?.content || ''
+  } catch (error) {
+    detailFilePreviewError.value =
+      error?.response?.data?.detail ||
+      t('lensAdmin.skillDetail.filePreviewUnavailable')
+  } finally {
+    detailFilePreviewLoading.value = false
+  }
+}
+
 function skillSourceType(row) {
   return row?.source_type || 'manual'
 }
@@ -781,8 +1151,8 @@ function skillFileCount(row) {
 function defaultForm() {
   return {
     name: '',
-    slug: '',
     description: '',
+    descriptionZh: '',
     content: '',
     environment: [],
     enabled: true
@@ -795,8 +1165,8 @@ function formFromRow(row) {
   return {
     uuid: row.uuid,
     name: row.name || '',
-    slug: row.slug || '',
-    description: skillDescription(row),
+    description: row?.definition?.description || '',
+    descriptionZh: row?.definition?.description_zh || '',
     content: skillContent(row),
     environment: skillEnvironmentForm(originalDefinition.environment),
     originalDefinition,
@@ -813,9 +1183,12 @@ function buildPayload() {
   if (description) {
     definition.description = description
   }
+  const descriptionZh = (form.value.descriptionZh || '').trim()
+  if (descriptionZh) {
+    definition.description_zh = descriptionZh
+  }
   return {
     name: form.value.name,
-    slug: form.value.slug,
     definition,
     enabled: !!form.value.enabled
   }
@@ -839,6 +1212,9 @@ async function load() {
   formError.value = ''
   try {
     skills.value = normalizeList(await listSkills())
+    if (skills.value.some((skill) => skill.source_type === 'github')) {
+      skills.value = normalizeList(await checkSkillUpdates())
+    }
   } catch (error) {
     showError(skillErrorMessage(error, t, t('lensAdmin.messages.loadFailed')))
   } finally {
@@ -918,12 +1294,17 @@ function closeModal() {
 
 function openDetail(row) {
   detailRow.value = row
+  selectedDetailFile.value = 'SKILL.md'
+  detailFilePreview.value = ''
+  detailFilePreviewError.value = ''
   showDetail.value = true
 }
 
 function closeDetail() {
   showDetail.value = false
   detailRow.value = null
+  detailFilePreview.value = ''
+  detailFilePreviewError.value = ''
 }
 
 function editFromDetail() {
@@ -1072,7 +1453,7 @@ async function download(row) {
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = `${row.slug || 'skill'}.zip`
+    link.download = `${row.name || 'skill'}.zip`
     link.click()
     URL.revokeObjectURL(url)
   } catch (error) {

--- a/frontend/src/pages/lens/assistantSkills.js
+++ b/frontend/src/pages/lens/assistantSkills.js
@@ -14,18 +14,24 @@ export function filterSelectableSkills(skills, keyword) {
     .trim()
     .toLocaleLowerCase()
   return (skills || []).filter((skill) => {
-    if (
-      typeof skill.slug === 'string' &&
-      skill.slug.endsWith('-workspace-guide')
-    ) {
+    if (skill.kind === 'workspace_guide') {
       return false
     }
     if (!query) return true
 
-    return [skill.name, skill.slug, skillDescription(skill)].some((value) =>
-      String(value || '')
-        .toLocaleLowerCase()
-        .includes(query)
+    return [skill.name, skill.package_name, skillDescription(skill)].some(
+      (value) =>
+        String(value || '')
+          .toLocaleLowerCase()
+          .includes(query)
     )
   })
+}
+
+export function sortSkillsBySelection(skills, selectedUuids) {
+  const selected = new Set(selectedUuids || [])
+  return [...(skills || [])].sort(
+    (left, right) =>
+      Number(selected.has(right.uuid)) - Number(selected.has(left.uuid))
+  )
 }

--- a/frontend/src/pages/lens/assistantWorkspaceGuide.js
+++ b/frontend/src/pages/lens/assistantWorkspaceGuide.js
@@ -1,0 +1,8 @@
+export function buildWorkspaceGuidePayload({ content }) {
+  const normalizedContent = String(content || '').trim()
+
+  return {
+    enabled: Boolean(normalizedContent),
+    content: normalizedContent
+  }
+}

--- a/frontend/src/pages/lens/components/RowActions.vue
+++ b/frontend/src/pages/lens/components/RowActions.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup>
-import { Pencil, Trash2 } from '@lucide/vue'
+import { Download, Pencil, Trash2 } from '@lucide/vue'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -30,12 +30,17 @@ const props = defineProps({
     default: true
   }
 })
-const emit = defineEmits(['edit', 'delete'])
+const emit = defineEmits(['download', 'edit', 'delete'])
 
 const { t } = useI18n()
 const confirming = ref(false)
 
 const actions = computed(() => [
+  {
+    key: 'download',
+    label: t('lensAdmin.skills.download'),
+    icon: Download
+  },
   {
     key: 'edit',
     label: t('common.edit'),
@@ -64,6 +69,10 @@ function requestDelete() {
 }
 
 function handleAction(action) {
+  if (action === 'download') {
+    emit('download', props.row)
+    return
+  }
   if (action === 'edit') {
     emit('edit', props.row)
     return

--- a/frontend/src/pages/lens/skillErrorMessage.js
+++ b/frontend/src/pages/lens/skillErrorMessage.js
@@ -31,12 +31,13 @@ const EXACT_ERROR_KEYS = {
   'Only public GitHub URLs are supported.': 'githubPublicOnly',
   'GitHub URL must include owner and repository.': 'githubRepositoryRequired',
   'GitHub download redirected to an unsafe host.': 'githubUnsafeRedirect',
+  'GitHub repository must publish a tag before it can be imported.':
+    'githubTagRequired',
   'Environment variables must be valid JSON.': 'environmentInvalid',
   'Skill generator model is not configured.': 'generatorNotConfigured'
 }
 
 const ERROR_RULES = [
-  [/^Skill slug '.+' already exists\./, 'skillSlugExists'],
   [/^GitHub download failed:/, 'githubDownloadFailed'],
   [
     /^(Skill transforms|A Skill may declare at most 32 transforms|Transform names|Transform ')/,

--- a/frontend/tests/adminSidebar.test.js
+++ b/frontend/tests/adminSidebar.test.js
@@ -28,8 +28,8 @@ test('standalone routes do not belong to an accordion menu', () => {
   assert.equal(getAdminSidebarMenu('/'), null)
 })
 
-test('selecting a menu opens it and selecting it again closes it', () => {
-  assert.equal(toggleAdminSidebarMenu(null, 'lens'), 'lens')
-  assert.equal(toggleAdminSidebarMenu('lens', 'data'), 'data')
-  assert.equal(toggleAdminSidebarMenu('data', 'data'), null)
+test('parent menu toggles preserve other expanded menus', () => {
+  assert.deepEqual(toggleAdminSidebarMenu([], 'lens'), ['lens'])
+  assert.deepEqual(toggleAdminSidebarMenu(['lens'], 'data'), ['lens', 'data'])
+  assert.deepEqual(toggleAdminSidebarMenu(['lens', 'data'], 'data'), ['lens'])
 })

--- a/frontend/tests/assistantSkills.test.js
+++ b/frontend/tests/assistantSkills.test.js
@@ -1,13 +1,16 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { filterSelectableSkills } from '../src/pages/lens/assistantSkills.js'
+import {
+  filterSelectableSkills,
+  sortSkillsBySelection
+} from '../src/pages/lens/assistantSkills.js'
 
 const skills = [
   {
     uuid: 'jira',
     name: 'Jira Issues',
-    slug: 'jira-issues',
+    package_name: 'jira-issues',
     definition: {
       description: 'Search project tickets',
       environment: [{ name: 'JIRA_TOKEN', required: true }]
@@ -16,13 +19,14 @@ const skills = [
   {
     uuid: 'github',
     name: 'GitHub Pull Requests',
-    slug: 'github-prs',
+    package_name: 'github-prs',
     package_manifest: { description: 'Review repository changes' }
   },
   {
     uuid: 'guide',
     name: 'Workspace Guide',
-    slug: 'project-workspace-guide'
+    package_name: 'project-workspace-guide',
+    kind: 'workspace_guide'
   }
 ]
 
@@ -35,7 +39,7 @@ test('returns every selectable Skill when the keyword is empty', () => {
   )
 })
 
-test('searches Skills by name, slug, and description without case sensitivity', () => {
+test('searches Skills by name, package name, and description without case sensitivity', () => {
   assert.deepEqual(
     filterSelectableSkills(skills, 'JIRA').map((skill) => skill.uuid),
     ['jira']
@@ -58,4 +62,13 @@ test('preserves environment declarations on filtered Skills', () => {
   assert.deepEqual(result.definition.environment, [
     { name: 'JIRA_TOKEN', required: true }
   ])
+})
+
+test('sorts selected Skills before unselected Skills', () => {
+  const results = sortSkillsBySelection(skills, ['github'])
+
+  assert.deepEqual(
+    results.map((skill) => skill.uuid),
+    ['github', 'jira', 'guide']
+  )
 })

--- a/frontend/tests/assistantWorkspaceGuide.test.js
+++ b/frontend/tests/assistantWorkspaceGuide.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildWorkspaceGuidePayload } from '../src/pages/lens/assistantWorkspaceGuide.js'
+
+test('keeps a workspace guide enabled for general chat assistants', () => {
+  const payload = buildWorkspaceGuidePayload({
+    content: 'Use the engineering workspace guide.',
+    selectedTask: 'general_chat'
+  })
+
+  assert.deepEqual(payload, {
+    enabled: true,
+    content: 'Use the engineering workspace guide.'
+  })
+})

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -928,6 +928,9 @@ class LensDeepAgentRuntime:
                         state.scenario,
                         state.command,
                         state.resources.context_skill_contents,
+                        workspace_guide=state.command.get(
+                            "workspace_guide", ""
+                        ),
                     ),
                     messages=(
                         state.resume_state.messages
@@ -1014,6 +1017,9 @@ class LensDeepAgentRuntime:
                 state.scenario,
                 state.command,
                 state.resources.context_skill_contents,
+                workspace_guide=state.command.get(
+                    "workspace_guide", ""
+                ),
                 mcp_deferred=state.mcp_middleware is not None,
                 runtime_guidance=state.runtime_guidance,
             ),

--- a/lensnode/lensnode/agent_runtime/system_prompts.py
+++ b/lensnode/lensnode/agent_runtime/system_prompts.py
@@ -6,23 +6,31 @@ from .prompts import (
     command_answer_language as _command_answer_language,
     history_artifact_guidance as _history_artifact_guidance,
 )
+
+
 def _system_prompt(
     scenario,
     command,
     context_skill_contents=None,
     *,
+    workspace_guide=None,
     mcp_deferred=False,
     runtime_guidance=None,
 ):
     """Build the per-task Deep Agents system prompt."""
 
     if _is_general_chat(command):
-        prompt = _general_chat_system_prompt(command, context_skill_contents)
+        prompt = _general_chat_system_prompt(
+            command,
+            context_skill_contents,
+            workspace_guide=workspace_guide,
+        )
     else:
         prompt = _knowledge_system_prompt(
             scenario,
             command,
             context_skill_contents,
+            workspace_guide=workspace_guide,
             runtime_guidance=runtime_guidance,
         )
     if mcp_deferred:
@@ -45,6 +53,7 @@ def _knowledge_system_prompt(
     command,
     context_skill_contents=None,
     *,
+    workspace_guide=None,
     runtime_guidance=None,
 ):
     """Build the workspace-grounded system prompt."""
@@ -119,6 +128,7 @@ def _knowledge_system_prompt(
         )
     return (
         f"{language_requirement}\n\n"
+        f"{_workspace_guide_prompt(workspace_guide)}"
         f"{scenario['prompt']}\n\n"
         "You are running inside SourceLens LensNode. The control plane has "
         "selected the workspace directories below.\n\n"
@@ -229,7 +239,12 @@ def _knowledge_system_prompt(
     )
 
 
-def _general_chat_system_prompt(command, context_skill_contents=None):
+def _general_chat_system_prompt(
+    command,
+    context_skill_contents=None,
+    *,
+    workspace_guide=None,
+):
     """Build the General Chat system prompt."""
 
     answer_language = _command_answer_language(command)
@@ -238,6 +253,7 @@ def _general_chat_system_prompt(command, context_skill_contents=None):
     history_artifact_guidance = _history_artifact_guidance(command)
     return (
         f"{language_requirement}\n\n"
+        f"{_workspace_guide_prompt(workspace_guide)}"
         "You are running inside SourceLens LensNode as General Chat.\n\n"
         "The bound Skills are your primary behavior contract. Follow their "
         "SKILL.md instructions and use bundled resources only when the Skill "
@@ -324,6 +340,21 @@ def _general_chat_system_prompt(command, context_skill_contents=None):
         f"{_route_guidance(command.get('runtime_route'))}"
         f"\n\n{language_requirement}"
     )
+
+
+def _workspace_guide_prompt(workspace_guide):
+    """Return the Assistant workspace guide system-prompt section."""
+
+    content = str(workspace_guide or "").strip()
+    if not content:
+        return ""
+    return (
+        "Assistant Workspace Guide\n"
+        "The following instructions are part of the Assistant configuration. "
+        "Apply them as trusted workspace context for this Run.\n\n"
+        f"{content}\n\n"
+    )
+
 
 def _subagent_guidance(agent_rounds):
     """Return depth-tiered guidance on when to use the task subagent.

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -490,7 +490,7 @@ def build_agent_tools(command, resources=None, config=None, emit_event=None):
 class _RunSkillScriptArgs(BaseModel):
     """Args schema for running an executable bundled with a Skill."""
 
-    skill: str = Field(description="Loaded Skill slug or name.")
+    skill: str = Field(description="Loaded Skill package name.")
     script: str = Field(
         description=(
             "Path of the executable relative to the Skill root, for example "
@@ -611,7 +611,7 @@ class _InspectSavedOutputArgs(BaseModel):
 class _RunSkillTransformArgs(BaseModel):
     """Args schema for running a declared Skill Transform."""
 
-    skill: str = Field(description="Loaded Skill slug or name.")
+    skill: str = Field(description="Loaded Skill package name.")
     transform: str = Field(description="Transform name declared in sourcelens.json.")
     stdin_ref: str = Field(
         min_length=1,
@@ -628,7 +628,7 @@ class _RunSkillTransformArgs(BaseModel):
 class _CallSkillApiArgs(BaseModel):
     """Args schema for an HTTP request configured by a loaded Skill."""
 
-    skill: str = Field(description="Loaded Skill slug or name.")
+    skill: str = Field(description="Loaded Skill package name.")
     base_url_env: str = Field(
         description="Environment variable containing the API base URL."
     )
@@ -2526,7 +2526,7 @@ def _transform_input_failure(
 
 
 def _resolve_skill_dir(skills_root, value):
-    """Resolve a loaded Skill directory by slug/name."""
+    """Resolve a loaded Skill directory by package name."""
 
     name = _safe_resource_name(value)
     if not name:

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -787,8 +787,10 @@ def _materialize_skill(config, cache_root, skills_root, skill):
 
     skill_uuid = str(skill.get("skill_uuid") or "").strip()
     content_hash = str(skill.get("content_hash") or "").replace(":", "-")
-    slug = _safe_name(skill.get("skill_slug") or skill.get("skill_name"))
-    if not skill_uuid or not content_hash or not slug:
+    package_name = _safe_name(
+        skill.get("skill_package_name") or skill.get("skill_name")
+    )
+    if not skill_uuid or not content_hash or not package_name:
         return None
 
     cache_dir = cache_root / "skills" / skill_uuid / content_hash
@@ -796,10 +798,10 @@ def _materialize_skill(config, cache_root, skills_root, skill):
     if not complete_file.exists():
         _rebuild_skill_cache(config, cache_dir, skill)
 
-    runtime_dir = skills_root / slug
+    runtime_dir = skills_root / package_name
     _copy_dir(cache_dir, runtime_dir)
     _enable_skill_scripts(runtime_dir)
-    return Path("skills") / slug
+    return Path("skills") / package_name
 
 
 def _rebuild_skill_cache(config, cache_dir, skill):
@@ -1057,7 +1059,8 @@ def _skill_markdown(skill):
         )
     return (
         "---\n"
-        f"name: {skill.get('skill_slug') or skill.get('skill_name')}\n"
+        "name: "
+        f"{skill.get('skill_package_name') or skill.get('skill_name')}\n"
         f"description: {description or skill.get('skill_name')}\n"
         "---\n\n"
         f"{body.strip()}\n"
@@ -1087,8 +1090,8 @@ def _context_skill_content(skill, skill_path=None, force=False):
     body = _skill_body(skill.get("definition") or {}).strip()
     if not body and not force:
         return ""
-    name = skill.get("skill_name") or skill.get("skill_slug") or "Skill"
-    slug = skill.get("skill_slug") or name
+    name = skill.get("skill_name") or "Skill"
+    package_name = skill.get("skill_package_name") or name
     path_line = f"\nRuntime path: `{skill_path}`\n" if skill_path else ""
     manifest = skill.get("package_manifest") or {}
     manifest_line = ""
@@ -1106,7 +1109,10 @@ def _context_skill_content(skill, skill_path=None, force=False):
             "Use its bundled scripts and resources when they match the "
             "user's request."
         )
-    return f"## {name}\n\nSlug: `{slug}`{path_line}{manifest_line}\n{body[:12000]}"
+    return (
+        f"## {name}\n\nPackage name: `{package_name}`"
+        f"{path_line}{manifest_line}\n{body[:12000]}"
+    )
 
 
 def _skill_metadata(skill):
@@ -1114,7 +1120,7 @@ def _skill_metadata(skill):
 
     return {
         "uuid": skill.get("skill_uuid"),
-        "slug": skill.get("skill_slug"),
+        "package_name": skill.get("skill_package_name"),
         "name": skill.get("skill_name"),
         "version": skill.get("version"),
         "content_hash": skill.get("content_hash"),

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -782,7 +782,7 @@ def test_runtime_resources_collect_context_skill_content(tmp_path):
         "loaded_skills": [
             {
                 "skill_uuid": "11111111-1111-1111-1111-111111111111",
-                "skill_slug": "repo-guide",
+                "skill_package_name": "repo-guide",
                 "skill_name": "Repo Guide",
                 "content_hash": "sha256:abc",
                 "definition": {
@@ -1046,6 +1046,21 @@ def test_system_prompt_includes_context_skill_guidance():
     assert "Workspace Guidance from bound context skills" in prompt
     assert "Inspect service-api first" in prompt
     assert "/workspace/product" in prompt
+
+
+def test_system_prompt_includes_assistant_workspace_guide():
+    prompt = _system_prompt(
+        {
+            "prompt": "Answer the question.",
+        },
+        {
+            "task": "general_chat",
+        },
+        workspace_guide="Use the configured engineering scope.",
+    )
+
+    assert "Assistant Workspace Guide" in prompt
+    assert "Use the configured engineering scope." in prompt
 
 
 def test_system_prompt_omits_codegraph_guidance_by_default():

--- a/lensnode/tests/test_skill_artifacts.py
+++ b/lensnode/tests/test_skill_artifacts.py
@@ -354,7 +354,7 @@ def test_materialize_skill_repairs_scripts_from_existing_cache(tmp_path):
     skills_root = tmp_path / "runtime" / "skills"
     skill = {
         "skill_uuid": "skill-uuid",
-        "skill_slug": "cached-skill",
+        "skill_package_name": "cached-skill",
         "content_hash": "sha256:cached",
     }
     cache_dir = cache_root / "skills/skill-uuid/sha256-cached"

--- a/release-notes/426.yaml
+++ b/release-notes/426.yaml
@@ -1,0 +1,9 @@
+type: feature
+audience: user
+en: >-
+  Improved Assistant and Skill management with Workspace Guide configuration,
+  clearer Skill cards, detailed package previews, collapsible file lists, and
+  read-only previews for supported package files.
+zh-CN: >-
+  改进 Assistant 与 Skill 管理：支持工作区指引配置，优化 Skill 卡片和详情预览，
+  文件列表可折叠，并支持预览常见的文本类 Skill 文件。


### PR DESCRIPTION
### **User description**
## Summary
- Manage Workspace Guide as an Assistant field and freeze it into Run snapshots.
- Improve Skill package metadata, lifecycle handling, source updates, and Assistant bindings.
- Add a Skills card management experience with Chinese descriptions, detail drawers, collapsible file lists, and read-only previews for text package files.
- Improve sidebar expansion behavior and simplify environment configuration entry points.
- Move Skill download into the row action menu and clarify source icons and labels.

Closes #426

## Test plan
- [x] Frontend ESLint for changed components
- [x] Frontend targeted tests
- [x] Frontend production build
- [x] Python compilation for changed backend view
- [x] git diff --check
- [ ] Backend pytest (local pytest executable is unavailable)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Workspace Guide moved from Skill binding to Assistant field, frozen in run snapshots

- Skill model refactored: UUID-based storage, package_name, kind, GitHub tag tracking

- GitHub import supports multi-directory repositories and tag-based versioning

- Skills UI redesigned with card layout, search/filter, file preview, detail drawer

- Sidebar supports multiple open menus; environments simplified


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Assistant"] -->|workspace_guide field| B["Workspace Guide"]
  A --> C["Run Snapshot"]
  C --> D["LensNode System Prompt"]
  E["GitHub Repo"] -->|tags & multi-root| F["Skill Import"]
  F --> G["Skill Package (UUID-based)"]
  G --> H["Detail Drawer & File Preview"]
  I["Skills List"] -->|card layout| J["Search, Filter, Update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>30 files</summary><table>
<tr>
  <td><strong>skill_packages.py</strong><dd><code>Refactor Skill import and add GitHub tag support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-cc71de242ffc87a9877ef3e80874717d7f703ba2d302bc7bc9a794ddaa0d9f2d">+263/-58</a></td>

</tr>

<tr>
  <td><strong>skills.py</strong><dd><code>Add file preview and check-updates endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-d8404fc248580fa728ddc95fac7bc3f679803524195df0dbba6773a2361e774b">+101/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>system_prompts.py</strong><dd><code>Include workspace guide in system prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-3412700156257c47eb378ccbe14d3ca9f3d96f4731ff1582070256d753c9df9e">+33/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_resources.py</strong><dd><code>Use package_name instead of slug for skill directories</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-e79157882a85cd3df3a202294c6ae1a39e298509fd474a6e9f009065e54ce53b">+15/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>skill_generation.py</strong><dd><code>Migrate workspace guide to Assistant field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-589a49e56682f596af693a5650efe69ad3185e3eb4be3ea883cbe7193a911fd4">+15/-44</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>0044_skill_metadata_and_workspace_guide.py</strong><dd><code>Add Skill metadata fields and Assistant workspace guide</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-9b6cb42b0658985a7729e07d364dada6b3eeee9069815d15c10b4cfafca35e24">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add workspace_guide and new Skill fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_tools.py</strong><dd><code>Update skill reference descriptions to package_name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Include workspace_guide in runtime snapshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add update_available field and new fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Pass workspace_guide to system prompt builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin.py</strong><dd><code>Update admin list display for Skill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-9ee5945e57293b467fee3d89ba8d52cc8aa94852c747b2f070a83c8ab15d95f6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway.py</strong><dd><code>Use UUID for download filename</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-7a38a41d1d2cc8239be8f186a349fee86254f97ad1ad16b566c0bacdc0d4fb4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_events.py</strong><dd><code>Update sanitized fields to package_name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-c9a17a59ab1b816ecb943fc96701791319bddd6e65c78a3dfe42616fbd6e33b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Skills.vue</strong><dd><code>Redesign Skills page with card layout and filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-41fd2ec43b7cc5f93d8b17a5b6c07770c5d53e8447bab69f3e72e32d87cd2fe2">+509/-128</a></td>

</tr>

<tr>
  <td><strong>AssistantFormDrawerDirectEnvironment.vue</strong><dd><code>Update skill selection and step display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-1bbf22475c1d3e7a28848d3821a473ca289b3ce9c70ed901042e503be4fbc9ff">+13/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AdminSidebar.vue</strong><dd><code>Support multiple open sidebar menus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-68245495c461d476760afe3a8f4ca43037fde7fb7ad1a6e64bdc24b2c67dc8e1">+13/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RowActions.vue</strong><dd><code>Add download action to row actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-30c74832cce688a68f8bdf9d221205a13d1fade45141ed4ffcbdb686f753dcd4">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Assistants.vue</strong><dd><code>Update workspace guide payload building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BaseDrawer.vue</strong><dd><code>Add 3xl width option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-9179f20c96236a212c5eb8b5f85b8f2690570886366191e6365fc58666c4c7b4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>skillErrorMessage.js</strong><dd><code>Add GitHub tag error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-55496b43201811de4df56f555062b00991271603ead7bb846297c173a01bef85">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantSkills.js</strong><dd><code>Add skill sorting function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-ad23f3df444617d390bf67c844f9b057fc5ef9752a57bfc7fde4d6d3df1262f7">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add checkSkillUpdates and previewSkillFile API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>adminSidebarState.js</strong><dd><code>Support multiple open menus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-a4ecc3aa7005be3c8fa7beb5916f171604058f0c66f01edbb0314d36ad830c3f">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantWorkspaceGuide.js</strong><dd><code>Add workspace guide payload builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-a2e716530db81d3ae9e9119c5efca4998410da9883011f8c82b1a787f88fa7f6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AdminHeader.vue</strong><dd><code>Adjust sidebar header for multiple menus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-72b027d627396e485c9cc13fc1b63078364fa57d249b1af9b940fef26d8e5334">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routes.js</strong><dd><code>Add routes for new endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-fdffa2bc39ec533772c5d1721f53458cdacd5d8f73488016a3d750f04240d6ea">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.css</strong><dd><code>Add styles for card layout and file preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-910f45e97c7505d23011ea07dca95463172d2221403a947301a20b54396d4f18">+11/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese translations for new UI elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+28/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English translations for new UI elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+28/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Update tests for new Skill model fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+55/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Add workspace guide runtime snapshot test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Add workspace guide system prompt test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_skill_artifacts.py</strong><dd><code>Update test for package_name field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-7d2c34e525ee5acc16e3f9bf3eedd8c83cdcf794f34b410f01f1e28057e4fe7d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantSkills.test.js</strong><dd><code>Add skill sorting test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-8abe9ddcac7fa90b00d74bb7ca9253592023a23912c5223bbdbcf7a9cff181c6">+18/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>adminSidebar.test.js</strong><dd><code>Update tests for multi-open sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-de4dc22387107a474a3800075c69c9b812210609f5a675e45c92a89578bfa15f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantWorkspaceGuide.test.js</strong><dd><code>Add workspace guide payload test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-5fbaeff571b6f192f409686755e2ad2e3ff17331ff5e04b359bd6325126c68e8">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>426.yaml</strong><dd><code>Add release note for issue 426</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/427/files#diff-f5880ba44dd9d13d7899b30a5ff8d3722a2cb1e8ce5a109e2df3b0b56022b9ca">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

