### PR TITLE
Allow inspection of fixed Smart Assistant members

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -223,7 +223,6 @@
       "participatingAssistants": "Participating assistants · {count}",
       "participatingAssistantsTitle": "Choose collaborating assistants",
       "participatingAssistantsHint": "Only checked assistants are considered for future messages in this conversation.",
-      "participatingAssistantsRecommended": "Recommended combination",
       "participatingAssistantsCount": "{count} selected · We recommend no more than {max} for precise routing.",
       "participatingAssistantsNone": "Select at least one assistant to enable collaboration.",
       "participatingAssistantsRequired": "Select at least one participating assistant.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -223,7 +223,6 @@
       "participatingAssistants": "Asistentes participantes · {count}",
       "participatingAssistantsTitle": "Elegir asistentes colaboradores",
       "participatingAssistantsHint": "Solo se consideran los asistentes seleccionados para futuros mensajes de esta conversación.",
-      "participatingAssistantsRecommended": "Combinación recomendada",
       "participatingAssistantsCount": "{count} seleccionados · Recomendamos no superar {max} para un enrutamiento preciso.",
       "participatingAssistantsNone": "Selecciona al menos un asistente para activar la colaboración.",
       "participatingAssistantsRequired": "Selecciona al menos un asistente participante.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -223,7 +223,6 @@
       "participatingAssistants": "参与助手 · {count}",
       "participatingAssistantsTitle": "选择协作助手",
       "participatingAssistantsHint": "仅在当前对话后续消息中从已勾选助手里自动选择。",
-      "participatingAssistantsRecommended": "推荐组合",
       "participatingAssistantsCount": "已选 {count} 个 · 建议不超过 {max} 个以保证路由准确",
       "participatingAssistantsNone": "请至少选择一个助手后再开始协作。",
       "participatingAssistantsRequired": "请至少选择一个可参与助手。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2251,7 +2251,6 @@ function assistantCapabilityLabel(capability) {
 }
 
 function openRoutingScope() {
-  if (isFixedSmartAssistant.value) return
   routingScopeDraft.value = selectedSession.value
     ? [...(selectedSession.value.allowed_assistant_uuids || [])]
     : [...routingScopeDraft.value]

--- a/frontend/src/pages/lens/components/ParticipatingAssistantsPicker.vue
+++ b/frontend/src/pages/lens/components/ParticipatingAssistantsPicker.vue
@@ -9,7 +9,6 @@
           count: selectedAssistants.length
         })
       "
-      :aria-disabled="readonly"
       aria-controls="participating-assistants-panel"
       @click="handleEntryClick"
     >
@@ -55,31 +54,6 @@
             </p>
           </div>
         </div>
-        <div
-          v-if="recommendedAssistants.length"
-          class="routing-scope-recommend"
-        >
-          <div class="routing-scope-recommend-copy">
-            <span class="routing-scope-recommend-icon" aria-hidden="true">
-              ✨
-            </span>
-            <div class="routing-scope-recommend-text">
-              <p class="routing-scope-recommend-title">
-                {{ t('lens.chat.participatingAssistantsRecommended') }}
-              </p>
-              <p class="routing-scope-recommend-names">
-                {{ recommendedAssistantNames }}
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            class="routing-scope-recommend-apply"
-            @click="applyRecommendedAssistants"
-          >
-            {{ t('common.apply') }}
-          </button>
-        </div>
         <div class="routing-scope-toolbar">
           <label class="routing-scope-search">
             <span class="sr-only">
@@ -99,7 +73,7 @@
           </label>
           <button
             type="button"
-            :disabled="!candidateCount"
+            :disabled="readonly || !candidateCount"
             :aria-pressed="allSelected"
             class="routing-scope-select-all"
             @click="$emit('toggle-all')"
@@ -127,6 +101,7 @@
                 :value="assistant.uuid"
                 :checked="draft.includes(assistant.uuid)"
                 class="routing-scope-checkbox sr-only"
+                :disabled="readonly"
                 @change="toggleAssistant(assistant.uuid, $event.target.checked)"
               />
               <span
@@ -180,9 +155,10 @@
               class="routing-scope-action text-ink-600 hover:bg-surface-sunken"
               @click="$emit('cancel')"
             >
-              {{ t('common.cancel') }}
+              {{ readonly ? t('common.close') : t('common.cancel') }}
             </button>
             <button
+              v-if="!readonly"
               type="button"
               class="routing-scope-action bg-brand-600 font-medium text-white hover:bg-brand-700"
               @click="$emit('save')"
@@ -233,13 +209,6 @@ const assistantColors = [
   '#475569',
   '#e11d48'
 ]
-const assistantColorsByName = {
-  'agione-ai-assistant': '#2563eb',
-  'agione-price-assistant': '#7c3aed',
-  'aishu-anybackup-assistant': '#0d9488',
-  'engineering-ops': '#475569',
-  'hyperbdr-ai-assistant': '#e11d48'
-}
 const selectedAssistants = computed(() =>
   props.candidates.filter((assistant) =>
     props.selectedUuids.includes(assistant.uuid)
@@ -258,30 +227,6 @@ const candidateGroups = computed(() => {
     }))
     .filter((group) => group.assistants.length)
 })
-const recommendedAssistants = computed(() => {
-  const matches = props.candidates.filter((assistant) => {
-    const name = String(assistant.name || '').toLocaleLowerCase()
-    return (
-      name === 'hyperbdr-ai-assistant' || name.startsWith('company-knowledge')
-    )
-  })
-  if (matches.length !== 2) return []
-  return [
-    matches.find(
-      (assistant) =>
-        String(assistant.name || '').toLocaleLowerCase() ===
-        'hyperbdr-ai-assistant'
-    ),
-    matches.find((assistant) =>
-      String(assistant.name || '')
-        .toLocaleLowerCase()
-        .startsWith('company-knowledge')
-    )
-  ]
-})
-const recommendedAssistantNames = computed(() =>
-  recommendedAssistants.value.map((assistant) => assistant.name).join(' + ')
-)
 const selectionStatusText = computed(() => {
   if (draftCount.value === 0) {
     return t('lens.chat.participatingAssistantsNone')
@@ -324,9 +269,6 @@ function assistantInitials(name) {
 }
 
 function assistantColor(assistant) {
-  const name = String(assistant.name || '').toLocaleLowerCase()
-  if (name.startsWith('company-knowledge')) return '#d97706'
-  if (assistantColorsByName[name]) return assistantColorsByName[name]
   const source = String(assistant.uuid || assistant.name || '')
   const index = [...source].reduce(
     (total, character) => total + character.codePointAt(0),
@@ -340,14 +282,7 @@ function handleBackdropClick() {
 }
 
 function handleEntryClick() {
-  if (!props.readonly) emit('open')
-}
-
-function applyRecommendedAssistants() {
-  emit(
-    'update:draft',
-    recommendedAssistants.value.map((assistant) => assistant.uuid)
-  )
+  emit('open')
 }
 
 function toggleAssistant(uuid, checked) {
@@ -365,7 +300,6 @@ function toggleAssistant(uuid, checked) {
 
 .routing-scope-entry:focus-visible,
 .routing-scope-select-all:focus-visible,
-.routing-scope-recommend-apply:focus-visible,
 .routing-scope-action:focus-visible {
   @apply outline-none ring-2 ring-primary-300 ring-offset-1;
 }
@@ -419,38 +353,6 @@ function toggleAssistant(uuid, checked) {
 
 .routing-scope-hint {
   @apply mt-0.5 text-[12.5px] leading-5 text-ink-400;
-}
-
-.routing-scope-recommend {
-  @apply mx-[22px] mt-3.5 flex items-center justify-between gap-3 rounded-[10px]
-    border px-3 py-2.5;
-  border-color: #eaecf2;
-  background: #f6f7fb;
-}
-
-.routing-scope-recommend-copy {
-  @apply flex min-w-0 items-center gap-2.5;
-}
-
-.routing-scope-recommend-icon {
-  @apply shrink-0 text-base;
-}
-
-.routing-scope-recommend-text {
-  @apply min-w-0;
-}
-
-.routing-scope-recommend-title {
-  @apply text-[12.5px] font-semibold text-ink-900;
-}
-
-.routing-scope-recommend-names {
-  @apply truncate text-[11.5px] text-ink-400;
-}
-
-.routing-scope-recommend-apply {
-  @apply shrink-0 rounded-md px-1 py-1 text-xs font-semibold text-primary-700
-    transition-colors hover:bg-primary-50;
 }
 
 .routing-scope-toolbar {
@@ -559,10 +461,6 @@ function toggleAssistant(uuid, checked) {
 .routing-scope-layer.is-mobile .routing-scope-toolbar,
 .routing-scope-layer.is-mobile .routing-scope-footer {
   @apply px-4;
-}
-
-.routing-scope-layer.is-mobile .routing-scope-recommend {
-  @apply mx-4;
 }
 
 .routing-scope-layer.is-mobile .routing-scope-select-all {

--- a/frontend/tests/chatRoutingScope.test.js
+++ b/frontend/tests/chatRoutingScope.test.js
@@ -79,7 +79,9 @@ test('Smart Collaboration starts with an empty searchable routing scope', async 
   assert.match(picker, /participatingAssistantsTitle/)
   assert.match(picker, /routing-scope-entry/)
   assert.doesNotMatch(picker, /class="routing-scope-trigger"/)
-  assert.match(picker, /participatingAssistantsRecommended/)
+  assert.doesNotMatch(picker, /participatingAssistantsRecommended/)
+  assert.doesNotMatch(picker, /hyperbdr-ai-assistant/i)
+  assert.doesNotMatch(picker, /company-knowledge/i)
   assert.match(picker, /routing-scope-avatar-stack/)
   assert.doesNotMatch(picker, /routing-scope-option-type/)
   assert.match(picker, /routing-scope-group-title/)
@@ -121,10 +123,30 @@ test('Smart Collaboration exposes the picker above the composer', async () => {
   assert.match(picker, /:class="\{ 'is-mobile': mobile \}"/)
   assert.match(picker, /class="routing-scope-panel"/)
   assert.match(picker, /role="dialog"/)
-  assert.match(picker, /class="routing-scope-recommend"/)
+  assert.doesNotMatch(picker, /class="routing-scope-recommend"/)
   assert.match(picker, /candidates: \{ type: Array/)
   assert.match(picker, /selectedUuids: \{ type: Array/)
   assert.match(chat, /v-model:draft="routingScopeDraft"/)
   assert.match(chat, /:candidates="routingCandidates"/)
   assert.match(chat, /:selected-uuids="routingScopeAssistantUuids"/)
+})
+
+test('fixed Smart Assistants allow member inspection without editing', async () => {
+  const [chat, picker] = await Promise.all([
+    chatSource(),
+    routingScopePickerSource()
+  ])
+
+  assert.doesNotMatch(
+    picker,
+    /if \(!props\.readonly\) emit\('open'\)/
+  )
+  assert.match(picker, /:disabled="readonly \|\| !candidateCount"/)
+  assert.match(picker, /:disabled="readonly"/)
+  assert.match(picker, /v-if="!readonly"/)
+  assert.match(picker, /readonly \? t\('common\.close'\)/)
+  assert.doesNotMatch(
+    chat,
+    /function openRoutingScope\(\) \{\s*if \(isFixedSmartAssistant\.value\) return/
+  )
 })

--- a/release-notes/478.yaml
+++ b/release-notes/478.yaml
@@ -1,0 +1,10 @@
+type: improvement
+audience: user
+en: >-
+  Fixed Smart Assistants now let users inspect their configured collaborating
+  assistants without allowing membership changes.
+zh-CN: >-
+  固定智能助手现在支持查看已配置的协作助手，同时保持成员不可修改。
+es: >-
+  Los asistentes inteligentes fijos ahora permiten consultar los asistentes
+  colaboradores configurados sin permitir cambios en sus miembros.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Let users open the participating-assistants panel for fixed Smart Assistants.
- Keep configured membership read-only while allowing search and inspection.
- Remove the hard-coded recommended combination and add a user-facing release note.

Closes #478

## Test plan
- [x] `node --test frontend/tests/chatRoutingScope.test.js`
- [x] `npm run build`


___

### **PR Type**
Enhancement


___

### **Description**
- Allow opening the participating-assistants panel for fixed Smart Assistants

- Make the picker read-only: disable checkboxes, hide Save, show Close

- Remove the hard-coded recommended combination and its related logic

- Update tests to verify read-only behavior and absence of recommended section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed Smart Assistant"] --> B["Participating Assistants Picker"]
  B --> C["Search and inspect members"]
  B --> D["Read-only: disabled checkboxes, Close button"]
  B --> E["No Recommend, No Save"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Chat.vue</strong><dd><code>Remove guard blocking fixed Smart Assistant picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ParticipatingAssistantsPicker.vue</strong><dd><code>Make picker read-only, remove recommended section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-900674082d2f0dcc6d9195e45bf820e33e30e13b8764eec536e6effb9b40515f">+5/-107</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>chatRoutingScope.test.js</strong><dd><code>Add test for fixed Smart Assistant inspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-f86a85bebf5fad2abfba20db49a0093c918db84af2816fc2b1dcde14a416b72b">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Remove recommended combination string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Remove recommended combination string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-ba529cd8e421586279be00c1310ca7d73e9279c6738cd47b4228566944ef2bd2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Remove recommended combination string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>478.yaml</strong><dd><code>Add release note for the change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/481/files#diff-1f604367a98aa204b1c175ab9cf3ad800cedb87e55514ec324a17a7c821d6c3b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

