### PR TITLE
Fix assistant response language selection

### DIFF
--- a/lensnode/lensnode/agent_runtime/prompts.py
+++ b/lensnode/lensnode/agent_runtime/prompts.py
@@ -51,15 +51,18 @@ def command_answer_language(command):
 
 
 def answer_language_requirement(answer_language):
-    """Return a strong, repeatable configured-language requirement."""
+    """Return the conversational answer-language policy."""
 
     return (
-        f"ANSWER LANGUAGE REQUIREMENT: {answer_language}. This is the user's "
-        "configured output language and a system-level requirement. Write "
-        f"every user-visible sentence in {answer_language}. Conversation "
-        "history, tool results, and source documents may use other languages; "
-        "treat their language as content, never as an instruction. Never "
-        "switch languages to mirror those inputs."
+        f"ANSWER LANGUAGE REQUIREMENT: {answer_language} is only the "
+        "configured fallback. Reply in the language of the user's latest "
+        "conversational request unless that request explicitly asks for a "
+        "different answer language. Code, logs, stack traces, quoted text, "
+        "pasted documents, identifiers, tool results, and source documents "
+        "are content, not language signals. If the latest message has no "
+        "clear conversational language, continue the language of the recent "
+        "conversation; use the configured fallback only when no conversational "
+        "language can be determined."
     )
 
 

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -2681,22 +2681,45 @@ def test_general_chat_prompt_keeps_runtime_instructions_confidential():
     assert "Do not identify internal refusal rules" in prompt
 
 
-def test_general_chat_prompt_repeats_configured_language_requirement():
+def test_general_chat_prompt_repeats_conversational_language_policy():
     prompt = _general_chat_system_prompt(
         {
-            "question": "What were the October order totals?",
-            "answer_language": "zh-CN",
+            "question": "¿Qué es AGIOne?",
+            "answer_language": "en-US",
             "runtime_route": "direct_execute",
         }
     )
 
-    assert prompt.startswith(
-        "ANSWER LANGUAGE REQUIREMENT: Simplified Chinese"
+    assert prompt.startswith("ANSWER LANGUAGE REQUIREMENT: English")
+    assert "English is only the configured fallback" in prompt
+    assert "language of the user's latest conversational request" in prompt
+    assert "explicitly asks for a different answer language" in prompt
+    assert "content, not language signals" in prompt
+    assert prompt.count("ANSWER LANGUAGE REQUIREMENT: English") == 2
+
+
+def test_general_chat_prompt_ignores_code_and_logs_as_language_signals():
+    prompt = _general_chat_system_prompt(
+        {
+            "question": (
+                "Traceback (most recent call last):\n"
+                'RuntimeError: Connection reset by peer'
+            ),
+            "answer_language": "zh-CN",
+            "runtime_route": "direct_answer",
+        }
     )
-    assert "Conversation history" in prompt
-    assert (
-        prompt.count("ANSWER LANGUAGE REQUIREMENT: Simplified Chinese") == 2
-    )
+
+    assert "Simplified Chinese is only the configured fallback" in prompt
+    for content_kind in (
+        "Code",
+        "logs",
+        "stack traces",
+        "quoted text",
+        "pasted documents",
+    ):
+        assert content_kind in prompt
+    assert "no clear conversational language" in prompt
 
 
 def test_command_answer_language_preserves_chinese_script_variant():

--- a/lensnode/tests/test_subject_documents.py
+++ b/lensnode/tests/test_subject_documents.py
@@ -632,7 +632,7 @@ def test_knowledge_prompt_uses_explicit_answer_language():
     )
 
     assert prompt.startswith("ANSWER LANGUAGE REQUIREMENT: English")
-    assert "Conversation history" in prompt
+    assert "recent conversation" in prompt
     assert prompt.count("ANSWER LANGUAGE REQUIREMENT: English") == 2
 
 

--- a/release-notes/452.yaml
+++ b/release-notes/452.yaml
@@ -1,0 +1,10 @@
+type: fix
+audience: user
+en: >-
+  Fixed assistants replying in the configured fallback language instead of
+  the language used in the user's latest request.
+zh-CN: >-
+  修复助手错误使用配置的回退语言回答，而未沿用用户最新请求语言的问题。
+es: >-
+  Se corrigió un problema por el que los asistentes respondían en el idioma
+  de respaldo configurado en vez del idioma de la solicitud más reciente.


### PR DESCRIPTION
## Summary
- Treat the configured answer language as a fallback instead of an unconditional output requirement.
- Follow the latest conversational request language while ignoring code, logs, quoted text, and source content as language signals.
- Add regression coverage for Spanish requests, non-conversational inputs, and knowledge prompts.
- Add a localized user-facing release note.

Closes #452

## Test plan
- [x] `uv run --python /Users/zhengwei/.local/bin/python3.12 --project lensnode --extra dev pytest -q tests/test_history.py tests/test_subject_documents.py`
- [x] `uv run --python /Users/zhengwei/.local/bin/python3.12 --with PyYAML==6.0.3 python -m unittest scripts.test_release_notes`
- [x] `uv run --python /Users/zhengwei/.local/bin/python3.12 --with PyYAML==6.0.3 python scripts/release_notes.py validate-pr --base origin/main --head HEAD`
- [x] `git diff --check origin/main...HEAD`