### PR TITLE
Fix assistant loading and chat session reliability

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -540,11 +540,125 @@ class AccessGrantsField(serializers.Field):
         return validated
 
 
+class AssistantListSerializer(serializers.ModelSerializer):
+    """Compact assistant representation for collection responses."""
+
+    lensnode = serializers.UUIDField(source="lensnode.uuid", read_only=True)
+    lensnode_name = serializers.CharField(source="lensnode.name", read_only=True)
+    mode = serializers.CharField(read_only=True)
+    collaboration_members = serializers.SerializerMethodField()
+    skill_summary = serializers.SerializerMethodField()
+    mcp_summary = serializers.SerializerMethodField()
+    supports_document_attachments = serializers.SerializerMethodField()
+    vision_model_capability = serializers.SerializerMethodField()
+    can_process_images = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Assistant
+        fields = [
+            "uuid",
+            "name",
+            "capability",
+            "slug",
+            "lensnode",
+            "lensnode_name",
+            "mode",
+            "routing_mode",
+            "collaboration_members",
+            "status",
+            "visibility",
+            "skill_summary",
+            "mcp_summary",
+            "supports_document_attachments",
+            "vision_model_capability",
+            "can_process_images",
+        ]
+
+    def get_collaboration_members(self, assistant):
+        """Return prefetched Smart Assistant members for list views."""
+
+        if not assistant.mode_handler.supports_members:
+            return []
+        return [
+            {
+                "uuid": str(member.uuid),
+                "name": member.name,
+                "capability": member.capability,
+                "status": member.status,
+            }
+            for member in sorted(
+                assistant.collaboration_members.all(),
+                key=lambda item: (item.name, str(item.uuid)),
+            )
+        ]
+
+    def get_skill_summary(self, assistant):
+        """Summarize prefetched Skill bindings without per-row queries."""
+
+        bindings = list(assistant.skill_bindings.all())
+        return {
+            "total": len(bindings),
+            "enabled": sum(binding.enabled for binding in bindings),
+        }
+
+    def get_mcp_summary(self, assistant):
+        """Summarize prefetched MCP bindings without per-row queries."""
+
+        bindings = list(assistant.mcp_bindings.all())
+        return {
+            "total": len(bindings),
+            "enabled": sum(binding.enabled for binding in bindings),
+        }
+
+    def get_supports_document_attachments(self, assistant):
+        """Return whether an Assistant can execute with Run documents."""
+
+        if assistant.lensnode_id:
+            return assistant_supports_document_attachments(assistant)
+        cache = getattr(self, "_document_capability_cache", None)
+        if cache is None:
+            cache = {}
+            self._document_capability_cache = cache
+        if assistant.capability not in cache:
+            cache[assistant.capability] = assistant_supports_document_attachments(
+                assistant
+            )
+        return cache[assistant.capability]
+
+    def _vision_capability(self, assistant):
+        """Cache model capability resolution for the current response."""
+
+        cache = getattr(self, "_vision_capability_cache", None)
+        if cache is None:
+            cache = {}
+            self._vision_capability_cache = cache
+        key = str(assistant.multimodal_model_ref or "")
+        if key not in cache:
+            cache[key] = resolve_model_capability(assistant.multimodal_model_ref)
+        return cache[key]
+
+    def get_vision_model_capability(self, assistant):
+        """Return the configured vision-model capability."""
+
+        return self._vision_capability(assistant)
+
+    def get_can_process_images(self, assistant):
+        """Return whether the Assistant accepts image input."""
+
+        capability = self._vision_capability(assistant)
+        return bool(
+            assistant.status == Assistant.Status.ACTIVE
+            and capability.get("enabled")
+            and capability.get("supports_vision")
+        )
+
+
 class AssistantSerializer(serializers.ModelSerializer):
     """Assistant serializer with LensNode and capability validation."""
 
     lensnode_uuid = serializers.UUIDField(write_only=True, required=False)
     lensnode = serializers.UUIDField(source="lensnode.uuid", read_only=True)
+    lensnode_name = serializers.CharField(source="lensnode.name", read_only=True)
     collaboration_member_uuids = serializers.ListField(
         child=serializers.UUIDField(),
         write_only=True,
@@ -578,6 +692,7 @@ class AssistantSerializer(serializers.ModelSerializer):
             "capability",
             "slug",
             "lensnode",
+            "lensnode_name",
             "lensnode_uuid",
             "routing_mode",
             "collaboration_member_uuids",

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -1009,6 +1009,31 @@ class LensApiTests(TestCase):
         ]
         self.assertIn(self.assistant.slug, active_slugs)
 
+    def test_assistant_list_uses_compact_rows_but_retrieve_has_bindings(self):
+        """Keep list payloads small while retaining the edit contract."""
+
+        AssistantSkill.objects.create(assistant=self.assistant, skill=self.skill)
+        AssistantMCP.objects.create(assistant=self.assistant, mcp=self.mcp)
+
+        list_response = self.client.get("/api/lens/assistants/")
+        row = list_response.data["results"][0]
+
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(row["skill_summary"], {"total": 1, "enabled": 1})
+        self.assertEqual(row["mcp_summary"], {"total": 1, "enabled": 1})
+        self.assertNotIn("skill_bindings", row)
+        self.assertNotIn("mcp_bindings", row)
+        self.assertNotIn("access_grants", row)
+        self.assertNotIn("settings", row)
+
+        detail_response = self.client.get(
+            f"/api/lens/assistants/{self.assistant.uuid}/"
+        )
+
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertEqual(len(detail_response.data["skill_bindings"]), 1)
+        self.assertEqual(len(detail_response.data["mcp_bindings"]), 1)
+
     def test_assistant_status_cannot_bypass_lifecycle_actions(self):
         response = self.client.patch(
             f"/api/lens/assistants/{self.assistant.uuid}/",

--- a/backend/lens/views/assistants.py
+++ b/backend/lens/views/assistants.py
@@ -9,9 +9,16 @@ from rest_framework.views import APIView
 
 from accounts.permissions import HasRequiredFeature
 
+from core.paginations import APIPagination
 from lens.models import Assistant, user_sees_all_assistants
-from lens.serializers import AssistantSerializer
+from lens.serializers import AssistantListSerializer, AssistantSerializer
 from .base import BaseAuthenticatedViewSet
+
+
+class AssistantPagination(APIPagination):
+    """Keep Assistant collection responses bounded and predictable."""
+
+    max_page_size = 100
 
 
 class AssistantViewSet(BaseAuthenticatedViewSet):
@@ -35,6 +42,14 @@ class AssistantViewSet(BaseAuthenticatedViewSet):
         ),
     )
     serializer_class = AssistantSerializer
+    pagination_class = AssistantPagination
+
+    def get_serializer_class(self):
+        """Use the compact contract for the collection endpoint."""
+
+        if self.action == "list":
+            return AssistantListSerializer
+        return super().get_serializer_class()
 
     def get_permissions(self):
         """Require the admin console feature for write actions."""
@@ -52,7 +67,18 @@ class AssistantViewSet(BaseAuthenticatedViewSet):
     def get_queryset(self):
         """Scope assistants to those the caller may see."""
 
-        queryset = super().get_queryset().visible_to(self.request.user).filter(
+        if self.action == "list":
+            queryset = Assistant.objects.select_related("lensnode").prefetch_related(
+                "skill_bindings",
+                "mcp_bindings",
+                Prefetch(
+                    "collaboration_members",
+                    queryset=Assistant.objects.order_by("name", "uuid"),
+                ),
+            )
+        else:
+            queryset = super().get_queryset()
+        queryset = queryset.visible_to(self.request.user).filter(
             is_system=False
         )
         if self.action == "restore":

--- a/frontend/src/api/inFlight.js
+++ b/frontend/src/api/inFlight.js
@@ -1,0 +1,18 @@
+/** Share concurrent requests for the same read-only resource. */
+export function createInFlightRequestCache() {
+  const pending = new Map()
+
+  function run(key, load) {
+    if (pending.has(key)) return pending.get(key)
+
+    const request = Promise.resolve(load())
+    pending.set(key, request)
+    const clear = () => {
+      if (pending.get(key) === request) pending.delete(key)
+    }
+    request.then(clear, clear)
+    return request
+  }
+
+  return { run }
+}

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -1,7 +1,10 @@
 import api from '@/api'
 import { citationSourceUrl } from '@/pages/lens/codeCitations'
 
+import { createInFlightRequestCache } from './inFlight'
 import { collectPaginatedResults } from './pagination'
+
+const assistantListRequests = createInFlightRequestCache()
 
 function unwrapResponse(response) {
   return response?.data?.data ?? response?.data ?? null
@@ -18,12 +21,15 @@ function unwrapList(payload) {
 }
 
 export async function listAssistants(params = {}) {
-  return collectPaginatedResults(async (page) => {
-    const response = await api.get('/lens/assistants/', {
-      params: { page_size: 1000, ...params, page }
+  const key = JSON.stringify(params)
+  return assistantListRequests.run(key, () =>
+    collectPaginatedResults(async (page) => {
+      const response = await api.get('/lens/assistants/', {
+        params: { page_size: 100, ...params, page }
+      })
+      return unwrapResponse(response)
     })
-    return unwrapResponse(response)
-  })
+  )
 }
 
 export async function getPublicAssistant(slug) {

--- a/frontend/src/pages/lens/Assistants.vue
+++ b/frontend/src/pages/lens/Assistants.vue
@@ -135,7 +135,7 @@
                     </div>
                   </td>
                   <td class="table-cell text-ink-600">
-                    {{ lensNodeName(row.lensnode) }}
+                    {{ lensNodeName(row) }}
                   </td>
                   <td class="assistant-type-column table-cell text-ink-600">
                     <div>
@@ -349,6 +349,7 @@ import AdminLayout from '@/admin/layout/AdminLayout.vue'
 import {
   archiveAssistant,
   createAssistant,
+  getAssistant,
   listAssistants,
   listGlobalSettings,
   listLensNodes,
@@ -405,6 +406,8 @@ const environmentVariableSets = ref([])
 const mcps = ref([])
 const globalSettings = ref([])
 const llmConfigOptions = ref([])
+let formResourcesPromise = null
+let globalSettingsPromise = null
 
 const activeColumns = computed(() =>
   [
@@ -442,6 +445,7 @@ function goNextPage() {
 }
 
 function lensNodeName(value) {
+  if (value?.lensnode_name) return value.lensnode_name
   const uuid = typeof value === 'object' ? value?.uuid : value
   const found = lensnodes.value.find((lensnode) => lensnode.uuid === uuid)
   return found?.name || uuid || emptyValue
@@ -468,6 +472,7 @@ function mcpCountLabel(row) {
 }
 
 async function copyShareUrl(row) {
+  await loadGlobalSettings()
   if (await copyToClipboard(shareUrl(row))) {
     showSuccess(t('lens.share.copied'))
   } else {
@@ -483,36 +488,66 @@ async function load() {
   loading.value = true
   formError.value = ''
   try {
-    const [
-      assistantRows,
-      lensnodeRows,
-      skillRows,
-      environmentVariableSetRows,
-      mcpRows,
-      settingRows,
-      llmRows
-    ] = await Promise.all([
-      listAssistants(showArchived.value ? { archived: true } : {}),
-      listLensNodes(),
-      listSkills(),
-      listEnvironmentVariableSets(),
-      listMcpServers(),
-      listGlobalSettings(),
-      llmAdminApi.getLLMConfigAll({ scope: 'global' }).catch(() => [])
-    ])
-
+    const assistantRows = await listAssistants(
+      showArchived.value ? { archived: true } : {}
+    )
     assistants.value = normalizeList(assistantRows)
-    lensnodes.value = normalizeList(lensnodeRows)
-    skills.value = normalizeList(skillRows)
-    environmentVariableSets.value = normalizeList(environmentVariableSetRows)
-    mcps.value = normalizeList(mcpRows)
-    globalSettings.value = normalizeList(settingRows)
-    llmConfigOptions.value = normalizeList(llmRows)
   } catch (error) {
     showError(extractErrorMessage(error, t('lensAdmin.messages.loadFailed')))
   } finally {
     loading.value = false
   }
+}
+
+async function loadGlobalSettings() {
+  if (globalSettings.value.length) return
+  if (!globalSettingsPromise) {
+    globalSettingsPromise = listGlobalSettings()
+      .then((rows) => {
+        globalSettings.value = normalizeList(rows)
+      })
+      .finally(() => {
+        globalSettingsPromise = null
+      })
+  }
+  await globalSettingsPromise
+}
+
+async function loadFormResources() {
+  if (formResourcesPromise) {
+    await formResourcesPromise
+    return
+  }
+  if (lensnodes.value.length || skills.value.length || mcps.value.length) return
+
+  formResourcesPromise = Promise.all([
+    listLensNodes(),
+    listSkills(),
+    listEnvironmentVariableSets(),
+    listMcpServers(),
+    llmAdminApi.getLLMConfigAll({ scope: 'global' }).catch(() => [])
+  ])
+    .then(
+      ([
+        lensnodeRows,
+        skillRows,
+        environmentVariableSetRows,
+        mcpRows,
+        llmRows
+      ]) => {
+        lensnodes.value = normalizeList(lensnodeRows)
+        skills.value = normalizeList(skillRows)
+        environmentVariableSets.value = normalizeList(
+          environmentVariableSetRows
+        )
+        mcps.value = normalizeList(mcpRows)
+        llmConfigOptions.value = normalizeList(llmRows)
+      }
+    )
+    .finally(() => {
+      formResourcesPromise = null
+    })
+  await formResourcesPromise
 }
 
 async function switchArchiveView(archived) {
@@ -525,7 +560,8 @@ async function switchArchiveView(archived) {
   await load()
 }
 
-function startCreate() {
+async function startCreate() {
+  await loadFormResources()
   detailAssistant.value = null
   mode.value = 'create'
   formError.value = ''
@@ -533,15 +569,19 @@ function startCreate() {
   showDrawer.value = true
 }
 
-function startEdit(row) {
+async function startEdit(row) {
+  const [assistant] = await Promise.all([
+    getAssistant(row.uuid),
+    loadFormResources()
+  ])
   mode.value = 'edit'
   formError.value = ''
-  form.value = formFromRow(row)
+  form.value = formFromRow(assistant)
   showDrawer.value = true
 }
 
-function openDetails(row) {
-  detailAssistant.value = row
+async function openDetails(row) {
+  detailAssistant.value = await getAssistant(row.uuid)
 }
 
 function closeDetails() {

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -2040,13 +2040,22 @@ const selectedSessionArchived = computed(
   () => selectedSession.value?.status === 'archived'
 )
 
-const routingCandidates = computed(() =>
-  assistants.value.filter(
+const routingCandidates = computed(() => {
+  const candidates = assistants.value.filter(
     (assistant) =>
       assistant.status === 'active' &&
       (assistant.mode || assistant.routing_mode || 'direct') === 'direct'
   )
-)
+
+  if (!isFixedSmartAssistant.value) return candidates
+
+  const configured = new Set(
+    (selectedAssistant.value?.collaboration_members || []).map(
+      (member) => member.uuid
+    )
+  )
+  return candidates.filter((assistant) => configured.has(assistant.uuid))
+})
 
 const filteredRoutingCandidates = computed(() =>
   filterRoutingCandidates(routingCandidates.value, routingScopeQuery.value)
@@ -3218,10 +3227,17 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
     return
   }
 
-  sessions.value = await listSessions(selectedAssistant.value?.slug || '', {
-    routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
-    archived: showArchivedSessions.value
-  })
+  const loadGeneration = ++sessionLoadGeneration
+  const loadedSessions = await listSessions(
+    selectedAssistant.value?.slug || '',
+    {
+      routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
+      archived: showArchivedSessions.value
+    }
+  )
+  if (loadGeneration !== sessionLoadGeneration) return
+
+  sessions.value = loadedSessions
 
   const requestedUuid =
     selectUuid || (useRouteSession ? route.query.session || '' : '')
@@ -3329,10 +3345,10 @@ function clearSessionSelection() {
 
 async function switchSessionView(archived) {
   if (showArchivedSessions.value === archived) return
+  sessionLoadGeneration += 1
   showArchivedSessions.value = archived
   cancelRename()
   closeDeleteSession()
-  await router.replace({ path: route.path })
   await loadSessions('', {
     useRouteSession: false
   })
@@ -4550,7 +4566,7 @@ watch(
 )
 
 watch(
-  () => [route.name, route.params.slug],
+  [() => route.name, () => route.params.slug],
   () => {
     // On a hard load with a stored token, defer the first bootstrap to
     // onMounted so it runs after the user is hydrated — avoids a flash of

--- a/frontend/tests/assistantDetails.test.js
+++ b/frontend/tests/assistantDetails.test.js
@@ -103,3 +103,14 @@ test('assistant list delegates lower-frequency data to a drawer', async () => {
   assert.match(drawer, /:disabled="assistant.status !== 'active'"/)
   assert.match(drawer, /\$emit\('edit', assistant\)/)
 })
+
+test('assistant management loads form resources only when editing', async () => {
+  const page = await source('pages/lens/Assistants.vue')
+
+  assert.match(page, /async function loadFormResources\(\)/)
+  assert.match(page, /await loadFormResources\(\)/)
+  assert.doesNotMatch(
+    page,
+    /async function load\(\)[\s\S]*?Promise\.all\(\[\s*listAssistants[\s\S]*?listSkills/
+  )
+})

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -107,6 +107,19 @@ test('selects a conversation when its route query changes', async () => {
   assert.notEqual(selectWithoutRouteUpdate, -1)
 })
 
+test('does not bootstrap again when only the session query changes', async () => {
+  const source = await chatSource()
+
+  assert.match(
+    source,
+    /watch\(\s*\[\(\) => route\.name, \(\) => route\.params\.slug\],/
+  )
+  assert.doesNotMatch(
+    source,
+    /watch\(\s*\(\) => \[route\.name, route\.params\.slug\],/
+  )
+})
+
 test('switches assistants through the assistant chat route', async () => {
   const source = await assistantSwitcherSource()
 
@@ -136,6 +149,36 @@ test('loads sessions after selecting the route assistant', async () => {
   assert.notEqual(selectAssistant, -1)
   assert.notEqual(loadSessions, -1)
   assert.ok(loadSessions > selectAssistant)
+})
+
+test('ignores a stale session list after switching to archived sessions', async () => {
+  const source = await chatSource()
+
+  assert.match(
+    source,
+    /const loadGeneration = \+\+sessionLoadGeneration/
+  )
+  assert.match(
+    source,
+    /const loadedSessions = await listSessions\(/
+  )
+  assert.match(
+    source,
+    /if \(loadGeneration !== sessionLoadGeneration\) return/
+  )
+  assert.match(
+    source,
+    /async function switchSessionView\(archived\) \{\s*if \(showArchivedSessions\.value === archived\) return\s*sessionLoadGeneration \+= 1/
+  )
+  const switchStart = source.indexOf('async function switchSessionView')
+  const switchEnd = source.indexOf('function sortManagedSessions', switchStart)
+  const switchSource = source.slice(switchStart, switchEnd)
+
+  assert.ok(
+    switchSource.indexOf('await loadSessions') <
+      switchSource.indexOf('router.replace') ||
+      !switchSource.includes('router.replace')
+  )
 })
 
 test('shows an assistant welcome state on mobile before the first message', async () => {

--- a/frontend/tests/chatRoutingScope.test.js
+++ b/frontend/tests/chatRoutingScope.test.js
@@ -145,6 +145,18 @@ test('fixed Smart Assistants allow member inspection without editing', async () 
   assert.match(picker, /:disabled="readonly"/)
   assert.match(picker, /v-if="!readonly"/)
   assert.match(picker, /readonly \? t\('common\.close'\)/)
+  assert.match(
+    chat,
+    /if \(!isFixedSmartAssistant\.value\) return candidates/
+  )
+  assert.match(
+    chat,
+    /selectedAssistant\.value\?\.collaboration_members/
+  )
+  assert.match(
+    chat,
+    /return candidates\.filter\(\(assistant\) => configured\.has\(assistant\.uuid\)\)/
+  )
   assert.doesNotMatch(
     chat,
     /function openRoutingScope\(\) \{\s*if \(isFixedSmartAssistant\.value\) return/

--- a/frontend/tests/inFlightRequests.test.js
+++ b/frontend/tests/inFlightRequests.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createInFlightRequestCache } from '../src/api/inFlight.js'
+
+test('shares one in-flight request for the same assistant-list key', async () => {
+  const cache = createInFlightRequestCache()
+  let calls = 0
+  let resolveRequest
+  const load = () => {
+    calls += 1
+    return new Promise((resolve) => {
+      resolveRequest = resolve
+    })
+  }
+
+  const first = cache.run('active', load)
+  const second = cache.run('active', load)
+  resolveRequest(['assistant-1'])
+
+  assert.equal(calls, 1)
+  assert.deepEqual(await first, ['assistant-1'])
+  assert.deepEqual(await second, ['assistant-1'])
+})
+
+test('does not share requests with different list filters', async () => {
+  const cache = createInFlightRequestCache()
+  let calls = 0
+
+  await Promise.all([
+    cache.run('active', async () => ++calls),
+    cache.run('archived', async () => ++calls)
+  ])
+
+  assert.equal(calls, 2)
+})
+
+test('clears a failed request so the next load can retry', async () => {
+  const cache = createInFlightRequestCache()
+  const failure = new Error('temporary failure')
+
+  await assert.rejects(
+    cache.run('active', async () => {
+      throw failure
+    }),
+    failure
+  )
+
+  assert.deepEqual(await cache.run('active', async () => ['assistant-1']), [
+    'assistant-1'
+  ])
+})

--- a/release-notes/485.yaml
+++ b/release-notes/485.yaml
@@ -1,0 +1,10 @@
+type: improvement
+audience: user
+en: >-
+  Improved Assistant loading performance and made archived conversations and
+  fixed Smart Assistant member views more reliable.
+zh-CN: >-
+  优化助手加载性能，并提升已归档会话切换与固定智能助手成员查看的可靠性。
+es: >-
+  Se mejoró el rendimiento de carga de asistentes y la fiabilidad de las
+  conversaciones archivadas y la vista de miembros de asistentes inteligentes.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Return compact paginated Assistant data and deduplicate concurrent list requests.
- Defer assistant-editor resources until editing and preserve full detail data for the drawer.
- Limit fixed Smart Assistant member inspection to configured members and keep it read-only.
- Prevent stale session loads and URL updates from resetting the archived-session view.

Closes #485

## Test plan

- [x] `npm run test:unit` (470 tests)
- [x] `npm run build`
- [x] `git diff --check`
- [x] Local `ego-browser` archive/recent session switching


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Compact assistant list payload and deduplicate requests.

- Defer editor resources until editing.

- Filter fixed Smart Assistant members to configured set.

- Prevent stale session loads and unnecessary re-bootstraps.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Assistant List"] --> B["Compact Serializer"]
  A --> C["In-Flight Request Cache"]
  D["Edit Assistant"] --> E["Deferred Resources"]
  F["Chat Session"] --> G["Stale Load Protection"]
  F --> H["Member Filtering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Add compact list serializer for Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>assistants.py</strong><dd><code>Use compact serializer and pagination for list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-92f7afe14b73e094100797819700512a986348eb93b85cdbcad59f0901f7191a">+28/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Assistants.vue</strong><dd><code>Defer form resources and load full detail on edit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-1b2ad42324551728465bb14655134be4689adc447d69ae29aa00951195ff651a">+70/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>inFlight.js</strong><dd><code>Create in-flight request cache utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-e2a878d14a7186dd3deb1bdc771141c71ce254ad388840d1351c16a9f33c0b79">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Deduplicate assistant list requests with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Test compact list and detail separation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assistantDetails.test.js</strong><dd><code>Test deferred resource loading for editing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-9a637f7754913e70742eea12b76eda72affec78f127dfc7a7cc9109cf6d4f959">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatBootstrap.test.js</strong><dd><code>Test stale session ignore and watch fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatRoutingScope.test.js</strong><dd><code>Test member filtering for fixed Smart Assistant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-f86a85bebf5fad2abfba20db49a0093c918db84af2816fc2b1dcde14a416b72b">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inFlightRequests.test.js</strong><dd><code>Test in-flight request cache behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-7f68f3d4304542016bd2675c4476c19f3d05a734d7f69ddee6b42ca3d41a511b">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Chat.vue</strong><dd><code>Filter members and protect against stale session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+25/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>485.yaml</strong><dd><code>Add release note for assistant reliability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/486/files#diff-c63ba8cfd1d73ec3703cea82b6ab80230bf1735b487866057f31b30c813d545c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

