### PR TITLE
Preserve bundled Turnstile key when runtime config is empty

### DIFF
--- a/frontend/src/config/runtime.js
+++ b/frontend/src/config/runtime.js
@@ -6,8 +6,11 @@ const parseBoolean = (value) => {
 
 export const getTurnstileConfig = (buildSiteKey = '') => {
   const runtime = globalThis.__SOURCELENS_CONFIG__ || {}
-  const siteKey = runtime.turnstileSiteKey ?? buildSiteKey ?? ''
   const runtimeEnabled = parseBoolean(runtime.turnstileEnabled)
+  const siteKey =
+    runtimeEnabled === false
+      ? (runtime.turnstileSiteKey ?? '')
+      : runtime.turnstileSiteKey || buildSiteKey || ''
 
   return {
     enabled: runtimeEnabled ?? Boolean(siteKey),

--- a/frontend/tests/turnstileRuntimeConfig.test.js
+++ b/frontend/tests/turnstileRuntimeConfig.test.js
@@ -31,6 +31,18 @@ test('runtime configuration enables a configured Turnstile site key', () => {
   })
 })
 
+test('empty runtime site key preserves the bundled site key', () => {
+  globalThis.__SOURCELENS_CONFIG__ = {
+    turnstileEnabled: true,
+    turnstileSiteKey: ''
+  }
+
+  assert.deepEqual(getTurnstileConfig('bundled-key'), {
+    enabled: true,
+    siteKey: 'bundled-key'
+  })
+})
+
 test('build configuration remains the fallback outside a container', () => {
   assert.deepEqual(getTurnstileConfig('bundled-key'), {
     enabled: true,

--- a/release-notes/484.yaml
+++ b/release-notes/484.yaml
@@ -1,0 +1,11 @@
+type: fix
+audience: user
+en: >-
+  Fixed login human verification when the runtime configuration does not
+  provide a Turnstile site key but the production frontend includes one.
+zh-CN: >-
+  修复运行时配置未提供 Turnstile Site Key、但生产前端已内置该配置时的登录人机验证。
+es: >-
+  Se corrigió la verificación humana del inicio de sesión cuando la
+  configuración de ejecución no proporciona una clave de sitio de Turnstile,
+  pero el frontend de producción ya incluye una.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Preserve the frontend build-time Turnstile site key when the runtime config does not provide one.
- Keep an explicit `TURNSTILE_ENABLED=false` override effective.
- Add regression coverage for the production runtime configuration.

## Root cause

The runtime config generated an empty site key when the server-side environment did not define `VITE_TURNSTILE_SITE_KEY`. That empty value replaced the valid key embedded in the production image, hiding the widget while the backend continued to require a Turnstile token.

## Verification

- `npm run test:unit` (459 passed)
- Production Vite build passed
- `git diff --check` passed

This PR contains only the Turnstile runtime fix and its test; README changes are not included.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Preserve bundled Turnstile key when runtime config is empty

- Add regression test for the fallback behavior

- Add release notes for the login fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Bundled site key"] --> B{Has runtime site key?}
    B -- Yes --> C["Use runtime site key"]
    B -- No (empty) --> D["Use bundled site key"]
    C --> E["Final config"]
    D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.js</strong><dd><code>Fix Turnstile site key fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/config/runtime.js

<ul><li>Fixed site key fallback: when runtime site key is empty, use bundled <br>key.<br> <li> Added handling for runtimeEnabled=false to not fallback to bundled <br>key.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/484/files#diff-01bd3826b6dafe9a98af8476f23ca3993290fd33c0547e38440ed56f96712797">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>turnstileRuntimeConfig.test.js</strong><dd><code>Add regression test for bundled key fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/turnstileRuntimeConfig.test.js

- Added test case: empty runtime site key preserves bundled key.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/484/files#diff-91e970d9ab076afeec543d4c40e1610c5dbf61d88915a4fca9016e6fd7350eb1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>484.yaml</strong><dd><code>Add release note for Turnstile fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/484.yaml

- Added release notes in English, Chinese, and Spanish.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/484/files#diff-ea62fee290a5d98611d288ca4dca89ee0f5c2540297cfae59c4e86d51a6659d5">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

