### PR TITLE
Fix Smart Collaboration access and assistant visibility

### DIFF
--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -2136,6 +2136,34 @@ class LensApiTests(TestCase):
         with self.assertRaises(PermissionDenied):
             serializer.save()
 
+    def test_smart_session_run_allows_hidden_coordinator(self):
+        """Smart sessions may run through their hidden system coordinator."""
+
+        GlobalSetting.objects.create(
+            key="lens.smart_collaboration.model_ref",
+            value="11111111-1111-1111-1111-111111111111",
+        )
+        self.assistant.visibility = Assistant.Visibility.PUBLIC
+        self.assistant.save(update_fields=["visibility"])
+        session_response = self.client.post(
+            "/api/lens/sessions/",
+            {"routing_mode": "smart"},
+            format="json",
+        )
+        self.assertEqual(session_response.status_code, 201)
+
+        run_response = self.client.post(
+            f"/api/lens/sessions/{session_response.data['uuid']}/runs/",
+            {
+                "question": "Coordinate this request.",
+                "enqueue": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(run_response.status_code, 201)
+        self.assertEqual(run_response.data["execution"]["task"], "general_chat")
+
     def test_smart_run_can_limit_one_run_without_updating_session_scope(self):
         """A routing assistant override belongs to the Run snapshot only."""
 

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -88,6 +88,17 @@ from .shares import _shared_qa_default_title, _unique_share_token
 logger = logging.getLogger(__name__)
 
 
+def _session_assistant_is_runnable(session, user):
+    """Return whether a session may start work for its owning user."""
+
+    assistant = session.assistant
+    if assistant.status != Assistant.Status.ACTIVE:
+        return False
+    if session.routing_mode == Session.RoutingMode.SMART:
+        return assistant.is_system
+    return assistant.is_accessible_by(user)
+
+
 async def run_stream_view(request, uuid):
     """Stream run events as SSE without DRF response buffering."""
 
@@ -258,10 +269,7 @@ class SessionViewSet(BaseAuthenticatedViewSet):
         """Create an execution run for a session."""
 
         session = self.get_object()
-        if (
-            session.assistant.status != Assistant.Status.ACTIVE
-            or not session.assistant.is_accessible_by(request.user)
-        ):
+        if not _session_assistant_is_runnable(session, request.user):
             raise PermissionDenied(
                 "You do not have access to this assistant."
             )
@@ -287,10 +295,7 @@ class SessionViewSet(BaseAuthenticatedViewSet):
         """Upload one attachment for a session question."""
 
         session = self.get_object()
-        if (
-            session.assistant.status != Assistant.Status.ACTIVE
-            or not session.assistant.is_accessible_by(request.user)
-        ):
+        if not _session_assistant_is_runnable(session, request.user):
             raise PermissionDenied(
                 "You do not have access to this assistant."
             )

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -350,7 +350,7 @@
               {{ assistantDescription }}
             </p>
             <div
-              v-if="isSmartCollaborationConversation && selectedSession"
+              v-if="isSmartCollaborationConversation"
               class="relative mt-2"
             >
               <button
@@ -359,7 +359,7 @@
                 @click="openRoutingScope"
               >
                 {{ t('lens.chat.participatingAssistants', {
-                  count: selectedSession.allowed_assistant_uuids?.length || 0
+                  count: routingScopeAssistantUuids.length
                 }) }}
               </button>
               <div
@@ -389,7 +389,7 @@
                   <button
                     type="button"
                     class="rounded px-2 py-1 text-xs text-ink-600 hover:bg-surface-sunken"
-                    @click="routingScopeOpen = false"
+                    @click="cancelRoutingScope"
                   >
                     {{ t('common.cancel') }}
                   </button>
@@ -1985,6 +1985,7 @@ const mySharesOpen = ref(false)
 const booted = ref(false)
 const routingScopeOpen = ref(false)
 const routingScopeDraft = ref([])
+const routingScopeSnapshot = ref([])
 const mentionedAssistantUuid = ref('')
 const mentionActiveIndex = ref(0)
 const isSmartCollaborationConversation = computed(
@@ -2012,6 +2013,12 @@ const routingCandidates = computed(() =>
   assistants.value.filter((assistant) => assistant.status === 'active')
 )
 
+const routingScopeAssistantUuids = computed(() =>
+  selectedSession.value?.allowed_assistant_uuids?.length
+    ? selectedSession.value.allowed_assistant_uuids
+    : routingScopeDraft.value
+)
+
 const mentionToken = computed(() => {
   if (!isSmartCollaborationConversation.value) return null
   return /^@([^\s]*)/.exec(question.value)
@@ -2019,8 +2026,9 @@ const mentionToken = computed(() => {
 
 const mentionCandidates = computed(() => {
   const allowed = new Set(
-    selectedSession.value?.allowed_assistant_uuids ||
-      routingCandidates.value.map((assistant) => assistant.uuid)
+    routingScopeAssistantUuids.value.length
+      ? routingScopeAssistantUuids.value
+      : routingCandidates.value.map((assistant) => assistant.uuid)
   )
   const query = (mentionToken.value?.[1] || '').toLocaleLowerCase()
   return routingCandidates.value.filter(
@@ -2205,10 +2213,18 @@ function messageMentionSegments(content) {
 }
 
 function openRoutingScope() {
-  routingScopeDraft.value = [
-    ...(selectedSession.value?.allowed_assistant_uuids || [])
-  ]
+  routingScopeDraft.value = selectedSession.value
+    ? [...(selectedSession.value.allowed_assistant_uuids || [])]
+    : routingScopeDraft.value.length
+      ? [...routingScopeDraft.value]
+      : routingCandidates.value.map((assistant) => assistant.uuid)
+  routingScopeSnapshot.value = [...routingScopeDraft.value]
   routingScopeOpen.value = true
+}
+
+function cancelRoutingScope() {
+  routingScopeDraft.value = [...routingScopeSnapshot.value]
+  routingScopeOpen.value = false
 }
 
 function selectAssistantMention(assistant) {
@@ -2266,8 +2282,12 @@ function handleComposerKeydown(event) {
 }
 
 async function saveRoutingScope() {
-  if (!selectedSession.value || !routingScopeDraft.value.length) {
+  if (!routingScopeDraft.value.length) {
     showWarning(t('lens.chat.participatingAssistantsRequired'))
+    return
+  }
+  if (!selectedSession.value) {
+    routingScopeOpen.value = false
     return
   }
   try {
@@ -3032,6 +3052,9 @@ async function bootstrap() {
 
     if (isSmartCollaborationConversation.value) {
       selectedAssistantUuid.value = ''
+      routingScopeDraft.value = routingCandidates.value.map(
+        (assistant) => assistant.uuid
+      )
       await loadMyShareState()
       await loadSessions()
       booted.value = true
@@ -3141,7 +3164,11 @@ async function createNewSession(notify = true) {
   try {
     session = await createSession(
       isSmartCollaborationConversation.value
-        ? { routing_mode: 'smart', title: '' }
+        ? {
+            routing_mode: 'smart',
+            title: '',
+            allowed_assistant_uuids: routingScopeAssistantUuids.value
+          }
         : { assistant_uuid: selectedAssistant.value.uuid, title: '' }
     )
   } catch {

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -221,6 +221,21 @@ test('creates the first session only when the user submits a prompt', async () =
   assert.ok(createFirstSession < bindSession)
 })
 
+test('lets Smart Collaboration select assistants before its first session', async () => {
+  const source = await chatSource()
+  const scopeButton = source.indexOf(
+    'v-if="isSmartCollaborationConversation"\n              class="relative mt-2"'
+  )
+  const scopeCandidates = source.indexOf('const routingScopeAssistantUuids')
+  const sessionPayload = source.indexOf(
+    'allowed_assistant_uuids: routingScopeAssistantUuids.value'
+  )
+
+  assert.notEqual(scopeButton, -1)
+  assert.notEqual(scopeCandidates, -1)
+  assert.notEqual(sessionPayload, -1)
+})
+
 test('keeps every conversation layout free of repeated message avatars', async () => {
   const source = await chatSource()
 


### PR DESCRIPTION
## Summary\n- Allow Smart Collaboration runs and attachments to use the hidden system coordinator without ordinary assistant access checks.\n- Show the participating-assistant selector before the first Smart session and preserve the selected range for first-session creation.\n- Keep lazy first-session creation and add backend/frontend regression coverage.\n\nCloses #458\n\n## Test plan\n- [x] Frontend chat, regression, and keyboard tests (40 passed)\n- [x] Backend Smart Collaboration API regression tests (3 passed)\n- [x] Frontend production build\n- [x] git diff --check\n\nNo changelog or release-notes files were added.