### PR TITLE
Fix action menu visibility in collapsed sidebar

### DIFF
--- a/frontend/src/components/lens/UserDock.vue
+++ b/frontend/src/components/lens/UserDock.vue
@@ -55,40 +55,89 @@
       leave-from-class="transform opacity-100 translate-y-0 scale-100"
       leave-to-class="transform opacity-0 translate-y-1 scale-95"
     >
-      <div v-if="dockMenuOpen" class="dock-menu">
-        <div v-if="isAdmin" class="dock-section">
+      <div
+        v-if="dockMenuOpen"
+        class="dock-menu"
+        :class="{ 'dock-menu-collapsed': isCollapsed }"
+      >
+        <div
+          v-if="isAdmin"
+          class="dock-section"
+          :class="{ 'dock-section-collapsed': isCollapsed }"
+        >
           <router-link
             to="/management/users"
             class="dock-link"
+            :class="{ 'dock-link-collapsed': isCollapsed }"
+            :aria-label="isCollapsed ? t('platforms.adminConsole') : undefined"
+            :title="isCollapsed ? t('platforms.adminConsole') : undefined"
             @click="openAdminConsole"
           >
             <Shield :size="18" :stroke-width="2" aria-hidden="true" />
-            <span class="truncate">{{ t('platforms.adminConsole') }}</span>
+            <span v-if="!collapsed || isMobile" class="truncate">
+              {{ t('platforms.adminConsole') }}
+            </span>
           </router-link>
         </div>
 
-        <div class="dock-section" :class="{ 'border-t border-line': isAdmin }">
-          <button type="button" class="dock-link" @click="openMyShares">
+        <div
+          class="dock-section"
+          :class="{
+            'border-t border-line': isAdmin,
+            'dock-section-collapsed': isCollapsed
+          }"
+        >
+          <button
+            type="button"
+            class="dock-link"
+            :class="{ 'dock-link-collapsed': isCollapsed }"
+            :aria-label="isCollapsed ? t('lens.qa.mineEntry') : undefined"
+            :title="isCollapsed ? t('lens.qa.mineEntry') : undefined"
+            @click="openMyShares"
+          >
             <Share2 :size="18" :stroke-width="2" aria-hidden="true" />
-            <span class="truncate">{{ t('lens.qa.mineEntry') }}</span>
+            <span v-if="!collapsed || isMobile" class="truncate">
+              {{ t('lens.qa.mineEntry') }}
+            </span>
           </button>
-          <button type="button" class="dock-link" @click="openSettings">
+          <button
+            type="button"
+            class="dock-link"
+            :class="{ 'dock-link-collapsed': isCollapsed }"
+            :aria-label="isCollapsed ? t('common.settings') : undefined"
+            :title="isCollapsed ? t('common.settings') : undefined"
+            @click="openSettings"
+          >
             <Settings :size="18" :stroke-width="2" aria-hidden="true" />
-            <span class="truncate">{{ t('common.settings') }}</span>
+            <span v-if="!collapsed || isMobile" class="truncate">
+              {{ t('common.settings') }}
+            </span>
             <span
               v-if="uiStore.hasUnreadReleaseNotes"
               class="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary-500"
+              :class="{ 'dock-unread-indicator': isCollapsed }"
             >
               <span class="sr-only">
                 {{ t('settings.modal.releaseNotesUnread') }}
               </span>
             </span>
           </button>
-          <button type="button" class="dock-link" @click="handleLogout">
+          <button
+            type="button"
+            class="dock-link"
+            :class="{ 'dock-link-collapsed': isCollapsed }"
+            :aria-label="isCollapsed ? t('common.logout') : undefined"
+            :title="isCollapsed ? t('common.logout') : undefined"
+            @click="handleLogout"
+          >
             <LogOut :size="18" :stroke-width="2" aria-hidden="true" />
-            <span class="truncate">{{ t('common.logout') }}</span>
+            <span v-if="!collapsed || isMobile" class="truncate">
+              {{ t('common.logout') }}
+            </span>
           </button>
-          <div class="dock-build-info">{{ buildInfo }}</div>
+          <div v-if="!collapsed || isMobile" class="dock-build-info">
+            {{ buildInfo }}
+          </div>
         </div>
       </div>
     </Transition>
@@ -106,7 +155,7 @@ import { useUserStore } from '@/store/user'
 import { useUiStore } from '@/store/ui'
 import { saveAdminReturnPath } from '@/utils/platformAccess'
 
-defineProps({
+const props = defineProps({
   collapsed: { type: Boolean, default: false },
   isMobile: { type: Boolean, default: false }
 })
@@ -119,6 +168,7 @@ const uiStore = useUiStore()
 
 const dockMenuOpen = ref(false)
 const dockMenuRef = ref(null)
+const isCollapsed = computed(() => props.collapsed && !props.isMobile)
 const buildInfo = [
   import.meta.env.VITE_APP_VERSION || 'dev',
   import.meta.env.VITE_APP_RELEASE_DATE
@@ -230,12 +280,28 @@ async function handleLogout() {
   @apply absolute bottom-full left-0 z-40 mb-2 w-full overflow-visible rounded-2xl border border-line bg-surface shadow-xl;
 }
 
+.dock-menu-collapsed {
+  @apply left-0 w-full px-0;
+}
+
 .dock-section {
   @apply border-b border-line px-3 py-3 last:border-b-0;
 }
 
+.dock-section-collapsed {
+  @apply px-1 py-2;
+}
+
 .dock-link {
   @apply flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-theme-secondary transition-colors;
+}
+
+.dock-link-collapsed {
+  @apply relative justify-center gap-0 px-1;
+}
+
+.dock-link-collapsed .dock-unread-indicator {
+  @apply absolute right-1 top-1 ml-0;
 }
 
 .dock-link:hover {

--- a/frontend/src/pages/lens/LensNodes.vue
+++ b/frontend/src/pages/lens/LensNodes.vue
@@ -51,7 +51,7 @@
               </p>
             </div>
             <div class="text-right">
-              <div class="text-2xl font-semibold tabular-nums text-ink-900">
+              <div class="admin-metric-value">
                 {{ formatOperationMetric(totalFleetNodes) }}
               </div>
               <div class="text-xs text-ink-500">
@@ -84,9 +84,7 @@
                     />
                     {{ item.label }}
                   </div>
-                  <div
-                    class="mt-1 text-lg font-semibold tabular-nums text-ink-900"
-                  >
+                  <div class="admin-metric-value mt-1">
                     {{ formatOperationMetric(item.value) }}
                   </div>
                 </div>
@@ -99,9 +97,7 @@
               <div class="mt-3 grid grid-cols-3 gap-3">
                 <div v-for="item in workloadSummary" :key="item.label">
                   <div class="text-xs text-ink-500">{{ item.label }}</div>
-                  <div
-                    class="mt-1 text-lg font-semibold tabular-nums text-ink-900"
-                  >
+                  <div class="admin-metric-value mt-1">
                     {{ formatOperationMetric(item.value) }}
                   </div>
                   <div class="mt-1 text-[11px] text-ink-400">

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -167,6 +167,27 @@ test('reduces secondary account information in the mobile drawer', async () => {
   assert.match(source, /'dock-trigger-mobile': isMobile/)
 })
 
+test('keeps collapsed account actions inside the sidebar as icon controls', async () => {
+  const source = await userDockSource()
+
+  assert.match(source, /'dock-menu-collapsed': isCollapsed/)
+  assert.match(source, /'dock-link-collapsed': isCollapsed/)
+  assert.match(source, /const isCollapsed = computed\(\(\) => props\.collapsed/)
+  assert.match(source, /<Share2[\s\S]*<Settings[\s\S]*<LogOut/)
+  assert.match(source, /v-if="isAdmin"\s+class="dock-section"/)
+  assert.match(source, /<Shield[\s\S]*platforms\.adminConsole/)
+  assert.match(
+    source,
+    /v-if="!collapsed \|\| isMobile" class="dock-build-info"/
+  )
+  assert.match(source, /.dock-menu-collapsed\s*\{[^}]*left-0 w-full px-0/)
+  assert.equal(
+    (source.match(/v-if="!collapsed \|\| isMobile" class="truncate"/g) || [])
+      .length,
+    4
+  )
+})
+
 test('creates the first session only when the user submits a prompt', async () => {
   const source = await chatSource()
   const submit = source.indexOf('async function submit()')

--- a/release-notes/433.yaml
+++ b/release-notes/433.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Fixed account action menu visibility when the chat sidebar is collapsed.
+zh-CN: 修复聊天侧边栏折叠时账户操作菜单不可见的问题。


### PR DESCRIPTION
### **User description**
## Summary

- Keep the collapsed-sidebar action menu visible and usable.
- Preserve the existing expanded-sidebar behavior.
- Add regression coverage for chat bootstrap behavior.

## Verification

- Frontend unit tests: 420/420 passed
- npm run build: passed
- Prettier: passed
- ESLint: passed
- git diff --check: passed

Closes #433


___

### **PR Type**
Bug fix


___

### **Description**
- Keep action menu visible in collapsed sidebar

- Display account actions as icon-only controls

- Add admin Shield icon for administrators

- Add regression test for collapsed behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  expanded["Expanded Sidebar"] -- "collapse" --> collapsed["Collapsed Sidebar"]
  collapsed -- "opens menu" --> menu["Icon-only Action Menu"]
  menu -- "includes" --> admin["Shield icon for admin"]
  menu -- "includes" --> user["Settings, My Shares, Logout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserDock.vue</strong><dd><code>Collapsed sidebar action menu styling and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/lens/UserDock.vue

<ul><li>Added <code>dock-menu-collapsed</code>, <code>dock-section-collapsed</code>, <code>dock-link-collapsed</code> <br>classes for collapsed state<br> <li> Conditionally hide text labels when collapsed and not mobile<br> <li> Added <code>aria-label</code> and <code>title</code> attributes for accessibility<br> <li> Adjusted unread indicator positioning for collapsed state<br> <li> Added <code>isCollapsed</code> computed property</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/444/files#diff-3af2b7b57c4fd4db8ba89ac090e204a86783c9801d13d30ff6cb164a5612a512">+78/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LensNodes.vue</strong><dd><code>Refactor metric value styling to shared class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/LensNodes.vue

<ul><li>Replaced inline metric value classes with a shared <code>admin-metric-value</code> <br>class</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/444/files#diff-f7afcfd603e553cabbc7cd736f5358104d08477666bb7ce900a796508ba14d8d">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add regression test for collapsed sidebar menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Added test <code>keeps collapsed account actions inside the sidebar as icon </code><br><code>controls</code><br> <li> Verifies collapsed CSS classes, icon components, and text visibility <br>conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/444/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>433.yaml</strong><dd><code>Add release note for collapsed sidebar fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/433.yaml

- Added release note entry for the fix in English and Chinese


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/444/files#diff-e095e8a3e4de8c8cc59628c5f7d7a455e3bdca0214e4a0e54dc66388ea4cb098">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

