### PR TITLE
Fix document uploads on dynamically selected LensNodes

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -66,8 +66,8 @@ from .runtime_events import (
 from .routing_descriptions import refresh_routing_description
 from .services import (
     CLARIFICATION_MAX_ORIGINAL_CHARS,
+    assistant_supports_document_attachments,
     create_execution_run,
-    supports_document_attachments,
     validate_retry_run,
 )
 from .vision_capabilities import (
@@ -615,9 +615,19 @@ class AssistantSerializer(serializers.ModelSerializer):
         }
 
     def get_supports_document_attachments(self, assistant):
-        """Return whether the assigned LensNode accepts Run documents."""
+        """Return whether the Assistant can execute with Run documents."""
 
-        return supports_document_attachments(assistant.lensnode)
+        if assistant.lensnode_id:
+            return assistant_supports_document_attachments(assistant)
+        cache = getattr(self, "_document_capability_cache", None)
+        if cache is None:
+            cache = {}
+            self._document_capability_cache = cache
+        if assistant.capability not in cache:
+            cache[assistant.capability] = (
+                assistant_supports_document_attachments(assistant)
+            )
+        return cache[assistant.capability]
 
     def get_vision_model_capability(self, assistant):
         """Return the authoritative capability of the assigned vision model."""

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -1118,7 +1118,21 @@ def create_execution_run(
         if existing:
             return existing
 
-    lensnode = select_execution_lensnode(assistant)
+    requested_attachment_uuids = [
+        str(value) for value in (attachment_uuids or [])
+    ]
+    selected_context = select_session_attachment_context(
+        session,
+        question,
+        requested_attachment_uuids,
+    )
+    requires_document_attachments = any(
+        item["kind"] == "document" for item in selected_context
+    )
+    lensnode = select_execution_lensnode(
+        assistant,
+        require_document_attachments=requires_document_attachments,
+    )
 
     validate_retry_run(session, retry_of_run)
 
@@ -1169,14 +1183,6 @@ def create_execution_run(
     )
     if routing_assistant_uuid is not None:
         _set_routing_execution_question(run, routing_assistant_uuid)
-    requested_attachment_uuids = [
-        str(value) for value in (attachment_uuids or [])
-    ]
-    selected_context = select_session_attachment_context(
-        session,
-        question,
-        requested_attachment_uuids,
-    )
     attachment_order = {
         value: order for order, value in enumerate(requested_attachment_uuids)
     }
@@ -1280,14 +1286,34 @@ def run_execution_question(run):
     return str(run.input_message.content or "")
 
 
-def select_execution_lensnode(assistant):
+def select_execution_lensnode(
+    assistant,
+    *,
+    require_document_attachments=False,
+):
     """Return the bound node or the least-loaded compatible online node."""
 
     if assistant.lensnode_id:
         return assistant.lensnode
 
+    candidates = _compatible_execution_lensnodes(
+        assistant,
+        require_document_attachments=require_document_attachments,
+    )
+    if not candidates:
+        raise LensNodeDispatchError("LENSNODE_UNAVAILABLE")
+    return min(candidates, key=lambda item: (item.active_runs, item.created_at))
+
+
+def _compatible_execution_lensnodes(
+    assistant,
+    *,
+    require_document_attachments=False,
+):
+    """Return online nodes that can execute an unbound Assistant."""
+
     candidates = []
-    for lensnode in LensNode.objects.filter(
+    queryset = LensNode.objects.filter(
         status=LensNode.Status.ONLINE,
         enrollment_status=LensNode.EnrollmentStatus.APPROVED,
         token_revoked=False,
@@ -1302,15 +1328,19 @@ def select_execution_lensnode(assistant):
                 ]
             ),
         )
-    ):
+    )
+    for lensnode in queryset:
         if execution_task_for_capability(assistant.capability) not in task_names(
             lensnode
         ):
             continue
+        if (
+            require_document_attachments
+            and not supports_document_attachments(lensnode)
+        ):
+            continue
         candidates.append(lensnode)
-    if not candidates:
-        raise LensNodeDispatchError("LENSNODE_UNAVAILABLE")
-    return min(candidates, key=lambda item: (item.active_runs, item.created_at))
+    return candidates
 
 
 @transaction.atomic
@@ -1476,6 +1506,19 @@ def supports_document_attachments(lensnode):
     return bool(
         isinstance(labels, dict)
         and labels.get(DOCUMENT_ATTACHMENT_CAPABILITY) is True
+    )
+
+
+def assistant_supports_document_attachments(assistant):
+    """Return whether an Assistant can execute with Run documents."""
+
+    if assistant.lensnode_id:
+        return supports_document_attachments(assistant.lensnode)
+    return bool(
+        _compatible_execution_lensnodes(
+            assistant,
+            require_document_attachments=True,
+        )
     )
 
 

--- a/backend/lens/tests/test_document_attachments.py
+++ b/backend/lens/tests/test_document_attachments.py
@@ -323,6 +323,55 @@ class DocumentAttachmentTests(TestCase):
 
         self.assertIs(payload["supports_document_attachments"], False)
 
+    def test_unbound_assistant_reports_dynamic_document_capability(self):
+        self.assistant.lensnode = None
+        self.assistant.save(update_fields=["lensnode"])
+        self.lensnode.tasks = [{"name": self.assistant.capability}]
+        self.lensnode.save(update_fields=["tasks"])
+
+        payload = AssistantSerializer(self.assistant).data
+
+        self.assertIs(payload["supports_document_attachments"], True)
+
+    def test_unbound_assistant_routes_oversized_text_to_capable_node(self):
+        self.assistant.lensnode = None
+        self.assistant.save(update_fields=["lensnode"])
+        self.lensnode.tasks = [{"name": self.assistant.capability}]
+        self.lensnode.labels = {}
+        self.lensnode.save(update_fields=["labels", "tasks"])
+        capable_node = LensNode.objects.create(
+            name="Document-capable LensNode",
+            status=LensNode.Status.ONLINE,
+            enrollment_status=LensNode.EnrollmentStatus.APPROVED,
+            tasks=[{"name": self.assistant.capability}],
+            labels={"run_document_attachments": True},
+        )
+        self.client.force_authenticate(self.user)
+
+        upload = self.client.post(
+            f"/api/lens/sessions/{self.session.uuid}/attachments/",
+            {"file": _text_upload(content="x" * 8001)},
+            format="multipart",
+        )
+
+        self.assertEqual(upload.status_code, 201, upload.content)
+        self.assertEqual(upload.data["kind"], "document")
+        self.assertEqual(upload.data["byte_size"], 8001)
+
+        response = self.client.post(
+            f"/api/lens/sessions/{self.session.uuid}/runs/",
+            {
+                "question": "",
+                "enqueue": False,
+                "attachment_uuids": [upload.data["uuid"]],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.content)
+        run = self.session.run_set.get(uuid=response.data["uuid"])
+        self.assertEqual(run.lensnode, capable_node)
+
     def test_store_rejects_spoofed_document_extension(self):
         upload = SimpleUploadedFile(
             "tender.pdf",

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -70,11 +70,11 @@ from lens.serializers import (
 )
 from lens.services import (
     LensNodeDispatchError,
+    assistant_supports_document_attachments,
     cancel_descendant_runs,
     cancel_run_on_lensnode,
     create_execution_run,
     stream_run_events_async,
-    supports_document_attachments,
 )
 from lens.shared_qa_files import snapshot_shared_qa_files
 
@@ -323,7 +323,7 @@ class SessionViewSet(BaseAuthenticatedViewSet):
         if (
             is_document
             and session.routing_mode != Session.RoutingMode.SMART
-            and not supports_document_attachments(session.assistant.lensnode)
+            and not assistant_supports_document_attachments(session.assistant)
         ):
             raise ValidationError(
                 "DOCUMENT_ATTACHMENTS_UNSUPPORTED_BY_LENSNODE"

--- a/release-notes/document-attachment-dynamic-nodes.yaml
+++ b/release-notes/document-attachment-dynamic-nodes.yaml
@@ -1,0 +1,12 @@
+type: fix
+audience: user
+en: >-
+  Fixed document uploads and automatic long-input attachments for assistants
+  that select a compatible LensNode dynamically at Run time.
+zh-CN: >-
+  修复未绑定固定 LensNode 的助手无法上传文档、也无法将超长输入自动转为附件的
+  问题；此类助手现在会在 Run 执行时选择支持文档的兼容节点。
+es: >-
+  Se corrigieron las cargas de documentos y los adjuntos automáticos para
+  entradas largas en asistentes que seleccionan un LensNode compatible al
+  ejecutar el Run.


### PR DESCRIPTION
### **User description**
## Summary

- derive document attachment support for unbound assistants from compatible online LensNodes
- restrict document-bearing Runs to dynamically selected nodes that advertise document attachment support
- cover dynamic capability reporting and oversized-text routing with regression tests
- add localized release notes for the user-visible fix

Closes #471

## Test plan

- [x] `docker exec sourcelens-api-dev python manage.py test lens.tests.test_document_attachments --keepdb --verbosity 1` (53 passed)
- [x] `.venv/bin/python scripts/release_notes.py validate-pr --base origin/main --head HEAD`
- [x] `git diff --check origin/main...HEAD`


___

### **PR Type**
Bug fix


___

### **Description**
- Derive document support from online LensNodes for unbound assistants

- Restrict document-bearing Runs to document-capable nodes

- Add regression tests and release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[Unbound Assistant] --> B[Query compatible online LensNodes]
    B --> C[Filter by capability and document support]
    C --> D[Select least-loaded node]
    B --> E[Report document support via serializer]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Refactor document capability check with caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/serializers.py

<ul><li>Refactor <code>get_supports_document_attachments</code> to use <br><code>assistant_supports_document_attachments</code><br> <li> Add caching for unbound assistant capability checks</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/472/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Implement dynamic document capability filtering and dispatch</code></dd></summary>
<hr>

backend/lens/services.py

<ul><li>Move attachment context evaluation before lensnode selection<br> <li> Add <code>_compatible_execution_lensnodes</code> helper with document filter<br> <li> Add <code>assistant_supports_document_attachments</code> function<br> <li> Update <code>select_execution_lensnode</code> to accept <br><code>require_document_attachments</code></ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/472/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+58/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Use assistant-level document support in session attachments view</code></dd></summary>
<hr>

backend/lens/views/sessions.py

<ul><li>Replace <code>supports_document_attachments</code> import with <br><code>assistant_supports_document_attachments</code><br> <li> Update document attachment validation to use assistant-level check</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/472/files#diff-5271360df826bc1230406d5a73425315af7aafd55724812d08e243956049a6ed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_document_attachments.py</strong><dd><code>Add regression tests for dynamic document support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_document_attachments.py

<ul><li>Add test for dynamic document capability reporting<br> <li> Add test for oversize text routing to capable node</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/472/files#diff-abb5e8fe2ed314bd844c7f25d56c651e637f0a72584e61b2d938b0018f41a437">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-attachment-dynamic-nodes.yaml</strong><dd><code>Add release notes for dynamic document support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/document-attachment-dynamic-nodes.yaml

- Add release notes for the fix in English, Chinese, and Spanish


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/472/files#diff-143655b5cba570bfd2d270639f3ac0448a1b78330bfe162cbd98ed412c3212d9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

