### PR TITLE
Improve Smart Collaboration run observability

### DIFF
--- a/backend/lens/tests/test_run_trace.py
+++ b/backend/lens/tests/test_run_trace.py
@@ -304,12 +304,82 @@ class AdminRunTrajectoryAPITests(RunTraceFixtureMixin, TestCase):
             900,
         )
 
+    def test_admin_pages_parent_and_child_events_with_one_global_cursor(self):
+        child_assistant = Assistant.objects.create(
+            name="Delegated trace assistant",
+            slug=f"delegated-trace-{uuid.uuid4()}",
+            lensnode=self.node,
+            selected_task="general_chat",
+        )
+        child_session = Session.objects.create(
+            assistant=child_assistant,
+            user=self.user,
+        )
+        child_run = create_execution_run(
+            child_session,
+            "Inspect the delegated run",
+            enqueue=False,
+            parent_run=self.run,
+        )
+        started_at = timezone.now() - timedelta(seconds=3)
+        append_run_trace_events(
+            self.run.uuid,
+            self.node.uuid,
+            [
+                self.trace_event(
+                    sequence=1,
+                    timestamp=started_at.isoformat(),
+                ),
+                self.trace_event(
+                    sequence=2,
+                    timestamp=(started_at + timedelta(seconds=2)).isoformat(),
+                ),
+            ],
+        )
+        append_run_trace_events(
+            child_run.uuid,
+            self.node.uuid,
+            [
+                self.trace_event(
+                    sequence=1,
+                    timestamp=(started_at + timedelta(seconds=1)).isoformat(),
+                )
+            ],
+        )
+
+        first_page = self.client.get(
+            f"/api/lens/admin/runs/{self.run.uuid}/trajectory/",
+            {"page_size": 2},
+        )
+        second_page = self.client.get(
+            f"/api/lens/admin/runs/{self.run.uuid}/trajectory/",
+            {
+                "page_size": 2,
+                "after_sequence": first_page.data["next_after_sequence"],
+            },
+        )
+
+        self.assertEqual(first_page.status_code, 200, first_page.data)
+        self.assertEqual(
+            [event["sequence"] for event in first_page.data["results"]],
+            [1, 2],
+        )
+        self.assertTrue(first_page.data["has_more"])
+        self.assertEqual(second_page.status_code, 200, second_page.data)
+        self.assertEqual(
+            [event["sequence"] for event in second_page.data["results"]],
+            [3],
+        )
+        self.assertEqual(
+            second_page.data["results"][0]["trace_run_role"],
+            "child",
+        )
+        self.assertFalse(second_page.data["has_more"])
+
     def test_non_admin_cannot_read_trajectory(self):
         client = APIClient()
         client.force_authenticate(self.user)
 
-        response = client.get(
-            f"/api/lens/admin/runs/{self.run.uuid}/trajectory/"
-        )
+        response = client.get(f"/api/lens/admin/runs/{self.run.uuid}/trajectory/")
 
         self.assertEqual(response.status_code, 403)

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -1127,13 +1127,13 @@ class AdminRunResumeView(APIView):
         return Response(_admin_run_row(refreshed))
 
 
-def _trace_event_response(event):
+def _trace_event_response(event, *, trace_run=None, display_sequence=None):
     """Serialize one immutable trajectory row."""
 
     return {
         "uuid": str(event.uuid),
         "event_id": str(event.event_id),
-        "sequence": event.sequence,
+        "sequence": display_sequence if display_sequence is not None else event.sequence,
         "attempt": event.attempt,
         "event_type": event.event_type,
         "timestamp": event.timestamp.isoformat(),
@@ -1144,13 +1144,22 @@ def _trace_event_response(event):
         "parent_call_id": event.parent_call_id or None,
         "payload": event.payload,
         "created_at": event.created_at.isoformat(),
+        "trace_run_uuid": str(trace_run.uuid) if trace_run else None,
+        "trace_run_role": "child" if trace_run and trace_run.parent_run_id else "parent",
+        "assistant_name": (
+            trace_run.session.assistant.name
+            if trace_run and trace_run.session and trace_run.session.assistant
+            else None
+        ),
     }
 
 
-def _run_trace_summary(run):
+def _run_trace_summary(run, trace_runs=None):
     """Return unfiltered timing, category, call, and usage aggregates."""
 
-    events = run.trace_events.all()
+    events = RunTraceEvent.objects.filter(
+        run__in=trace_runs or [run]
+    )
     aggregate = events.aggregate(
         event_count=Count("uuid"),
         first_timestamp=Min("timestamp"),
@@ -1244,40 +1253,77 @@ class AdminRunTrajectoryView(APIView):
             0,
             minimum=0,
         )
-        queryset = RunTraceEvent.objects.filter(
-            run=run,
-            sequence__gt=after_sequence,
+        trace_runs = [run]
+        trace_runs.extend(
+            run.delegated_runs.select_related(
+                "session__assistant",
+            ).all()
         )
+        trace_events = []
+        for trace_run in trace_runs:
+            trace_events.extend(
+                (event, trace_run)
+                for event in RunTraceEvent.objects.filter(run=trace_run)
+            )
+        trace_events.sort(key=lambda item: (item[0].timestamp, item[0].created_at))
+        trace_events = [
+            item for item in trace_events if item[0].sequence > after_sequence
+        ]
         event_type = (params.get("event_type") or "").strip()[:128]
         if event_type:
-            queryset = queryset.filter(event_type=event_type)
+            trace_events = [
+                item for item in trace_events if item[0].event_type == event_type
+            ]
         category = (params.get("category") or "").strip().lower()[:128]
         if category:
-            queryset = queryset.filter(event_type__startswith=f"{category}.")
+            trace_events = [
+                item
+                for item in trace_events
+                if item[0].event_type.startswith(f"{category}.")
+            ]
         call_id = (params.get("call_id") or "").strip()[:128]
         if call_id:
-            queryset = queryset.filter(Q(call_id=call_id) | Q(parent_call_id=call_id))
+            trace_events = [
+                item
+                for item in trace_events
+                if item[0].call_id == call_id or item[0].parent_call_id == call_id
+            ]
         keyword = (params.get("q") or "").strip()[:256]
         if keyword:
-            queryset = queryset.annotate(
-                payload_text=Cast("payload", output_field=TextField())
-            ).filter(
-                Q(event_type__icontains=keyword)
-                | Q(call_id__icontains=keyword)
-                | Q(parent_call_id__icontains=keyword)
-                | Q(payload_text__icontains=keyword)
-            )
-        total = queryset.count()
-        rows = list(queryset.order_by("sequence")[:page_size])
-        next_after_sequence = rows[-1].sequence if rows else None
+            trace_events = [
+                item
+                for item in trace_events
+                if keyword.lower() in " ".join(
+                    [
+                        item[0].event_type or "",
+                        item[0].call_id or "",
+                        item[0].parent_call_id or "",
+                        str(item[0].payload or ""),
+                    ]
+                ).lower()
+            ]
+        numbered_events = [
+            (index, event, trace_run)
+            for index, (event, trace_run) in enumerate(trace_events, start=1)
+        ]
+        total = len(numbered_events)
+        rows = numbered_events[:page_size]
+        next_after_sequence = rows[-1][1].sequence if rows else None
         return Response(
             {
-                "results": [_trace_event_response(event) for event in rows],
+                "results": [
+                    _trace_event_response(
+                        event,
+                        trace_run=trace_run,
+                        display_sequence=event.sequence,
+                    )
+                    for sequence, event, trace_run in rows
+                ],
                 "total": total,
                 "page_size": page_size,
                 "after_sequence": after_sequence,
                 "next_after_sequence": next_after_sequence,
                 "has_more": total > len(rows),
-                "summary": _run_trace_summary(run),
+                "summary": _run_trace_summary(run, trace_runs),
             }
         )

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -2,13 +2,17 @@
 
 import uuid as uuid_lib
 
-from accounts.permissions import HasRequiredFeature
 from agentcore_metering.adapters.django.models import LLMUsage
 from django.db import transaction
 from django.db.models import Count, Max, Min, Q, TextField
 from django.db.models.functions import Cast
 from django.utils import timezone
 from django.utils.dateparse import parse_date
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from accounts.permissions import HasRequiredFeature
 from lens.attachments import get_session_image_attachments
 from lens.citations import public_run_citations
 from lens.document_attachments import (
@@ -21,10 +25,7 @@ from lens.runtime_events import (
     sanitize_loaded_skills,
     sanitize_termination_detail,
 )
-from lens.serializers import (
-    MessageAttachmentSerializer,
-    RunOutputFileSerializer,
-)
+from lens.serializers import MessageAttachmentSerializer, RunOutputFileSerializer
 from lens.services import (
     cancel_descendant_runs,
     cancel_run_on_lensnode,
@@ -33,9 +34,6 @@ from lens.services import (
     supports_run_admission_checkpoint,
     supports_run_checkpoint_resume,
 )
-from rest_framework import status
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 
 def _admin_safe_int(value, default, *, minimum=1, maximum=None):
@@ -443,9 +441,7 @@ def _admin_run_row(run):
         },
         "planned_evidence": counts["planned_evidence"],
         "routing_mode": runtime_snapshot.get("routing_mode") or "direct",
-        "allowed_assistant_uuids": runtime_snapshot.get(
-            "allowed_assistant_uuids", []
-        ),
+        "allowed_assistant_uuids": runtime_snapshot.get("allowed_assistant_uuids", []),
         "delegated_assistants": _sanitize_delegated_assistants(
             runtime_snapshot.get("subagents", [])
         ),
@@ -496,9 +492,7 @@ def _configured_resource_name(candidates, resources, identity_keys):
 
     for resource in resources:
         identities = {
-            str(resource.get(key)).strip()
-            for key in identity_keys
-            if resource.get(key)
+            str(resource.get(key)).strip() for key in identity_keys if resource.get(key)
         }
         if identities.intersection(candidates):
             return (
@@ -532,17 +526,11 @@ def _classify_resource_call(
         )
         if not configured_name:
             server_token = name.split("__")[1:2]
-            server_token = (
-                server_token[0].replace("-", "_")
-                if server_token
-                else ""
-            )
+            server_token = server_token[0].replace("-", "_") if server_token else ""
             for resource in configured_mcps:
                 configured_token = str(resource.get("mcp_name") or "")
                 normalized = "".join(
-                    char.lower()
-                    for char in configured_token
-                    if char.isalnum()
+                    char.lower() for char in configured_token if char.isalnum()
                 )
                 if server_token and server_token.replace("_", "") in normalized:
                     configured_name = configured_token
@@ -558,11 +546,14 @@ def _classify_resource_call(
         }
     ):
         resource_type = "skill"
-        resource_name = _configured_resource_name(
-            candidates,
-            configured_skills,
-            skill_keys,
-        ) or name
+        resource_name = (
+            _configured_resource_name(
+                candidates,
+                configured_skills,
+                skill_keys,
+            )
+            or name
+        )
     return resource_type, resource_name
 
 
@@ -607,9 +598,7 @@ def _admin_run_resource_usage(run, execution):
     configured_skills = sanitize_loaded_skills(
         execution.loaded_skills if execution else []
     )
-    configured_mcps = sanitize_loaded_mcps(
-        execution.loaded_mcps if execution else []
-    )
+    configured_mcps = sanitize_loaded_mcps(execution.loaded_mcps if execution else [])
     calls = {}
     resources = {}
 
@@ -685,14 +674,11 @@ def _admin_run_resource_usage(run, execution):
     else:
         seen_call_ids = set()
         events = run.trace_events.filter(
-            Q(event_type__startswith="tool.")
-            | Q(event_type__startswith="subtool.")
+            Q(event_type__startswith="tool.") | Q(event_type__startswith="subtool.")
         ).exclude(call_id="")
         for event in events.order_by("sequence"):
             payload = event.payload if isinstance(event.payload, dict) else {}
-            name = str(
-                payload.get("name") or payload.get("tool_name") or ""
-            ).strip()
+            name = str(payload.get("name") or payload.get("tool_name") or "").strip()
             if not name or event.call_id in seen_call_ids:
                 continue
             seen_call_ids.add(event.call_id)
@@ -710,9 +696,7 @@ def _admin_run_resource_usage(run, execution):
         "calls": list(calls.values()),
         "resources": list(resources.values()),
         "configured_count": len(configured_skills) + len(configured_mcps),
-        "called_resource_count": sum(
-            item["calls"] > 0 for item in resources.values()
-        ),
+        "called_resource_count": sum(item["calls"] > 0 for item in resources.values()),
         "total_calls": sum(item["calls"] for item in calls.values()),
     }
 
@@ -806,8 +790,7 @@ def _admin_run_detail(run):
                     "task": execution.task,
                     "status": execution.status,
                     "target_dirs": execution.target_dirs,
-                    "routing_mode": runtime_snapshot.get("routing_mode")
-                    or "direct",
+                    "routing_mode": runtime_snapshot.get("routing_mode") or "direct",
                     "allowed_assistant_uuids": runtime_snapshot.get(
                         "allowed_assistant_uuids", []
                     ),
@@ -1133,7 +1116,9 @@ def _trace_event_response(event, *, trace_run=None, display_sequence=None):
     return {
         "uuid": str(event.uuid),
         "event_id": str(event.event_id),
-        "sequence": display_sequence if display_sequence is not None else event.sequence,
+        "sequence": (
+            display_sequence if display_sequence is not None else event.sequence
+        ),
         "attempt": event.attempt,
         "event_type": event.event_type,
         "timestamp": event.timestamp.isoformat(),
@@ -1145,7 +1130,9 @@ def _trace_event_response(event, *, trace_run=None, display_sequence=None):
         "payload": event.payload,
         "created_at": event.created_at.isoformat(),
         "trace_run_uuid": str(trace_run.uuid) if trace_run else None,
-        "trace_run_role": "child" if trace_run and trace_run.parent_run_id else "parent",
+        "trace_run_role": (
+            "child" if trace_run and trace_run.parent_run_id else "parent"
+        ),
         "assistant_name": (
             trace_run.session.assistant.name
             if trace_run and trace_run.session and trace_run.session.assistant
@@ -1157,9 +1144,7 @@ def _trace_event_response(event, *, trace_run=None, display_sequence=None):
 def _run_trace_summary(run, trace_runs=None):
     """Return unfiltered timing, category, call, and usage aggregates."""
 
-    events = RunTraceEvent.objects.filter(
-        run__in=trace_runs or [run]
-    )
+    events = RunTraceEvent.objects.filter(run__in=trace_runs or [run])
     aggregate = events.aggregate(
         event_count=Count("uuid"),
         first_timestamp=Min("timestamp"),
@@ -1259,63 +1244,59 @@ class AdminRunTrajectoryView(APIView):
                 "session__assistant",
             ).all()
         )
-        trace_events = []
-        for trace_run in trace_runs:
-            trace_events.extend(
-                (event, trace_run)
-                for event in RunTraceEvent.objects.filter(run=trace_run)
-            )
-        trace_events.sort(key=lambda item: (item[0].timestamp, item[0].created_at))
+        trace_runs_by_id = {trace_run.id: trace_run for trace_run in trace_runs}
+        ordered_events = RunTraceEvent.objects.filter(
+            run__in=trace_runs,
+        ).order_by("created_at", "run_id", "sequence", "uuid")
         trace_events = [
-            item for item in trace_events if item[0].sequence > after_sequence
+            (sequence, event, trace_runs_by_id[event.run_id])
+            for sequence, event in enumerate(ordered_events, start=1)
+            if sequence > after_sequence
         ]
         event_type = (params.get("event_type") or "").strip()[:128]
         if event_type:
             trace_events = [
-                item for item in trace_events if item[0].event_type == event_type
+                item for item in trace_events if item[1].event_type == event_type
             ]
         category = (params.get("category") or "").strip().lower()[:128]
         if category:
             trace_events = [
                 item
                 for item in trace_events
-                if item[0].event_type.startswith(f"{category}.")
+                if item[1].event_type.startswith(f"{category}.")
             ]
         call_id = (params.get("call_id") or "").strip()[:128]
         if call_id:
             trace_events = [
                 item
                 for item in trace_events
-                if item[0].call_id == call_id or item[0].parent_call_id == call_id
+                if item[1].call_id == call_id or item[1].parent_call_id == call_id
             ]
         keyword = (params.get("q") or "").strip()[:256]
         if keyword:
             trace_events = [
                 item
                 for item in trace_events
-                if keyword.lower() in " ".join(
+                if keyword.lower()
+                in " ".join(
                     [
-                        item[0].event_type or "",
-                        item[0].call_id or "",
-                        item[0].parent_call_id or "",
-                        str(item[0].payload or ""),
+                        item[1].event_type or "",
+                        item[1].call_id or "",
+                        item[1].parent_call_id or "",
+                        str(item[1].payload or ""),
                     ]
                 ).lower()
             ]
-        numbered_events = [
-            (index, event, trace_run)
-            for index, (event, trace_run) in enumerate(trace_events, start=1)
-        ]
-        total = len(numbered_events)
-        rows = numbered_events[:page_size]
-        next_after_sequence = rows[-1][1].sequence if rows else None
+        total = len(trace_events)
+        rows = trace_events[:page_size]
+        next_after_sequence = rows[-1][0] if rows else None
         return Response(
             {
                 "results": [
                     _trace_event_response(
                         event,
                         trace_run=trace_run,
-                        display_sequence=event.sequence,
+                        display_sequence=sequence,
                     )
                     for sequence, event, trace_run in rows
                 ],

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -1401,6 +1401,7 @@
                 <RunTrajectoryPanel
                   v-show="activeExecutionView === 'trace'"
                   :run-uuid="selectedUuid"
+                  :assistant-name="detail.assistant_name"
                   :run-status="detail.status"
                   :active="
                     activeDetailTab === 'execution' &&

--- a/frontend/src/admin/pages/lens/RunObservation.vue
+++ b/frontend/src/admin/pages/lens/RunObservation.vue
@@ -2224,7 +2224,7 @@ function scheduleDetailRefresh() {
   }, 2000)
 }
 
-onMounted(async () => {
+onMounted(() => {
   filters.value.user_id = String(route.query.user_id || '')
   filters.value.group_id = String(route.query.group_id || '')
   filters.value.username = String(route.query.username || '')
@@ -2232,12 +2232,16 @@ onMounted(async () => {
   filters.value.lensnode = String(route.query.lensnode || '')
   filters.value.model = String(route.query.model || '')
   advancedFiltersOpen.value = advancedFilterCount.value > 0
-  try {
-    assistants.value = await listAssistants()
-  } catch {
-    assistants.value = []
-  }
-  fetchRuns()
+  void Promise.all([
+    listAssistants()
+      .then((items) => {
+        assistants.value = items
+      })
+      .catch(() => {
+        assistants.value = []
+      }),
+    fetchRuns()
+  ])
 })
 
 watch(detailVisible, (visible) => {

--- a/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
+++ b/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
@@ -115,19 +115,6 @@
         @select-event="onTimelineSelect"
       />
       <div
-        v-if="assistantNames.length"
-        class="trajectory-assistant-legend"
-        data-testid="trajectory-assistant-legend"
-      >
-        <span class="trajectory-assistant-legend-label">Subagents</span>
-        <span
-          v-for="name in assistantNames"
-          :key="name"
-          class="assistant-tag"
-        >{{ name }}</span>
-      </div>
-
-      <div
         v-if="rows.length"
         data-testid="trajectory-ledger"
         class="trajectory-split"
@@ -450,7 +437,7 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import JsonTree from '@/components/ui/JsonTree.vue'
 import TrajectoryTimeline from './TrajectoryTimeline.vue'
 import {
-  buildTimelineLanes,
+  buildTimelineGroups,
   buildTrajectoryRows,
   clampInspectorWidth,
   eventCategory,
@@ -459,6 +446,7 @@ import {
 
 const props = defineProps({
   runUuid: { type: String, default: '' },
+  assistantName: { type: String, default: '' },
   active: { type: Boolean, default: false },
   runStatus: { type: String, default: '' }
 })
@@ -566,16 +554,11 @@ const rows = computed(() =>
 const groupedRows = computed(() => groupTrajectoryRows(rows.value))
 
 const timelineLanes = computed(() =>
-  buildTimelineLanes(baseEvents.value, summary.value)
-)
-
-const assistantNames = computed(() =>
-  [...new Set(
-    baseEvents.value
-      .filter((event) => event.trace_run_role === 'child')
-      .map((event) => event.assistant_name)
-      .filter(Boolean)
-  )]
+  buildTimelineGroups(
+    baseEvents.value,
+    summary.value,
+    props.assistantName || 'Parent Run'
+  )
 )
 
 const timelineDomain = computed(() => {
@@ -992,16 +975,6 @@ onBeforeUnmount(() => {
   min-width: 0;
   color: var(--t-text-1);
   background: var(--t-bg-1);
-}
-
-.trajectory-assistant-legend {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  margin-top: 8px;
-  color: var(--sl-text-muted, #64748b);
-  font-size: 11px;
 }
 
 .assistant-tag {

--- a/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
+++ b/frontend/src/admin/pages/lens/RunTrajectoryPanel.vue
@@ -114,6 +114,18 @@
         @range-change="timelineRange = $event"
         @select-event="onTimelineSelect"
       />
+      <div
+        v-if="assistantNames.length"
+        class="trajectory-assistant-legend"
+        data-testid="trajectory-assistant-legend"
+      >
+        <span class="trajectory-assistant-legend-label">Subagents</span>
+        <span
+          v-for="name in assistantNames"
+          :key="name"
+          class="assistant-tag"
+        >{{ name }}</span>
+      </div>
 
       <div
         v-if="rows.length"
@@ -156,6 +168,12 @@
                     <span class="kind-tag-label">{{
                       kindLabel(row.event)
                     }}</span>
+                  </span>
+                  <span
+                    v-if="row.event.trace_run_role === 'child'"
+                    class="assistant-tag"
+                  >
+                    {{ row.event.assistant_name || 'Subagent' }}
                   </span>
                 </td>
                 <td class="content-cell">
@@ -549,6 +567,15 @@ const groupedRows = computed(() => groupTrajectoryRows(rows.value))
 
 const timelineLanes = computed(() =>
   buildTimelineLanes(baseEvents.value, summary.value)
+)
+
+const assistantNames = computed(() =>
+  [...new Set(
+    baseEvents.value
+      .filter((event) => event.trace_run_role === 'child')
+      .map((event) => event.assistant_name)
+      .filter(Boolean)
+  )]
 )
 
 const timelineDomain = computed(() => {
@@ -965,6 +992,28 @@ onBeforeUnmount(() => {
   min-width: 0;
   color: var(--t-text-1);
   background: var(--t-bg-1);
+}
+
+.trajectory-assistant-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  color: var(--sl-text-muted, #64748b);
+  font-size: 11px;
+}
+
+.assistant-tag {
+  display: inline-flex;
+  max-width: 220px;
+  overflow: hidden;
+  padding: 2px 6px;
+  border: 1px solid var(--sl-border, #cbd5e1);
+  border-radius: 3px;
+  color: var(--sl-text, #334155);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :root[data-theme='dark'] .run-trajectory {

--- a/frontend/src/admin/pages/lens/TrajectoryTimeline.vue
+++ b/frontend/src/admin/pages/lens/TrajectoryTimeline.vue
@@ -1,10 +1,17 @@
 <template>
   <section class="trajectory-timeline" aria-label="Trajectory timeline">
-    <div class="plot">
+    <div class="plot" :style="timelineStyle">
       <div class="labels" aria-hidden="true">
-        <span>Input</span>
-        <span>Model</span>
-        <span>Tools</span>
+        <div
+          v-for="group in laneGroups"
+          :key="group.key"
+          class="lane-group-label"
+        >
+          <strong :title="group.label">{{ group.label }}</strong>
+          <span v-for="lane in group.lanes" :key="lane.key">
+            {{ lane.label }}
+          </span>
+        </div>
       </div>
       <div
         ref="trackEl"
@@ -49,6 +56,14 @@
             @pointerenter="onSpanEnter(step, $event)"
             @pointermove="onSpanMove(step, $event)"
             @pointerleave="onSpanLeave"
+          />
+        </div>
+
+        <div v-if="!empty" class="lane-group-lines" aria-hidden="true">
+          <span
+            v-for="line in groupLines"
+            :key="line"
+            :style="{ top: `${line}px` }"
           />
         </div>
 
@@ -124,18 +139,44 @@ const viewport = ref(null)
 let dragState = null
 let tooltipTimer = null
 
-const LANE_INDEX = { input: 0, model: 1, tools: 2 }
-
 const flatSteps = computed(() => {
   const steps = []
-  for (const lane of props.lanes) {
-    const laneIndex = LANE_INDEX[lane.key] ?? 0
+  for (const [laneIndex, lane] of props.lanes.entries()) {
     for (const step of lane.steps) {
       steps.push({ ...step, lane: laneIndex })
     }
   }
   return steps.sort((a, b) => a.startMs - b.startMs)
 })
+
+const laneGroups = computed(() => {
+  const groups = []
+  for (const lane of props.lanes) {
+    let group = groups.at(-1)
+    if (!group || group.key !== lane.groupKey) {
+      group = {
+        key: lane.groupKey || 'run',
+        label: lane.groupLabel || 'Run',
+        lanes: []
+      }
+      groups.push(group)
+    }
+    group.lanes.push(lane)
+  }
+  return groups
+})
+
+const timelineHeight = computed(() =>
+  Math.max(50, props.lanes.length * 14 + 14)
+)
+
+const timelineStyle = computed(() => ({
+  '--timeline-height': `${timelineHeight.value}px`
+}))
+
+const groupLines = computed(() =>
+  laneGroups.value.slice(1).map((_, index) => (index + 1) * 42)
+)
 
 const empty = computed(() => flatSteps.value.length === 0)
 
@@ -522,38 +563,50 @@ function durationText(value) {
 
 .plot {
   display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
-  height: 50px;
+  grid-template-columns: 148px minmax(0, 1fr);
+  height: var(--timeline-height, 50px);
   overflow: hidden;
   background: var(--t-bg-2);
 }
 
 .labels {
-  position: relative;
+  box-sizing: border-box;
+  overflow: hidden;
+  padding-top: 7px;
   border-right: 1px solid var(--t-border-l1);
   color: var(--t-text-3);
   font-size: 10px;
   line-height: 1;
 }
 
-.labels span {
-  position: absolute;
-  right: 3px;
+.lane-group-label {
+  display: grid;
+  grid-template-columns: minmax(0, 92px) 44px;
+  grid-template-rows: repeat(3, 14px);
+  height: 42px;
+  padding: 0 4px;
+  border-top: 1px solid transparent;
+}
+
+.lane-group-label + .lane-group-label {
+  border-top-color: var(--t-border-l2);
+}
+
+.lane-group-label strong {
+  grid-row: 1 / 4;
+  align-self: center;
+  overflow: hidden;
+  color: var(--t-text-2);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lane-group-label span {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  height: 8px;
-  text-align: right;
-}
-
-.labels span:nth-child(1) {
-  top: 7px;
-}
-.labels span:nth-child(2) {
-  top: 21px;
-}
-.labels span:nth-child(3) {
-  top: 35px;
+  color: var(--t-text-4);
 }
 
 .track {
@@ -623,6 +676,24 @@ function durationText(value) {
   bottom: 7px;
   left: 0;
   right: 0;
+}
+
+.lane-group-lines {
+  position: absolute;
+  z-index: 1;
+  top: 7px;
+  right: 0;
+  bottom: 7px;
+  left: 0;
+  pointer-events: none;
+}
+
+.lane-group-lines span {
+  position: absolute;
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: var(--t-border-l2);
 }
 
 .span {

--- a/frontend/src/admin/pages/lens/TrajectoryTimeline.vue
+++ b/frontend/src/admin/pages/lens/TrajectoryTimeline.vue
@@ -83,6 +83,7 @@
           :style="{ left: tooltip.x + 'px', top: tooltip.y + 'px' }"
         >
           <strong>{{ tooltip.kind }}</strong>
+          <span v-if="tooltip.assistant">{{ tooltip.assistant }}</span>
           <span>{{ tooltip.range }}</span>
           <span v-if="tooltip.duration">{{ tooltip.duration }}</span>
         </div>
@@ -481,7 +482,14 @@ function showTooltip(step, event) {
       4,
       Math.min(trackRect.height - 4, rect.top - trackRect.top)
     )
-    tooltip.value = { kind, range, duration, x, y }
+    tooltip.value = {
+      kind,
+      assistant: step.assistantName,
+      range,
+      duration,
+      x,
+      y
+    }
   }, TOOLTIP_DELAY_MS)
 }
 

--- a/frontend/src/admin/pages/lens/runTrajectory.js
+++ b/frontend/src/admin/pages/lens/runTrajectory.js
@@ -61,6 +61,7 @@ export function buildTimelineLanes(events, summary) {
       left,
       width: Math.min(width, 100 - left),
       subagent,
+      assistantName: event.assistant_name || null,
       startMs,
       durationMs: endMs - startMs,
       seqs: seqs.length > 0 ? seqs : [event.sequence]
@@ -72,7 +73,10 @@ export function buildTimelineLanes(events, summary) {
     if (!['model', 'tool', 'subtool'].includes(category)) continue
     const times = group.map(eventTime).filter(Number.isFinite)
     if (!times.length) continue
-    const subagent = group.some((event) => isSubagentEvent(category, event))
+    const subagent = group.some(
+      (event) =>
+        event.trace_run_role === 'child' || isSubagentEvent(category, event)
+    )
     pushStep(
       category,
       group[0],

--- a/frontend/src/admin/pages/lens/runTrajectory.js
+++ b/frontend/src/admin/pages/lens/runTrajectory.js
@@ -104,6 +104,33 @@ export function buildTimelineLanes(events, summary) {
   ]
 }
 
+export function buildTimelineGroups(
+  events,
+  summary,
+  parentLabel = 'Parent Run'
+) {
+  const groups = new Map()
+  for (const event of events) {
+    const isChild = event.trace_run_role === 'child'
+    const label = isChild ? event.assistant_name || 'Subagent' : parentLabel
+    const key = isChild ? `child:${label}` : 'parent'
+    const group = groups.get(key) || { key, label, events: [] }
+    group.events.push(event)
+    groups.set(key, group)
+  }
+
+  const laneLabels = { input: 'Input', model: 'Model', tools: 'Tools' }
+  return [...groups.values()].flatMap((group) =>
+    buildTimelineLanes(group.events, summary).map((lane) => ({
+      ...lane,
+      key: `${group.key}:${lane.key}`,
+      groupKey: group.key,
+      groupLabel: group.label,
+      label: laneLabels[lane.key]
+    }))
+  )
+}
+
 function eventDepth(event, parentByCall) {
   let parent = event.parent_call_id
   let depth = 0

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -383,6 +383,9 @@
         "activityProgress": "Recorded {count} activities",
         "activityCompleted": "Completed {count} activities",
         "currentAssistant": "Current assistant: {name}",
+        "running": "Running",
+        "completed": "Completed",
+        "fullTask": "View full task",
         "documentProgress": {
           "downloading": "Downloading document {current}/{total}",
           "extractingText": "Extracting document text {current}/{total}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -383,6 +383,9 @@
         "activityProgress": "Registradas {count} actividades",
         "activityCompleted": "Completadas {count} actividades",
         "currentAssistant": "Asistente actual: {name}",
+        "running": "En ejecución",
+        "completed": "Completado",
+        "fullTask": "Ver tarea completa",
         "documentProgress": {
           "downloading": "Descargando documento {current}/{total}",
           "extractingText": "Extrayendo texto del documento {current}/{total}",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -383,6 +383,9 @@
         "activityProgress": "已记录 {count} 项活动",
         "activityCompleted": "已完成 {count} 项活动",
         "currentAssistant": "当前助手：{name}",
+        "running": "执行中",
+        "completed": "已完成",
+        "fullTask": "查看完整任务",
         "documentProgress": {
           "downloading": "正在下载文档 {current}/{total}",
           "extractingText": "正在提取文档文本 {current}/{total}",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -436,35 +436,15 @@
                       ⌄
                     </span>
                   </summary>
-                  <div
+                  <AssistantActivityGroups
                     v-if="
                       structuredProgress(message._runtimeState).kind ===
                         'workflow' &&
                       delegatedTaskGroups(message._runtimeState).length
                     "
-                    class="runtime-activity-groups runtime-delegation-groups"
-                  >
-                    <div
-                      v-for="group in delegatedTaskGroups(
-                        message._runtimeState
-                      )"
-                      :key="group.key"
-                      class="runtime-activity-group"
-                    >
-                      <div class="runtime-activity-group-title">
-                        {{ group.assistantName }}
-                      </div>
-                      <div
-                        v-for="task in group.tasks"
-                        :key="task"
-                        class="runtime-activity-task"
-                      >
-                        <span class="runtime-activity-task-text">
-                          {{ task }}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+                    :groups="delegatedTaskGroups(message._runtimeState)"
+                    :live="false"
+                  />
                   <div
                     v-if="
                       structuredProgress(message._runtimeState).kind ===
@@ -559,52 +539,19 @@
                       </div>
                     </div>
                   </div>
-                  <div
+                  <AssistantActivityGroups
                     v-else-if="
                       structuredProgress(message._runtimeState).kind ===
                       'activity'
                     "
-                    class="runtime-activity-groups"
-                  >
-                    <div
-                      v-for="group in assistantActivityGroups(
+                    :groups="
+                      assistantActivityGroups(
                         message._runtimeState,
                         structuredProgress(message._runtimeState).items
-                      )"
-                      :key="group.key"
-                      class="runtime-activity-group"
-                    >
-                      <div
-                        v-if="group.assistantName"
-                        class="runtime-activity-group-title"
-                      >
-                        {{ group.assistantName }}
-                      </div>
-                      <div
-                        v-for="task in group.tasks"
-                        :key="task"
-                        class="runtime-activity-task"
-                      >
-                        <span class="runtime-activity-task-text">
-                          {{ task }}
-                        </span>
-                      </div>
-                      <div
-                        v-for="activity in group.items"
-                        :key="activity.id"
-                        class="runtime-node-activity"
-                      >
-                        <span class="runtime-activity-indicator">✓</span>
-                        <span>{{ activityLabel(activity.kind) }}</span>
-                        <span
-                          v-if="activity.count > 1"
-                          class="runtime-activity-count"
-                        >
-                          ×{{ activity.count }}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+                      )
+                    "
+                    :live="false"
+                  />
                   <div
                     v-else
                     v-for="item in structuredProgress(message._runtimeState)
@@ -1190,32 +1137,14 @@
                         · {{ assistantNamesLabel(runtimeState) }}
                       </span>
                     </div>
-                    <div
+                    <AssistantActivityGroups
                       v-if="
                         liveStructuredProgress.kind === 'workflow' &&
                         delegatedTaskGroups(runtimeState).length
                       "
-                      class="runtime-activity-groups runtime-delegation-groups"
-                    >
-                      <div
-                        v-for="group in delegatedTaskGroups(runtimeState)"
-                        :key="group.key"
-                        class="runtime-activity-group"
-                      >
-                        <div class="runtime-activity-group-title">
-                          {{ group.assistantName }}
-                        </div>
-                        <div
-                          v-for="task in group.tasks"
-                          :key="task"
-                          class="runtime-activity-task"
-                        >
-                          <span class="runtime-activity-task-text">
-                            {{ task }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+                      :groups="delegatedTaskGroups(runtimeState)"
+                      :live="true"
+                    />
                     <div
                       v-if="liveStructuredProgress.kind === 'workflow'"
                       class="runtime-workflow"
@@ -1320,68 +1249,17 @@
                         </div>
                       </div>
                     </div>
-                    <div
+                    <AssistantActivityGroups
                       v-else-if="liveStructuredProgress.kind === 'activity'"
                       ref="liveActivityScrollRef"
-                      class="runtime-activity-groups"
-                    >
-                      <div
-                        v-for="group in assistantActivityGroups(
+                      :groups="
+                        assistantActivityGroups(
                           runtimeState,
                           liveStructuredProgress.items
-                        )"
-                        :key="group.key"
-                        class="runtime-activity-group"
-                      >
-                        <div
-                          v-if="group.assistantName"
-                          class="runtime-activity-group-title"
-                        >
-                          {{ group.assistantName }}
-                        </div>
-                        <div
-                          v-for="task in group.tasks"
-                          :key="task"
-                          class="runtime-activity-task"
-                        >
-                          <span class="runtime-activity-task-text">
-                            {{ task }}
-                          </span>
-                        </div>
-                        <div
-                          v-for="activity in group.items"
-                          :key="activity.id"
-                          class="runtime-node-activity"
-                        >
-                          <span
-                            class="runtime-activity-indicator"
-                            :class="{
-                              'is-current': isCurrentStandaloneActivity(
-                                activity,
-                                liveStructuredProgress.items
-                              )
-                            }"
-                            aria-hidden="true"
-                          >
-                            {{
-                              isCurrentStandaloneActivity(
-                                activity,
-                                liveStructuredProgress.items
-                              )
-                                ? ''
-                                : '✓'
-                            }}
-                          </span>
-                          <span>{{ activityLabel(activity.kind) }}</span>
-                          <span
-                            v-if="activity.count > 1"
-                            class="runtime-activity-count"
-                          >
-                            ×{{ activity.count }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+                        )
+                      "
+                      :live="true"
+                    />
                     <div
                       v-else
                       v-for="item in liveStructuredProgress.items"
@@ -1920,6 +1798,7 @@ import QaShareModal from '@/components/lens/QaShareModal.vue'
 import FilePreviewModal from '@/components/lens/FilePreviewModal.vue'
 import CodeCitationDrawer from '@/pages/lens/components/CodeCitationDrawer.vue'
 import MessageCitations from '@/pages/lens/components/MessageCitations.vue'
+import AssistantActivityGroups from '@/pages/lens/components/AssistantActivityGroups.vue'
 import ParticipatingAssistantsPicker from '@/pages/lens/components/ParticipatingAssistantsPicker.vue'
 import {
   extensionOf,
@@ -1983,6 +1862,7 @@ import {
 import {
   activitiesForNode,
   applyRuntimeEvent,
+  buildAssistantActivityGroups,
   calculateRunElapsedSeconds,
   createConversationAutoScroller,
   createRuntimeState,
@@ -2713,45 +2593,13 @@ function assistantNamesLabel(state) {
 }
 
 function assistantActivityGroups(state, activities) {
-  const groups = new Map()
-  for (const delegation of state?.delegations || []) {
-    const name = String(delegation?.assistantName || '').trim()
-    const task = String(delegation?.delegatedTask || '').trim()
-    const key = name || 'default'
-    if (!groups.has(key)) {
-      groups.set(key, {
-        key,
-        assistantName: name,
-        tasks: [],
-        items: []
-      })
-    }
-    if (task && !groups.get(key).tasks.includes(task)) {
-      groups.get(key).tasks.push(task)
-    }
-  }
-  for (const activity of activities || []) {
-    const rawName = String(activity?.assistantName || '').trim()
-    const name = rawName || (
-      isSmartCollaborationConversation.value
-        ? t('lens.chat.smartCollaboration')
-        : ''
-    )
-    const key = name || 'default'
-    if (!groups.has(key)) {
-      groups.set(key, {
-        key,
-        assistantName: name,
-        tasks: [],
-        items: []
-      })
-    }
-    const group = groups.get(key)
-    const task = String(activity?.delegatedTask || '').trim()
-    if (task && !group.tasks.includes(task)) group.tasks.push(task)
-    group.items.push(activity)
-  }
-  return [...groups.values()]
+  return buildAssistantActivityGroups({
+    delegations: state?.delegations,
+    activities,
+    fallbackAssistantName: isSmartCollaborationConversation.value
+      ? t('lens.chat.smartCollaboration')
+      : ''
+  })
 }
 
 function delegatedTaskGroups(state) {
@@ -2766,10 +2614,6 @@ function isCurrentActivity(activity, item) {
   return (
     livePlanStatus(item, items) === 'in_progress' && latest?.id === activity.id
   )
-}
-
-function isCurrentStandaloneActivity(activity, items) {
-  return isRunActive.value && items.at(-1)?.id === activity.id
 }
 
 watch(
@@ -5342,58 +5186,6 @@ onBeforeUnmount(() => {
   color: var(--sl-text-muted);
   font-size: 0.71rem;
   scrollbar-width: thin;
-}
-
-.runtime-standalone-activities {
-  margin-left: 0;
-}
-
-.runtime-activity-groups {
-  display: grid;
-  gap: 0.45rem;
-  margin-left: 0;
-}
-
-.runtime-delegation-groups {
-  margin-bottom: 0.5rem;
-}
-
-.runtime-activity-group {
-  padding: 0.3rem 0.45rem;
-  border: 1px solid var(--sl-border-default);
-  border-radius: 0.45rem;
-  background: var(--sl-bg-raised);
-}
-
-.runtime-activity-group-title {
-  margin-bottom: 0.15rem;
-  color: var(--sl-text-primary);
-  font-size: 0.72rem;
-  font-weight: 650;
-}
-
-.runtime-activity-task {
-  display: flex;
-  min-width: 0;
-  gap: 0.35rem;
-  margin: 0 0 0.25rem;
-  padding: 0.25rem 0.35rem;
-  border-radius: 0.3rem;
-  background: var(--sl-bg-hover);
-  color: var(--sl-text-secondary);
-  font-size: 0.7rem;
-  line-height: 1.15rem;
-}
-
-.runtime-activity-task-label {
-  flex: 0 0 auto;
-  color: var(--sl-text-muted);
-  font-weight: 600;
-}
-
-.runtime-activity-task-text {
-  min-width: 0;
-  overflow-wrap: anywhere;
 }
 
 .runtime-activity-task-inline {

--- a/frontend/src/pages/lens/components/AssistantActivityGroups.vue
+++ b/frontend/src/pages/lens/components/AssistantActivityGroups.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="runtime-assistant-groups">
+    <details
+      v-for="group in groups"
+      :key="group.key"
+      :open="live"
+      class="runtime-assistant-card"
+    >
+      <summary class="runtime-assistant-summary">
+        <span
+          class="runtime-assistant-status-indicator"
+          :class="{ 'is-live': live }"
+          aria-hidden="true"
+        >
+          {{ live ? '' : '✓' }}
+        </span>
+        <span class="runtime-assistant-summary-content">
+          <span class="runtime-assistant-heading">
+            <strong>{{ group.assistantName }}</strong>
+            <span class="runtime-assistant-status-text">
+              {{
+                live
+                  ? t('lens.chat.runtime.running')
+                  : t('lens.chat.runtime.completed')
+              }}
+            </span>
+          </span>
+          <span v-if="group.tasks[0]" class="runtime-assistant-task-summary">
+            {{ group.tasks[0] }}
+          </span>
+        </span>
+        <span class="runtime-assistant-chevron" aria-hidden="true">⌄</span>
+      </summary>
+
+      <div class="runtime-assistant-details">
+        <div
+          v-if="group.summaryItems.length"
+          class="runtime-assistant-activity-list"
+        >
+          <div
+            v-for="activity in group.summaryItems"
+            :key="activity.kind"
+            class="runtime-assistant-activity"
+          >
+            <span aria-hidden="true">✓</span>
+            <span>{{ activityLabel(activity.kind) }}</span>
+            <span
+              v-if="activity.count > 1"
+              class="runtime-assistant-activity-count"
+            >
+              ×{{ activity.count }}
+            </span>
+          </div>
+        </div>
+
+        <details v-if="group.tasks.length" class="runtime-assistant-full-task">
+          <summary>{{ t('lens.chat.runtime.fullTask') }}</summary>
+          <p v-for="task in group.tasks" :key="task">{{ task }}</p>
+        </details>
+      </div>
+    </details>
+  </div>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+defineProps({
+  groups: {
+    type: Array,
+    default: () => []
+  },
+  live: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const { t } = useI18n()
+
+function activityLabel(kind) {
+  const known = new Set([
+    'analyzingResults',
+    'findingCapability',
+    'preparingOutput',
+    'queryingData',
+    'readingContext',
+    'readingSources',
+    'searchingSources',
+    'usingCapability'
+  ])
+  const safeKind = known.has(kind) ? kind : 'usingCapability'
+  return t(`lens.chat.runtime.activity.${safeKind}`)
+}
+</script>
+
+<style scoped>
+.runtime-assistant-groups {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.5rem;
+}
+
+.runtime-assistant-card {
+  border: 1px solid var(--sl-border-default);
+  border-radius: 0.45rem;
+  background: var(--sl-bg-raised);
+}
+
+.runtime-assistant-summary {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.45rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.runtime-assistant-summary::-webkit-details-marker {
+  display: none;
+}
+
+.runtime-assistant-summary-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.runtime-assistant-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  color: var(--sl-text-primary);
+  font-size: 0.72rem;
+}
+
+.runtime-assistant-status-text {
+  color: var(--sl-text-muted);
+  font-size: 0.68rem;
+  font-weight: 400;
+}
+
+.runtime-assistant-status-indicator {
+  display: inline-flex;
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.1rem;
+  color: var(--sl-success);
+  font-size: 0.68rem;
+}
+
+.runtime-assistant-status-indicator.is-live {
+  border: 2px solid var(--sl-border-default);
+  border-top-color: var(--sl-accent);
+  border-radius: 999px;
+  animation: runtime-assistant-spin 0.8s linear infinite;
+}
+
+.runtime-assistant-task-summary {
+  display: -webkit-box;
+  margin-top: 0.15rem;
+  overflow: hidden;
+  color: var(--sl-text-secondary);
+  font-size: 0.7rem;
+  line-height: 1rem;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.runtime-assistant-chevron {
+  flex: 0 0 auto;
+  color: var(--sl-text-muted);
+  transition: transform 0.16s ease;
+}
+
+.runtime-assistant-card[open]
+  > .runtime-assistant-summary
+  .runtime-assistant-chevron {
+  transform: rotate(180deg);
+}
+
+.runtime-assistant-details {
+  padding: 0 0.45rem 0.45rem 1.85rem;
+}
+
+.runtime-assistant-activity-list {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.runtime-assistant-activity {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--sl-text-muted);
+  font-size: 0.7rem;
+}
+
+.runtime-assistant-activity-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.runtime-assistant-full-task {
+  margin-top: 0.35rem;
+  color: var(--sl-text-muted);
+  font-size: 0.68rem;
+}
+
+.runtime-assistant-full-task > summary {
+  width: fit-content;
+  min-height: 1.5rem;
+  cursor: pointer;
+  color: var(--sl-accent);
+}
+
+.runtime-assistant-full-task p {
+  margin: 0.25rem 0 0;
+  padding: 0.35rem;
+  border-radius: 0.3rem;
+  background: var(--sl-bg-hover);
+  color: var(--sl-text-secondary);
+  line-height: 1.05rem;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+@keyframes runtime-assistant-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .runtime-assistant-status-indicator.is-live {
+    animation: none;
+  }
+
+  .runtime-assistant-chevron {
+    transition: none;
+  }
+}
+</style>

--- a/frontend/src/pages/lens/runtimeEvents.js
+++ b/frontend/src/pages/lens/runtimeEvents.js
@@ -206,6 +206,61 @@ export function createRuntimeState() {
   }
 }
 
+export function buildAssistantActivityGroups({
+  delegations = [],
+  activities = [],
+  fallbackAssistantName = ''
+} = {}) {
+  const groups = new Map()
+
+  function ensureGroup(assistantName) {
+    const name = String(assistantName || fallbackAssistantName).trim()
+    const key = name || 'default'
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        assistantName: name,
+        tasks: [],
+        items: []
+      })
+    }
+    return groups.get(key)
+  }
+
+  for (const delegation of delegations || []) {
+    const group = ensureGroup(delegation?.assistantName)
+    const task = String(delegation?.delegatedTask || '').trim()
+    if (task && !group.tasks.includes(task)) group.tasks.push(task)
+  }
+
+  for (const activity of activities || []) {
+    const group = ensureGroup(activity?.assistantName)
+    const task = String(activity?.delegatedTask || '').trim()
+    if (task && !group.tasks.includes(task)) group.tasks.push(task)
+    group.items.push(activity)
+  }
+
+  return [...groups.values()].map((group) => {
+    const summaries = new Map()
+    group.items.forEach((item, index) => {
+      const kind = String(item?.kind || 'usingCapability')
+      const current = summaries.get(kind)
+      summaries.set(kind, {
+        ...(current || item),
+        kind,
+        count: Number(current?.count || 0) + Number(item?.count || 1),
+        lastIndex: index
+      })
+    })
+    const summaryItems = [...summaries.values()]
+      .sort((left, right) => right.lastIndex - left.lastIndex)
+      .slice(0, 3)
+      .sort((left, right) => left.lastIndex - right.lastIndex)
+      .map(({ kind, count }) => ({ kind, count }))
+    return { ...group, summaryItems }
+  })
+}
+
 function trackDelegation(state, event) {
   const assistantName = String(
     event?.assistant_name || event?.payload?.assistant_name || ''

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -276,11 +276,18 @@ test('shows the current delegated assistant above Smart Collaboration progress',
 
 test('shows each delegated task inside its assistant activity group', async () => {
   const source = await chatSource()
+  const component = await readFile(
+    new URL(
+      '../src/pages/lens/components/AssistantActivityGroups.vue',
+      import.meta.url
+    ),
+    'utf8'
+  )
 
-  assert.match(source, /class="runtime-activity-task"/)
-  assert.match(source, /group\.tasks/)
+  assert.match(source, /<AssistantActivityGroups/)
+  assert.match(component, /group\.tasks/)
+  assert.match(component, /class="runtime-assistant-full-task"/)
   assert.doesNotMatch(source, /lens\.chat\.runtime\.delegatedTask/)
-  assert.match(source, /activity\?\.delegatedTask/)
 })
 
 test('keeps browser scroll anchoring enabled while activities grow', async () => {
@@ -415,5 +422,28 @@ test('keeps completed agent activity visible until the user collapses it', async
   assert.match(
     source.slice(completedDetails, completedProgress + 240),
     /<details[\s\S]*?open[\s\S]*?class="runtime-progress-card"/
+  )
+})
+
+test('renders delegated assistants as bounded progressive-disclosure cards', async () => {
+  const source = await chatSource()
+  const component = await readFile(
+    new URL(
+      '../src/pages/lens/components/AssistantActivityGroups.vue',
+      import.meta.url
+    ),
+    'utf8'
+  )
+
+  assert.match(source, /<AssistantActivityGroups/)
+  assert.match(source, /:live="true"/)
+  assert.match(source, /:live="false"/)
+  assert.match(component, /<details[\s\S]*?:open="live"/)
+  assert.match(component, /class="runtime-assistant-task-summary"/)
+  assert.match(component, /class="runtime-assistant-full-task"/)
+  assert.match(component, /group\.summaryItems/)
+  assert.match(
+    component,
+    /\.runtime-assistant-task-summary \{[\s\S]*?-webkit-line-clamp: 2;/
   )
 })

--- a/frontend/tests/runTrajectory.test.js
+++ b/frontend/tests/runTrajectory.test.js
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   buildTimelineLanes,
+  buildTimelineGroups,
   buildTrajectoryRows,
   clampInspectorWidth,
   eventCategory,
@@ -228,6 +229,85 @@ test('timeline lanes fill per-call duration and keep events on lanes', () => {
   assert.equal(toolStep.subagent, true)
   assert.equal(toolStep.startMs, 5000)
   assert.equal(toolStep.durationMs, 3000)
+})
+
+test('timeline groups keep input, model and tools together per assistant', () => {
+  const summary = {
+    first_timestamp: new Date(0).toISOString(),
+    last_timestamp: new Date(1000).toISOString()
+  }
+  const events = ['parent', 'Office', 'ttt'].flatMap((assistant, index) => [
+    {
+      event_id: `${assistant}-input`,
+      event_type: 'request.started',
+      timestamp: new Date(index * 100).toISOString(),
+      ...(assistant === 'parent'
+        ? {}
+        : { trace_run_role: 'child', assistant_name: assistant })
+    },
+    {
+      event_id: `${assistant}-model`,
+      event_type: 'model.completed',
+      call_id: `${assistant}-model-call`,
+      timestamp: new Date(index * 100 + 10).toISOString(),
+      ...(assistant === 'parent'
+        ? {}
+        : { trace_run_role: 'child', assistant_name: assistant })
+    },
+    {
+      event_id: `${assistant}-tool`,
+      event_type: 'tool.completed',
+      call_id: `${assistant}-tool-call`,
+      timestamp: new Date(index * 100 + 20).toISOString(),
+      ...(assistant === 'parent'
+        ? {}
+        : { trace_run_role: 'child', assistant_name: assistant })
+    }
+  ])
+
+  const groups = buildTimelineGroups(events, summary, 'Smart Collaboration')
+
+  assert.deepEqual(
+    groups.map((lane) => [lane.groupLabel, lane.label]),
+    [
+      ['Smart Collaboration', 'Input'],
+      ['Smart Collaboration', 'Model'],
+      ['Smart Collaboration', 'Tools'],
+      ['Office', 'Input'],
+      ['Office', 'Model'],
+      ['Office', 'Tools'],
+      ['ttt', 'Input'],
+      ['ttt', 'Model'],
+      ['ttt', 'Tools']
+    ]
+  )
+})
+
+test('timeline groups keep a direct assistant run as one three-lane group', () => {
+  const summary = {
+    first_timestamp: new Date(0).toISOString(),
+    last_timestamp: new Date(1000).toISOString()
+  }
+  const groups = buildTimelineGroups(
+    [
+      {
+        event_id: 'direct-model',
+        event_type: 'model.completed',
+        timestamp: new Date(500).toISOString()
+      }
+    ],
+    summary,
+    'AGIOne-AI-Assistant'
+  )
+
+  assert.deepEqual(
+    groups.map((lane) => [lane.groupLabel, lane.label]),
+    [
+      ['AGIOne-AI-Assistant', 'Input'],
+      ['AGIOne-AI-Assistant', 'Model'],
+      ['AGIOne-AI-Assistant', 'Tools']
+    ]
+  )
 })
 
 test('timeline lanes treat single events as minimal markers', () => {

--- a/frontend/tests/runtimeEvents.test.js
+++ b/frontend/tests/runtimeEvents.test.js
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   activitiesForNode,
   applyRuntimeEvent,
+  buildAssistantActivityGroups,
   buildWorkflowTree,
   calculateRunElapsedSeconds,
   createConversationAutoScroller,
@@ -129,6 +130,57 @@ test('exposes delegated tasks as progress when no child tool activity exists', (
 
   assert.equal(progress.kind, 'activity')
   assert.deepEqual(progress.items, [])
+})
+
+test('builds compact assistant activity groups without truncating tasks', () => {
+  const delegatedTask = 'Inspect the complete company knowledge base. '.repeat(
+    60
+  )
+  const groups = buildAssistantActivityGroups({
+    delegations: [{ assistantName: 'Company-Knowledge-Base', delegatedTask }],
+    activities: [
+      {
+        id: 1,
+        assistantName: 'Company-Knowledge-Base',
+        kind: 'readingSources',
+        count: 2
+      },
+      {
+        id: 2,
+        assistantName: 'Company-Knowledge-Base',
+        kind: 'searchingSources',
+        count: 1
+      },
+      {
+        id: 3,
+        assistantName: 'Company-Knowledge-Base',
+        kind: 'queryingData',
+        count: 3
+      },
+      {
+        id: 4,
+        assistantName: 'Company-Knowledge-Base',
+        kind: 'preparingOutput',
+        count: 1
+      },
+      {
+        id: 5,
+        assistantName: 'Company-Knowledge-Base',
+        kind: 'readingSources',
+        count: 4
+      }
+    ]
+  })
+
+  assert.equal(groups[0].tasks[0], delegatedTask.trim())
+  assert.deepEqual(
+    groups[0].summaryItems.map((item) => [item.kind, item.count]),
+    [
+      ['queryingData', 3],
+      ['preparingOutput', 1],
+      ['readingSources', 6]
+    ]
+  )
 })
 
 test('flushes pending stream text synchronously before completion', () => {

--- a/frontend/tests/spanishLanguage.test.js
+++ b/frontend/tests/spanishLanguage.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import { createI18n } from 'vue-i18n'
 
 import { toDocumentLang } from '../src/utils/documentLang.js'
 
@@ -93,57 +94,18 @@ test('Spanish translations preserve interpolation placeholders', () => {
   }
 })
 
-test('Spanish translations preserve required whitespace around placeholders', () => {
-  for (const directory of ['locales', 'admin/locales']) {
-    const english = JSON.parse(readSource(`${directory}/en.json`))
-    const spanish = JSON.parse(readSource(`${directory}/es.json`))
-    const mismatches = []
+test('Spanish literal interpolations follow Spanish punctuation', () => {
+  const spanish = JSON.parse(readSource('locales/es.json'))
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'es',
+    messages: { es: spanish }
+  })
 
-    const compare = (source, translation, key = '') => {
-      if (source && typeof source === 'object' && !Array.isArray(source)) {
-        for (const childKey of Object.keys(source)) {
-          compare(
-            source[childKey],
-            translation[childKey],
-            key ? `${key}.${childKey}` : childKey
-          )
-        }
-        return
-      }
-
-      if (typeof source !== 'string') return
-      for (const placeholder of source.match(/\{[^{}]+\}/g) || []) {
-        const sourceIndex = source.indexOf(placeholder)
-        const translatedIndex = translation.indexOf(placeholder)
-        if (translatedIndex < 0) continue
-
-        const sourceHasSpaceBefore = /\s/.test(source[sourceIndex - 1] || '')
-        const sourceHasSpaceAfter = /\s/.test(
-          source[sourceIndex + placeholder.length] || ''
-        )
-        const translationHasSpaceBefore = /\s/.test(
-          translation[translatedIndex - 1] || ''
-        )
-        const translationHasSpaceAfter = /\s/.test(
-          translation[translatedIndex + placeholder.length] || ''
-        )
-
-        if (
-          (sourceHasSpaceBefore && !translationHasSpaceBefore) ||
-          (sourceHasSpaceAfter && !translationHasSpaceAfter)
-        ) {
-          mismatches.push(key)
-        }
-      }
-    }
-
-    compare(english, spanish)
-    assert.deepEqual(
-      [...new Set(mismatches)],
-      [],
-      `Invalid placeholder whitespace in ${directory}`
-    )
-  }
+  assert.equal(
+    i18n.global.t('lens.chat.mentionAssistantQuestionRequired'),
+    'Introduce la pregunta que se procesará después de elegir @.'
+  )
 })
 
 test('critical Spanish product copy is accurate and fully translated', () => {

--- a/lensnode/lensnode/agent_runtime/remote_subagent.py
+++ b/lensnode/lensnode/agent_runtime/remote_subagent.py
@@ -30,6 +30,7 @@ class RemoteSubagentRunnable(Runnable):
         token,
         http_client,
         cancel_event=None,
+        on_activity=None,
         poll_interval_s=0.3,
         push_wait_s=5,
         timeout_s=3600,
@@ -40,6 +41,7 @@ class RemoteSubagentRunnable(Runnable):
         self.token = token
         self.http_client = http_client
         self.cancel_event = cancel_event
+        self.on_activity = on_activity
         self.poll_interval_s = max(float(poll_interval_s), 0.05)
         self.push_wait_s = max(float(push_wait_s), self.poll_interval_s)
         self.timeout_s = max(float(timeout_s), 1)
@@ -76,6 +78,7 @@ class RemoteSubagentRunnable(Runnable):
         deadline = time.monotonic() + self.timeout_s
         while payload.get("status") not in TERMINAL_STATUSES:
             self._check_cancelled()
+            self._touch_activity()
             if time.monotonic() >= deadline:
                 raise TimeoutError("Delegated assistant timed out.")
             payload = delegation_events.wait(
@@ -83,6 +86,7 @@ class RemoteSubagentRunnable(Runnable):
                 min(self.push_wait_s, deadline - time.monotonic()),
             )
             if payload is not None:
+                self._touch_activity()
                 continue
             time.sleep(self.poll_interval_s)
             response = self.http_client.get(
@@ -91,6 +95,7 @@ class RemoteSubagentRunnable(Runnable):
             )
             response.raise_for_status()
             payload = self._response_data(response)
+            self._touch_activity()
 
         self._check_cancelled()
         if payload.get("status") == "done":
@@ -107,6 +112,12 @@ class RemoteSubagentRunnable(Runnable):
 
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise RunCancelledError("Parent Run cancelled delegated work.")
+
+    def _touch_activity(self):
+        """Keep the parent watchdog alive while a child Run is active."""
+
+        if self.on_activity is not None:
+            self.on_activity()
 
     @staticmethod
     def _question(input):

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -688,9 +688,13 @@ class LensDeepAgentRuntime:
             self.config,
             state.command,
         )
+        budget_gates_enabled = (
+            state.runtime_mode.execution_gates
+            or bool(state.command.get("parent_run_uuid"))
+        )
         state.token_budget_wrapup_event = (
             threading.Event()
-            if state.runtime_mode.execution_gates
+            if budget_gates_enabled
             else None
         )
         state.model = LensGatewayChatModel(
@@ -712,7 +716,7 @@ class LensDeepAgentRuntime:
             trace_context=state.trace_context,
             emit_observation=state.emit_trace_observation,
             observation_name="agent",
-            general_chat_execution_gates=state.runtime_mode.execution_gates,
+            general_chat_execution_gates=budget_gates_enabled,
             token_budget_max_tokens=state.token_budget["max_tokens"],
             token_budget_final_reserve_tokens=state.token_budget[
                 "final_reserve_tokens"
@@ -1186,6 +1190,7 @@ class LensDeepAgentRuntime:
                 token=self.config.token,
                 http_client=self.http_client,
                 cancel_event=state.cancel_event,
+                on_activity=state.on_activity,
                 timeout_s=float(
                     state.command.get("remaining_run_timeout_s")
                     or state.command.get("run_timeout_s")

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -2026,7 +2026,7 @@ def test_delivered_artifact_completes_after_token_budget_wrapup():
     assert termination_detail == {}
 
 
-def test_knowledge_qa_skips_general_chat_execution_gates(
+def test_knowledge_qa_skips_execution_gates_for_direct_runs(
     monkeypatch,
     tmp_path,
 ):
@@ -2156,6 +2156,88 @@ def test_knowledge_qa_skips_general_chat_execution_gates(
         "checkpoint",
         ("ready", "knowledge_qa"),
     ]
+
+
+def test_delegated_knowledge_qa_enables_execution_gates(
+    monkeypatch,
+    tmp_path,
+):
+    model_options = []
+
+    class Model:
+        stop_reason = None
+        token_usage = {"total_tokens": 1}
+
+        def __init__(self, **options):
+            model_options.append(options)
+
+    monkeypatch.setattr(agent_runtime, "LensGatewayChatModel", Model)
+    monkeypatch.setattr(
+        agent_runtime,
+        "prepare_runtime_resources",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            root=tmp_path,
+            context_skill_contents=[],
+            mcp_configs=[],
+            skill_paths=[],
+            mcp_config_path=tmp_path / "mcp.json",
+        ),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "cleanup_runtime_resources",
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_apply_offload_thresholds",
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_agent_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "load_mcp_tools",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "build_deferred_mcp_tools",
+        lambda *_args, **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "create_deep_agent",
+        lambda **_: object(),
+    )
+    monkeypatch.setattr(
+        agent_runtime,
+        "_run_agent_with_turn_limit",
+        lambda *_args, **_kwargs: ("answer", False, None),
+    )
+    config = SimpleNamespace(
+        workspace_path=str(tmp_path),
+        ai_gateway_url="http://gateway/ai/",
+        token="token",
+        request_timeout_s=30,
+        offload_tool_tokens=5000,
+        offload_human_tokens=None,
+        summary_trigger_tokens=0,
+    )
+
+    agent_runtime.LensDeepAgentRuntime(config)._answer_sync({
+        "run_uuid": "child",
+        "parent_run_uuid": "parent",
+        "task": "knowledge_qa",
+        "question": "Question",
+        "agent_model_ref": "model-ref",
+        "token_budget": {"max_tokens": 100, "final_reserve_tokens": 10},
+    })
+
+    assert model_options[0]["general_chat_execution_gates"] is True
 
 
 def test_unverified_answer_distinguishes_unavailable_from_execution_failure():
@@ -4438,6 +4520,46 @@ def test_remote_subagent_returns_cross_node_child_answer():
     assert calls[1][1].endswith(
         "/parent-run/delegations/child-run/"
     )
+
+
+def test_remote_subagent_refreshes_parent_activity_while_waiting():
+    activity = []
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Client:
+        def post(self, *_args, **_kwargs):
+            return Response({"run_uuid": "child-run", "status": "queued"})
+
+        def get(self, *_args, **_kwargs):
+            return Response({
+                "run_uuid": "child-run",
+                "status": "done",
+                "answer": "done",
+            })
+
+    runnable = agent_runtime.RemoteSubagentRunnable(
+        assistant_uuid="assistant-1",
+        parent_run_uuid="parent-run",
+        delegation_base_url="http://control/api/lens/lensnode/runs",
+        token="token",
+        http_client=Client(),
+        on_activity=lambda: activity.append(True),
+        poll_interval_s=0.05,
+        push_wait_s=0.05,
+    )
+
+    runnable.invoke({"messages": [HumanMessage(content="Inspect logs")]})
+
+    assert activity
 
 
 def test_remote_subagent_uses_websocket_completion_push():

--- a/release-notes/467.yaml
+++ b/release-notes/467.yaml
@@ -1,0 +1,13 @@
+type: improvement
+audience: user
+en: >-
+  Improved Smart Collaboration progress with compact assistant summaries and
+  clearer assistant-specific Run timelines, while keeping full delegated tasks
+  available on demand.
+zh-CN: >-
+  优化智能协作进度展示，通过紧凑的助手摘要和更清晰的分助手 Run 时间轴呈现执行
+  过程，同时保留按需查看完整委派任务的能力。
+es: >-
+  Se mejoró el progreso de la colaboración inteligente con resúmenes compactos
+  por asistente y cronologías de ejecución más claras, manteniendo disponibles
+  las tareas delegadas completas bajo demanda.


### PR DESCRIPTION
### **User description**
## Summary
- keep parent runs active while delegated child runs execute
- include delegated assistants in Run traces and group Input / Model / Tools lanes by assistant
- load Run filters and results concurrently
- compact assistant progress while preserving full delegated task details
- use stable parent/child trace pagination and validate Spanish literal interpolation through rendered output

Closes #467

## Test plan
- [x] `npm run test:unit` — 448 tests passed
- [x] `npm run build`
- [x] `python manage.py test lens.tests.test_run_trace --keepdb` — 11 tests passed
- [x] `uv run --project . --extra dev pytest tests/test_history.py -q` — 157 tests passed
- [x] Black and isort checks for changed backend files
- [x] ESLint for changed frontend files — zero errors
- [x] Release-note fragment validation
- [x] ego-browser task space 158 — desktop and 390×844 mobile flows


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Keep parent runs active during child delegation

- Show delegated assistants in run traces with grouped lanes

- Compact assistant progress into progressive-disclosure cards

- Load run filters and data concurrently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ParentRun["Parent Run<br/>(no timeout)"] -- "delegates" --> ChildRun["Child Run<br/>(subagent)"]
  ParentRun -.-> TrajectoryAPI["Trajectory API<br/>(parent + child events)"]
  TrajectoryAPI --> TimelineGroups["Lane groups<br/>(by assistant)"]
  ChildRun --> AssistantCards["Assistant activity<br/>progressive-disclosure cards"]
  AssistantCards --> FullTask["Full task text<br/>on demand"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_run_trace.py</strong><dd><code>Test trajectory pagination with child runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-6512ac4a7311769f20185c4eb5e99c98b4ff250069dbb3c3ec72b979bba448bb">+73/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Test delegated execution gates and subagent activity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+123/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chatBootstrap.test.js</strong><dd><code>Test assistant card rendering and task truncation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+33/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runTrajectory.test.js</strong><dd><code>Test timeline groups for assistants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-c2a93eb2418728a6f9b1fa0002488177dcf0dffba0ceb06c6cf0afe7e27515f3">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.test.js</strong><dd><code>Test compact activity group building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-d7d2b70aa02bcdd1939291c69bd4ff83be175c852c2801a044fc8016cb56ffd1">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spanishLanguage.test.js</strong><dd><code>Validate Spanish interpolation via rendered output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-be6b4fbef31f401a65a219b66002d80813b991d412a7526138ef933fa7a23905">+12/-50</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>admin_runs.py</strong><dd><code>Include child run events in trajectory endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+90/-63</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RunObservation.vue</strong><dd><code>Pass assistant name and load data concurrently</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-7f6b2e1f83df1c9116981563c0b244d15ccc2ecf861ce091cb12aeb51c0c8e29">+12/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RunTrajectoryPanel.vue</strong><dd><code>Use grouped lanes and show assistant tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-acd33a4919f80bdd229fb22f29fdc24d30cc85dce17d6d94170ef474014fb797">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TrajectoryTimeline.vue</strong><dd><code>Support lane groups with labels and tooltip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-f63077bdcbe51fd43d5f541c7992697bb2ed6fe28ede5a83cb3eb1e83d193b0a">+105/-26</a></td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Extract assistant activity groups to component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+31/-239</a></td>

</tr>

<tr>
  <td><strong>AssistantActivityGroups.vue</strong><dd><code>New component for compact assistant cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-266c01876f080a5e88191d5cbec91ea2512ee4ae4b69904bffb1a58370ac54fe">+246/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runTrajectory.js</strong><dd><code>Add buildTimelineGroups for per-assistant lanes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-798120b5a90f954a7675c56abbcdbe64bd863f6e63edc46fa74aa066491b9264">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtimeEvents.js</strong><dd><code>Add buildAssistantActivityGroups helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-28c7bcc1bbf1dfe7d295ab09a3d21d268b38458df7a9af855078cc027d3ec7c7">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add running, completed, fullTask keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>remote_subagent.py</strong><dd><code>Add on_activity callback to keep parent alive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-a2eda728963d5494672d12e44fc5d423344806da2fbbf4c3e3c9773608266b87">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Enable execution gates for delegated runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>es.json</strong><dd><code>Add Spanish translations for new keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-ba529cd8e421586279be00c1310ca7d73e9279c6738cd47b4228566944ef2bd2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese translations for new keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>467.yaml</strong><dd><code>Add release note for run observability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/468/files#diff-6c303641e97591d2a39857e16984d1f07a17f52083f66c9ddc47eb35b695bdca">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

