### PR TITLE
feat(lens): add compact collapsed conversation history

### DIFF
--- a/frontend/e2e/chat-mobile-drawer.spec.js
+++ b/frontend/e2e/chat-mobile-drawer.spec.js
@@ -296,10 +296,29 @@ test('desktop sidebar still expands and collapses', async ({ page }) => {
   await page.goto('/lens/assistants/drawer-test/chat')
 
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
-  await page.getByRole('button', { name: 'Collapse' }).click()
+  await page.locator('.sidebar-collapse-btn[aria-label="Collapse"]').click()
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 64 })
   await page.locator('.sidebar-collapse-btn[aria-label="Expand"]').click()
   await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+})
+
+test('desktop history collapses into a compact Recent row', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await mockChat(page)
+  await page.goto('/lens/assistants/drawer-test/chat')
+
+  await expect.poll(() => sidebarBox(page)).toMatchObject({ x: 0, width: 264 })
+  await page.locator('.sessions-collapse-toggle').click()
+  await expect(page.locator('.sessions-collapsed')).toBeVisible()
+  await expect(page.locator('.sessions-collapsed-trigger')).toContainText(
+    'Recent'
+  )
+  await expect(page.locator('.sessions-collapsed-action')).toHaveCount(1)
+  await expect(page.locator('.session-item')).toHaveCount(0)
+
+  await page.locator('.sessions-collapsed-trigger').click()
+  await expect(page.locator('.sessions-collapsed')).toHaveCount(0)
+  await expect(page.locator('.session-item')).toHaveCount(3)
 })
 
 test.describe('touch input accessibility', () => {

--- a/frontend/src/components/ui/RowActionMenu.vue
+++ b/frontend/src/components/ui/RowActionMenu.vue
@@ -82,6 +82,10 @@ const props = defineProps({
   label: {
     type: String,
     default: ''
+  },
+  placement: {
+    type: String,
+    default: 'left'
   }
 })
 
@@ -120,8 +124,21 @@ function openMenu(focusFirst = false) {
     return height + estimatedItemHeight + dividerHeight
   }, 8)
   const opensUpward = rect.bottom + estimatedHeight > window.innerHeight
+  const rightPosition = rect.right + 4
+  const leftPosition = rect.left - menuWidth - 4
+  const preferredLeft =
+    props.placement === 'right' ? rightPosition : rect.right - menuWidth
+  const fallbackLeft =
+    props.placement === 'right' ? leftPosition : preferredLeft
+  const boundedLeft =
+    preferredLeft + menuWidth <= window.innerWidth - 8
+      ? preferredLeft
+      : fallbackLeft
   menuStyle.value = {
-    left: `${Math.max(8, Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8))}px`,
+    left: `${Math.max(
+      8,
+      Math.min(boundedLeft, window.innerWidth - menuWidth - 8)
+    )}px`,
     top: opensUpward ? undefined : `${rect.bottom + 4}px`,
     bottom: opensUpward ? `${window.innerHeight - rect.top + 4}px` : undefined
   }

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -124,116 +124,153 @@
           v-if="!sidebarCollapsedActive || isMobile"
           class="sessions-section"
         >
-          <div class="sessions-head">
-            <h2 class="sr-only">{{ t('lens.chat.sessionLists') }}</h2>
-            <div
-              class="session-filters"
-              role="group"
-              :aria-label="t('lens.chat.sessionLists')"
+          <div
+            v-if="sessionHistoryCollapsed && !isMobile"
+            class="sessions-collapsed"
+          >
+            <button
+              type="button"
+              class="sessions-collapsed-trigger"
+              :aria-label="t('lens.chat.sessions')"
+              :title="t('lens.chat.sessions')"
+              @click="sessionHistoryCollapsed = false"
             >
-              <button
-                type="button"
-                :class="{ 'session-filter-active': !showArchivedSessions }"
-                :aria-pressed="!showArchivedSessions"
-                @click="switchSessionView(false)"
-              >
-                {{ t('lens.chat.sessions') }}
-              </button>
-              <button
-                type="button"
-                :class="{ 'session-filter-active': showArchivedSessions }"
-                :aria-pressed="showArchivedSessions"
-                @click="switchSessionView(true)"
-              >
-                {{ t('lens.chat.archivedSessions') }}
-              </button>
-            </div>
+              <span>{{ t('lens.chat.sessions') }}</span>
+              <ChevronRight :size="15" :stroke-width="2" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="sessions-collapsed-action"
+              :aria-label="t('lens.chat.newSession')"
+              :title="t('lens.chat.newSession')"
+              @click="createNewSession"
+            >
+              <Pencil :size="16" :stroke-width="2" aria-hidden="true" />
+            </button>
           </div>
-          <div class="sessions-list">
-            <div
-              v-for="session in sessions"
-              :key="session.uuid"
-              class="session-item"
-              :class="{
-                'session-item-active': selectedSessionUuid === session.uuid
-              }"
-            >
-              <input
-                v-if="renamingSessionUuid === session.uuid"
-                v-model="renameDraft"
-                class="session-rename-input"
-                :placeholder="t('lens.chat.untitledSession')"
-                @click.stop
-                @keydown.enter.stop.prevent="saveRename(session)"
-                @keydown.esc.stop="cancelRename"
-                @blur="saveRename(session)"
-              />
-              <template v-else>
-                <div
-                  class="min-w-0 flex-1 cursor-pointer"
-                  :title="session.title || t('lens.chat.untitledSession')"
-                  @click="selectSession(session)"
+          <template v-else>
+            <div class="sessions-head">
+              <h2 class="sr-only">{{ t('lens.chat.sessionLists') }}</h2>
+              <div
+                class="session-filters"
+                role="group"
+                :aria-label="t('lens.chat.sessionLists')"
+              >
+                <button
+                  type="button"
+                  :class="{ 'session-filter-active': !showArchivedSessions }"
+                  :aria-pressed="!showArchivedSessions"
+                  @click="switchSessionView(false)"
                 >
-                  <div class="session-title-row">
-                    <Pin
-                      v-if="session.pinned_at"
-                      class="session-pinned-icon"
-                      :size="13"
-                      :stroke-width="2.2"
-                      :aria-label="t('lens.chat.pinned')"
-                    />
-                    <div class="session-title">
-                      {{ session.title || t('lens.chat.untitledSession') }}
+                  {{ t('lens.chat.sessions') }}
+                </button>
+                <button
+                  type="button"
+                  :class="{ 'session-filter-active': showArchivedSessions }"
+                  :aria-pressed="showArchivedSessions"
+                  @click="switchSessionView(true)"
+                >
+                  {{ t('lens.chat.archivedSessions') }}
+                </button>
+                <button
+                  v-if="!isMobile"
+                  type="button"
+                  class="sessions-collapse-toggle"
+                  :aria-label="t('common.collapse')"
+                  :title="t('common.collapse')"
+                  @click="sessionHistoryCollapsed = true"
+                >
+                  <ChevronUp :size="15" :stroke-width="2" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+            <div class="sessions-list">
+              <div
+                v-for="session in sessions"
+                :key="session.uuid"
+                class="session-item"
+                :class="{
+                  'session-item-active': selectedSessionUuid === session.uuid
+                }"
+              >
+                <input
+                  v-if="renamingSessionUuid === session.uuid"
+                  v-model="renameDraft"
+                  class="session-rename-input"
+                  :placeholder="t('lens.chat.untitledSession')"
+                  @click.stop
+                  @keydown.enter.stop.prevent="saveRename(session)"
+                  @keydown.esc.stop="cancelRename"
+                  @blur="saveRename(session)"
+                />
+                <template v-else>
+                  <div
+                    class="min-w-0 flex-1 cursor-pointer"
+                    :title="session.title || t('lens.chat.untitledSession')"
+                    @click="selectSession(session)"
+                  >
+                    <div class="session-title-row">
+                      <Pin
+                        v-if="session.pinned_at"
+                        class="session-pinned-icon"
+                        :size="13"
+                        :stroke-width="2.2"
+                        :aria-label="t('lens.chat.pinned')"
+                      />
+                      <div class="session-title">
+                        {{ session.title || t('lens.chat.untitledSession') }}
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <div class="flex shrink-0 items-center gap-1">
-                  <span
-                    v-if="sessionActivity.hasActivity(session.uuid)"
-                    class="session-activity-indicator"
-                    :title="t('lens.chat.sessionActive')"
-                  >
-                    <LoaderCircle
-                      :size="15"
-                      :stroke-width="2.2"
-                      aria-hidden="true"
+                  <div class="flex shrink-0 items-center gap-1">
+                    <span
+                      v-if="sessionActivity.hasActivity(session.uuid)"
+                      class="session-activity-indicator"
+                      :title="t('lens.chat.sessionActive')"
+                    >
+                      <LoaderCircle
+                        :size="15"
+                        :stroke-width="2.2"
+                        aria-hidden="true"
+                      />
+                      <span class="sr-only">
+                        {{ t('lens.chat.sessionActive') }}
+                      </span>
+                    </span>
+                    <span
+                      v-else-if="sessionHasUnreadAnswer(session.uuid)"
+                      class="session-unread-indicator"
+                      :title="t('lens.chat.unreadAnswer')"
+                    >
+                      <span class="sr-only">
+                        {{ t('lens.chat.unreadAnswer') }}
+                      </span>
+                    </span>
+                    <RowActionMenu
+                      class="session-overflow"
+                      placement="right"
+                      :actions="sessionActions(session)"
+                      :label="
+                        t('lens.chat.sessionActions', {
+                          title: session.title || t('lens.chat.untitledSession')
+                        })
+                      "
+                      @click.stop
+                      @select="handleSessionAction(session, $event)"
                     />
-                    <span class="sr-only">
-                      {{ t('lens.chat.sessionActive') }}
-                    </span>
-                  </span>
-                  <span
-                    v-else-if="sessionHasUnreadAnswer(session.uuid)"
-                    class="session-unread-indicator"
-                    :title="t('lens.chat.unreadAnswer')"
-                  >
-                    <span class="sr-only">
-                      {{ t('lens.chat.unreadAnswer') }}
-                    </span>
-                  </span>
-                  <RowActionMenu
-                    class="session-overflow"
-                    :actions="sessionActions(session)"
-                    :label="
-                      t('lens.chat.sessionActions', {
-                        title: session.title || t('lens.chat.untitledSession')
-                      })
-                    "
-                    @click.stop
-                    @select="handleSessionAction(session, $event)"
-                  />
-                </div>
-              </template>
+                  </div>
+                </template>
+              </div>
+              <p v-if="!sessions.length" class="session-list-empty">
+                {{
+                  showArchivedSessions
+                    ? t('lens.chat.noArchivedSessions')
+                    : t('lens.chat.noRecentSessions')
+                }}
+              </p>
             </div>
-            <p v-if="!sessions.length" class="session-list-empty">
-              {{
-                showArchivedSessions
-                  ? t('lens.chat.noArchivedSessions')
-                  : t('lens.chat.noRecentSessions')
-              }}
-            </p>
-          </div>
+          </template>
         </section>
       </div>
 
@@ -1613,6 +1650,8 @@ import {
   Archive,
   ArchiveRestore,
   ArrowLeft,
+  ChevronRight,
+  ChevronUp,
   MessagesSquare,
   PanelLeftClose,
   PanelLeftOpen,
@@ -1785,6 +1824,7 @@ const loading = ref({ run: false })
 const streamController = ref(null)
 const sidebarOpen = ref(false)
 const sidebarCollapsed = ref(false)
+const sessionHistoryCollapsed = ref(false)
 const showArchivedSessions = ref(false)
 const deleteSessionTarget = ref(null)
 const deletingSession = ref(false)
@@ -4237,7 +4277,7 @@ onBeforeUnmount(() => {
 }
 
 .session-filters {
-  @apply flex items-center gap-1;
+  @apply flex w-full items-center gap-1;
 }
 
 .session-filters button {
@@ -4247,6 +4287,17 @@ onBeforeUnmount(() => {
 .session-filters button:hover,
 .session-filter-active {
   @apply bg-surface-hover text-theme;
+}
+
+.sessions-collapse-toggle {
+  @apply ml-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md
+    text-theme-muted transition-colors;
+}
+
+.sessions-collapse-toggle:hover,
+.sessions-collapse-toggle:focus-visible {
+  @apply bg-surface-hover text-theme;
+  outline: none;
 }
 
 .sessions-list {
@@ -4304,6 +4355,32 @@ onBeforeUnmount(() => {
 .session-item-active .session-overflow,
 .session-overflow.row-action-menu-open {
   @apply opacity-100;
+}
+
+.sessions-collapsed {
+  @apply flex items-center gap-1 px-1;
+}
+
+.sessions-collapsed-trigger {
+  @apply flex min-w-0 flex-1 items-center gap-1 rounded-md px-1 py-2
+    text-left text-sm font-semibold text-theme-muted transition-colors;
+}
+
+.sessions-collapsed-trigger:hover,
+.sessions-collapsed-trigger:focus-visible,
+.sessions-collapsed-action:hover,
+.sessions-collapsed-action:focus-visible {
+  @apply bg-surface-hover text-theme;
+  outline: none;
+}
+
+.sessions-collapsed-trigger span {
+  @apply truncate;
+}
+
+.sessions-collapsed-action {
+  @apply flex h-8 w-8 shrink-0 items-center justify-center rounded-md
+    text-theme-muted transition-colors;
 }
 
 .session-rename-input {

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -149,6 +149,17 @@ test('keeps the closed mobile sidebar out of keyboard navigation', async () => {
   assert.match(source, /:aria-hidden="isMobile && !sidebarOpen"/)
 })
 
+test('collapses the conversation history into a compact Recent row', async () => {
+  const source = await chatSource()
+
+  assert.match(source, /sessionHistoryCollapsed = true/)
+  assert.match(source, /class="sessions-collapsed"/)
+  assert.match(source, /class="sessions-collapsed-trigger"[\s\S]*<ChevronRight/)
+  assert.match(source, /class="sessions-collapsed-action"/)
+  assert.match(source, /placement="right"/)
+  assert.match(source, /\.sessions-collapsed\s*\{[\s\S]*items-center/)
+})
+
 test('shows only a direct share action for mobile answer tools', async () => {
   const source = await chatSource()
 

--- a/release-notes/448.yaml
+++ b/release-notes/448.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: Added a compact collapsed state for desktop conversation history.
+zh-CN: 新增桌面端会话历史的紧凑折叠状态。


### PR DESCRIPTION
Closes #435

### **User description**
## Summary

- Add a desktop compact collapsed state for recent conversation history.
- Keep new-session and expand controls available in the compact row.
- Improve desktop session action-menu placement and add regression coverage.

## Validation

- `npm run test:unit` — 423 passed
- `chat-mobile-drawer.spec.js` — 11 passed
- `npm run build` — passed
- ESLint check — 0 errors


___

### **PR Type**
Enhancement


___

### **Description**
- Add compact collapsed state for desktop conversation history.

- Improve RowActionMenu placement with new `placement` prop.

- Add unit and e2e tests for the collapsed behavior.

- Update release notes for the new feature.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Desktop sidebar"] --> B["Collapse toggle button"]
  B --> C["Compact collapsed row"]
  C --> D["Expand trigger"]
  C --> E["New session button"]
  D --> F["Full session list"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RowActionMenu.vue</strong><dd><code>Add placement prop to RowActionMenu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/RowActionMenu.vue

<ul><li>Added <code>placement</code> prop (default 'left') to control menu alignment.<br> <li> Updated menu positioning logic to support right-aligned placement and <br>prevent overflow.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/448/files#diff-8329649ce7285b0226d6f5015e7936cf3666e305466a4b865f437011b87efa4b">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Add compact collapsed conversation history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added <code>sessionHistoryCollapsed</code> reactive state and toggle button.<br> <li> Implemented collapsed view with trigger and new session action.<br> <li> Added collapse toggle in session filters (ChevronUp icon).<br> <li> Updated RowActionMenu usage with <code>placement="right"</code>.<br> <li> Added new icons (ChevronRight, ChevronUp) and related CSS.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/448/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+179/-102</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-mobile-drawer.spec.js</strong><dd><code>Add e2e test for collapsed history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/e2e/chat-mobile-drawer.spec.js

<ul><li>Added e2e test for desktop history collapse (compact Recent row).<br> <li> Updated existing test to use correct selector for collapse button.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/448/files#diff-cb89d191cc946ddb676d704f3a7398dba03f09b1e45585cd92e06cefb093cdaa">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add unit test for collapsed history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Added unit test to verify collapsed state components in source.<br> <li> Checks for sessionHistoryCollapsed, collapsed classes, icons, and <br>placement.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/448/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>448.yaml</strong><dd><code>Add release note for collapsed history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/448.yaml

<ul><li>Added release note for the compact collapsed conversation history <br>feature.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/448/files#diff-536b53e1b10c09a1fe9bcea70cd60d01cf0c2fa57317d0b91520e34690fe444e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

