### PR TITLE
Add reusable Smart Collaboration Assistants

### DIFF
--- a/backend/lens/assistant_lifecycle.py
+++ b/backend/lens/assistant_lifecycle.py
@@ -72,6 +72,21 @@ def create_assistant_session(assistant_uuid, user, title=""):
     assistant = Assistant.objects.get(uuid=assistant_uuid)
     assistant = lock_assistant_for_new_work(assistant, user)
     normalized_title = " ".join(str(title or "").split())
+    if assistant.mode_handler.supports_members and not assistant.is_system:
+        members = fixed_collaboration_assistants(assistant, user)
+        return Session.objects.create(
+            assistant=assistant,
+            user=user,
+            title=normalized_title,
+            routing_mode=Session.RoutingMode.SMART,
+            allowed_assistant_uuids=[str(item.uuid) for item in members],
+            title_manually_edited=bool(normalized_title),
+            title_generation_status=(
+                Session.TitleGenerationStatus.SKIPPED
+                if normalized_title
+                else Session.TitleGenerationStatus.PENDING
+            ),
+        )
     if not normalized_title:
         existing = _find_reusable_empty_session(assistant, user)
         if existing is not None:
@@ -89,6 +104,30 @@ def create_assistant_session(assistant_uuid, user, title=""):
     )
 
 
+def fixed_collaboration_assistants(assistant, user):
+    """Return active accessible members for a Smart Assistant."""
+
+    if not assistant.mode_handler.supports_members or assistant.is_system:
+        raise AssistantNotRunnableError
+    members = list(
+        assistant.collaboration_members.filter(
+            status=Assistant.Status.ACTIVE,
+            is_system=False,
+            routing_mode=Assistant.RoutingMode.DIRECT,
+        ).order_by("name", "uuid")
+    )
+    configured_ids = {
+        str(value) for value in assistant.collaboration_members.values_list(
+            "uuid", flat=True
+        )
+    }
+    if not members or {str(item.uuid) for item in members} != configured_ids:
+        raise AssistantNotRunnableError
+    if not all(item.is_accessible_by(user) for item in members):
+        raise AssistantNotRunnableError
+    return members
+
+
 def smart_collaboration_assistants(
     user,
     assistant_uuids=None,
@@ -99,6 +138,7 @@ def smart_collaboration_assistants(
     assistants = Assistant.objects.visible_to(user).filter(
         status=Assistant.Status.ACTIVE,
         is_system=False,
+        routing_mode=Assistant.RoutingMode.DIRECT,
         capability__in=[
             Assistant.Capability.GENERAL_CHAT,
             Assistant.Capability.CODE_ANALYSIS,

--- a/backend/lens/migrations/0046_assistant_fixed_collaboration.py
+++ b/backend/lens/migrations/0046_assistant_fixed_collaboration.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens", "0045_orchestrator_capability"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="assistant",
+            name="routing_mode",
+            field=models.CharField(
+                choices=[
+                    ("direct", "Direct"),
+                    ("smart", "Smart Collaboration"),
+                ],
+                db_index=True,
+                default="direct",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="assistant",
+            name="collaboration_members",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="collaboration_coordinators",
+                symmetrical=False,
+                to="lens.assistant",
+            ),
+        ),
+    ]

--- a/backend/lens/models.py
+++ b/backend/lens/models.py
@@ -134,6 +134,14 @@ class Assistant(TimestampedUUIDModel):
         CODE_ANALYSIS = "code_analysis", "Code Analysis"
         KNOWLEDGE_QA = "knowledge_qa", "Knowledge Q&A"
 
+    class Mode(models.TextChoices):
+        """Product-level Assistant modes."""
+
+        DIRECT = "direct", "Standard Mode"
+        SMART = "smart", "Smart Collaboration"
+
+    RoutingMode = Mode
+
     objects = AssistantQuerySet.as_manager()
 
     name = models.CharField(max_length=160)
@@ -143,6 +151,12 @@ class Assistant(TimestampedUUIDModel):
         max_length=24,
         choices=Capability.choices,
         default=Capability.GENERAL_CHAT,
+    )
+    routing_mode = models.CharField(
+        max_length=16,
+        choices=RoutingMode.choices,
+        default=RoutingMode.DIRECT,
+        db_index=True,
     )
     slug = models.SlugField(max_length=180, unique=True)
     visibility = models.CharField(
@@ -156,6 +170,12 @@ class Assistant(TimestampedUUIDModel):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="assistants",
+    )
+    collaboration_members = models.ManyToManyField(
+        "self",
+        symmetrical=False,
+        blank=True,
+        related_name="collaboration_coordinators",
     )
 
     class AgentRounds(models.TextChoices):
@@ -201,6 +221,30 @@ class Assistant(TimestampedUUIDModel):
 
     def __str__(self):
         return self.name
+
+    @property
+    def mode(self):
+        """Return the product mode while keeping routing_mode compatible."""
+
+        return self.routing_mode
+
+    @mode.setter
+    def mode(self, value):
+        """Set the product mode through the compatibility column."""
+
+        self.routing_mode = value
+
+    @property
+    def mode_handler(self):
+        """Return the polymorphic behavior object for this Assistant."""
+
+        return assistant_mode_for(self.routing_mode)
+
+    @property
+    def is_smart(self):
+        """Return whether this Assistant is a Smart Collaboration preset."""
+
+        return self.mode_handler.key == self.Mode.SMART
 
     def __init__(self, *args, **kwargs):
         """Accept the removed task argument while old callers migrate."""
@@ -258,6 +302,60 @@ class Assistant(TimestampedUUIDModel):
             self.status == Assistant.Status.ACTIVE
             and self.is_accessible_by(user)
         )
+
+
+class AssistantMode:
+    """Polymorphic product behavior shared by Assistant modes."""
+
+    key = Assistant.Mode.DIRECT
+    configures_execution_resources = True
+    requires_skill = True
+    supports_members = False
+
+    def normalize_capability(self, capability):
+        """Return the execution capability accepted by this mode."""
+
+        return capability
+
+    def execution_capability(self, capability):
+        """Return the capability used by the runtime coordinator."""
+
+        return capability
+
+
+class DirectAssistantMode(AssistantMode):
+    """Behavior for an Assistant that executes directly."""
+
+
+class SmartAssistantMode(AssistantMode):
+    """Behavior for a reusable Smart Collaboration Assistant."""
+
+    key = Assistant.Mode.SMART
+    configures_execution_resources = False
+    requires_skill = False
+    supports_members = True
+
+    def normalize_capability(self, capability):
+        """Smart mode delegates through the general_chat coordinator."""
+
+        return Assistant.Capability.GENERAL_CHAT
+
+    def execution_capability(self, capability):
+        """Return the internal coordinator capability for Smart mode."""
+
+        return Assistant.Capability.GENERAL_CHAT
+
+
+_ASSISTANT_MODES = {
+    Assistant.Mode.DIRECT: DirectAssistantMode(),
+    Assistant.Mode.SMART: SmartAssistantMode(),
+}
+
+
+def assistant_mode_for(mode):
+    """Return the behavior object for a stored Assistant mode."""
+
+    return _ASSISTANT_MODES.get(mode, _ASSISTANT_MODES[Assistant.Mode.DIRECT])
 
 
 class AssistantAccess(TimestampedUUIDModel):

--- a/backend/lens/routing_descriptions.py
+++ b/backend/lens/routing_descriptions.py
@@ -115,6 +115,19 @@ def build_routing_description(assistant, answer_language="en-US"):
 
     language = _language_key(answer_language)
     text = _ROUTING_TEXT[language]
+    if getattr(assistant, "is_smart", False):
+        smart_text = {
+            "en": "Smart collaboration team",
+            "es": "equipo de colaboración inteligente",
+            "zh": "智能协作团队",
+        }[language]
+        parts = [_field_sentence(text["capability"], smart_text, language)]
+        description = _compact(assistant.description)
+        if description:
+            parts.append(
+                _field_sentence(text["overview"], description, language)
+            )
+        return "".join(parts)[:1000]
     capability = _CAPABILITY_DESCRIPTIONS.get(
         assistant.capability,
         {},

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -14,6 +14,7 @@ from .assistant_lifecycle import (
     AssistantNotRunnableError,
     create_assistant_session,
     create_smart_collaboration_session,
+    fixed_collaboration_assistants,
     smart_collaboration_assistants,
 )
 from .attachments import ATTACHMENT_MAX_PER_MESSAGE, AttachmentError
@@ -36,6 +37,7 @@ from .environment_variables import (
 from .model_checks import check_assistant_model_refs
 from .models import (
     Assistant,
+    assistant_mode_for,
     AssistantAccess,
     AssistantMCP,
     AssistantSkill,
@@ -543,6 +545,12 @@ class AssistantSerializer(serializers.ModelSerializer):
 
     lensnode_uuid = serializers.UUIDField(write_only=True, required=False)
     lensnode = serializers.UUIDField(source="lensnode.uuid", read_only=True)
+    collaboration_member_uuids = serializers.ListField(
+        child=serializers.UUIDField(),
+        write_only=True,
+        required=False,
+    )
+    collaboration_members = serializers.SerializerMethodField()
     skill_bindings = SkillBindingsField(required=False)
     mcp_bindings = McpBindingsField(required=False)
     access_grants = AccessGrantsField(required=False)
@@ -552,6 +560,11 @@ class AssistantSerializer(serializers.ModelSerializer):
     supports_document_attachments = serializers.SerializerMethodField()
     vision_model_capability = serializers.SerializerMethodField()
     can_process_images = serializers.SerializerMethodField()
+    mode = serializers.ChoiceField(
+        choices=Assistant.Mode.choices,
+        required=False,
+        write_only=True,
+    )
     kind = serializers.CharField(required=False, write_only=True)
     selected_task = serializers.CharField(required=False, write_only=True)
 
@@ -561,10 +574,14 @@ class AssistantSerializer(serializers.ModelSerializer):
             "uuid",
             "name",
             "description",
+            "mode",
             "capability",
             "slug",
             "lensnode",
             "lensnode_uuid",
+            "routing_mode",
+            "collaboration_member_uuids",
+            "collaboration_members",
             "selected_dirs",
             "multimodal_model_ref",
             "agent_model_ref",
@@ -591,6 +608,7 @@ class AssistantSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "uuid",
             "lensnode",
+            "collaboration_members",
             "skill_summary",
             "mcp_summary",
             "supports_document_attachments",
@@ -607,6 +625,24 @@ class AssistantSerializer(serializers.ModelSerializer):
             "total": assistant.skill_bindings.count(),
             "enabled": enabled,
         }
+
+    def get_collaboration_members(self, assistant):
+        """Return Smart Assistant members for Assistant list views."""
+
+        if not assistant.mode_handler.supports_members:
+            return []
+        return [
+            {
+                "uuid": str(member.uuid),
+                "name": member.name,
+                "capability": member.capability,
+                "status": member.status,
+            }
+            for member in sorted(
+                assistant.collaboration_members.all(),
+                key=lambda item: (item.name, str(item.uuid)),
+            )
+        ]
 
     def get_supports_document_attachments(self, assistant):
         """Return whether the Assistant can execute with Run documents."""
@@ -678,6 +714,7 @@ class AssistantSerializer(serializers.ModelSerializer):
         """Return assistant data including generated Workspace Guide state."""
 
         data = super().to_representation(instance)
+        data["mode"] = instance.mode
         data["workspace_guide"] = get_workspace_guide_payload(instance)
         return data
 
@@ -686,6 +723,7 @@ class AssistantSerializer(serializers.ModelSerializer):
 
         attrs.pop("kind", None)
         attrs.pop("selected_task", None)
+        mode = attrs.pop("mode", None)
         lensnode_uuid = attrs.pop("lensnode_uuid", None)
         if lensnode_uuid is not None:
             attrs["lensnode"] = LensNode.objects.get(uuid=lensnode_uuid)
@@ -701,10 +739,73 @@ class AssistantSerializer(serializers.ModelSerializer):
                 Assistant.Capability.GENERAL_CHAT,
             ),
         )
-        requires_workspace = capability in {
-            Assistant.Capability.CODE_ANALYSIS,
-            Assistant.Capability.KNOWLEDGE_QA,
-        }
+        routing_mode = attrs.get(
+            "routing_mode",
+            getattr(
+                self.instance,
+                "routing_mode",
+                Assistant.RoutingMode.DIRECT,
+            ),
+        )
+        if mode is not None:
+            if "routing_mode" in attrs and attrs["routing_mode"] != mode:
+                raise serializers.ValidationError(
+                    {"mode": "mode and routing_mode must match."}
+                )
+            routing_mode = mode
+            attrs["routing_mode"] = mode
+        mode_behavior = assistant_mode_for(routing_mode)
+        member_uuids = attrs.get("collaboration_member_uuids")
+        if mode_behavior.supports_members:
+            normalized_capability = mode_behavior.normalize_capability(capability)
+            if capability != normalized_capability and mode is None:
+                raise serializers.ValidationError(
+                    {
+                        "capability": (
+                            "Smart mode does not expose a direct capability."
+                        )
+                    }
+                )
+            if self.instance is not None and self.instance.is_system:
+                raise serializers.ValidationError(
+                    {"routing_mode": "System Assistants cannot be Smart teams."}
+                )
+            if member_uuids is None and (
+                self.instance is None
+                or not self.instance.collaboration_members.exists()
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "collaboration_member_uuids": (
+                            "At least one collaboration member is required."
+                        )
+                    }
+                )
+            self._validate_collaboration_members(member_uuids)
+            attrs["capability"] = normalized_capability
+            capability = normalized_capability
+            attrs["lensnode"] = None
+            attrs["selected_dirs"] = []
+            attrs["multimodal_model_ref"] = None
+            attrs["skill_bindings"] = []
+            attrs["mcp_bindings"] = []
+            lensnode = None
+        elif member_uuids is not None:
+            raise serializers.ValidationError(
+                {
+                    "collaboration_member_uuids": (
+                        "Only smart Assistants may have collaboration members."
+                    )
+                }
+            )
+        requires_workspace = (
+            mode_behavior.configures_execution_resources
+            and capability
+            in {
+                Assistant.Capability.CODE_ANALYSIS,
+                Assistant.Capability.KNOWLEDGE_QA,
+            }
+        )
         if requires_workspace and lensnode is None:
             raise serializers.ValidationError(
                 {"lensnode_uuid": "A LensNode is required."}
@@ -720,30 +821,31 @@ class AssistantSerializer(serializers.ModelSerializer):
         )
         if not requires_workspace:
             attrs["selected_dirs"] = []
-            skill_bindings = attrs.get("skill_bindings")
-            if skill_bindings is None and self.instance is not None:
-                has_enabled_skill = self.instance.skill_bindings.filter(
-                    enabled=True,
-                    skill__enabled=True,
-                ).exists()
-            else:
-                enabled_skill_uuids = [
-                    binding.get("skill_uuid")
-                    for binding in (skill_bindings or [])
-                    if binding.get("enabled", True)
-                ]
-                has_enabled_skill = Skill.objects.filter(
-                    uuid__in=enabled_skill_uuids,
-                    enabled=True,
-                ).exists()
-            if not has_enabled_skill:
-                raise serializers.ValidationError(
-                    {
-                        "skill_bindings": (
-                            "general_chat requires at least one enabled skill"
-                        )
-                    }
-                )
+            if mode_behavior.requires_skill:
+                skill_bindings = attrs.get("skill_bindings")
+                if skill_bindings is None and self.instance is not None:
+                    has_enabled_skill = self.instance.skill_bindings.filter(
+                        enabled=True,
+                        skill__enabled=True,
+                    ).exists()
+                else:
+                    enabled_skill_uuids = [
+                        binding.get("skill_uuid")
+                        for binding in (skill_bindings or [])
+                        if binding.get("enabled", True)
+                    ]
+                    has_enabled_skill = Skill.objects.filter(
+                        uuid__in=enabled_skill_uuids,
+                        enabled=True,
+                    ).exists()
+                if not has_enabled_skill:
+                    raise serializers.ValidationError(
+                        {
+                            "skill_bindings": (
+                                "general_chat requires at least one enabled skill"
+                            )
+                        }
+                    )
         elif lensnode is not None:
             validate_selected_dirs(selected_dirs, lensnode)
         elif selected_dirs:
@@ -773,6 +875,48 @@ class AssistantSerializer(serializers.ModelSerializer):
                     }
                 )
         return attrs
+
+    def _validate_collaboration_members(self, member_uuids):
+        """Validate Smart Assistant members at the API boundary."""
+
+        if member_uuids is None:
+            return
+        if not member_uuids:
+            raise serializers.ValidationError(
+                {
+                    "collaboration_member_uuids": (
+                        "At least one collaboration member is required."
+                    )
+                }
+            )
+        if len(set(member_uuids)) != len(member_uuids):
+            raise serializers.ValidationError(
+                {"collaboration_member_uuids": "Member UUIDs must be unique."}
+            )
+        members = list(Assistant.objects.filter(uuid__in=member_uuids))
+        if len(members) != len(member_uuids):
+            raise serializers.ValidationError(
+                {"collaboration_member_uuids": "Assistant member not found."}
+            )
+        instance_uuid = str(getattr(self.instance, "uuid", ""))
+        invalid = [
+            member
+            for member in members
+            if (
+                member.is_system
+                or member.status != Assistant.Status.ACTIVE
+                or member.routing_mode != Assistant.RoutingMode.DIRECT
+                or str(member.uuid) == instance_uuid
+            )
+        ]
+        if invalid:
+            raise serializers.ValidationError(
+                {
+                    "collaboration_member_uuids": (
+                        "Members must be active direct Assistants."
+                    )
+                }
+            )
 
     def _sync_bindings(self, assistant, validated_data):
         skill_bindings = validated_data.pop("skill_bindings", None)
@@ -920,10 +1064,19 @@ class AssistantSerializer(serializers.ModelSerializer):
                     granted_by=granted_by,
                 )
 
+    def _set_collaboration_members(self, assistant, member_uuids):
+        """Persist collaboration members resolved by their public UUIDs."""
+
+        members = Assistant.objects.filter(uuid__in=member_uuids)
+        assistant.collaboration_members.set(members)
+
     @transaction.atomic
     def create(self, validated_data):
         """Create assistant and optional bindings."""
 
+        collaboration_member_uuids = validated_data.pop(
+            "collaboration_member_uuids", None
+        )
         skill_bindings = validated_data.pop("skill_bindings", None)
         mcp_bindings = validated_data.pop("mcp_bindings", None)
         access_grants = validated_data.pop("access_grants", None)
@@ -938,6 +1091,11 @@ class AssistantSerializer(serializers.ModelSerializer):
         )
         self._sync_access_grants(assistant, access_grants)
         sync_workspace_guide_skill(assistant, workspace_guide)
+        if assistant.mode_handler.supports_members:
+            self._set_collaboration_members(
+                assistant,
+                collaboration_member_uuids or [],
+            )
         check_assistant_model_refs(assistant)
         refresh_routing_description(assistant)
         return assistant
@@ -946,12 +1104,24 @@ class AssistantSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         """Update assistant and optional bindings."""
 
+        was_smart = instance.mode_handler.supports_members
+        collaboration_member_uuids = validated_data.pop(
+            "collaboration_member_uuids", None
+        )
         access_grants = validated_data.pop("access_grants", None)
         workspace_guide = validated_data.pop("workspace_guide", None)
         self._sync_bindings(instance, validated_data)
         assistant = super().update(instance, validated_data)
         self._sync_access_grants(assistant, access_grants)
         sync_workspace_guide_skill(assistant, workspace_guide)
+        if assistant.mode_handler.supports_members:
+            if collaboration_member_uuids is not None:
+                self._set_collaboration_members(
+                    assistant,
+                    collaboration_member_uuids,
+                )
+        elif collaboration_member_uuids is not None or was_smart:
+            assistant.collaboration_members.clear()
         check_assistant_model_refs(assistant)
         refresh_routing_description(assistant)
         return assistant
@@ -2836,6 +3006,10 @@ class SessionSerializer(serializers.ModelSerializer):
         source="assistant.slug",
         read_only=True,
     )
+    assistant_mode = serializers.CharField(
+        source="assistant.mode",
+        read_only=True,
+    )
     has_shareable_answer = serializers.SerializerMethodField()
     routing_assistants = serializers.SerializerMethodField()
 
@@ -2846,6 +3020,7 @@ class SessionSerializer(serializers.ModelSerializer):
             "assistant",
             "assistant_name",
             "assistant_slug",
+            "assistant_mode",
             "routing_mode",
             "allowed_assistant_uuids",
             "routing_assistants",
@@ -2892,6 +3067,16 @@ class SessionSerializer(serializers.ModelSerializer):
             return value
         if self.instance.routing_mode != Session.RoutingMode.SMART:
             raise serializers.ValidationError("Only smart sessions support this.")
+        if (
+            not self.instance.assistant.is_system
+            and self.instance.assistant.routing_mode
+            == Assistant.RoutingMode.SMART
+            and set(str(item) for item in value)
+            != set(self.instance.allowed_assistant_uuids or [])
+        ):
+            raise serializers.ValidationError(
+                "Smart Assistant session members cannot be changed."
+            )
         try:
             assistants = smart_collaboration_assistants(
                 self.context["request"].user,
@@ -2967,6 +3152,15 @@ class SessionCreateSerializer(serializers.Serializer):
                     {"assistant_uuid": "This field is required."}
                 )
         else:
+            if attrs.get("assistant_uuid"):
+                raise serializers.ValidationError(
+                    {
+                        "assistant_uuid": (
+                            "Use an Assistant URL or the ad-hoc Smart "
+                            "Collaboration entry, not both."
+                        )
+                    }
+                )
             attrs.pop("assistant_uuid", None)
         return attrs
 

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -2072,6 +2072,7 @@ def _build_run_runtime_snapshot(
         "settings_hash": _canonical_hash(settings_payload),
         "workspace_guide": assistant.workspace_guide,
         "assistant_capability": assistant.capability,
+        "assistant_mode": assistant.mode,
         "routing_mode": session.routing_mode,
         "allowed_assistant_uuids": list(
             routing_assistant_uuids

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -78,6 +78,7 @@ from lens.tasks import (
     acquire_datasource_lock,
     release_datasource_lock,
 )
+from lens.views.assistants import AssistantViewSet
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import AccessToken
@@ -2064,7 +2065,7 @@ class LensApiTests(TestCase):
         )
 
     def test_orchestrator_is_not_an_assistant_capability(self):
-        """Smart Collaboration is a session mode, not an Assistant type."""
+        """Smart Collaboration is a mode, not an execution capability."""
 
         serializer = AssistantSerializer(
             data={
@@ -2076,6 +2077,293 @@ class LensApiTests(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn("capability", serializer.errors)
+
+    def test_smart_mode_is_exposed_independently_from_capability(self):
+        """Smart mode has its own API identity and coordinator capability."""
+
+        serializer = AssistantSerializer(
+            data={
+                "name": "Support Team",
+                "slug": "support-team-mode",
+                "mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [str(self.assistant.uuid)],
+            },
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        assistant = serializer.save()
+        self.assertEqual(assistant.mode, Assistant.Mode.SMART)
+        self.assertEqual(
+            AssistantSerializer(
+                assistant,
+                context={"request": SimpleNamespace(user=self.user)},
+            ).data["mode"],
+            Assistant.Mode.SMART,
+        )
+        self.assertEqual(
+            assistant.mode_handler.execution_capability(assistant.capability),
+            Assistant.Capability.GENERAL_CHAT,
+        )
+
+    def test_smart_mode_does_not_require_general_chat_skill(self):
+        """Smart mode can coordinate members without direct Chat Skills."""
+
+        serializer = AssistantSerializer(
+            data={
+                "name": "Skill Free Team",
+                "slug": "skill-free-team",
+                "mode": "smart",
+                "capability": "code_analysis",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [str(self.assistant.uuid)],
+            },
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        assistant = serializer.save()
+        self.assertEqual(assistant.capability, Assistant.Capability.GENERAL_CHAT)
+        self.assertFalse(assistant.skill_bindings.filter(enabled=True).exists())
+
+    def test_switching_to_smart_clears_direct_execution_resources(self):
+        """Smart mode must not retain bindings from direct execution."""
+
+        AssistantSkill.objects.create(
+            assistant=self.assistant,
+            skill=self.skill,
+        )
+        AssistantMCP.objects.create(
+            assistant=self.assistant,
+            mcp=self.mcp,
+        )
+        serializer = AssistantSerializer(
+            self.assistant,
+            data={
+                "mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [],
+            },
+            partial=True,
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        serializer = AssistantSerializer(
+            self.assistant,
+            data={
+                "mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [str(self.assistant.uuid)],
+            },
+            partial=True,
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        member = Assistant.objects.create(
+            name="General Helper",
+            slug="general-helper-for-switch",
+            visibility=Assistant.Visibility.PUBLIC,
+            selected_task="general_chat",
+        )
+        serializer = AssistantSerializer(
+            self.assistant,
+            data={
+                "mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [str(member.uuid)],
+            },
+            partial=True,
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        assistant = serializer.save()
+        self.assertIsNone(assistant.lensnode)
+        self.assertEqual(assistant.selected_dirs, [])
+        self.assertFalse(assistant.skill_bindings.exists())
+        self.assertFalse(assistant.mcp_bindings.exists())
+        self.assertIsNone(assistant.multimodal_model_ref)
+
+    def test_fixed_smart_assistant_persists_direct_members(self):
+        """Admins can create a reusable Smart Collaboration Assistant."""
+
+        second = Assistant.objects.create(
+            name="General Helper",
+            slug="general-helper",
+            visibility=Assistant.Visibility.PUBLIC,
+            selected_task="general_chat",
+        )
+        serializer = AssistantSerializer(
+            data={
+                "name": "Support Team",
+                "slug": "support-team",
+                "routing_mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [
+                    str(self.assistant.uuid),
+                    str(second.uuid),
+                ],
+            },
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        assistant = serializer.save()
+        assistant.refresh_from_db()
+
+        self.assertEqual(assistant.routing_mode, Assistant.RoutingMode.SMART)
+        self.assertEqual(
+            list(assistant.collaboration_members.order_by("name")),
+            [self.assistant, second],
+        )
+        payload = AssistantSerializer(
+            assistant,
+            context={"request": SimpleNamespace(user=self.user)},
+        ).data
+        self.assertEqual(
+            [item["uuid"] for item in payload["collaboration_members"]],
+            [str(self.assistant.uuid), str(second.uuid)],
+        )
+
+    def test_smart_member_list_uses_prefetched_members(self):
+        """Serializing Smart team members does not issue one query per team."""
+
+        second = Assistant.objects.create(
+            name="Second Helper",
+            slug="second-helper-for-prefetch",
+            visibility=Assistant.Visibility.PUBLIC,
+            selected_task="general_chat",
+        )
+        teams = []
+        for name, slug in (
+            ("First Team", "first-team-for-prefetch"),
+            ("Second Team", "second-team-for-prefetch"),
+        ):
+            team = Assistant.objects.create(
+                name=name,
+                slug=slug,
+                routing_mode=Assistant.RoutingMode.SMART,
+                agent_model_ref="11111111-1111-1111-1111-111111111111",
+            )
+            team.collaboration_members.set([self.assistant, second])
+            teams.append(team)
+
+        assistants = list(
+            AssistantViewSet.queryset.filter(pk__in=[team.pk for team in teams])
+        )
+        serializer = AssistantSerializer(
+            context={"request": SimpleNamespace(user=self.user)}
+        )
+
+        with CaptureQueriesContext(connection) as context:
+            members = [
+                serializer.get_collaboration_members(assistant)
+                for assistant in assistants
+            ]
+
+        self.assertEqual(len(context), 0)
+        self.assertEqual([len(team_members) for team_members in members], [2, 2])
+
+    def test_fixed_smart_assistant_rejects_nested_members(self):
+        """A Smart team cannot contain another Smart Assistant."""
+
+        nested = Assistant.objects.create(
+            name="Nested Team",
+            slug="nested-team",
+            routing_mode=Assistant.RoutingMode.SMART,
+            agent_model_ref="11111111-1111-1111-1111-111111111111",
+        )
+        serializer = AssistantSerializer(
+            data={
+                "name": "Outer Team",
+                "slug": "outer-team",
+                "routing_mode": "smart",
+                "agent_model_ref": "11111111-1111-1111-1111-111111111111",
+                "collaboration_member_uuids": [str(nested.uuid)],
+            },
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("collaboration_member_uuids", serializer.errors)
+
+    def test_fixed_smart_session_snapshots_members(self):
+        """A fixed Assistant creates a Smart Session with a member snapshot."""
+
+        second = Assistant.objects.create(
+            name="General Helper",
+            slug="general-helper",
+            visibility=Assistant.Visibility.PUBLIC,
+            selected_task="general_chat",
+        )
+        fixed = Assistant.objects.create(
+            name="Support Team",
+            slug="support-team",
+            routing_mode=Assistant.RoutingMode.SMART,
+            agent_model_ref="11111111-1111-1111-1111-111111111111",
+            visibility=Assistant.Visibility.PUBLIC,
+        )
+        fixed.collaboration_members.set([self.assistant, second])
+
+        serializer = SessionCreateSerializer(
+            data={"assistant_uuid": str(fixed.uuid)},
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        session = serializer.save()
+
+        self.assertEqual(session.routing_mode, Session.RoutingMode.SMART)
+        self.assertEqual(
+            set(session.allowed_assistant_uuids),
+            {str(self.assistant.uuid), str(second.uuid)},
+        )
+
+    def test_smart_session_creation_rejects_mixed_assistant_payload(self):
+        """A configured Smart Assistant cannot fall back to the ad-hoc flow."""
+
+        serializer = SessionCreateSerializer(
+            data={
+                "assistant_uuid": str(self.assistant.uuid),
+                "routing_mode": "smart",
+            },
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("assistant_uuid", serializer.errors)
+
+    def test_fixed_smart_session_scope_cannot_be_edited(self):
+        """Smart Session member scope is immutable after creation."""
+
+        fixed = Assistant.objects.create(
+            name="Support Team",
+            slug="support-team",
+            routing_mode=Assistant.RoutingMode.SMART,
+            agent_model_ref="11111111-1111-1111-1111-111111111111",
+            visibility=Assistant.Visibility.PUBLIC,
+        )
+        fixed.collaboration_members.add(self.assistant)
+        session = Session.objects.create(
+            assistant=fixed,
+            user=self.user,
+            routing_mode=Session.RoutingMode.SMART,
+            allowed_assistant_uuids=[str(self.assistant.uuid)],
+        )
+        serializer = SessionSerializer(
+            session,
+            data={"allowed_assistant_uuids": []},
+            partial=True,
+            context={"request": SimpleNamespace(user=self.user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("allowed_assistant_uuids", serializer.errors)
 
     def test_smart_collaboration_session_uses_global_model_and_allowed_range(self):
         GlobalSetting.objects.create(

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -441,6 +441,7 @@ def _admin_run_row(run):
         },
         "planned_evidence": counts["planned_evidence"],
         "routing_mode": runtime_snapshot.get("routing_mode") or "direct",
+        "assistant_mode": runtime_snapshot.get("assistant_mode") or "direct",
         "allowed_assistant_uuids": runtime_snapshot.get("allowed_assistant_uuids", []),
         "delegated_assistants": _sanitize_delegated_assistants(
             runtime_snapshot.get("subagents", [])
@@ -791,6 +792,9 @@ def _admin_run_detail(run):
                     "status": execution.status,
                     "target_dirs": execution.target_dirs,
                     "routing_mode": runtime_snapshot.get("routing_mode") or "direct",
+                    "assistant_mode": (
+                        runtime_snapshot.get("assistant_mode") or "direct"
+                    ),
                     "allowed_assistant_uuids": runtime_snapshot.get(
                         "allowed_assistant_uuids", []
                     ),

--- a/backend/lens/views/assistants.py
+++ b/backend/lens/views/assistants.py
@@ -1,6 +1,7 @@
 """Assistant CRUD and public assistant metadata views."""
 
 from django.db import transaction
+from django.db.models import Prefetch
 from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -28,6 +29,10 @@ class AssistantViewSet(BaseAuthenticatedViewSet):
         "mcp_bindings",
         "access_grants__group",
         "access_grants__user",
+        Prefetch(
+            "collaboration_members",
+            queryset=Assistant.objects.order_by("name", "uuid"),
+        ),
     )
     serializer_class = AssistantSerializer
 

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -96,7 +96,10 @@ def _session_assistant_is_runnable(session, user):
     if assistant.status != Assistant.Status.ACTIVE:
         return False
     if session.routing_mode == Session.RoutingMode.SMART:
-        return assistant.is_system
+        return assistant.is_system or (
+            assistant.mode_handler.supports_members
+            and assistant.is_accessible_by(user)
+        )
     return assistant.is_accessible_by(user)
 
 

--- a/docs/design-fixed-smart-collaboration-assistants.md
+++ b/docs/design-fixed-smart-collaboration-assistants.md
@@ -1,0 +1,355 @@
+# Smart Assistants
+
+## Objective
+
+Allow an administrator to create a reusable Smart Assistant. Users select it
+from the normal Assistant list and
+chat at the normal Assistant URL, while each Session runs through the existing
+Smart Collaboration coordinator and a member set chosen by the administrator.
+
+The existing ad-hoc Smart Collaboration entry at `/lens/chat` remains
+available. It continues to let a user choose a participant range per Session.
+
+### Current state
+
+- A normal Assistant owns one execution capability and creates a direct
+  Session.
+- Ad-hoc Smart Collaboration is a Session mode. It creates a hidden system
+  coordinator from `lens.smart_collaboration.model_ref` and stores a
+  user-selected list in `Session.allowed_assistant_uuids`.
+- The runtime already snapshots the coordinator model, routing mode, allowed
+  member UUIDs, and complete subagent definitions into each Run.
+- The admin Assistant wizard cannot persist a collaboration team.
+
+### User stories
+
+1. As an administrator, I can create a Smart Assistant and select its member
+   Assistants.
+2. As a user, I can select that Assistant like any other Assistant and create
+   Sessions without choosing the team again.
+3. As an operator, I can inspect a Session or Run and see the fixed Assistant
+   and the exact member snapshot used for that conversation.
+4. As an administrator, I can edit the team without changing historical
+   Sessions.
+
+## Design decisions
+
+### Assistant mode is independent from execution capability
+
+An Assistant has a product-level `mode`:
+
+- `direct` is the default and preserves every existing Assistant.
+- `smart` identifies an administrator-managed collaboration Assistant.
+
+The persisted `routing_mode` field remains as a compatibility column and is
+exposed alongside the new `mode` API field during migration. Mode behavior is
+implemented polymorphically (`DirectAssistantMode` and `SmartAssistantMode`)
+so callers do not infer product semantics from `capability`.
+
+`capability` describes the low-level execution primitive for direct Assistants.
+Smart mode may internally use `general_chat` as its coordinator primitive, but
+it is not a General Chat Assistant in the product model and does not inherit
+General Chat's Skill, MCP, LensNode, workspace, or multimodal requirements.
+
+Add a directed, self-referential many-to-many relation for collaboration
+members. A Smart Assistant is the coordinator definition; its
+members are ordinary, non-system, direct Assistants.
+
+This does not add `orchestrator` back to Assistant capabilities. Direct
+capabilities remain `general_chat`, `code_analysis`, or `knowledge_qa`;
+Smart mode delegates to its configured team through the internal coordinator.
+
+### Sessions snapshot the team
+
+Creating a Session with a Smart Assistant will:
+
+1. verify that the coordinator and every member are active and accessible to
+   the user;
+2. create the Session with the fixed Assistant as `session.assistant`;
+3. set `Session.routing_mode=smart`;
+4. copy the current member UUIDs to `Session.allowed_assistant_uuids`.
+
+Later edits to Assistant membership affect only new Sessions. Existing
+Sessions and Run snapshots are unchanged.
+
+The existing ad-hoc Smart Collaboration flow still uses the hidden system
+Assistant and the global model setting. It remains the only Smart Session whose
+participant range a user can edit.
+
+### Users cannot change a Session's team membership
+
+For a non-system Assistant with `routing_mode=smart`, PATCH requests that try
+to change `Session.allowed_assistant_uuids` are rejected. The chat composer
+shows the configured participants as a read-only summary.
+
+Per-message `@Assistant` selection remains available and may select one or
+more Assistants inside the Session snapshot. It does not alter the
+Session range.
+
+### Security and nesting
+
+- Smart membership never grants access to a member Assistant.
+  A user must be able to access every member when a Session is created and
+  when a Run is started.
+- A Smart Assistant cannot include itself, a system Assistant,
+  an archived Assistant, or another `routing_mode=smart` Assistant.
+- At least one member is required.
+- Duplicate member UUIDs are rejected at the API boundary.
+- Existing direct and ad-hoc Smart Collaboration permissions remain intact.
+
+## API contract
+
+No endpoint is added. `POST/PATCH /api/lens/assistants/` gains additive fields:
+
+```json
+{
+  "mode": "smart",
+  "collaboration_member_uuids": [
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222"
+  ]
+}
+```
+
+`routing_mode: "smart"` is accepted for backwards compatibility and is
+returned with the same value while clients migrate to `mode`.
+
+Assistant responses gain:
+
+```json
+{
+  "routing_mode": "smart",
+  "collaboration_members": [
+    {
+      "uuid": "11111111-1111-1111-1111-111111111111",
+      "name": "Code Advisor",
+      "capability": "code_analysis",
+      "status": "active"
+    }
+  ]
+}
+```
+
+`collaboration_member_uuids` is write-only.
+`collaboration_members` is read-only and ordered by Assistant name. Existing
+clients that omit the new fields continue to create direct Assistants.
+
+Creating a Smart Session uses the existing payload:
+
+```json
+{
+  "assistant_uuid": "33333333-3333-3333-3333-333333333333"
+}
+```
+
+The response remains the existing Session representation and includes
+`routing_mode=smart`, `allowed_assistant_uuids`, and `routing_assistants`.
+
+Validation uses the project's existing DRF field-error shape. Invalid member
+configuration is a `400`; inaccessible Assistants remain a `403` at Session or
+Run creation.
+
+## Backend changes
+
+### Data model
+
+- `Assistant.routing_mode`: indexed choice field, default `direct`.
+- `Assistant.collaboration_members`: directed self many-to-many field,
+  symmetrical false, blank at the database layer.
+- One additive migration; no data migration is required.
+
+### Serializer and lifecycle
+
+- Extend `AssistantSerializer` with the new input/output contract and boundary
+  validation.
+- Synchronize member relations inside the existing create/update transactions.
+- Smart coordinators use the internal `general_chat` primitive, do not require
+  a Skill, and do not require a bound LensNode. Their own model, analysis
+  rounds, token profile, prompt settings, visibility, and access grants remain
+  configurable.
+- `create_assistant_session` branches on Assistant routing mode and freezes the
+  member UUIDs for Smart Assistants.
+- `_session_assistant_is_runnable` accepts either the existing hidden system
+  coordinator or an accessible Smart Assistant.
+- `SessionSerializer` rejects participant-range updates for Smart Sessions.
+- `smart_collaboration_assistants` excludes Smart Assistants so
+  delegation cannot nest.
+
+### Code style
+
+Follow the existing Django service/serializer split and English docstrings:
+
+```python
+def fixed_collaboration_members(assistant, user):
+    """Return active Smart members that remain accessible to the user."""
+
+    members = assistant.collaboration_members.filter(
+        routing_mode=Assistant.RoutingMode.DIRECT,
+        status=Assistant.Status.ACTIVE,
+        is_system=False,
+    )
+    return [member for member in members if member.is_accessible_by(user)]
+```
+
+Views continue to handle HTTP concerns only; validation and business rules stay
+in serializers and lifecycle services.
+
+## Frontend changes
+
+### Admin Assistant wizard
+
+- Add an Assistant Mode choice: Direct or Smart.
+- When Smart is selected:
+  - force execution capability to General Chat;
+  - show a searchable multi-select of active direct Assistants;
+  - require at least one member before continuing;
+  - hide LensNode, workspace directory, Skill, MCP, and multimodal controls
+    that apply to direct execution;
+  - retain a Workspace Guide for coordinator context; execution workspace
+    configuration remains with each Direct Assistant;
+  - keep coordinator model, analysis depth, token profile, prompt context,
+    visibility, and access controls.
+- The Assistant list and detail drawer label the mode and show the configured
+  member count/names.
+
+The page continues to use AdminLayout, BaseDrawer, BaseSelect, BaseButton,
+design tokens, responsive cards/tables, and localized text in Chinese, English,
+and Spanish.
+
+### Chat
+
+- Treat either the existing `LensSmartChat` route or a selected Assistant with
+  `routing_mode=smart` as a Smart Collaboration conversation.
+- Keep separate flags for ad-hoc Smart Collaboration and Smart Assistants so
+  Session creation sends the correct payload.
+- Initialize a Smart conversation's pre-Session participant summary from
+  `collaboration_members`.
+- Render the participant picker read-only for a Smart Assistant.
+- Keep `@Assistant` chips and runtime assistant activity unchanged.
+- Exclude Smart Assistants from routing and mention candidates.
+
+## Project structure
+
+Expected implementation files:
+
+```text
+backend/lens/models.py
+backend/lens/migrations/<next>_assistant_fixed_collaboration.py
+backend/lens/serializers.py
+backend/lens/assistant_lifecycle.py
+backend/lens/views/assistants.py
+backend/lens/views/sessions.py
+backend/lens/tests/test_api.py
+frontend/src/pages/lens/Assistants.vue
+frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+frontend/src/pages/lens/AssistantDetailDrawer.vue
+frontend/src/pages/lens/Chat.vue
+frontend/src/pages/lens/components/ParticipatingAssistantsPicker.vue
+frontend/src/admin/locales/{en,es,zh-CN}.json
+frontend/src/locales/{en,es,zh-CN}.json
+frontend/tests/<focused tests>.test.js
+```
+
+No new frontend dependency or endpoint is required.
+
+## Testing strategy
+
+### Backend integration tests
+
+- create and update a Smart Assistant;
+- reject empty, duplicate, system, self, archived, and nested members;
+- create a Smart Session without the global Smart Collaboration setting;
+- snapshot members into the Session and Run;
+- reject user edits to a Smart Session range;
+- preserve editable ranges for the ad-hoc system coordinator;
+- preserve all existing direct Assistant and Smart Collaboration tests.
+
+### Frontend tests
+
+- admin payload contains routing mode and member UUIDs;
+- wizard gating requires a member for Smart mode;
+- chat distinguishes ad-hoc Smart Collaboration and Smart Assistant payloads;
+- configured participants are read-only while `@Assistant` remains available;
+- all new localization keys exist in Chinese, English, and Spanish.
+
+### Browser acceptance
+
+Use `ego-browser`, not Playwright, to verify:
+
+1. an administrator creates a Smart Assistant with two members;
+2. it appears in the Assistant list and switcher;
+3. opening it shows the configured member summary without edit controls;
+4. a new Session receives the configured members;
+5. `@Assistant` can select a subset for one message;
+6. desktop and 390-pixel mobile layouts have no horizontal overflow.
+
+## Commands
+
+```shell
+# Backend focused tests
+docker exec sourcelens-api-dev \
+  python manage.py test lens.tests.test_api --keepdb --verbosity 1
+
+# Frontend unit tests
+cd frontend && npm test
+
+# Frontend lint and production build
+cd frontend && npm run lint
+cd frontend && npm run build
+
+# Diff hygiene
+git diff --check
+```
+
+If a migration is added, restart `sourcelens-api-dev` once so the development
+entrypoint applies it. Ordinary API code remains hot-reloaded; worker code is
+not expected to change.
+
+## Boundaries
+
+### Always
+
+- Preserve existing ad-hoc Smart Collaboration behavior and URLs.
+- Keep new API fields additive and default existing Assistants to direct.
+- Snapshot membership at Session creation.
+- Recheck member status and access before execution.
+- Add failing tests before behavioral implementation.
+- Use localized UI text and existing design tokens/components.
+
+### Ask first
+
+- Remove or replace the existing `/lens/chat` ad-hoc entry.
+- Allow nested collaboration Assistants.
+- Let a Smart Assistant bypass a member Assistant's access grants.
+- Retroactively update existing Sessions after membership edits.
+
+### Never
+
+- Store member configuration only in frontend state.
+- Resolve members by mutable names or slugs in runtime snapshots.
+- Expose the hidden system coordinator in Assistant lists.
+- Modify agentcore submodules for this feature.
+- Run Playwright for acceptance unless explicitly requested.
+
+## Success criteria
+
+- Administrators can create and edit a Smart Assistant from
+  the existing Assistant wizard.
+- Users can select it from the normal Assistant switcher and start a chat.
+- New Sessions automatically use exactly the configured accessible member set.
+- Users cannot edit the configured member range.
+- Per-message multi-Assistant mentions work inside that range.
+- Historical Sessions and Runs retain their original member snapshots.
+- Existing direct Assistants and ad-hoc Smart Collaboration continue to pass
+  regression tests.
+- Backend tests, frontend tests, lint, build, diff checks, and ego-browser
+  acceptance pass.
+
+## Review decisions requested
+
+Before implementation, confirm these two product decisions:
+
+1. Keep the existing ad-hoc Smart Collaboration entry alongside Smart
+   Assistants.
+2. Membership edits affect only new Sessions; existing Sessions keep their
+   original member snapshot.

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -1134,6 +1134,12 @@
       "codeAnalysis": "Code Analysis",
       "generalChat": "General Chat"
     },
+    "routingModes": {
+      "direct": "Standard Mode",
+      "smart": "Smart Collaboration",
+      "directHint": "Runs directly with a single assistant and the selected capability.",
+      "smartHint": "Completes tasks through collaboration among configured members."
+    },
     "columns": {
       "assistant": "Assistant",
       "lensnode": "Node",
@@ -1397,7 +1403,8 @@
       "maxDepth": "Max Depth",
       "feishuAppId": "Feishu App ID",
       "feishuAppSecret": "Feishu App Secret",
-      "visibility": "Visibility"
+      "visibility": "Visibility",
+      "routingMode": "Assistant mode"
     },
     "placeholders": {
       "assistantDescription": "Describe what this assistant helps users do.",
@@ -1491,7 +1498,9 @@
       "archiveTitle": "Archive assistant",
       "archiveMessage": "Archive {name}? Links stop working until restored.",
       "skillCount": "{count} Skills",
-      "mcpCount": "{count} MCP Servers"
+      "mcpCount": "{count} MCP Servers",
+      "collaborationMembers": "Collaboration members",
+      "noCollaborationMembers": "No collaboration members configured"
     },
     "datasourceWizard": {
       "createTitle": "Create Data Source",
@@ -1717,20 +1726,28 @@
       "step1Title": "Basics & Models",
       "step1Desc": "Set name, slug, agent model (required), and optional multimodal model",
       "agentModelHint": "Required — the LensNode uses this model to run deep analysis agents.",
+      "smartAgentModelHint": "Required — the Smart coordinator uses this model to route and synthesize work.",
       "multimodalModelHint": "Optional — for vision or image-aware tasks.",
       "noVisionModel": "No model supporting image input is currently configured.",
       "configureVisionModel": "Configure a vision model",
       "maxConcurrencyHint": "Maximum simultaneous runs for this assistant. Extra requests queue automatically.",
       "step2Title": "Execution",
       "step2Desc": "Choose the type first, then configure its node, directories, and retrieval policy",
+      "step2SmartDesc": "Choose the Direct Assistants that this Smart Assistant can collaborate with.",
+      "collaborationMembers": "Collaboration members",
+      "collaborationMembersHint": "Choose active direct assistants. This team is reused for new sessions.",
+      "noCollaborationMembers": "Create an active direct assistant first.",
+      "smartResourcesHint": "Smart Assistants use their selected members. Skills, MCP, LensNode, and execution workspaces are managed by each member; add collaboration guidance below.",
       "generalChatExecutionHint": "General Chat uses bound Skills, bundled scripts, and bundled binaries. Workspace directory retrieval is disabled for this assistant.",
       "noAssistantDescription": "No assistant description",
       "step3Title": "Skills & Workspace",
       "step3Desc": "Bind Skills and MCP, and add workspace context — all optional",
+      "step3SmartDesc": "Add workspace guidance for Smart collaboration",
       "step4Title": "Access",
       "step4Desc": "Set visibility and choose which groups or users can access it",
       "contextLabel": "Workspace Guide (optional)",
       "contextHint": "Tell the Assistant about workspace structure, business context, team conventions, search priorities, and directories to avoid. It is injected as this Assistant's private context after saving.",
+      "smartContextHint": "Add project context, division-of-work principles, and retrieval priorities for Smart collaboration.",
       "contextPlaceholder": "# Information the model can't know just from reading code — write it here.\n\n## Project overview\n# SourceLens is a self-hosted AI code Q&A platform.\n# backend/ is the Django REST API; lensnode/ is a separately deployed execution node\n# that runs Deep Agents and pushes results back to the main service via WebSocket.\n# frontend/ is the Vue 3 admin console; it only talks to backend/ REST APIs.\n\n## Search priorities\n# Business logic lives in backend/lens/. backend/agentcore/ is a git submodule — don't look for business code there.\n# Frontend pages: frontend/src/pages/lens/. Admin components: frontend/src/admin/.\n# Agent behavior: lensnode/lensnode/agent_runtime.py.\n\n## Avoid misreading\n# references/ contains reference documents, not source code — don't analyze it as code.\n# For current field structure, read the latest migration only, not historical ones.",
       "back": "Back",
       "next": "Next",

--- a/frontend/src/admin/locales/es.json
+++ b/frontend/src/admin/locales/es.json
@@ -1134,6 +1134,12 @@
       "codeAnalysis": "Análisis de código",
       "generalChat": "Chat General"
     },
+    "routingModes": {
+      "direct": "Modo normal",
+      "smart": "Colaboración inteligente",
+      "directHint": "Se ejecuta directamente con un solo asistente y la capacidad elegida.",
+      "smartHint": "Completa las tareas mediante la colaboración de los miembros configurados."
+    },
     "columns": {
       "assistant": "Asistente",
       "lensnode": "Nodo",
@@ -1397,7 +1403,8 @@
       "maxDepth": "Profundidad máxima",
       "feishuAppId": "ID de la App de Feishu",
       "feishuAppSecret": "Secreto de la App de Feishu",
-      "visibility": "Visibilidad"
+      "visibility": "Visibilidad",
+      "routingMode": "Modo del asistente"
     },
     "placeholders": {
       "assistantDescription": "Describe qué ayuda este asistente a los usuarios a hacer.",
@@ -1491,7 +1498,9 @@
       "archiveTitle": "Asistente de archivo",
       "archiveMessage": "¿Archivar {name}? Los enlaces dejan de funcionar hasta que se restauren.",
       "skillCount": "{count} Skills",
-      "mcpCount": "{count} Servidores MCP"
+      "mcpCount": "{count} Servidores MCP",
+      "collaborationMembers": "Miembros de colaboración",
+      "noCollaborationMembers": "No hay miembros de colaboración configurados"
     },
     "datasourceWizard": {
       "createTitle": "Crear Fuente de Datos",
@@ -1717,20 +1726,28 @@
       "step1Title": "Conceptos básicos y Modelos",
       "step1Desc": "Establecer nombre, identificador, modelo de agente (obligatorio) y modelo multimodal opcional",
       "agentModelHint": "Requerido — el LensNode usa este modelo para ejecutar agentes de análisis profundo.",
+      "smartAgentModelHint": "Obligatorio: el coordinador inteligente usa este modelo para enrutar y sintetizar el trabajo.",
       "multimodalModelHint": "Opcional — para tareas con visión o reconocimiento de imágenes.",
       "noVisionModel": "Ningún modelo compatible con entrada de imagen está configurado actualmente.",
       "configureVisionModel": "Configurar un modelo de visión",
       "maxConcurrencyHint": "Número máximo de ejecuciones simultáneas para este asistente. Las solicitudes adicionales se ponen en cola automáticamente.",
       "step2Title": "Ejecución",
       "step2Desc": "Primero selecciona el tipo; después configura su nodo, directorios y política de recuperación",
+      "step2SmartDesc": "Selecciona los asistentes directos con los que puede colaborar este asistente inteligente.",
+      "collaborationMembers": "Miembros de colaboración",
+      "collaborationMembersHint": "Elige asistentes directos activos. Las nuevas sesiones reutilizarán estos miembros.",
+      "noCollaborationMembers": "Crea primero un asistente directo activo.",
+      "smartResourcesHint": "Los asistentes inteligentes usan sus miembros seleccionados. Skills, MCP, LensNode y los espacios de trabajo de ejecución se gestionan en cada miembro; agrega la guía de colaboración a continuación.",
       "generalChatExecutionHint": "El Chat General utiliza Skills vinculadas, scripts agrupados y binarios agrupados. La recuperación del directorio de trabajo está deshabilitada para este asistente.",
       "noAssistantDescription": "Sin descripción del asistente",
       "step3Title": "Skills y Espacio de trabajo",
       "step3Desc": "Vincula Skills y MCP, y agrega contexto de espacio de trabajo: todo opcional",
+      "step3SmartDesc": "Agrega una guía del espacio de trabajo para la colaboración inteligente",
       "step4Title": "Acceso",
       "step4Desc": "Establecer visibilidad y elegir qué grupos o usuarios pueden acceder a ella",
       "contextLabel": "Guía del espacio de trabajo (opcional)",
       "contextHint": "Cuéntale al Asistente sobre la estructura del espacio de trabajo, el contexto del negocio, las convenciones del equipo, las prioridades de búsqueda y los directorios que se deben evitar. Se inyecta como el contexto privado de este Asistente después de guardarlo.",
+      "smartContextHint": "Agrega contexto del proyecto, principios de reparto del trabajo y prioridades de recuperación para la colaboración inteligente.",
       "contextPlaceholder": "# Escribe aquí la información que el modelo no puede conocer con solo leer el código.\n\n## Descripción general del proyecto\n# SourceLens es una plataforma autoalojada de preguntas y respuestas sobre código mediante IA.\n# backend/ es la API REST de Django; lensnode/ es un nodo de ejecución desplegado por separado\n# que ejecuta Deep Agents y envía los resultados al servicio principal mediante WebSocket.\n# frontend/ es la consola de administración Vue 3; solo se comunica con las API REST de backend/.\n\n## Prioridades de búsqueda\n# La lógica de negocio está en backend/lens/. backend/agentcore/ es un submódulo de git: no busques allí el código de negocio.\n# Páginas del frontend: frontend/src/pages/lens/. Componentes de administración: frontend/src/admin/.\n# Comportamiento del Agent: lensnode/lensnode/agent_runtime.py.\n\n## Evita interpretaciones erróneas\n# references/ contiene documentos de referencia, no código fuente: no lo analices como código.\n# Para conocer la estructura actual de los campos, consulta solo la migración más reciente, no las históricas.",
       "back": "Atrás",
       "next": "Siguiente",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -1134,6 +1134,12 @@
       "codeAnalysis": "代码分析",
       "generalChat": "通用对话"
     },
+    "routingModes": {
+      "direct": "普通模式",
+      "smart": "智能协作",
+      "directHint": "由单个助手按所选能力直接执行。",
+      "smartHint": "由多个已配置成员协作完成任务。"
+    },
     "columns": {
       "assistant": "Assistant",
       "lensnode": "节点",
@@ -1397,7 +1403,8 @@
       "maxDepth": "最大递归深度",
       "feishuAppId": "飞书 App ID",
       "feishuAppSecret": "飞书 App Secret",
-      "visibility": "可见性"
+      "visibility": "可见性",
+      "routingMode": "助手模式"
     },
     "placeholders": {
       "assistantDescription": "说明该助手可以帮助用户完成什么。",
@@ -1491,7 +1498,9 @@
       "archiveTitle": "归档助手",
       "archiveMessage": "归档「{name}」？恢复前链接将无法使用。",
       "skillCount": "{count} 个 Skill",
-      "mcpCount": "{count} 个 MCP Server"
+      "mcpCount": "{count} 个 MCP Server",
+      "collaborationMembers": "协作成员",
+      "noCollaborationMembers": "尚未配置协作成员"
     },
     "datasourceWizard": {
       "createTitle": "新建数据源",
@@ -1717,20 +1726,28 @@
       "step1Title": "基础与模型",
       "step1Desc": "设置名称、Slug 与 Agent 模型（必填），以及可选的多模态模型",
       "agentModelHint": "必填 — LensNode 使用该模型运行深度分析 Agent。",
+      "smartAgentModelHint": "必填 — 智能协作协调器使用该模型进行任务分派与汇总。",
       "multimodalModelHint": "可选 — 用于视觉或图像相关任务。",
       "noVisionModel": "当前没有配置支持图片输入的模型。",
       "configureVisionModel": "配置视觉模型",
       "maxConcurrencyHint": "该 Assistant 同时运行的最大任务数，超出后自动排队。",
       "step2Title": "执行配置",
       "step2Desc": "先选择类型，再完成对应的执行节点、目录与检索配置",
+      "step2SmartDesc": "选择该智能助手可协作的直接助手。",
+      "collaborationMembers": "协作成员",
+      "collaborationMembersHint": "选择处于启用状态的直接助手，新 Session 会复用这组成员。",
+      "noCollaborationMembers": "请先创建一个启用的直接助手。",
+      "smartResourcesHint": "智能助手使用所选成员。Skill、MCP、LensNode 和执行工作区由成员助手管理；下方可补充智能协作指引。",
       "generalChatExecutionHint": "通用对话使用绑定的 Skill、包内脚本和包内二进制运行，不启用工作区目录检索。",
       "noAssistantDescription": "未填写助手说明",
       "step3Title": "技能与工作区",
       "step3Desc": "绑定 Skills 与 MCP，并补充工作区背景，均为可选",
+      "step3SmartDesc": "补充智能协作的工作区指引",
       "step4Title": "授权",
       "step4Desc": "设置可见性，并指定可访问该助手的组或用户",
       "contextLabel": "工作区指引（可选）",
       "contextHint": "用于告诉 Assistant 工作区目录结构、业务背景、团队约定、检索优先级和需要避开的目录。保存后会作为该 Assistant 的专属上下文注入。",
+      "smartContextHint": "用于补充智能协作的项目背景、分工原则和检索优先级。",
       "contextPlaceholder": "# 模型不读代码就不知道的信息，写在这里能让它更快、更准。\n\n## 项目说明\n# SourceLens 是一个私有部署的 AI 代码问答平台。\n# backend/ 是 Django REST API 主服务；lensnode/ 是独立部署的执行节点，\n# 负责运行 Deep Agent 并通过 WebSocket 把结果推回主服务。\n# frontend/ 是 Vue 3 管理台，只和 backend/ 的 REST API 通信。\n\n## 检索优先级\n# 业务逻辑找 backend/lens/；backend/agentcore/ 是 git 子模块，不要在那里找业务代码。\n# 前端页面在 frontend/src/pages/lens/，管理台组件在 frontend/src/admin/。\n# lensnode 的 agent 行为看 lensnode/lensnode/agent_runtime.py。\n\n## 避免误判\n# references/ 是参考文档，不是源码，不要当作代码分析对象。\n# backend/lens/migrations/ 只看最新迁移文件，不要从历史迁移推断当前字段结构。",
       "back": "上一步",
       "next": "下一步",

--- a/frontend/src/pages/lens/AssistantDetailDrawer.vue
+++ b/frontend/src/pages/lens/AssistantDetailDrawer.vue
@@ -44,6 +44,18 @@
           </div>
           <div>
             <dt class="detail-label">
+              {{ t('lensAdmin.fields.routingMode') }}
+            </dt>
+            <dd class="detail-value">
+              {{
+                t(
+                  `lensAdmin.routingModes.${(assistant.mode || assistant.routing_mode) === 'smart' ? 'smart' : 'direct'}`
+                )
+              }}
+            </dd>
+          </div>
+          <div>
+            <dt class="detail-label">
               {{ t('lensAdmin.fields.visibility') }}
             </dt>
             <dd class="detail-value">
@@ -63,6 +75,31 @@
             </dd>
           </div>
         </dl>
+      </section>
+
+      <section
+        v-if="(assistant.mode || assistant.routing_mode) === 'smart'"
+        data-testid="assistant-detail-collaboration-members"
+        class="space-y-3"
+      >
+        <h3 class="detail-heading">
+          {{ t('lensAdmin.assistantDetail.collaborationMembers') }}
+        </h3>
+        <ul v-if="assistant.collaboration_members?.length" class="detail-list">
+          <li
+            v-for="member in assistant.collaboration_members"
+            :key="member.uuid"
+            class="flex items-center justify-between gap-3 px-4 py-3"
+          >
+            <span class="min-w-0 truncate text-sm text-ink-700">
+              {{ member.name }}
+            </span>
+            <span class="text-xs text-ink-400">{{ member.capability }}</span>
+          </li>
+        </ul>
+        <p v-else class="detail-empty">
+          {{ t('lensAdmin.assistantDetail.noCollaborationMembers') }}
+        </p>
       </section>
 
       <section data-testid="assistant-detail-directories" class="space-y-3">

--- a/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
+++ b/frontend/src/pages/lens/AssistantFormDrawerDirectEnvironment.vue
@@ -70,6 +70,24 @@
           {{ t('lensAdmin.wizard.assistantDescriptionHint') }}
         </p>
       </FormRow>
+      <FormRow :label="t('lensAdmin.fields.routingMode')">
+        <BaseSelect
+          v-model="form.mode"
+          :disabled="mode === 'edit' && form.status !== 'active'"
+        >
+          <option value="direct">
+            {{ t('lensAdmin.routingModes.direct') }}
+          </option>
+          <option value="smart">{{ t('lensAdmin.routingModes.smart') }}</option>
+        </BaseSelect>
+        <p class="mt-1 text-xs text-ink-500">
+          {{
+            t(
+              `lensAdmin.routingModes.${isSmartMode ? 'smartHint' : 'directHint'}`
+            )
+          }}
+        </p>
+      </FormRow>
       <FormRow :label="t('lensAdmin.fields.slug')">
         <input
           v-model="form.slug"
@@ -95,10 +113,17 @@
           </option>
         </BaseSelect>
         <p class="mt-1 text-xs text-ink-500">
-          {{ t('lensAdmin.wizard.agentModelHint') }}
+          {{
+            t(
+              `lensAdmin.wizard.${isSmartMode ? 'smartAgentModelHint' : 'agentModelHint'}`
+            )
+          }}
         </p>
       </FormRow>
-      <FormRow :label="t('lensAdmin.fields.multimodalModel')">
+      <FormRow
+        v-if="!isSmartMode"
+        :label="t('lensAdmin.fields.multimodalModel')"
+      >
         <BaseSelect v-model="form.multimodal_model_ref">
           <option value="">{{ t('lensAdmin.placeholders.noModel') }}</option>
           <option
@@ -167,165 +192,226 @@
 
     <!-- Wizard Step 2 — Execution -->
     <div v-else-if="wizardStep === 2" class="space-y-4">
-      <p class="text-sm text-ink-500">{{ t('lensAdmin.wizard.step2Desc') }}</p>
-      <div class="grid gap-4 md:grid-cols-2">
-        <FormRow :label="t('lensAdmin.fields.type')">
-          <BaseSelect v-model="form.capability" required>
-            <option value="" disabled>
-              {{ t('lensAdmin.placeholders.selectType') }}
-            </option>
-            <option value="general_chat">
-              {{ t('lensAdmin.assistantTypes.generalChat') }}
-            </option>
-            <option value="code_analysis">
-              {{ t('lensAdmin.assistantTypes.codeAnalysis') }}
-            </option>
-            <option value="knowledge_qa">
-              {{ t('lensAdmin.assistantTypes.knowledgeQa') }}
-            </option>
-          </BaseSelect>
-        </FormRow>
-        <FormRow
-          v-if="requiresNodeSelection"
-          :label="t('lensAdmin.fields.lensnode')"
-        >
-          <BaseSelect
-            v-model="form.lensnode_uuid"
-            :required="requiresWorkspace"
+      <p class="text-sm text-ink-500">
+        {{
+          t(
+            `lensAdmin.wizard.${form.mode === 'smart' ? 'step2SmartDesc' : 'step2Desc'}`
+          )
+        }}
+      </p>
+      <div v-if="form.mode === 'direct'" class="space-y-4">
+        <div class="grid gap-4 md:grid-cols-2">
+          <FormRow :label="t('lensAdmin.fields.type')">
+            <BaseSelect v-model="form.capability" required>
+              <option value="" disabled>
+                {{ t('lensAdmin.placeholders.selectType') }}
+              </option>
+              <option value="general_chat">
+                {{ t('lensAdmin.assistantTypes.generalChat') }}
+              </option>
+              <option value="code_analysis">
+                {{ t('lensAdmin.assistantTypes.codeAnalysis') }}
+              </option>
+              <option value="knowledge_qa">
+                {{ t('lensAdmin.assistantTypes.knowledgeQa') }}
+              </option>
+            </BaseSelect>
+          </FormRow>
+          <FormRow
+            v-if="requiresNodeSelection"
+            :label="t('lensAdmin.fields.lensnode')"
           >
-            <option value="">
-              {{ t('lensAdmin.placeholders.selectLensNode') }}
-            </option>
-            <option
-              v-for="ln in compatibleLensnodes"
-              :key="ln.uuid"
-              :value="ln.uuid"
+            <BaseSelect
+              v-model="form.lensnode_uuid"
+              :required="requiresWorkspace"
             >
-              {{ ln.name }}
-            </option>
-          </BaseSelect>
-        </FormRow>
-      </div>
-      <div v-if="requiresWorkspace">
-        <div class="mb-1 flex items-center justify-between">
-          <span class="text-sm font-medium text-ink-700">{{
-            t('lensAdmin.fields.selectedDirs')
-          }}</span>
-          <button
-            v-if="form.lensnode_uuid"
-            type="button"
-            class="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-ink-500 transition-colors hover:bg-surface-sunken hover:text-ink-700 disabled:opacity-40"
-            :disabled="refreshingDirs"
-            @click="$emit('refresh-dirs')"
-          >
-            <svg
-              class="h-3.5 w-3.5"
-              :class="{ 'animate-spin': refreshingDirs }"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-            {{ t('common.refresh') }}
-          </button>
-        </div>
-        <BaseSelect
-          v-if="selectedLensNodeDirs.length"
-          v-model="selectedDirPath"
-          class="font-mono"
-        >
-          <option value="">{{ t('lensAdmin.placeholders.selectDir') }}</option>
-          <option
-            v-for="dir in selectedLensNodeDirs"
-            :key="dir.path"
-            :value="dir.path"
-          >
-            {{ dir.path }}
-          </option>
-        </BaseSelect>
-        <div
-          v-else
-          class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
-        >
-          {{ t('lensAdmin.placeholders.noDirs') }}
-        </div>
-        <div v-if="selectedDirPath" class="mt-2">
-          <label class="mb-1 block text-xs font-medium text-ink-500">
-            {{ t('lensAdmin.fields.includePaths') }}
-          </label>
-          <textarea
-            class="form-input min-h-20 font-mono"
-            :placeholder="t('lensAdmin.placeholders.includePaths')"
-            :value="selectedDirScopeText(selectedDirPath)"
-            @input="updateDirScope(selectedDirPath, $event.target.value)"
-          />
+              <option value="">
+                {{ t('lensAdmin.placeholders.selectLensNode') }}
+              </option>
+              <option
+                v-for="ln in compatibleLensnodes"
+                :key="ln.uuid"
+                :value="ln.uuid"
+              >
+                {{ ln.name }}
+              </option>
+            </BaseSelect>
+          </FormRow>
         </div>
       </div>
       <div
-        v-else-if="isGeneralChatTask"
-        class="rounded-md border border-primary-200 bg-primary-50 p-3 text-sm text-primary-700"
+        v-else
+        class="space-y-2 rounded-md border border-primary-200 bg-primary-50/50 p-3"
+        data-testid="fixed-collaboration-members"
       >
-        {{ t('lensAdmin.wizard.generalChatExecutionHint') }}
-      </div>
-      <FormRow
-        v-if="requiresWorkspace"
-        :label="t('lensAdmin.fields.retrievalPolicy')"
-      >
-        <div
-          class="grid gap-3 rounded-md border border-line bg-surface-sunken p-3"
-        >
-          <label class="block text-xs font-medium text-ink-600">
-            {{ t('lensAdmin.fields.excludeExtensions') }}
-            <textarea
-              v-model="form.exclude_extensions_text"
-              class="form-input mt-1 min-h-28 font-mono"
-              :placeholder="t('lensAdmin.placeholders.extensions')"
+        <div class="text-sm font-medium text-ink-800">
+          {{ t('lensAdmin.wizard.collaborationMembers') }}
+        </div>
+        <p class="text-xs text-ink-600">
+          {{ t('lensAdmin.wizard.collaborationMembersHint') }}
+        </p>
+        <div class="grid gap-2 sm:grid-cols-2">
+          <label
+            v-for="assistant in collaborationMemberOptions"
+            :key="assistant.uuid"
+            class="flex cursor-pointer items-center gap-2 rounded-md border border-line bg-surface px-3 py-2 text-sm"
+          >
+            <input
+              v-model="form.collaboration_member_uuids"
+              type="checkbox"
+              :value="assistant.uuid"
+              class="h-4 w-4 rounded border-line text-brand-600"
             />
-          </label>
-          <label class="block text-xs font-medium text-ink-600">
-            {{ t('lensAdmin.fields.excludeDirs') }}
-            <textarea
-              v-model="form.exclude_dirs_text"
-              class="form-input mt-1 min-h-28 font-mono"
-              :placeholder="t('lensAdmin.placeholders.excludeDirs')"
-            />
+            <span class="min-w-0 truncate">{{ assistant.name }}</span>
           </label>
         </div>
-      </FormRow>
-      <FormRow
-        v-if="isCodeAnalysisTask"
-        :label="t('lensAdmin.fields.enableCodegraph')"
-      >
-        <label
-          class="flex cursor-pointer items-center gap-3 rounded-md border border-line bg-surface-sunken p-3"
+        <p
+          v-if="!collaborationMemberOptions.length"
+          class="text-xs text-amber-700"
         >
-          <input
-            type="checkbox"
-            v-model="form.enable_codegraph"
-            class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
-          />
-          <span class="text-sm text-ink-700">{{
-            t('lensAdmin.fields.enableCodegraphHint')
-          }}</span>
-        </label>
-      </FormRow>
+          {{ t('lensAdmin.wizard.noCollaborationMembers') }}
+        </p>
+      </div>
+      <template v-if="form.mode === 'direct'">
+        <div v-if="requiresWorkspace">
+          <div class="mb-1 flex items-center justify-between">
+            <span class="text-sm font-medium text-ink-700">{{
+              t('lensAdmin.fields.selectedDirs')
+            }}</span>
+            <button
+              v-if="form.lensnode_uuid"
+              type="button"
+              class="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-ink-500 transition-colors hover:bg-surface-sunken hover:text-ink-700 disabled:opacity-40"
+              :disabled="refreshingDirs"
+              @click="$emit('refresh-dirs')"
+            >
+              <svg
+                class="h-3.5 w-3.5"
+                :class="{ 'animate-spin': refreshingDirs }"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+              {{ t('common.refresh') }}
+            </button>
+          </div>
+          <BaseSelect
+            v-if="selectedLensNodeDirs.length"
+            v-model="selectedDirPath"
+            class="font-mono"
+          >
+            <option value="">
+              {{ t('lensAdmin.placeholders.selectDir') }}
+            </option>
+            <option
+              v-for="dir in selectedLensNodeDirs"
+              :key="dir.path"
+              :value="dir.path"
+            >
+              {{ dir.path }}
+            </option>
+          </BaseSelect>
+          <div
+            v-else
+            class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
+          >
+            {{ t('lensAdmin.placeholders.noDirs') }}
+          </div>
+          <div v-if="selectedDirPath" class="mt-2">
+            <label class="mb-1 block text-xs font-medium text-ink-500">
+              {{ t('lensAdmin.fields.includePaths') }}
+            </label>
+            <textarea
+              class="form-input min-h-20 font-mono"
+              :placeholder="t('lensAdmin.placeholders.includePaths')"
+              :value="selectedDirScopeText(selectedDirPath)"
+              @input="updateDirScope(selectedDirPath, $event.target.value)"
+            />
+          </div>
+        </div>
+        <div
+          v-else-if="isGeneralChatTask"
+          class="rounded-md border border-primary-200 bg-primary-50 p-3 text-sm text-primary-700"
+        >
+          {{ t('lensAdmin.wizard.generalChatExecutionHint') }}
+        </div>
+        <FormRow
+          v-if="requiresWorkspace"
+          :label="t('lensAdmin.fields.retrievalPolicy')"
+        >
+          <div
+            class="grid gap-3 rounded-md border border-line bg-surface-sunken p-3"
+          >
+            <label class="block text-xs font-medium text-ink-600">
+              {{ t('lensAdmin.fields.excludeExtensions') }}
+              <textarea
+                v-model="form.exclude_extensions_text"
+                class="form-input mt-1 min-h-28 font-mono"
+                :placeholder="t('lensAdmin.placeholders.extensions')"
+              />
+            </label>
+            <label class="block text-xs font-medium text-ink-600">
+              {{ t('lensAdmin.fields.excludeDirs') }}
+              <textarea
+                v-model="form.exclude_dirs_text"
+                class="form-input mt-1 min-h-28 font-mono"
+                :placeholder="t('lensAdmin.placeholders.excludeDirs')"
+              />
+            </label>
+          </div>
+        </FormRow>
+        <FormRow
+          v-if="isCodeAnalysisTask"
+          :label="t('lensAdmin.fields.enableCodegraph')"
+        >
+          <label
+            class="flex cursor-pointer items-center gap-3 rounded-md border border-line bg-surface-sunken p-3"
+          >
+            <input
+              type="checkbox"
+              v-model="form.enable_codegraph"
+              class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
+            />
+            <span class="text-sm text-ink-700">{{
+              t('lensAdmin.fields.enableCodegraphHint')
+            }}</span>
+          </label>
+        </FormRow>
+      </template>
     </div>
 
     <!-- Wizard Step 3 — Workspace, Skills, Environment & MCP -->
     <div v-else-if="wizardStep === 3" class="space-y-5">
-      <p class="text-sm text-ink-500">{{ t('lensAdmin.wizard.step3Desc') }}</p>
+      <p class="text-sm text-ink-500">
+        {{
+          t(`lensAdmin.wizard.${isSmartMode ? 'step3SmartDesc' : 'step3Desc'}`)
+        }}
+      </p>
+      <div
+        v-if="isSmartMode"
+        class="rounded-md border border-primary-200 bg-primary-50 p-3 text-sm text-primary-700"
+      >
+        {{ t('lensAdmin.wizard.smartResourcesHint') }}
+      </div>
       <div>
         <span class="text-sm font-medium text-ink-700">{{
           t('lensAdmin.wizard.contextLabel')
         }}</span>
         <p class="mb-2 text-xs text-ink-500">
-          {{ t('lensAdmin.wizard.contextHint') }}
+          {{
+            t(
+              `lensAdmin.wizard.${
+                isSmartMode ? 'smartContextHint' : 'contextHint'
+              }`
+            )
+          }}
         </p>
         <textarea
           v-model="form.workspace_guide_overview"
@@ -333,182 +419,370 @@
           :placeholder="t('lensAdmin.wizard.contextPlaceholder')"
         />
       </div>
-      <div>
-        <div class="mb-2 text-sm font-medium text-ink-700">
-          {{
-            isGeneralChatTask
-              ? t('lensAdmin.wizard.skillsSectionRequired')
-              : t('lensAdmin.wizard.skillsSection')
-          }}
-        </div>
-        <p v-if="isGeneralChatTask" class="mb-2 text-xs text-ink-500">
-          {{ t('lensAdmin.wizard.generalChatSkillsHint') }}
-        </p>
-        <div v-if="selectableSkills.length" class="space-y-2">
-          <div class="relative">
-            <Search
-              :size="16"
-              class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-400"
-              aria-hidden="true"
-            />
-            <input
-              v-model="skillSearch"
-              class="form-input skill-search-input"
-              type="search"
-              :placeholder="t('lensAdmin.wizard.searchSkills')"
-              :aria-label="t('lensAdmin.wizard.searchSkills')"
-              autocomplete="off"
-            />
-          </div>
-          <p class="text-xs text-ink-500" aria-live="polite">
+      <template v-if="!isSmartMode">
+        <div>
+          <div class="mb-2 text-sm font-medium text-ink-700">
             {{
-              t('lensAdmin.wizard.skillSearchResults', {
-                count: filteredSelectableSkills.length,
-                total: selectableSkills.length
-              })
+              isGeneralChatTask
+                ? t('lensAdmin.wizard.skillsSectionRequired')
+                : t('lensAdmin.wizard.skillsSection')
             }}
+          </div>
+          <p v-if="isGeneralChatTask" class="mb-2 text-xs text-ink-500">
+            {{ t('lensAdmin.wizard.generalChatSkillsHint') }}
           </p>
+          <div v-if="selectableSkills.length" class="space-y-2">
+            <div class="relative">
+              <Search
+                :size="16"
+                class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-400"
+                aria-hidden="true"
+              />
+              <input
+                v-model="skillSearch"
+                class="form-input skill-search-input"
+                type="search"
+                :placeholder="t('lensAdmin.wizard.searchSkills')"
+                :aria-label="t('lensAdmin.wizard.searchSkills')"
+                autocomplete="off"
+              />
+            </div>
+            <p class="text-xs text-ink-500" aria-live="polite">
+              {{
+                t('lensAdmin.wizard.skillSearchResults', {
+                  count: filteredSelectableSkills.length,
+                  total: selectableSkills.length
+                })
+              }}
+            </p>
+            <div
+              v-if="filteredSelectableSkills.length"
+              class="max-h-96 space-y-2 overflow-y-auto rounded-md border border-line bg-surface-sunken p-2"
+              data-testid="assistant-skill-options"
+            >
+              <div
+                v-for="skill in filteredSelectableSkills"
+                :key="skill.uuid"
+                data-testid="assistant-skill-option"
+                class="overflow-hidden rounded-md border bg-surface transition-colors"
+                :class="
+                  isSkillSelected(skill.uuid)
+                    ? 'border-primary-300 bg-primary-50/60'
+                    : 'border-line hover:border-primary-200'
+                "
+              >
+                <label
+                  class="group flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
+                >
+                  <input
+                    type="checkbox"
+                    :value="skill.uuid"
+                    v-model="form.skill_uuids"
+                    class="sr-only"
+                  />
+                  <span
+                    class="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border transition-colors"
+                    :class="
+                      isSkillSelected(skill.uuid)
+                        ? 'border-primary-600 bg-primary-600 text-white'
+                        : 'border-line bg-surface text-transparent group-hover:border-primary-300'
+                    "
+                  >
+                    <svg
+                      class="h-3.5 w-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="3"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </span>
+                  <div class="min-w-0 flex-1 space-y-1">
+                    <div class="flex min-w-0 items-start justify-between gap-2">
+                      <div
+                        class="min-w-0 truncate text-sm font-semibold text-ink-900"
+                      >
+                        {{ skill.name }}
+                      </div>
+                    </div>
+                    <div class="truncate text-xs text-ink-400">
+                      {{ skill.package_name || skill.uuid }}
+                    </div>
+                    <p
+                      v-if="skillDescription(skill)"
+                      class="line-clamp-2 text-xs leading-5 text-ink-500"
+                    >
+                      {{ skillDescription(skill) }}
+                    </p>
+                  </div>
+                </label>
+                <div
+                  v-if="isSkillSelected(skill.uuid) && skillEnvironment(skill).length"
+                  class="px-3 pb-3"
+                  data-testid="assistant-skill-environments"
+                >
+                  <div class="ml-8 border-l border-primary-200 pl-3">
+                    <div class="space-y-2.5">
+                      <div
+                        class="space-y-2.5 rounded-md bg-surface-sunken p-2.5"
+                      >
+                        <div
+                          v-for="item in skillEnvironment(skill)"
+                          :key="item.name"
+                          class="flex items-center gap-2"
+                        >
+                          <label
+                            class="w-40 flex-shrink-0 truncate font-mono text-[11px] font-medium text-ink-700"
+                            :for="`skill-environment-${skill.uuid}-${item.name}`"
+                          >
+                            {{ item.name
+                            }}<span v-if="item.required" class="text-danger-600"
+                              >*</span
+                            >
+                          </label>
+                          <div class="relative min-w-0 flex-1">
+                            <input
+                              :id="`skill-environment-${skill.uuid}-${item.name}`"
+                              v-model="
+                                environmentDraft(skill.uuid).values[item.name]
+                              "
+                              class="form-input w-full pr-10 skill-environment-input font-mono"
+                              :type="
+                                isEnvironmentRevealed(skill.uuid, item.name)
+                                  ? 'text'
+                                  : 'password'
+                              "
+                              :placeholder="environmentInputPlaceholder(item)"
+                              :aria-label="item.name"
+                              autocomplete="off"
+                            />
+                            <button
+                              type="button"
+                              class="absolute right-1 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-ink-400 transition-colors hover:bg-surface-sunken hover:text-ink-700"
+                              :aria-label="
+                                environmentRevealLabel(skill.uuid, item.name)
+                              "
+                              :title="
+                                environmentRevealLabel(skill.uuid, item.name)
+                              "
+                              @click="
+                                toggleEnvironmentReveal(skill.uuid, item.name)
+                              "
+                            >
+                              <component
+                                :is="
+                                  isEnvironmentRevealed(skill.uuid, item.name)
+                                    ? EyeOffIcon
+                                    : EyeIcon
+                                "
+                                class="h-4 w-4"
+                                aria-hidden="true"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                        <p
+                          v-if="
+                            hasRequiredEnvironment(skill) &&
+                            !skillEnvironmentConfigured(skill)
+                          "
+                          class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 text-[11px] leading-4 text-primary-700"
+                          role="status"
+                        >
+                          {{
+                            t('lensAdmin.wizard.skillEnvironmentRequiredHint')
+                          }}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
+              role="status"
+            >
+              {{ t('lensAdmin.wizard.noMatchingSkills') }}
+            </div>
+          </div>
           <div
-            v-if="filteredSelectableSkills.length"
-            class="max-h-96 space-y-2 overflow-y-auto rounded-md border border-line bg-surface-sunken p-2"
-            data-testid="assistant-skill-options"
+            v-else
+            class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
+          >
+            {{ t('lensAdmin.wizard.noSkills') }}
+          </div>
+        </div>
+        <div>
+          <div class="mb-2 text-sm font-medium text-ink-700">
+            {{ t('lensAdmin.wizard.mcpSection') }}
+          </div>
+          <div
+            v-if="mcps.length"
+            class="space-y-2 rounded-md border border-line bg-surface-sunken p-2"
           >
             <div
-              v-for="skill in filteredSelectableSkills"
-              :key="skill.uuid"
-              data-testid="assistant-skill-option"
+              v-for="mcp in orderedMcps"
+              :key="mcp.uuid"
               class="overflow-hidden rounded-md border bg-surface transition-colors"
               :class="
-                isSkillSelected(skill.uuid)
+                isMcpSelected(mcp.uuid)
                   ? 'border-primary-300 bg-primary-50/60'
                   : 'border-line hover:border-primary-200'
               "
             >
               <label
-                class="group flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
+                class="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
               >
                 <input
                   type="checkbox"
-                  :value="skill.uuid"
-                  v-model="form.skill_uuids"
-                  class="sr-only"
+                  :value="mcp.uuid"
+                  v-model="form.mcp_uuids"
+                  class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
                 />
-                <span
-                  class="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border transition-colors"
-                  :class="
-                    isSkillSelected(skill.uuid)
-                      ? 'border-primary-600 bg-primary-600 text-white'
-                      : 'border-line bg-surface text-transparent group-hover:border-primary-300'
-                  "
-                >
-                  <svg
-                    class="h-3.5 w-3.5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="3"
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                </span>
-                <div class="min-w-0 flex-1 space-y-1">
-                  <div class="flex min-w-0 items-start justify-between gap-2">
-                    <div
-                      class="min-w-0 truncate text-sm font-semibold text-ink-900"
-                    >
-                      {{ skill.name }}
-                    </div>
+                <div class="min-w-0 flex-1">
+                  <div class="text-sm font-medium text-ink-900">
+                    {{ mcp.name }}
                   </div>
                   <div class="truncate text-xs text-ink-400">
-                    {{ skill.package_name || skill.uuid }}
+                    {{ mcp.transport }} · {{ mcp.endpoint || emptyValue }}
                   </div>
-                  <p
-                    v-if="skillDescription(skill)"
-                    class="line-clamp-2 text-xs leading-5 text-ink-500"
-                  >
-                    {{ skillDescription(skill) }}
-                  </p>
                 </div>
+                <StatusBadge :status="mcp.enabled ? 'enabled' : 'disabled'" />
               </label>
               <div
-                v-if="
-                  isSkillSelected(skill.uuid) && skillEnvironment(skill).length
-                "
+                v-if="isMcpSelected(mcp.uuid) && mcpEnvironment(mcp).length"
                 class="px-3 pb-3"
-                data-testid="assistant-skill-environments"
+                data-testid="assistant-mcp-environments"
               >
-                <div class="ml-8 border-l border-primary-200 pl-3">
-                  <div class="space-y-2.5">
-                    <div class="space-y-2.5 rounded-md bg-surface-sunken p-2.5">
-                      <div
-                        v-for="item in skillEnvironment(skill)"
-                        :key="item.name"
-                        class="flex items-center gap-2"
+                <div class="ml-7 border-l border-primary-200 pl-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <h3 class="text-xs font-semibold text-ink-700">
+                      {{ t('lensAdmin.wizard.environmentSection') }}
+                    </h3>
+                    <span
+                      v-if="hasRequiredMcpEnvironment(mcp)"
+                      class="flex-shrink-0 text-[11px] font-medium text-danger-600"
+                    >
+                      {{ t('lensAdmin.wizard.environmentRequired') }}
+                    </span>
+                  </div>
+                  <p class="mt-1 text-[11px] leading-4 text-ink-500">
+                    {{ t('lensAdmin.wizard.mcpEnvironmentSectionHint') }}
+                  </p>
+                  <div class="mt-2 space-y-2.5">
+                    <p class="text-[11px] leading-4 text-ink-500">
+                      {{
+                        t('lensAdmin.wizard.mcpEnvironmentConfigurationHint', {
+                          count: mcpEnvironment(mcp).length
+                        })
+                      }}
+                    </p>
+                    <BaseSelect
+                      v-model="form.mcp_environment_set_uuids[mcp.uuid]"
+                      class="text-xs"
+                      :aria-label="t('lensAdmin.wizard.selectEnvironmentSet')"
+                    >
+                      <option value="">
+                        {{ t('lensAdmin.wizard.selectEnvironmentSet') }}
+                      </option>
+                      <option value="__new__">
+                        {{ t('lensAdmin.wizard.createEnvironmentSet') }}
+                      </option>
+                      <option
+                        v-for="variableSet in enabledEnvironmentVariableSets"
+                        :key="variableSet.uuid"
+                        :value="variableSet.uuid"
                       >
-                        <label
-                          class="w-40 flex-shrink-0 truncate font-mono text-[11px] font-medium text-ink-700"
-                          :for="`skill-environment-${skill.uuid}-${item.name}`"
-                        >
-                          {{ item.name
-                          }}<span v-if="item.required" class="text-danger-600"
-                            >*</span
-                          >
-                        </label>
-                        <div class="relative min-w-0 flex-1">
-                          <input
-                            :id="`skill-environment-${skill.uuid}-${item.name}`"
-                            v-model="
-                              environmentDraft(skill.uuid).values[item.name]
-                            "
-                            class="form-input w-full pr-10 skill-environment-input font-mono"
-                            :type="
-                              isEnvironmentRevealed(skill.uuid, item.name)
-                                ? 'text'
-                                : 'password'
-                            "
-                            :placeholder="environmentInputPlaceholder(item)"
-                            :aria-label="item.name"
-                            autocomplete="off"
-                          />
-                          <button
-                            type="button"
-                            class="absolute right-1 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-ink-400 transition-colors hover:bg-surface-sunken hover:text-ink-700"
-                            :aria-label="
-                              environmentRevealLabel(skill.uuid, item.name)
-                            "
-                            :title="
-                              environmentRevealLabel(skill.uuid, item.name)
-                            "
-                            @click="
-                              toggleEnvironmentReveal(skill.uuid, item.name)
-                            "
-                          >
-                            <component
-                              :is="
-                                isEnvironmentRevealed(skill.uuid, item.name)
-                                  ? EyeOffIcon
-                                  : EyeIcon
-                              "
-                              class="h-4 w-4"
-                              aria-hidden="true"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                      <p
-                        v-if="
-                          hasRequiredEnvironment(skill) &&
-                          !skillEnvironmentConfigured(skill)
+                        {{ variableSet.name }}
+                      </option>
+                    </BaseSelect>
+                    <EnvironmentSetValues
+                      v-if="
+                        form.mcp_environment_set_uuids[mcp.uuid] &&
+                        form.mcp_environment_set_uuids[mcp.uuid] !== '__new__'
+                      "
+                      :variable-set="selectedMcpEnvironmentSet(mcp.uuid)"
+                      :allowed-keys="
+                        mcpEnvironment(mcp).map((item) => item.name)
+                      "
+                    />
+                    <p
+                      v-if="!form.mcp_environment_set_uuids[mcp.uuid]"
+                      class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 text-[11px] leading-4 text-primary-700"
+                      role="status"
+                    >
+                      {{ t('lensAdmin.wizard.environmentSetRequiredHint') }}
+                    </p>
+                    <div
+                      v-if="
+                        form.mcp_environment_set_uuids[mcp.uuid] === '__new__'
+                      "
+                      class="space-y-1"
+                    >
+                      <label class="text-[11px] font-medium text-ink-700">
+                        {{ t('lensAdmin.wizard.environmentSetNameLabel') }}
+                      </label>
+                      <input
+                        v-model="mcpEnvironmentDraft(mcp.uuid).name"
+                        class="form-input skill-environment-input"
+                        type="text"
+                        :placeholder="t('lensAdmin.wizard.environmentSetName')"
+                        :aria-label="
+                          t('lensAdmin.wizard.environmentSetNameLabel')
                         "
-                        class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 text-[11px] leading-4 text-primary-700"
-                        role="status"
-                      >
-                        {{ t('lensAdmin.wizard.skillEnvironmentRequiredHint') }}
+                        maxlength="160"
+                        autocomplete="off"
+                      />
+                      <p class="text-[11px] leading-4 text-ink-500">
+                        {{ t('lensAdmin.wizard.environmentSetNameHint') }}
                       </p>
+                    </div>
+                    <div
+                      v-if="form.mcp_environment_set_uuids[mcp.uuid]"
+                      class="space-y-2.5 rounded-md bg-surface-sunken p-2.5"
+                    >
+                      <div
+                        v-for="item in mcpEnvironment(mcp)"
+                        :key="item.name"
+                        class="space-y-1"
+                      >
+                        <div class="flex items-center justify-between gap-3">
+                          <label
+                            class="font-mono text-[11px] font-medium text-ink-700"
+                          >
+                            {{ item.name
+                            }}<span
+                              v-if="isMcpEnvironmentRequired(mcp, item)"
+                              class="text-danger-600"
+                            >
+                              *</span
+                            >
+                          </label>
+                          <span
+                            v-if="mcpEnvironmentItemSaved(mcp, item)"
+                            class="text-[11px] text-success-700"
+                          >
+                            {{ t('lensAdmin.wizard.environmentConfigured') }}
+                          </span>
+                        </div>
+                        <input
+                          v-model="
+                            mcpEnvironmentDraft(mcp.uuid).values[item.name]
+                          "
+                          class="form-input skill-environment-input font-mono"
+                          :type="item.secret ? 'password' : 'text'"
+                          :placeholder="environmentInputPlaceholder(item)"
+                          :aria-label="item.name"
+                          autocomplete="off"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -518,193 +792,11 @@
           <div
             v-else
             class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
-            role="status"
           >
-            {{ t('lensAdmin.wizard.noMatchingSkills') }}
+            {{ t('lensAdmin.wizard.noMcp') }}
           </div>
         </div>
-        <div
-          v-else
-          class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
-        >
-          {{ t('lensAdmin.wizard.noSkills') }}
-        </div>
-      </div>
-      <div>
-        <div class="mb-2 text-sm font-medium text-ink-700">
-          {{ t('lensAdmin.wizard.mcpSection') }}
-        </div>
-        <div
-          v-if="mcps.length"
-          class="space-y-2 rounded-md border border-line bg-surface-sunken p-2"
-        >
-          <div
-            v-for="mcp in orderedMcps"
-            :key="mcp.uuid"
-            class="overflow-hidden rounded-md border bg-surface transition-colors"
-            :class="
-              isMcpSelected(mcp.uuid)
-                ? 'border-primary-300 bg-primary-50/60'
-                : 'border-line hover:border-primary-200'
-            "
-          >
-            <label
-              class="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-primary-50/40"
-            >
-              <input
-                type="checkbox"
-                :value="mcp.uuid"
-                v-model="form.mcp_uuids"
-                class="h-4 w-4 flex-shrink-0 rounded border-line text-brand-600 focus:ring-brand-500"
-              />
-              <div class="min-w-0 flex-1">
-                <div class="text-sm font-medium text-ink-900">
-                  {{ mcp.name }}
-                </div>
-                <div class="truncate text-xs text-ink-400">
-                  {{ mcp.transport }} · {{ mcp.endpoint || emptyValue }}
-                </div>
-              </div>
-              <StatusBadge :status="mcp.enabled ? 'enabled' : 'disabled'" />
-            </label>
-            <div
-              v-if="isMcpSelected(mcp.uuid) && mcpEnvironment(mcp).length"
-              class="px-3 pb-3"
-              data-testid="assistant-mcp-environments"
-            >
-              <div class="ml-7 border-l border-primary-200 pl-3">
-                <div class="flex items-center justify-between gap-3">
-                  <h3 class="text-xs font-semibold text-ink-700">
-                    {{ t('lensAdmin.wizard.environmentSection') }}
-                  </h3>
-                  <span
-                    v-if="hasRequiredMcpEnvironment(mcp)"
-                    class="flex-shrink-0 text-[11px] font-medium text-danger-600"
-                  >
-                    {{ t('lensAdmin.wizard.environmentRequired') }}
-                  </span>
-                </div>
-                <p class="mt-1 text-[11px] leading-4 text-ink-500">
-                  {{ t('lensAdmin.wizard.mcpEnvironmentSectionHint') }}
-                </p>
-                <div class="mt-2 space-y-2.5">
-                  <p class="text-[11px] leading-4 text-ink-500">
-                    {{
-                      t('lensAdmin.wizard.mcpEnvironmentConfigurationHint', {
-                        count: mcpEnvironment(mcp).length
-                      })
-                    }}
-                  </p>
-                  <BaseSelect
-                    v-model="form.mcp_environment_set_uuids[mcp.uuid]"
-                    class="text-xs"
-                    :aria-label="t('lensAdmin.wizard.selectEnvironmentSet')"
-                  >
-                    <option value="">
-                      {{ t('lensAdmin.wizard.selectEnvironmentSet') }}
-                    </option>
-                    <option value="__new__">
-                      {{ t('lensAdmin.wizard.createEnvironmentSet') }}
-                    </option>
-                    <option
-                      v-for="variableSet in enabledEnvironmentVariableSets"
-                      :key="variableSet.uuid"
-                      :value="variableSet.uuid"
-                    >
-                      {{ variableSet.name }}
-                    </option>
-                  </BaseSelect>
-                  <EnvironmentSetValues
-                    v-if="
-                      form.mcp_environment_set_uuids[mcp.uuid] &&
-                      form.mcp_environment_set_uuids[mcp.uuid] !== '__new__'
-                    "
-                    :variable-set="selectedMcpEnvironmentSet(mcp.uuid)"
-                    :allowed-keys="mcpEnvironment(mcp).map((item) => item.name)"
-                  />
-                  <p
-                    v-if="!form.mcp_environment_set_uuids[mcp.uuid]"
-                    class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 text-[11px] leading-4 text-primary-700"
-                    role="status"
-                  >
-                    {{ t('lensAdmin.wizard.environmentSetRequiredHint') }}
-                  </p>
-                  <div
-                    v-if="
-                      form.mcp_environment_set_uuids[mcp.uuid] === '__new__'
-                    "
-                    class="space-y-1"
-                  >
-                    <label class="text-[11px] font-medium text-ink-700">
-                      {{ t('lensAdmin.wizard.environmentSetNameLabel') }}
-                    </label>
-                    <input
-                      v-model="mcpEnvironmentDraft(mcp.uuid).name"
-                      class="form-input skill-environment-input"
-                      type="text"
-                      :placeholder="t('lensAdmin.wizard.environmentSetName')"
-                      :aria-label="
-                        t('lensAdmin.wizard.environmentSetNameLabel')
-                      "
-                      maxlength="160"
-                      autocomplete="off"
-                    />
-                    <p class="text-[11px] leading-4 text-ink-500">
-                      {{ t('lensAdmin.wizard.environmentSetNameHint') }}
-                    </p>
-                  </div>
-                  <div
-                    v-if="form.mcp_environment_set_uuids[mcp.uuid]"
-                    class="space-y-2.5 rounded-md bg-surface-sunken p-2.5"
-                  >
-                    <div
-                      v-for="item in mcpEnvironment(mcp)"
-                      :key="item.name"
-                      class="space-y-1"
-                    >
-                      <div class="flex items-center justify-between gap-3">
-                        <label
-                          class="font-mono text-[11px] font-medium text-ink-700"
-                        >
-                          {{ item.name
-                          }}<span
-                            v-if="isMcpEnvironmentRequired(mcp, item)"
-                            class="text-danger-600"
-                          >
-                            *</span
-                          >
-                        </label>
-                        <span
-                          v-if="mcpEnvironmentItemSaved(mcp, item)"
-                          class="text-[11px] text-success-700"
-                        >
-                          {{ t('lensAdmin.wizard.environmentConfigured') }}
-                        </span>
-                      </div>
-                      <input
-                        v-model="
-                          mcpEnvironmentDraft(mcp.uuid).values[item.name]
-                        "
-                        class="form-input skill-environment-input font-mono"
-                        :type="item.secret ? 'password' : 'text'"
-                        :placeholder="environmentInputPlaceholder(item)"
-                        :aria-label="item.name"
-                        autocomplete="off"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          v-else
-          class="rounded-md border border-line bg-surface-sunken p-3 text-sm text-ink-500"
-        >
-          {{ t('lensAdmin.wizard.noMcp') }}
-        </div>
-      </div>
+      </template>
     </div>
 
     <!-- Wizard Step 4 — Authorization -->
@@ -1017,10 +1109,7 @@ import { useUserStore } from '@/store/user'
 
 import EnvironmentSetValues from './components/EnvironmentSetValues.vue'
 
-import {
-  EMPTY_VALUE,
-  formatLLMConfigLabel
-} from './adminHelpers'
+import { EMPTY_VALUE, formatLLMConfigLabel } from './adminHelpers'
 import {
   appendUniqueOptions,
   assignmentFirstOptions,
@@ -1058,6 +1147,15 @@ defineEmits(['close', 'save', 'refresh-dirs'])
 const { t } = useI18n()
 const userStore = useUserStore()
 const isAdmin = computed(() => userStore.userHasFeature('admin_console'))
+const isSmartMode = computed(() => props.form.mode === 'smart')
+const collaborationMemberOptions = computed(() =>
+  props.assistants.filter(
+    (assistant) =>
+      assistant.status === 'active' &&
+      (assistant.mode || assistant.routing_mode || 'direct') === 'direct' &&
+      assistant.uuid !== props.form.uuid
+  )
+)
 
 const emptyValue = EMPTY_VALUE
 const WIZARD_STEP_COUNT = 4
@@ -1268,14 +1366,15 @@ const canProceedWizard = computed(() => {
     )
   }
   if (wizardStep.value === 2) {
+    if (isSmartMode.value) {
+      return (props.form.collaboration_member_uuids || []).length > 0
+    }
     if (!props.form.capability) return false
     if (isGeneralChatTask.value) return true
-    return (
-      !!props.form.lensnode_uuid &&
-      selectedDirs().length > 0
-    )
+    return !!props.form.lensnode_uuid && selectedDirs().length > 0
   }
   if (wizardStep.value === 3) {
+    if (isSmartMode.value) return true
     const hasRequiredSkill =
       !isGeneralChatTask.value || (props.form.skill_uuids || []).length > 0
     return (
@@ -1309,11 +1408,22 @@ watch(
   }
 )
 
+watch(
+  () => props.form.mode,
+  (assistantMode) => {
+    if (assistantMode !== 'smart') return
+    props.form.capability = 'general_chat'
+    props.form.lensnode_uuid = ''
+    props.form.selected_dirs = []
+    props.form.skill_uuids = []
+    props.form.mcp_uuids = []
+    props.form.multimodal_model_ref = ''
+  }
+)
+
 const compatibleLensnodes = computed(() =>
   props.lensnodes.filter((lensnode) =>
-    (lensnode.tasks || []).some(
-      (task) => task.name === props.form.capability
-    )
+    (lensnode.tasks || []).some((task) => task.name === props.form.capability)
   )
 )
 
@@ -1709,7 +1819,6 @@ function updateDirScope(path, value) {
     dir.path === path ? { ...dir, include_paths_text: value } : dir
   )
 }
-
 </script>
 
 <style scoped>

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -138,7 +138,13 @@
                     {{ lensNodeName(row.lensnode) }}
                   </td>
                   <td class="assistant-type-column table-cell text-ink-600">
-                    {{ assistantTypeLabel(row.capability) }}
+                    <div>
+                      {{
+                        (row.mode || row.routing_mode) === 'smart'
+                          ? t('lensAdmin.routingModes.smart')
+                          : assistantTypeLabel(row.capability)
+                      }}
+                    </div>
                   </td>
                   <td class="table-cell text-ink-600">
                     <div
@@ -261,9 +267,9 @@
         :assistant="detailAssistant"
         :lensnode-name="lensNodeName(detailAssistant?.lensnode)"
         :assistant-type="
-          assistantTypeLabel(
-            detailAssistant?.capability
-          )
+          (detailAssistant?.mode || detailAssistant?.routing_mode) === 'smart'
+            ? t('lensAdmin.routingModes.smart')
+            : assistantTypeLabel(detailAssistant?.capability)
         "
         @close="closeDetails"
         @copy-share="copyShareUrl"
@@ -616,7 +622,9 @@ function defaultForm() {
     access_grant_options: [],
     settings: {},
     enable_codegraph: true,
-    status: 'active'
+    status: 'active',
+    mode: 'direct',
+    collaboration_member_uuids: []
   }
 }
 
@@ -633,6 +641,10 @@ function formFromRow(row) {
     name: row.name || '',
     description: row.description || '',
     capability: row.capability || 'general_chat',
+    mode: row.mode || row.routing_mode || 'direct',
+    collaboration_member_uuids: (row.collaboration_members || [])
+      .map((member) => member.uuid)
+      .filter(Boolean),
     slug: row.slug || '',
     lensnode_uuid: row.lensnode?.uuid || row.lensnode || '',
     selected_dirs: selectedDirsFromValue(row.selected_dirs || []),
@@ -738,14 +750,20 @@ function buildPayload() {
     name: form.value.name,
     description: form.value.description?.trim() || '',
     capability: form.value.capability || 'general_chat',
+    mode: form.value.mode || 'direct',
+    ...(form.value.mode === 'smart'
+      ? {
+          collaboration_member_uuids: [
+            ...(form.value.collaboration_member_uuids || [])
+          ]
+        }
+      : {}),
     slug: form.value.slug?.trim() || '',
     ...(form.value.lensnode_uuid
       ? { lensnode_uuid: form.value.lensnode_uuid }
       : {}),
     selected_dirs:
-      form.value.capability === 'general_chat'
-        ? []
-        : buildSelectedDirs(),
+      form.value.capability === 'general_chat' ? [] : buildSelectedDirs(),
     agent_model_ref: form.value.agent_model_ref || null,
     agent_rounds: form.value.agent_rounds || 'balanced',
     max_concurrency: Number(form.value.max_concurrency) || 5,

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1500,6 +1500,7 @@
                 :mobile="isMobile"
                 :open="routingScopeOpen"
                 :selected-uuids="routingScopeAssistantUuids"
+                :readonly="isFixedSmartAssistant"
                 @cancel="cancelRoutingScope"
                 @open="openRoutingScope"
                 @save="saveRoutingScope"
@@ -2011,8 +2012,15 @@ const routingScopeSnapshot = ref([])
 const routingScopeQuery = ref('')
 const mentionedAssistantUuids = ref([])
 const mentionActiveIndex = ref(0)
+const isSmartCollaborationRoute = computed(() => route.name === 'LensSmartChat')
+const isFixedSmartAssistant = computed(
+  () =>
+    !isSmartCollaborationRoute.value &&
+    (selectedAssistant.value?.mode || selectedAssistant.value?.routing_mode) ===
+      'smart'
+)
 const isSmartCollaborationConversation = computed(
-  () => route.name === 'LensSmartChat'
+  () => isSmartCollaborationRoute.value || isFixedSmartAssistant.value
 )
 
 const selectedAssistant = computed(
@@ -2033,7 +2041,11 @@ const selectedSessionArchived = computed(
 )
 
 const routingCandidates = computed(() =>
-  assistants.value.filter((assistant) => assistant.status === 'active')
+  assistants.value.filter(
+    (assistant) =>
+      assistant.status === 'active' &&
+      (assistant.mode || assistant.routing_mode || 'direct') === 'direct'
+  )
 )
 
 const filteredRoutingCandidates = computed(() =>
@@ -2051,7 +2063,11 @@ const routingAllSelected = computed(() => {
 const routingScopeAssistantUuids = computed(() =>
   selectedSession.value
     ? selectedSession.value.allowed_assistant_uuids || []
-    : routingScopeDraft.value
+    : isFixedSmartAssistant.value
+      ? (selectedAssistant.value?.collaboration_members || []).map(
+          (member) => member.uuid
+        )
+      : routingScopeDraft.value
 )
 
 const mentionToken = computed(() => {
@@ -2170,14 +2186,14 @@ const emptyVariant = computed(() =>
 )
 
 const assistantName = computed(() =>
-  isSmartCollaborationConversation.value
+  isSmartCollaborationRoute.value
     ? t('lens.chat.smartCollaboration')
     : selectedAssistant.value?.name || publicAssistant.value?.name || ''
 )
 
 const assistantDescription = computed(
   () =>
-    (isSmartCollaborationConversation.value
+    (isSmartCollaborationRoute.value
       ? t('lens.chat.smartCollaborationDescription')
       : '') ||
     selectedAssistant.value?.description?.trim() ||
@@ -2235,6 +2251,7 @@ function assistantCapabilityLabel(capability) {
 }
 
 function openRoutingScope() {
+  if (isFixedSmartAssistant.value) return
   routingScopeDraft.value = selectedSession.value
     ? [...(selectedSession.value.allowed_assistant_uuids || [])]
     : [...routingScopeDraft.value]
@@ -2329,6 +2346,10 @@ async function handleComposerKeydown(event) {
 }
 
 async function saveRoutingScope() {
+  if (isFixedSmartAssistant.value) {
+    routingScopeOpen.value = false
+    return
+  }
   if (!selectedSession.value) {
     routingScopeOpen.value = false
     return
@@ -3120,7 +3141,7 @@ async function bootstrap() {
     // renders immediately (no flash) and skips its own redundant fetch.
     lensStore.assistants = assistants.value
 
-    if (isSmartCollaborationConversation.value) {
+    if (isSmartCollaborationRoute.value) {
       selectedAssistantUuid.value = ''
       routingScopeDraft.value = []
       await loadMyShareState()
@@ -3147,6 +3168,10 @@ async function bootstrap() {
     }
 
     selectedAssistantUuid.value = current.uuid
+    routingScopeDraft.value =
+      (current.mode || current.routing_mode) === 'smart'
+        ? (current.collaboration_members || []).map((member) => member.uuid)
+        : []
     await loadMyShareState()
     await loadSessions()
     booted.value = true
@@ -3231,7 +3256,7 @@ async function createNewSession(notify = true, allowedAssistantUuids = []) {
   let session
   try {
     session = await createSession(
-      isSmartCollaborationConversation.value
+      isSmartCollaborationRoute.value
         ? {
             routing_mode: 'smart',
             title: '',
@@ -4511,7 +4536,7 @@ watch(
   (sessionUuid) => {
     if (
       !['LensAssistantChat', 'LensSmartChat'].includes(route.name) ||
-      (!isSmartCollaborationConversation.value &&
+      (!isSmartCollaborationRoute.value &&
         route.params.slug !== selectedAssistant.value?.slug) ||
       !sessionUuid ||
       sessionUuid === selectedSessionUuid.value

--- a/frontend/src/pages/lens/components/ParticipatingAssistantsPicker.vue
+++ b/frontend/src/pages/lens/components/ParticipatingAssistantsPicker.vue
@@ -9,8 +9,9 @@
           count: selectedAssistants.length
         })
       "
+      :aria-disabled="readonly"
       aria-controls="participating-assistants-panel"
-      @click="$emit('open')"
+      @click="handleEntryClick"
     >
       <span class="routing-scope-avatar-stack" aria-hidden="true">
         <span
@@ -208,7 +209,8 @@ const props = defineProps({
   mobile: { type: Boolean, default: false },
   open: { type: Boolean, default: false },
   query: { type: String, default: '' },
-  selectedUuids: { type: Array, default: () => [] }
+  selectedUuids: { type: Array, default: () => [] },
+  readonly: { type: Boolean, default: false }
 })
 
 const emit = defineEmits([
@@ -335,6 +337,10 @@ function assistantColor(assistant) {
 
 function handleBackdropClick() {
   emit('cancel')
+}
+
+function handleEntryClick() {
+  if (!props.readonly) emit('open')
 }
 
 function applyRecommendedAssistants() {

--- a/frontend/tests/regressionFixes.test.js
+++ b/frontend/tests/regressionFixes.test.js
@@ -221,6 +221,10 @@ test('assistant exposes one execution strategy without a token budget picker', a
 
   assert.equal(english.lensAdmin.fields.agentRounds, 'Execution strategy')
   assert.equal(chinese.lensAdmin.fields.agentRounds, '执行策略')
+  assert.equal(chinese.lensAdmin.routingModes.direct, '普通模式')
+  assert.equal(chinese.lensAdmin.routingModes.smart, '智能协作')
+  assert.equal(english.lensAdmin.routingModes.direct, 'Standard Mode')
+  assert.equal(english.lensAdmin.routingModes.smart, 'Smart Collaboration')
   assert.doesNotMatch(drawer, /tokenBudgetProfiles/)
   assert.doesNotMatch(drawer, /v-model="form\.token_budget_profile"/)
   assert.doesNotMatch(drawer, /token_budget_profile:/)
@@ -235,7 +239,9 @@ test('assistant node selection is available for every capability', async () => {
   assert.match(drawer, /!!props\.form\.capability/)
   assert.doesNotMatch(drawer, /isOrchestratorTask/)
   assert.match(drawer, /v-if="requiresNodeSelection"/)
+  assert.match(drawer, /v-if="form\.mode === 'direct'"/)
   assert.match(drawer, /v-else-if="isGeneralChatTask"/)
+  assert.doesNotMatch(drawer, /isDirectGeneralChat/)
   const retrievalStart = drawer.indexOf("t('lensAdmin.fields.retrievalPolicy')")
   assert.notEqual(retrievalStart, -1)
   assert.equal(
@@ -281,6 +287,39 @@ test('assistant form does not configure fixed Smart Collaboration delegates', as
   assert.doesNotMatch(drawer, /delegatedAssistantCount/)
   assert.doesNotMatch(drawer, /subagent_assistants/)
   assert.equal(chinese.lensAdmin.wizard.delegatedAssistantsSelected, undefined)
+})
+
+test('Smart assistant setup retains a workspace guide for its coordinator', async () => {
+  const [drawer, chinese] = await Promise.all([
+    source('pages/lens/AssistantFormDrawerDirectEnvironment.vue'),
+    source('admin/locales/zh-CN.json').then(JSON.parse)
+  ])
+
+  const thirdStep = drawer.slice(
+    drawer.indexOf('<!-- Wizard Step 3'),
+    drawer.indexOf('<!-- Wizard Step 4')
+  )
+
+  assert.match(thirdStep, /v-model="form\.workspace_guide_overview"/)
+  assert.match(thirdStep, /smartContextHint/)
+  assert.match(thirdStep, /smartResourcesHint/)
+  assert.equal(
+    chinese.lensAdmin.wizard.smartContextHint,
+    '用于补充智能协作的项目背景、分工原则和检索优先级。'
+  )
+})
+
+test('switching an assistant to Smart clears direct-only model settings', async () => {
+  const drawer = await source(
+    'pages/lens/AssistantFormDrawerDirectEnvironment.vue'
+  )
+
+  const modeWatcher = drawer.slice(
+    drawer.lastIndexOf('watch(\n  () => props.form.mode'),
+    drawer.indexOf('const compatibleLensnodes')
+  )
+
+  assert.match(modeWatcher, /props\.form\.multimodal_model_ref = ''/)
 })
 
 test('assistant Skill picker supports search and environment configuration', async () => {

--- a/release-notes/476.yaml
+++ b/release-notes/476.yaml
@@ -1,0 +1,10 @@
+type: feature
+audience: user
+en: >-
+  Added reusable Smart Assistants with administrator-managed teams whose
+  members are fixed for each conversation.
+zh-CN: >-
+  新增可复用的智能助手，管理员可配置协作团队，并为每次对话固定参与成员。
+es: >-
+  Se añadieron asistentes inteligentes reutilizables con equipos administrados
+  por el administrador y miembros fijos para cada conversación.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Add a reusable Smart Assistant mode with administrator-managed fixed member teams.
- Snapshot validated collaboration members into new Sessions while preserving historical team membership.
- Extend Assistant APIs, admin wizard UI, localized copy, and regression coverage.
- Keep ad-hoc Smart Collaboration compatible and prevent nested Smart members.

Closes #476

## Test plan
- [x] `npm run test:unit` (460 passed)
- [x] `npm run build`
- [x] `git diff --check`
- [ ] Backend pytest blocked locally by missing WeasyPrint `libgobject-2.0-0` runtime library


___

### **PR Type**
Enhancement


___

### **Description**
- Add Smart Assistant mode with fixed member teams.

- Snapshot collaboration members into new Sessions.

- Extend admin APIs, wizard UI, and localization.

- Prevent nested Smart members; add tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SmartAssistant["Smart Assistant with mode=smart"] --> FixedMembers["Fixed direct members"]
  FixedMembers --> Session["Smart Session snapshots member UUIDs"]
  Session --> Run["Run uses snapshot"]
  AdHoc["Ad-hoc Smart Collaboration"] -.->|"compatible"| Session
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Add Smart Assistant mode and member validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+222/-28</a></td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add AssistantMode and routing_mode field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-9dfb8901a8b3bd83ae35511f9f63bd07021b68816bf703d6a2eb430456f94a2a">+98/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistant_lifecycle.py</strong><dd><code>Add fixed collaboration member resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-abda41b88cbac8d986428ddbcfcfe9d79a7487d464ccc705efaa4b99df2e82ac">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin_runs.py</strong><dd><code>Add assistant_mode to admin run view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routing_descriptions.py</strong><dd><code>Update routing description for Smart mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-93f4dfd008a60456f366f73d9e6c9b42451d1202ca7a5776f304308116187e5c">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistants.py</strong><dd><code>Optimize assistant queryset with Prefetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-92f7afe14b73e094100797819700512a986348eb93b85cdbcad59f0901f7191a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Add assistant_mode to run snapshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sessions.py</strong><dd><code>Update session validation for Smart Assistants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-5271360df826bc1230406d5a73425315af7aafd55724812d08e243956049a6ed">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssistantFormDrawerDirectEnvironment.vue</strong><dd><code>Add Smart mode configuration in wizard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-1bbf22475c1d3e7a28848d3821a473ca289b3ce9c70ed901042e503be4fbc9ff">+572/-463</a></td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Update Chat for fixed Smart Assistant routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+33/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Assistants.vue</strong><dd><code>Add Smart mode to assistant list and form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+26/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssistantDetailDrawer.vue</strong><dd><code>Add collaboration members to detail drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-7374d7989ee5c25b721dd716a1b74c91f78f0949f25acf788a03884a32b132fd">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ParticipatingAssistantsPicker.vue</strong><dd><code>Add readonly mode to picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-900674082d2f0dcc6d9195e45bf820e33e30e13b8764eec536e6effb9b40515f">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for Smart Assistant mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+289/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>regressionFixes.test.js</strong><dd><code>Add regression tests for Smart Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-c6817d11aa2607c6dcdf8fef1d9bd8766a8fe8625f22ac8dbbf8d3181d0d1e06">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Database migrations</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0046_assistant_fixed_collaboration.py</strong><dd><code>Add migration for routing_mode and collaboration_members</code>&nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-22dad60c07ed5eb4d8728d4b7ccd20ea498e667de9ab71a7bbdce02523e59e16">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>es.json</strong><dd><code>Add Spanish locale for Smart Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-fc5efacc2d4df9cfc4192f70e7478c9ac6da757a78b4543d46b34dd0638149d2">+19/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Update Chinese locale for Smart Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+19/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Update English locale for Smart Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>476.yaml</strong><dd><code>Add release note for Smart Assistants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-c32ddabf13cc86d46a8534c03b722388303db8d8da7cc6346459ec10a1f221ae">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design-fixed-smart-collaboration-assistants.md</strong><dd><code>Design document for Smart Assistants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/477/files#diff-4368916153c404cb1d2f9e4c86cefd80eebfcf8321c1db768d9813ea862c56d5">+355/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

