### PR TITLE
Align chat composer shortcuts with ChatGPT

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1639,7 +1639,7 @@
                   :placeholder="t('lens.chat.questionPlaceholder')"
                   @keydown="handleComposerKeydown"
                   @keydown.enter.exact.prevent="handlePrimaryAction"
-                  @keydown.ctrl.enter.exact.prevent="insertNewline"
+                  @keydown.shift.enter.exact.prevent="insertNewline"
                   @paste="onComposerPaste"
                   @input="handleComposerInput"
                 />

--- a/frontend/tests/chatComposerKeyboard.test.js
+++ b/frontend/tests/chatComposerKeyboard.test.js
@@ -2,12 +2,13 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
-test('submits with Enter and preserves multiline input with Ctrl+Enter', async () => {
+test('submits with Enter and preserves multiline input with Shift+Enter', async () => {
   const source = await readFile(
     new URL('../src/pages/lens/Chat.vue', import.meta.url),
     'utf8'
   )
 
   assert.match(source, /@keydown\.enter\.exact\.prevent="handlePrimaryAction"/)
-  assert.match(source, /@keydown\.ctrl\.enter\.exact\.prevent="insertNewline"/)
+  assert.match(source, /@keydown\.shift\.enter\.exact\.prevent="insertNewline"/)
+  assert.doesNotMatch(source, /@keydown\.ctrl\.enter/)
 })


### PR DESCRIPTION
## Summary
- Submit chat messages with Enter.
- Insert multiline breaks with Shift+Enter.
- Leave Ctrl/Cmd+Enter unhandled to preserve native textarea behavior.

Closes #456

## Test plan
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Browser keyboard interaction verified with ego-browser.