### PR TITLE
Fix Smart Collaboration delegated execution isolation

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -91,7 +91,6 @@ HISTORY_MAX_TOTAL_CHARS = 32000
 CLARIFICATION_MAX_ORIGINAL_CHARS = HISTORY_MAX_TOTAL_CHARS
 CLARIFICATION_MAX_PROMPT_CHARS = 20000
 HISTORY_ARTIFACT_MAX_FILES = 3
-MAX_DELEGATION_DEPTH = 3
 MAX_SUBAGENTS_PER_RUN = 8
 
 QUERY_REWRITE_HISTORY_TURNS = 3
@@ -1314,70 +1313,6 @@ def select_execution_lensnode(assistant):
     return min(candidates, key=lambda item: (item.active_runs, item.created_at))
 
 
-@transaction.atomic
-def create_delegated_run(parent_run, assistant_uuid, question):
-    """Create a child Run on the selected assistant's own execution node."""
-
-    if parent_run.session.routing_mode != Session.RoutingMode.SMART:
-        raise LensNodeDispatchError("SUBAGENT_NOT_ALLOWED")
-    ancestry = set()
-    current = parent_run
-    depth = 0
-    while current is not None:
-        if current.pk in ancestry or depth >= MAX_DELEGATION_DEPTH:
-            raise LensNodeDispatchError("SUBAGENT_DEPTH_EXCEEDED")
-        ancestry.add(current.pk)
-        current = current.parent_run
-        depth += 1
-
-    configured = (
-        (parent_run.execution.runtime_snapshot or {}).get("subagents")
-        or []
-    )
-    allowed = {
-        str(item.get("uuid"))
-        for item in configured
-        if isinstance(item, dict)
-    }
-    if str(assistant_uuid) not in allowed:
-        raise LensNodeDispatchError("SUBAGENT_NOT_ALLOWED")
-    assistant = Assistant.objects.filter(
-        visibility__in=[
-            Assistant.Visibility.PUBLIC,
-            Assistant.Visibility.PRIVATE,
-        ],
-        uuid=assistant_uuid,
-        capability__in=[
-            Assistant.Capability.GENERAL_CHAT,
-            Assistant.Capability.CODE_ANALYSIS,
-            Assistant.Capability.KNOWLEDGE_QA,
-        ],
-        status=Assistant.Status.ACTIVE,
-    ).visible_to(parent_run.session.user).first()
-    if assistant is None:
-        raise LensNodeDispatchError("SUBAGENT_UNAVAILABLE")
-    if assistant.pk in {
-        item.session.assistant_id
-        for item in Run.objects.filter(pk__in=ancestry).select_related(
-            "session"
-        )
-    }:
-        raise LensNodeDispatchError("SUBAGENT_CYCLE")
-    session = Session.objects.create(
-        assistant=assistant,
-        user=parent_run.session.user,
-        title=f"Delegated: {parent_run.uuid}",
-        title_manually_edited=True,
-    )
-    return create_execution_run(
-        session=session,
-        question=question,
-        enqueue=True,
-        user=None,
-        parent_run=parent_run,
-    )
-
-
 def validate_retry_run(session, retry_of_run):
     """Reject Retry links outside the Session or with an existing cycle."""
 
@@ -1910,15 +1845,6 @@ def create_run_execution_snapshot(
         run.session,
         routing_assistant_uuids,
     )
-    if (
-        routing_assistant_uuids
-        and len(routing_assistant_uuids) == 1
-        and not any(
-            item.get("uuid") == str(routing_assistant_uuids[0])
-            for item in runtime_snapshot.get("subagents", [])
-        )
-    ):
-        raise LensNodeDispatchError("SUBAGENT_NODE_MISMATCH")
     execution, _ = RunExecution.objects.get_or_create(
         run=run,
         defaults={
@@ -1988,11 +1914,7 @@ def _build_run_runtime_snapshot(
                 "mcp_bindings__environment_variable_set",
             )
         )
-        subagents = [
-            item
-            for item in subagents
-            if item.lensnode_id is None or item.lensnode_id == lensnode.id
-        ][:MAX_SUBAGENTS_PER_RUN]
+        subagents = subagents[:MAX_SUBAGENTS_PER_RUN]
         subagents = [
             {
                 "uuid": str(item.uuid),

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -67,7 +67,6 @@ from lens.services import (
     build_run_history,
     build_run_history_artifacts,
     create_execution_run,
-    create_delegated_run,
     create_run_execution_snapshot,
     dispatch_run_to_lensnode,
     finish_lensnode_run,
@@ -200,69 +199,6 @@ class LensServiceTests(TransactionTestCase):
 
         self.assertEqual(selected, idle)
         self.assertEqual(busy_run.lensnode, self.lensnode)
-
-    def test_delegated_run_uses_selected_assistant_lensnode(self):
-        self.session.routing_mode = Session.RoutingMode.SMART
-        self.session.save(update_fields=["routing_mode"])
-        self.assistant.visibility = Assistant.Visibility.PUBLIC
-        self.assistant.save(update_fields=["visibility"])
-        child_node = LensNode.objects.create(
-            name="Data LensNode",
-            status=LensNode.Status.ONLINE,
-            enrollment_status=LensNode.EnrollmentStatus.APPROVED,
-            tasks=[{"name": "knowledge_qa"}],
-        )
-        child = Assistant.objects.create(
-            name="Data Assistant",
-            slug="data-assistant",
-            lensnode=child_node,
-            selected_task="knowledge_qa",
-            visibility=Assistant.Visibility.PUBLIC,
-        )
-        parent = create_execution_run(
-            session=self.session,
-            question="Investigate incident",
-            enqueue=False,
-        )
-        parent.execution.runtime_snapshot["subagents"] = [
-            {"uuid": str(child.uuid)}
-        ]
-        parent.execution.save(update_fields=["runtime_snapshot"])
-
-        delegated = create_delegated_run(
-            parent,
-            child.uuid,
-            "Query production error rate",
-        )
-
-        self.assertEqual(delegated.parent_run, parent)
-        self.assertEqual(delegated.session.assistant, child)
-        self.assertEqual(delegated.lensnode, child_node)
-
-    def test_delegated_run_rejects_depth_overflow(self):
-        self.session.routing_mode = Session.RoutingMode.SMART
-        self.session.save(update_fields=["routing_mode"])
-        self.assistant.visibility = Assistant.Visibility.PUBLIC
-        self.assistant.save(update_fields=["visibility"])
-        parent = create_execution_run(
-            session=self.session,
-            question="Root",
-            enqueue=False,
-        )
-        current = parent
-        for _ in range(3):
-            current = Run.objects.create(
-                session=self.session,
-                status=Run.Status.QUEUED,
-                input_message=parent.input_message,
-                parent_run=current,
-                lensnode=self.lensnode,
-            )
-        with self.assertRaisesMessage(
-            LensNodeDispatchError,
-            "SUBAGENT_DEPTH_EXCEEDED",
-        ):
-            create_delegated_run(current, self.assistant.uuid, "Too deep")
 
     def test_smart_run_rechecks_live_assistant_access(self):
         self.assistant.visibility = Assistant.Visibility.PRIVATE

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -15,11 +15,13 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from lens.citations import sanitize_run_citations
 from lens.document_attachments import (
     document_attachment_storage,
     get_document_attachment,
 )
 from lens.models import Run, RunOutputFile, Skill
+from lens.services import LensNodeDispatchError
 from lens.skill_packages import package_zip_bytes
 
 from .base import EventStreamRenderer, LensNodeAuthMixin

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -152,7 +152,15 @@ class SessionViewSet(BaseAuthenticatedViewSet):
                 status=Run.Status.DONE,
                 output_message__isnull=False,
             )
-            return queryset.filter(status=session_status).annotate(
+            delegated_sessions = Run.objects.filter(
+                session=OuterRef("pk"),
+                parent_run__isnull=False,
+            )
+            return queryset.filter(
+                status=session_status,
+            ).filter(
+                ~Exists(delegated_sessions),
+            ).annotate(
                 has_shareable_answer=Exists(shareable_runs),
             ).order_by(
                 F("pinned_at").desc(nulls_last=True),

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -353,10 +353,8 @@ class LensDeepAgentRuntime:
     def _subagents_enabled(self, state):
         """Return whether this run may delegate work to a subagent.
 
-        General Chat exposes the task tool only on the plan_execute route,
-        where a complex multi-step task can be split across subagents;
-        simple direct-answer and direct-execute runs keep it disabled.
-        Smart Collaboration always keeps the task tool available.
+        General Chat exposes the task tool only on the plan_execute route.
+        Smart Collaboration uses the configured local subagents.
         """
 
         if self._is_smart_collaboration(state.command):
@@ -747,6 +745,7 @@ class LensDeepAgentRuntime:
                 on_runtime_evidence=lambda _state: (
                     state.persist_execution_state()
                 ),
+                http_client=self.http_client,
             )
         else:
             state.tools = build_agent_tools(
@@ -1063,6 +1062,7 @@ class LensDeepAgentRuntime:
                     )
                 ]
                 if use_subagents
+                and not self._is_smart_collaboration(state.command)
                 else []
             ),
             "name": f"lensnode-{state.command.get('task') or 'agent'}",
@@ -1167,6 +1167,7 @@ class LensDeepAgentRuntime:
             if name in seen_names:
                 name = f"{name[:70]}-{index + 1}"
             seen_names.add(name)
+            observation_name = name.lower()
             command = {
                 "run_uuid": f"{state.run_uuid[:48]}-subagent-{index + 1}",
                 "task": snapshot.get("task") or "general_chat",
@@ -1184,6 +1185,7 @@ class LensDeepAgentRuntime:
                 on_activity=state.on_activity,
             )
             state.subagent_resources.append(resources)
+            backend = _build_execution_backend(self.config, resources.root)
             tools = build_agent_tools(
                 command,
                 resources,
@@ -1216,31 +1218,42 @@ class LensDeepAgentRuntime:
                 run_uuid=state.run_uuid,
                 trace_context=state.trace_context,
                 emit_observation=state.emit_trace_observation,
-                observation_name=name,
+                observation_name=observation_name,
+            )
+            description = (
+                str(snapshot.get("description") or "")
+                or f"Delegate work to the {raw_name} assistant."
+            )[:500]
+            system_prompt = (
+                "You are the delegated assistant named "
+                f"{raw_name}. Use only your provided tools and skills. "
+                "Return concise, evidence-based findings to the "
+                "Smart Collaboration coordinator.\n\n"
+                + str(snapshot.get("workspace_guide") or "")
+            )
+            skill_paths = [
+                _virtual_skill_path(resources, path)
+                for path in resources.skill_paths
+            ]
+            middleware = (
+                [state.trace_middleware]
+                if state.trace_middleware is not None
+                else []
+            )
+            runnable = create_deep_agent(
+                model=model,
+                tools=tools,
+                system_prompt=system_prompt,
+                backend=backend,
+                skills=skill_paths or None,
+                middleware=middleware,
+                name=f"{name}-subagent",
             )
             subagents.append(
                 {
                     "name": name,
-                    "description": (
-                        str(snapshot.get("description") or "")
-                        or f"Delegate work to the {raw_name} assistant."
-                    )[:500],
-                    "system_prompt": (
-                        "You are the delegated assistant named "
-                        f"{raw_name}. Use only your provided tools and skills. "
-                        "Return concise, evidence-based findings to the "
-                        "Smart Collaboration coordinator.\n\n"
-                        + str(snapshot.get("workspace_guide") or "")
-                    ),
-                    "model": model,
-                    "tools": tools,
-                    "skills": [
-                        _virtual_skill_path(resources, path)
-                        for path in resources.skill_paths
-                    ],
-                    "middleware": [state.trace_middleware]
-                    if state.trace_middleware is not None
-                    else [],
+                    "description": description,
+                    "runnable": runnable,
                 }
             )
         return subagents

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -1169,7 +1169,10 @@ class LensDeepAgentRuntime:
             seen_names.add(name)
             observation_name = name.lower()
             command = {
-                "run_uuid": f"{state.run_uuid[:48]}-subagent-{index + 1}",
+                "run_uuid": state.run_uuid,
+                "runtime_instance_id": (
+                    f"{state.run_uuid[:48]}-subagent-{index + 1}"
+                ),
                 "task": snapshot.get("task") or "general_chat",
                 "target_dirs": snapshot.get("target_dirs") or [],
                 "loaded_skills": snapshot.get("loaded_skills") or [],

--- a/lensnode/lensnode/agent_runtime/system_prompts.py
+++ b/lensnode/lensnode/agent_runtime/system_prompts.py
@@ -130,10 +130,10 @@ def _knowledge_system_prompt(
     if command.get("routing_mode") == "smart":
         collaboration_guidance = (
             "You are coordinating a Smart Collaboration request. Decompose "
-            "the request into "
-            "independent workstreams and delegate them to the named assistant "
-            "subagents when useful. You may issue multiple task calls in one "
-            "turn for parallel execution, then synthesize their findings.\n\n"
+            "the request into independent workstreams and call the task "
+            "tool for each selected assistant. You may issue multiple task "
+            "calls in one turn for parallel execution, then synthesize their "
+            "findings.\n\n"
         )
     return (
         collaboration_guidance +
@@ -190,7 +190,7 @@ def _knowledge_system_prompt(
         "multiple files at once, or run multiple searches at once, by "
         "issuing several tool calls in one message. Only go step by step "
         "when a later action genuinely depends on an earlier result.\n\n"
-        f"{_subagent_guidance(command.get('agent_rounds'))}"
+        f"{_subagent_guidance(command.get('agent_rounds'), command)}"
         "How search and read work:\n"
         "- search_workspace returns matching LINES (path + line number + "
         "surrounding context), not whole files, and works on files of any "
@@ -424,6 +424,7 @@ def _smart_collaboration_system_prompt(
         assistants.append(
             f"- {name}｜{capability_label or '专用能力'}"
             f"｜{description or '无额外说明'}"
+            f" [assistant_uuid={item.get('uuid', '')}]"
         )
     roster = "\n".join(assistants) or "- 当前没有可委派助手"
     if command.get("routing_assistant_uuid"):
@@ -443,7 +444,8 @@ def _smart_collaboration_system_prompt(
         "你是 SourceLens 的智能协作助手。根据用户问题，从下列允许范围中选择"
         "最合适的助手完成工作，并对结果进行整合。\n\n"
         "工作原则：\n"
-        "- 仅使用名单中的助手；独立子任务可以并行委派。\n"
+        "- 仅使用名单中的助手；独立子任务可以并行委派。使用 task 工具"
+        "并选择名单中的助手；所有子任务都属于当前 Run。\n"
         f"{routing_directive}"
         "- 委派后只根据实际返回的结果作答；缺少结果时明确说明。\n"
         "- 用户询问当前能力或可用助手时，只说明助手集合及其能力；仅在用户明确询问"
@@ -476,7 +478,7 @@ def _workspace_guide_prompt(workspace_guide):
     )
 
 
-def _subagent_guidance(agent_rounds):
+def _subagent_guidance(agent_rounds, command=None):
     """Return depth-tiered guidance on when to use the task subagent.
 
     Subagents are a completed agent loop each (multi-round, minute-scale),
@@ -486,6 +488,12 @@ def _subagent_guidance(agent_rounds):
     main loop and parallelize with batched tool calls instead.
     """
 
+    if (command or {}).get("routing_mode") == "smart":
+        return (
+            "Use the task tool for independent workstreams. Multiple task "
+            "calls in one turn are allowed; collect every subagent result "
+            "before synthesizing the final answer.\n\n"
+        )
     if agent_rounds in ("deep", "max"):
         return (
             "Delegating subtasks (task tool): when the question splits "

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -1122,6 +1122,7 @@ def build_general_chat_tools(
     emit_event=None,
     runtime_evidence=None,
     on_runtime_evidence=None,
+    http_client=None,
 ):
     """Build tools for General Chat without workspace retrieval tools."""
 

--- a/lensnode/lensnode/execution_queue.py
+++ b/lensnode/lensnode/execution_queue.py
@@ -9,6 +9,7 @@ class ExecutionClass(StrEnum):
     """Resource class used by the LensNode-local execution queue."""
 
     STANDARD = "standard"
+    DELEGATED = "delegated"
     EXCLUSIVE = "exclusive"
 
 
@@ -31,6 +32,8 @@ class LensNodeExecutionQueue:
         self._lock = asyncio.Lock()
         self._waiting = collections.deque()
         self._active_standard = 0
+        self._active_delegated = 0
+        self.max_delegated_concurrency = self.max_standard_concurrency
         self._exclusive_active = False
 
     async def acquire(
@@ -79,6 +82,11 @@ class LensNodeExecutionQueue:
                 raise RuntimeError("No exclusive LensNode work is active.")
             self._exclusive_active = False
             return
+        if execution_class == ExecutionClass.DELEGATED:
+            if self._active_delegated <= 0:
+                raise RuntimeError("No delegated LensNode work is active.")
+            self._active_delegated -= 1
+            return
         if self._active_standard <= 0:
             raise RuntimeError("No standard LensNode work is active.")
         self._active_standard -= 1
@@ -89,7 +97,8 @@ class LensNodeExecutionQueue:
         if self._exclusive_active:
             return
         self._admit_standard_waiters()
-        if self._active_standard:
+        self._admit_delegated_waiters()
+        if self._active_standard or self._active_delegated:
             return
         if not self._waiting:
             return
@@ -108,6 +117,22 @@ class LensNodeExecutionQueue:
                 and self._active_standard < self.max_standard_concurrency
             ):
                 self._active_standard += 1
+                request.admitted.set_result(None)
+            else:
+                waiting.append(request)
+        self._waiting = waiting
+
+    def _admit_delegated_waiters(self):
+        """Admit delegated work independently of the parent Run slot."""
+
+        waiting = collections.deque()
+        while self._waiting:
+            request = self._waiting.popleft()
+            if (
+                request.execution_class == ExecutionClass.DELEGATED
+                and self._active_delegated < self.max_delegated_concurrency
+            ):
+                self._active_delegated += 1
                 request.admitted.set_result(None)
             else:
                 waiting.append(request)

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -1198,8 +1198,13 @@ class LensNodeClient:
                     }
                 )
 
+            execution_class = (
+                ExecutionClass.DELEGATED
+                if message.get("parent_run_uuid")
+                else ExecutionClass.STANDARD
+            )
             await self._acquire_execution(
-                ExecutionClass.STANDARD,
+                execution_class,
                 on_queued=report_queued,
             )
             slot_acquired = True
@@ -1228,9 +1233,7 @@ class LensNodeClient:
                     await self.executor.drain_pending_workers()
             finally:
                 if slot_acquired:
-                    await self.execution_queue.release(
-                        ExecutionClass.STANDARD
-                    )
+                    await self.execution_queue.release(execution_class)
                 self.running_tasks.pop(run_uuid, None)
                 self.running_commands.pop(run_uuid, None)
                 self.admitted_runs.discard(run_uuid)

--- a/lensnode/lensnode/runtime_resources.py
+++ b/lensnode/lensnode/runtime_resources.py
@@ -101,7 +101,10 @@ def prepare_runtime_resources(
     workspace = Path(config.workspace_path)
     base = workspace / ".sourcelens"
     cache_root = base / "cache"
-    runtime_root = _run_runtime_path(workspace, command["run_uuid"])
+    runtime_instance_id = (
+        command.get("runtime_instance_id") or command["run_uuid"]
+    )
+    runtime_root = _run_runtime_path(workspace, runtime_instance_id)
     skills_root = runtime_root / "skills"
     mcp_root = runtime_root / "mcp"
 

--- a/lensnode/tests/test_deliverable.py
+++ b/lensnode/tests/test_deliverable.py
@@ -100,6 +100,32 @@ def test_save_deliverable_uploads_file(monkeypatch, tmp_path):
     assert any(name == "tool.save_deliverable.done" for name, _ in events)
 
 
+def test_save_deliverable_ignores_runtime_instance_id(monkeypatch, tmp_path):
+    (tmp_path / "report.html").write_text("ok", encoding="utf-8")
+    captured = {}
+
+    def handler(request):
+        captured["body"] = request.read()
+        return httpx.Response(201, json={"ok": True})
+
+    _install_transport(monkeypatch, handler)
+    tool = _build_save_deliverable_tool(
+        {
+            "run_uuid": "parent-run",
+            "runtime_instance_id": "parent-run-subagent-1",
+        },
+        _resources(tmp_path),
+        _config(),
+        None,
+    )
+
+    payload = json.loads(tool.invoke({"path": "report.html"}))
+
+    assert payload["ok"] is True
+    assert b"\r\nparent-run\r\n" in captured["body"]
+    assert b"parent-run-subagent-1" not in captured["body"]
+
+
 def test_save_deliverable_rejects_escape(monkeypatch, tmp_path):
     def handler(request):
         raise AssertionError("upload must not be attempted")

--- a/lensnode/tests/test_execution_queue.py
+++ b/lensnode/tests/test_execution_queue.py
@@ -80,3 +80,17 @@ def test_cancelling_queued_work_does_not_leak_capacity():
         await queue.release(ExecutionClass.STANDARD)
 
     asyncio.run(exercise())
+
+
+def test_delegated_work_has_capacity_while_parent_is_running():
+    async def exercise():
+        queue = LensNodeExecutionQueue(max_standard_concurrency=1)
+        await queue.acquire(ExecutionClass.STANDARD)
+        await asyncio.wait_for(
+            queue.acquire(ExecutionClass.DELEGATED),
+            timeout=1,
+        )
+        await queue.release(ExecutionClass.DELEGATED)
+        await queue.release(ExecutionClass.STANDARD)
+
+    asyncio.run(exercise())

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -899,6 +899,31 @@ def test_runtime_resources_collect_context_skill_content(tmp_path):
         cleanup_runtime_resources(resources)
 
 
+def test_runtime_resources_use_runtime_instance_id_for_scratch(tmp_path):
+    config = type(
+        "Config",
+        (),
+        {
+            "workspace_path": str(tmp_path),
+        },
+    )()
+    parent_run_uuid = "00000000-0000-0000-0000-000000000002"
+    runtime_instance_id = f"{parent_run_uuid}-subagent-1"
+    command = {
+        "run_uuid": parent_run_uuid,
+        "runtime_instance_id": runtime_instance_id,
+        "loaded_skills": [],
+        "loaded_mcps": [],
+    }
+
+    resources = prepare_runtime_resources(config, command)
+
+    try:
+        assert resources.root.name == runtime_instance_id
+    finally:
+        cleanup_runtime_resources(resources)
+
+
 def test_mcp_credentials_are_materialized_only_in_run_directory(tmp_path):
     config = type(
         "Config",

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -4180,12 +4180,25 @@ def test_smart_subagent_uses_its_own_model_and_tools(monkeypatch):
         lambda command, *_args, **_kwargs: [command["task"]],
     )
     monkeypatch.setattr(agent_runtime, "load_mcp_tools", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        agent_runtime,
+        "_build_execution_backend",
+        lambda _config, root: ("backend", root),
+    )
 
     class Model:
         def __init__(self, **kwargs):
             self.model_ref = kwargs["model_ref"]
+            self.observation_name = kwargs["observation_name"]
 
     monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    captured = {}
+
+    def capture_deep_agent(**kwargs):
+        captured.update(kwargs)
+        return "compiled-subagent"
+
+    monkeypatch.setattr(agent_runtime, "create_deep_agent", capture_deep_agent)
     state = SimpleNamespace(
         run_uuid="00000000-0000-0000-0000-000000000021",
         command={
@@ -4215,9 +4228,84 @@ def test_smart_subagent_uses_its_own_model_and_tools(monkeypatch):
         state
     )
 
-    assert subagents[0]["model"].model_ref == "data-model"
-    assert subagents[0]["tools"] == ["general_chat"]
-    assert subagents[0]["skills"] == ["skills/data"]
+    assert subagents[0]["runnable"] == "compiled-subagent"
+    assert captured["model"].model_ref == "data-model"
+    assert captured["tools"] == ["general_chat"]
+    assert captured["backend"] == ("backend", Path("/run/subagent"))
+    assert captured["skills"] == ["skills/data"]
+
+
+def test_smart_collaboration_builds_local_subagents(monkeypatch):
+    """Smart Collaboration must use local Deep Agents subagents."""
+
+    state = SimpleNamespace(
+        run_uuid="00000000-0000-0000-0000-000000000022",
+        command={
+            "run_uuid": "00000000-0000-0000-0000-000000000022",
+            "routing_mode": "smart",
+            "subagents": [
+                {
+                    "uuid": "assistant-1",
+                    "name": "Production data",
+                    "description": "Query read-only production data.",
+                    "task": "general_chat",
+                    "agent_model_ref": "data-model",
+                    "loaded_skills": [],
+                    "loaded_mcps": [],
+                }
+            ],
+        },
+        cancel_event=None,
+        on_activity=None,
+        trace_context={},
+        emit_trace_observation=None,
+        trace_middleware=None,
+        subagent_resources=[],
+        emit_agent_event=lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            root=Path("/run/subagent"),
+            mcp_configs=[],
+            skill_paths=[],
+        ),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_agent_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(agent_runtime, "load_mcp_tools", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        agent_runtime,
+        "_build_execution_backend",
+        lambda _config, root: ("backend", root),
+    )
+
+    class Model:
+        def __init__(self, **kwargs):
+            self.model_ref = kwargs["model_ref"]
+            self.observation_name = kwargs["observation_name"]
+
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        lambda **_kwargs: "compiled-subagent",
+    )
+
+    subagents = agent_runtime.LensDeepAgentRuntime(
+        SimpleNamespace(
+            ai_gateway_url="http://gateway/ai/",
+            token="token",
+            request_timeout_s=30,
+        )
+    )._build_configured_subagents(state)
+
+    assert len(subagents) == 1
+    assert subagents[0]["runnable"] == "compiled-subagent"
 
 
 def test_summarization_middleware_forwards_run_uuid(monkeypatch):

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -4169,10 +4169,16 @@ def test_smart_subagent_uses_its_own_model_and_tools(monkeypatch):
         token="token",
         request_timeout_s=30,
     )
+    prepared_command = {}
+
+    def prepare_resources(_config, command, **_kwargs):
+        prepared_command.update(command)
+        return resources
+
     monkeypatch.setattr(
         agent_runtime,
         "prepare_runtime_resources",
-        lambda *_args, **_kwargs: resources,
+        prepare_resources,
     )
     monkeypatch.setattr(
         agent_runtime,
@@ -4233,6 +4239,10 @@ def test_smart_subagent_uses_its_own_model_and_tools(monkeypatch):
     assert captured["tools"] == ["general_chat"]
     assert captured["backend"] == ("backend", Path("/run/subagent"))
     assert captured["skills"] == ["skills/data"]
+    assert prepared_command["run_uuid"] == state.run_uuid
+    assert prepared_command["runtime_instance_id"] == (
+        f"{state.run_uuid}-subagent-1"
+    )
 
 
 def test_smart_collaboration_builds_local_subagents(monkeypatch):


### PR DESCRIPTION
## Summary
- Compile Smart Collaboration subagents with isolated execution backends and virtual skill paths.
- Keep delegated task calls in the parent Run and normalize observation names for gateway compatibility.
- Preserve the parent Run identity for deliverable uploads while isolating delegated scratch resources.
- Add independent delegated LensNode capacity and hide delegated sessions from the user-facing session list.
- Update collaboration prompts, tool wiring, and regression coverage.

Closes #463

## Test plan
- [x] Python compilation for all changed Python files
- [x] git diff --check
- [x] LensNode targeted tests: 210 passed
- [ ] LensNode targeted suite: 1 unrelated existing failure in `test_lensnode_exclusive_work_blocks_later_standard_run`
- [ ] Backend targeted tests not run locally: backend dependencies are not installed in the selected environment

## Merge policy
- Do not merge automatically; review and merge manually when checks and approvals are complete.

Release notes are intentionally omitted.