### PR TITLE
Support Enter to submit chat messages

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1487,8 +1487,8 @@
                   class="composer-input"
                   rows="1"
                   :placeholder="t('lens.chat.questionPlaceholder')"
-                  @keydown.enter.exact.prevent="insertNewline"
-                  @keydown.ctrl.enter.exact.prevent="handlePrimaryAction"
+                  @keydown.enter.exact.prevent="handlePrimaryAction"
+                  @keydown.ctrl.enter.exact.prevent="insertNewline"
                   @paste="onComposerPaste"
                   @input="autoResizeTextarea"
                 />

--- a/frontend/tests/chatComposerKeyboard.test.js
+++ b/frontend/tests/chatComposerKeyboard.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('submits with Enter and preserves multiline input with Ctrl+Enter', async () => {
+  const source = await readFile(
+    new URL('../src/pages/lens/Chat.vue', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(source, /@keydown\.enter\.exact\.prevent="handlePrimaryAction"/)
+  assert.match(source, /@keydown\.ctrl\.enter\.exact\.prevent="insertNewline"/)
+})


### PR DESCRIPTION
## Summary
- Submit chat messages with Enter.
- Preserve multiline input with Ctrl+Enter.
- Add a keyboard-binding regression test.

Closes #450

## Test plan
- [x] `npm run test:unit`
- [x] `npx eslint src/pages/lens/Chat.vue tests/chatComposerKeyboard.test.js`
- [x] `npm run build`
- [x] Browser keyboard interaction verified with ego-browser.