### PR TITLE
Fix standalone installation health and login flow

### DIFF
--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -55,7 +55,9 @@ services:
         condition: service_healthy
     command: gunicorn
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health/celery"]
+      # Gate dependent services on API readiness only. Full Celery readiness is
+      # checked by install.sh after worker and scheduler have started.
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -78,6 +80,9 @@ services:
         VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-}
         VITE_SENTRY_SEND_DEFAULT_PII: ${VITE_SENTRY_SEND_DEFAULT_PII:-}
         VITE_GA_ID: ${VITE_GA_ID:-}
+    environment:
+      TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-true}
+      VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:-}
     expose:
       - "80"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,9 @@ x-sourcelens-ui-common: &sourcelens-ui-common
       VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-}
       VITE_SENTRY_SEND_DEFAULT_PII: ${VITE_SENTRY_SEND_DEFAULT_PII:-}
       VITE_GA_ID: ${VITE_GA_ID:-}
+  environment:
+    TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-true}
+    VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:-}
   expose:
     - "80"
   networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,6 +46,8 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy custom nginx configuration for SPA routing
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/40-runtime-config.sh /docker-entrypoint.d/40-runtime-config.sh
+RUN chmod +x /docker-entrypoint.d/40-runtime-config.sh
 
 # Stamp the release version onto the runtime image so scripts/install.sh can
 # read it (docker inspect Config.Labels) for its version-skip check. Absent =>

--- a/frontend/docker/40-runtime-config.sh
+++ b/frontend/docker/40-runtime-config.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+case "${TURNSTILE_ENABLED:-false}" in
+  true | TRUE | True | 1 | yes | YES | Yes)
+    turnstile_enabled=true
+    ;;
+  *)
+    turnstile_enabled=false
+    ;;
+esac
+
+site_key_base64="$(
+  printf '%s' "${VITE_TURNSTILE_SITE_KEY:-}" | base64 | tr -d '\n'
+)"
+
+printf '%s\n' \
+  "window.__SOURCELENS_CONFIG__ = {" \
+  "  turnstileEnabled: ${turnstile_enabled}," \
+  "  turnstileSiteKey: atob(\"${site_key_base64}\")" \
+  "}" \
+  > /usr/share/nginx/html/runtime-config.js

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <script src="/runtime-config.js"></script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/frontend/public/runtime-config.js
+++ b/frontend/public/runtime-config.js
@@ -1,0 +1,1 @@
+window.__SOURCELENS_CONFIG__ = {}

--- a/frontend/src/components/TurnstileWidget.vue
+++ b/frontend/src/components/TurnstileWidget.vue
@@ -4,13 +4,16 @@
 
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { getTurnstileConfig } from '@/config/runtime'
 
 const SCRIPT_SRC =
   'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
 
 const emit = defineEmits(['verified', 'expired', 'error'])
 
-const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
+const { enabled, siteKey } = getTurnstileConfig(
+  import.meta.env.VITE_TURNSTILE_SITE_KEY
+)
 const container = ref(null)
 let widgetId = null
 
@@ -37,8 +40,8 @@ function loadScript() {
 }
 
 onMounted(async () => {
-  // No site key configured: bypass (development) so the flow is usable.
-  if (!siteKey) {
+  // Bypass when Turnstile is disabled or no site key is configured.
+  if (!enabled || !siteKey) {
     emit('verified', '')
     return
   }
@@ -60,9 +63,9 @@ onMounted(async () => {
  * Reset the widget so the user can solve the challenge again.
  */
 function reset() {
-  if (siteKey && widgetId !== null && window.turnstile) {
+  if (enabled && siteKey && widgetId !== null && window.turnstile) {
     window.turnstile.reset(widgetId)
-  } else if (!siteKey) {
+  } else if (!enabled || !siteKey) {
     // Bypass mode: verification always passes, so re-emit a fresh token
     // to restore the consumer's state after a failed submit.
     emit('verified', '')
@@ -70,12 +73,12 @@ function reset() {
 }
 
 onBeforeUnmount(() => {
-  if (siteKey && widgetId !== null && window.turnstile) {
+  if (enabled && siteKey && widgetId !== null && window.turnstile) {
     window.turnstile.remove(widgetId)
   }
 })
 
-defineExpose({ reset, hasSiteKey: !!siteKey })
+defineExpose({ reset, hasSiteKey: enabled && !!siteKey })
 </script>
 
 <style scoped>

--- a/frontend/src/config/runtime.js
+++ b/frontend/src/config/runtime.js
@@ -1,0 +1,16 @@
+const parseBoolean = (value) => {
+  if (typeof value === 'boolean') return value
+  if (typeof value !== 'string') return undefined
+  return value.toLowerCase() === 'true'
+}
+
+export const getTurnstileConfig = (buildSiteKey = '') => {
+  const runtime = globalThis.__SOURCELENS_CONFIG__ || {}
+  const siteKey = runtime.turnstileSiteKey ?? buildSiteKey ?? ''
+  const runtimeEnabled = parseBoolean(runtime.turnstileEnabled)
+
+  return {
+    enabled: runtimeEnabled ?? Boolean(siteKey),
+    siteKey
+  }
+}

--- a/frontend/tests/turnstileRuntimeConfig.test.js
+++ b/frontend/tests/turnstileRuntimeConfig.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getTurnstileConfig } from '../src/config/runtime.js'
+
+test.afterEach(() => {
+  delete globalThis.__SOURCELENS_CONFIG__
+})
+
+test('runtime configuration disables a bundled Turnstile site key', () => {
+  globalThis.__SOURCELENS_CONFIG__ = {
+    turnstileEnabled: false,
+    turnstileSiteKey: ''
+  }
+
+  assert.deepEqual(getTurnstileConfig('bundled-key'), {
+    enabled: false,
+    siteKey: ''
+  })
+})
+
+test('runtime configuration enables a configured Turnstile site key', () => {
+  globalThis.__SOURCELENS_CONFIG__ = {
+    turnstileEnabled: true,
+    turnstileSiteKey: 'runtime-key'
+  }
+
+  assert.deepEqual(getTurnstileConfig('bundled-key'), {
+    enabled: true,
+    siteKey: 'runtime-key'
+  })
+})
+
+test('build configuration remains the fallback outside a container', () => {
+  assert.deepEqual(getTurnstileConfig('bundled-key'), {
+    enabled: true,
+    siteKey: 'bundled-key'
+  })
+})

--- a/install.sh
+++ b/install.sh
@@ -721,6 +721,19 @@ generate_env() {
     set_env_key "${env_file}" NGINX_HTTP_PORT "${HTTP_PORT}"
     set_env_key "${env_file}" NGINX_HTTPS_PORT "${HTTPS_PORT}"
     ensure_turnstile_boots "${env_file}"
+    local stored_admin_username stored_admin_email
+    stored_admin_username="$(
+      read_env_key "${env_file}" DJANGO_SUPERUSER_USERNAME
+    )"
+    stored_admin_email="$(
+      read_env_key "${env_file}" DJANGO_SUPERUSER_EMAIL
+    )"
+    if [[ -n "${stored_admin_username}" ]]; then
+      ADMIN_USERNAME="${stored_admin_username}"
+    fi
+    if [[ -n "${stored_admin_email}" ]]; then
+      ADMIN_EMAIL="${stored_admin_email}"
+    fi
     ADMIN_PASSWORD="$(read_env_key "${env_file}" DJANGO_SUPERUSER_PASSWORD)"
     return 0
   fi
@@ -959,9 +972,9 @@ start_stack() {
 # Health check
 # ---------------------------------------------------------------------------
 health_check() {
-  log_step "Waiting for health endpoint (timeout: ${HEALTH_TIMEOUT}s)"
+  log_step "Waiting for system health endpoint (timeout: ${HEALTH_TIMEOUT}s)"
   local deadline=$((SECONDS + HEALTH_TIMEOUT))
-  local url="http://127.0.0.1:${HTTP_PORT}/health"
+  local url="http://127.0.0.1:${HTTP_PORT}/health/celery"
   until curl -fsS --max-time 5 "${url}" >/dev/null 2>&1; do
     if ((SECONDS >= deadline)); then
       log_error "health check timed out after ${HEALTH_TIMEOUT}s"
@@ -990,6 +1003,7 @@ write_install_info() {
     printf 'SOURCELENS_INSTALL_DIR=%s\n' "${INSTALL_DIR}"
     printf 'SOURCELENS_URL=%s\n' "${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
     printf 'SOURCELENS_USERNAME=%s\n' "${ADMIN_USERNAME}"
+    printf 'SOURCELENS_EMAIL=%s\n' "${ADMIN_EMAIL}"
     printf 'SOURCELENS_INITIAL_PASSWORD=%s\n' "${ADMIN_PASSWORD}"
     printf 'SOURCELENS_REGISTRY=%s\n' "${REGISTRY}"
     printf 'SOURCELENS_HTTP_PORT=%s\n' "${HTTP_PORT}"
@@ -1019,7 +1033,7 @@ final_summary() {
   log_step "Installation complete"
   log_ok "SourceLens v${VERSION} installed at ${INSTALL_DIR}"
   log_info "URL:              ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
-  log_info "Username:         ${ADMIN_USERNAME}"
+  log_info "Email:            ${ADMIN_EMAIL}"
   log_info "Initial password: ${ADMIN_PASSWORD}"
   log_info "Install dir:      ${INSTALL_DIR}"
   log_info "Config file:      ${INSTALL_DIR}/.env"

--- a/release-notes/480.yaml
+++ b/release-notes/480.yaml
@@ -1,0 +1,13 @@
+type: fix
+audience: admin
+en: >-
+  Fixed the one-command standalone installation so service readiness no longer
+  blocks startup, the installer shows the administrator email required for
+  login, and Turnstile is disabled consistently when keys are not configured.
+zh-CN: >-
+  修复一键式 standalone 安装：服务就绪检查不再阻塞启动，安装器会显示登录所需的
+  管理员邮箱，且未配置密钥时前后端会一致关闭 Turnstile。
+es: >-
+  Se corrigió la instalación standalone con un solo comando: la comprobación
+  de servicios ya no bloquea el inicio, se muestra el correo del administrador
+  para iniciar sesión y Turnstile se desactiva si no se configuran claves.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Break the standalone startup dependency cycle by gating dependent services on API readiness and checking full Celery readiness after the stack starts.
- Print and persist the administrator email required by the login form, including preserved credentials on installer reruns.
- Configure Turnstile at frontend container startup so installations without Cloudflare keys consistently disable verification in both the backend and UI.

## Test plan

- [x] `npm run test:unit` (320 passed)
- [x] `npm run build`
- [x] `node --test frontend/tests/turnstileRuntimeConfig.test.js` (3 passed)
- [x] `bash -n install.sh`
- [x] `sh -n frontend/docker/40-runtime-config.sh`
- [x] `docker compose -f docker-compose.standalone.yml config --quiet`
- [x] `docker compose -f docker-compose.yml config --quiet`
- [x] `git diff --check`
- [x] Release-note unit tests and PR validation
- [x] Ubuntu standalone installation completed with all services running and `/runtime-config.js` reporting `turnstileEnabled: false`
- [ ] Final browser credential submission after rebuilding the frontend image

## Merge policy

- Do not merge automatically; review and merge manually when checks and approvals are complete.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Break startup dependency cycle for standalone installation

- Print and persist admin email required for login

- Configure Turnstile runtime config for consistent disable

- Check Celery readiness after stack starts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend healthcheck"] --> B["/health (API readiness only)"]
  C["install.sh health_check"] --> D["/health/celery (full readiness)"]
  E["Frontend runtime config"] --> F["TurnstileWidget: enabled check"]
  B --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>TurnstileWidget.vue</strong><dd><code>Use runtime config for Turnstile bypass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-b17e3ee7c311de27bd2c3ee26e40781e3dd4e94469454d38d02aacd530e5b42e">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>install.sh</strong><dd><code>Restructure install health check and admin email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.standalone.yml</strong><dd><code>Update standalone health check and env vars</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-9ce448f74e566e43c1699bd469713bd9cd36e5f11ffccd6b824cd840f3077228">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>runtime-config.js</strong><dd><code>Add empty runtime config placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-0e6306a0ccdc01095416bfb977ba144a4b3f95f91e491c247f477548f463474b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Include runtime config script in index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Add Turnstile environment to frontend stack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>runtime.js</strong><dd><code>Add runtime config helper for Turnstile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-01bd3826b6dafe9a98af8476f23ca3993290fd33c0547e38440ed56f96712797">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>40-runtime-config.sh</strong><dd><code>Generate runtime Turnstile config at container start</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-5f959dfd0f38b741bb9cf5b1f4821c1ee26f43dd504c2e649d2d5b20de8aeb9f">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>Add runtime config script to Docker image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>turnstileRuntimeConfig.test.js</strong><dd><code>Add unit tests for runtime Turnstile config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-91e970d9ab076afeec543d4c40e1610c5dbf61d88915a4fca9016e6fd7350eb1">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>480.yaml</strong><dd><code>Add release notes for standalone fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/480/files#diff-b47551a092a82468e5c7f1c736d7432645c7e3c2018e661d0d57b9ce7b9962d3">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

