### PR TITLE
Improve Markdown code block experience

### DIFF
--- a/frontend/src/components/ui/MarkdownRenderer.vue
+++ b/frontend/src/components/ui/MarkdownRenderer.vue
@@ -1,11 +1,17 @@
 <template>
-  <div class="markdown-content prose max-w-none" v-html="renderedContent"></div>
+  <div
+    class="markdown-content prose max-w-none"
+    v-html="renderedContent"
+    @click="handleMarkdownClick"
+  ></div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
 import { marked } from 'marked'
 import hljs from 'highlight.js/lib/core'
+import { useI18n } from 'vue-i18n'
+import { copyToClipboard } from '@/utils/clipboard'
 import { sanitizeHtml, escapeHtml } from '@/utils/sanitize'
 
 // Import common languages for syntax highlighting
@@ -33,14 +39,37 @@ const props = defineProps({
   }
 })
 
+const { t } = useI18n()
+const copyResetTimers = new WeakMap()
+
+const languageLabels = {
+  bash: 'Bash',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  json: 'JSON',
+  python: 'Python',
+  py: 'Python',
+  sh: 'Bash',
+  shell: 'Bash',
+  xml: 'XML'
+}
+
 // Configure marked. marked v16 removed the `highlight` option, so syntax
 // highlighting runs in a custom code renderer instead. Emitting the
 // `hljs` class lets the global highlight.js theme style the block (dark
 // background + token colors) even when the language is unknown.
 const renderer = new marked.Renderer()
 renderer.code = ({ text, lang }) => {
+  const declaredLanguage = typeof lang === 'string' ? lang.trim() : ''
   const language =
-    props.enableHighlight && lang && hljs.getLanguage(lang) ? lang : ''
+    props.enableHighlight &&
+    declaredLanguage &&
+    hljs.getLanguage(declaredLanguage)
+      ? declaredLanguage
+      : ''
+  const label = declaredLanguage
+    ? languageLabels[declaredLanguage.toLowerCase()] || declaredLanguage
+    : ''
   let body
   try {
     body = language
@@ -49,7 +78,21 @@ renderer.code = ({ text, lang }) => {
   } catch (err) {
     body = escapeHtml(text)
   }
-  return `<pre><code class="hljs language-${language}">${body}</code></pre>`
+  const languageClass = language ? ` language-${escapeHtml(language)}` : ''
+  const languageLabel = label
+    ? `<span class="markdown-code-language">${escapeHtml(label)}</span>`
+    : ''
+  return (
+    '<div class="markdown-code-block">' +
+    '<div class="markdown-code-header">' +
+    languageLabel +
+    `<button type="button" class="markdown-code-copy" ` +
+    `data-markdown-code-copy aria-label="${escapeHtml(t('common.copy'))}" ` +
+    `title="${escapeHtml(t('common.copy'))}"></button>` +
+    '</div>' +
+    `<pre><code class="hljs${languageClass}">${body}</code></pre>` +
+    '</div>'
+  )
 }
 
 const renderTable = renderer.table.bind(renderer)
@@ -234,6 +277,35 @@ const renderedContent = computed(() => {
     return `<pre class="text-theme-secondary">${escapeHtml(props.content || '')}</pre>`
   }
 })
+
+async function handleMarkdownClick(event) {
+  const button = event.target.closest('[data-markdown-code-copy]')
+  if (!button) return
+
+  const code = button.closest('.markdown-code-block')?.querySelector('code')
+  if (!code) return
+
+  const copied = await copyToClipboard(code.textContent || '')
+  if (!copied) return
+
+  const copiedLabel = t('common.copied')
+  button.title = copiedLabel
+  button.setAttribute('aria-label', copiedLabel)
+  button.setAttribute('data-markdown-code-copied', '')
+
+  const existingTimer = copyResetTimers.get(button)
+  if (existingTimer) clearTimeout(existingTimer)
+  copyResetTimers.set(
+    button,
+    setTimeout(() => {
+      const copyLabel = t('common.copy')
+      button.title = copyLabel
+      button.setAttribute('aria-label', copyLabel)
+      button.removeAttribute('data-markdown-code-copied')
+      copyResetTimers.delete(button)
+    }, 1800)
+  )
+}
 </script>
 
 <style scoped>
@@ -290,22 +362,215 @@ const renderedContent = computed(() => {
 }
 
 .markdown-content :deep(pre) {
-  @apply my-4 overflow-x-auto rounded-lg border border-ink-700 bg-ink-900 p-4 text-sm;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-all;
+  @apply m-0 max-w-full overflow-x-auto border-0 p-4 text-sm;
+  background: #f3f3f3;
+  white-space: pre;
+  tab-size: 4;
 }
 
 .markdown-content :deep(pre code) {
-  @apply bg-transparent p-0 text-gray-100;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-all;
+  @apply block min-w-full w-max bg-transparent p-0 font-mono;
+  color: #18181b;
+  white-space: pre;
+  word-break: normal;
+}
+
+.markdown-content :deep(.markdown-code-block) {
+  @apply my-4 w-full min-w-0 max-w-full overflow-hidden rounded-lg border;
+  border-color: transparent;
+  background: #f3f3f3;
+}
+
+.markdown-content :deep(.markdown-code-header) {
+  @apply flex min-h-12 items-center border-b px-3.5 py-2;
+  border-color: transparent;
+  background: #f3f3f3;
+}
+
+.markdown-content :deep(.markdown-code-language) {
+  @apply font-mono text-sm font-medium;
+  color: #27272a;
+}
+
+.markdown-content :deep(.markdown-code-copy) {
+  @apply ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border transition-colors;
+  --markdown-copy-bg: transparent;
+  border-color: transparent;
+  background: var(--markdown-copy-bg);
+  color: #27272a;
+}
+
+.markdown-content :deep(.markdown-code-copy::before) {
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+  box-shadow:
+    -3px -3px 0 -1px var(--markdown-copy-bg),
+    -3px -3px 0 0 currentColor;
+  content: '';
+}
+
+.markdown-content :deep(.markdown-code-copy[data-markdown-code-copied]::before) {
+  width: 0.8rem;
+  height: 0.45rem;
+  border-width: 0 0 1.75px 1.75px;
+  border-radius: 0;
+  box-shadow: none;
+  transform: translateY(-1px) rotate(-45deg);
+}
+
+.markdown-content :deep(.markdown-code-copy:hover) {
+  --markdown-copy-bg: #e4e4e7;
+  border-color: #d4d4d8;
+}
+
+.markdown-content :deep(.markdown-code-copy:active) {
+  --markdown-copy-bg: #d4d4d8;
+  transform: translateY(1px);
+}
+
+.markdown-content :deep(.markdown-code-copy:focus-visible) {
+  @apply outline-none ring-2 ring-primary-500 ring-offset-2;
+  --tw-ring-offset-color: #f3f3f3;
 }
 
 /* Custom styles for code highlighting - terminal theme */
 .markdown-content :deep(.hljs) {
-  @apply bg-gray-900;
+  background: #f3f3f3;
+}
+
+.markdown-content :deep(.hljs-comment),
+.markdown-content :deep(.hljs-quote) {
+  color: #6e7781;
+}
+
+.markdown-content :deep(.hljs-keyword),
+.markdown-content :deep(.hljs-selector-tag),
+.markdown-content :deep(.hljs-subst) {
+  color: #a626a4;
+}
+
+.markdown-content :deep(.hljs-title),
+.markdown-content :deep(.hljs-section),
+.markdown-content :deep(.hljs-built_in),
+.markdown-content :deep(.hljs-type) {
+  color: #6f42c1;
+}
+
+.markdown-content :deep(.hljs-string),
+.markdown-content :deep(.hljs-doctag),
+.markdown-content :deep(.hljs-attr),
+.markdown-content :deep(.hljs-template-tag),
+.markdown-content :deep(.hljs-template-variable) {
+  color: #17813b;
+}
+
+.markdown-content :deep(.hljs-number),
+.markdown-content :deep(.hljs-literal),
+.markdown-content :deep(.hljs-symbol),
+.markdown-content :deep(.hljs-bullet) {
+  color: #b54708;
+}
+
+.markdown-content :deep(.hljs-variable),
+.markdown-content :deep(.hljs-params),
+.markdown-content :deep(.hljs-property) {
+  color: #0550ae;
+}
+
+:global(:root[data-theme='dark'] .markdown-content pre),
+:global(:root[data-theme='dark'] .markdown-content .hljs),
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-block) {
+  background: #19191b;
+}
+
+:global(:root[data-theme='dark'] .markdown-content pre code) {
+  color: #f4f4f5;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-comment),
+:global(:root[data-theme='dark'] .markdown-content .hljs-quote) {
+  color: #88846f;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-keyword),
+:global(:root[data-theme='dark'] .markdown-content .hljs-selector-tag),
+:global(:root[data-theme='dark'] .markdown-content .hljs-subst) {
+  color: #f92672;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-title),
+:global(:root[data-theme='dark'] .markdown-content .hljs-section),
+:global(:root[data-theme='dark'] .markdown-content .hljs-built_in),
+:global(:root[data-theme='dark'] .markdown-content .hljs-type) {
+  color: #a6e22e;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-string),
+:global(:root[data-theme='dark'] .markdown-content .hljs-doctag),
+:global(:root[data-theme='dark'] .markdown-content .hljs-attr),
+:global(:root[data-theme='dark'] .markdown-content .hljs-template-tag),
+:global(:root[data-theme='dark'] .markdown-content .hljs-template-variable) {
+  color: #e6db74;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-number),
+:global(:root[data-theme='dark'] .markdown-content .hljs-literal),
+:global(:root[data-theme='dark'] .markdown-content .hljs-symbol),
+:global(:root[data-theme='dark'] .markdown-content .hljs-bullet) {
+  color: #ae81ff;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .hljs-variable),
+:global(:root[data-theme='dark'] .markdown-content .hljs-params),
+:global(:root[data-theme='dark'] .markdown-content .hljs-property) {
+  color: #f8f8f2;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-block),
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-header) {
+  border-color: #505054;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-header) {
+  min-height: 3.5rem;
+  padding: 0.75rem 1rem;
+  background: #363638;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-language) {
+  font-size: 1rem;
+  color: #d4d4d8;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-copy) {
+  --markdown-copy-bg: #454548;
+  border-color: #5c5c61;
+  color: #f4f4f5;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-copy:hover) {
+  --markdown-copy-bg: #505055;
+  border-color: #74747a;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-code-copy:active) {
+  --markdown-copy-bg: #303034;
+}
+
+:global(
+  :root[data-theme='dark'] .markdown-content .markdown-code-copy:focus-visible
+) {
+  --tw-ring-offset-color: #363638;
+}
+
+:global(:root[data-theme='dark'] .markdown-content pre) {
+  padding: 1.5rem 2rem;
+}
+
+:global(:root[data-theme='dark'] .markdown-content pre code) {
+  line-height: 1.75;
 }
 
 .markdown-content :deep(.markdown-table-scroll) {

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -42,9 +42,21 @@ export function sanitizeHtml(dirty) {
       'th',
       'td',
       'span',
-      'div'
+      'div',
+      'button'
     ],
-    ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'target', 'rel']
+    ALLOWED_ATTR: [
+      'href',
+      'src',
+      'alt',
+      'title',
+      'class',
+      'target',
+      'rel',
+      'type',
+      'aria-label',
+      'data-markdown-code-copy'
+    ]
   })
 }
 

--- a/frontend/tests/markdownRendererCodeBlocks.test.js
+++ b/frontend/tests/markdownRendererCodeBlocks.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const rendererSource = readFileSync(
+  new URL('../src/components/ui/MarkdownRenderer.vue', import.meta.url),
+  'utf8'
+)
+const sanitizerSource = readFileSync(
+  new URL('../src/utils/sanitize.js', import.meta.url),
+  'utf8'
+)
+
+test('block code renderer emits an isolated copyable container', () => {
+  assert.match(rendererSource, /markdown-code-block/)
+  assert.match(rendererSource, /markdown-code-header/)
+  assert.match(rendererSource, /data-markdown-code-copy/)
+  assert.match(rendererSource, /<pre><code class="hljs/)
+})
+
+test('code copying uses plain code text and localized success feedback', () => {
+  assert.match(rendererSource, /querySelector\('code'\)/)
+  assert.match(rendererSource, /copyToClipboard\(code\.textContent \|\| ''\)/)
+  assert.match(rendererSource, /t\('common\.copied'\)/)
+  assert.match(rendererSource, /t\('common\.copy'\)/)
+  assert.match(rendererSource, /data-markdown-code-copied/)
+  assert.match(rendererSource, /if \(!copied\) return/)
+})
+
+test('copy control is icon-only while retaining accessible labels', () => {
+  assert.match(
+    rendererSource,
+    /title="\$\{escapeHtml\(t\('common\.copy'\)\)\}"><\/button>/
+  )
+  assert.match(rendererSource, /markdown-code-copy::before/)
+  assert.match(rendererSource, /aria-label=/)
+})
+
+test('code styles preserve formatting and scroll long lines', () => {
+  assert.match(rendererSource, /white-space: pre;/)
+  assert.match(rendererSource, /overflow-x-auto/)
+  assert.match(rendererSource, /word-break: normal;/)
+})
+
+test('light and dark themes define separate syntax palettes', () => {
+  assert.match(rendererSource, /\.hljs-keyword[\s\S]*?color: #a626a4/)
+  assert.match(
+    rendererSource,
+    /:root\[data-theme='dark'\][\s\S]*?\.hljs-keyword[\s\S]*?color: #f92672/
+  )
+  assert.match(rendererSource, /\.hljs-string[\s\S]*?color: #17813b/)
+})
+
+test('sanitizer allows only the code copy controls required by the renderer', () => {
+  assert.match(sanitizerSource, /'button'/)
+  assert.match(sanitizerSource, /'type'/)
+  assert.match(sanitizerSource, /'aria-label'/)
+  assert.match(sanitizerSource, /'data-markdown-code-copy'/)
+  assert.doesNotMatch(sanitizerSource, /'onclick'/)
+  assert.doesNotMatch(sanitizerSource, /'style'/)
+})
+
+test('inline code is not targeted by the block copy selector', () => {
+  assert.match(rendererSource, /closest\('\[data-markdown-code-copy\]'\)/)
+  assert.match(rendererSource, /closest\('\.markdown-code-block'\)/)
+})

--- a/release-notes/451.yaml
+++ b/release-notes/451.yaml
@@ -1,0 +1,10 @@
+type: improvement
+audience: user
+en: >-
+  Improved assistant code blocks with syntax highlighting, preserved
+  formatting, and one-click copying in light and dark themes.
+zh-CN: >-
+  优化助手代码块体验，支持语法高亮、格式保留，以及明暗主题下的一键复制。
+es: >-
+  Se mejoraron los bloques de código de las respuestas con resaltado de
+  sintaxis, formato conservado y copia con un clic en temas claro y oscuro.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Closes #451

## Background

Assistant answers already use the shared `MarkdownRenderer`, but fenced code
blocks were rendered as plain `<pre><code>` elements. They had no block-level
copy action, wrapped and broke long code lines, and did not provide a clear
visual hierarchy for the language and code body.

## What changed

- Render every fenced Markdown code block inside a shared, stable container.
- Add a lightweight header with a normalized language label when the fence
  declares a language.
- Add an accessible icon-only copy button for each individual code block.
- Copy `code.textContent` through the existing `copyToClipboard()` helper so
  indentation, newlines, and HTML special characters remain exact plain text.
- Show localized copy success through the button icon, title, and ARIA label,
  then restore the original state after 1.8 seconds.
- Keep copy failure honest by leaving the button in its original state.
- Preserve code formatting with `white-space: pre`, a four-space tab size, and
  code-block-local horizontal scrolling instead of breaking long lines.
- Keep existing highlight.js support for JavaScript, Python, Bash, JSON, and
  XML, including their registered aliases.
- Safely render unknown and undeclared languages without automatic language
  guessing.
- Keep the container and copy action when `enableHighlight` is disabled.
- Add separate light and dark syntax palettes and code-block surfaces.
- Keep inline code unchanged and free of block-level copy controls.

Because the implementation remains in the shared renderer, the behavior is
automatically available in chat history, completed streaming answers, public
Q&A, share previews and reviews, Run answer previews, Skills Markdown,
Markdown file previews, and LLM configuration test results.

## Security

- Extend the DOMPurify allowlist only with the required `button`, `type`,
  `aria-label`, and `data-markdown-code-copy` entries.
- Do not allow inline event handlers, arbitrary styles, or SVG markup.
- Continue escaping code whenever highlighting is unavailable or fails.
- Escape declared language labels before inserting them into generated HTML.
- Do not encode code content in data attributes.

## Accessibility and interaction

- Use a native `button` with `type="button"`.
- Provide localized `title` and `aria-label` values using `common.copy` and
  `common.copied`.
- Provide hover, active, and keyboard `focus-visible` states.
- Use an icon-only visual control while preserving assistive text.
- Keep separate copy state and timers for multiple code blocks.

## Responsive and theme behavior

- Light theme uses a low-contrast gray code surface and a restrained syntax
  palette suitable for light backgrounds.
- Dark theme uses a distinct header, dark code body, clear border, and the
  existing Monokai-style syntax colors.
- Long lines scroll inside the code body without causing page-level horizontal
  overflow.
- The copy action remains visible and usable at mobile widths.

## Tests

Added focused unit coverage for:

- fenced block wrapper, header, copy action, and code structure;
- plain-text copying via `code.textContent`;
- localized success state and failure behavior;
- icon-only control with accessible labels;
- indentation preservation and horizontal scrolling;
- separate light and dark syntax palettes;
- sanitizer allowlist requirements and rejection of dangerous attributes;
- inline code exclusion.

### Automated validation

- `npm run test:unit` — **478 passed, 0 failed**
- `npm run build` — **passed**
- `node --test frontend/tests/markdownRendererCodeBlocks.test.js` —
  **7 passed, 0 failed**
- `git diff --check` — **passed**

The production build emitted existing non-blocking warnings about stale
Browserslist/baseline data, mixed dynamic and static imports, and large chunks.
No build errors occurred.

### Browser validation

Validated against the shared SourceLens runtime at `http://localhost:8000`:

- light and dark desktop rendering;
- mobile rendering and page-overflow containment;
- Python syntax token colors;
- unknown-language safe rendering;
- multiple code blocks copying independently;
- exact copied text, including indentation, newlines, and special characters;
- localized copied state;
- failed copy attempts not showing a false success state;
- inline code not receiving a copy action.

## Scope

- No backend, API, model, database, migration, or prompt changes.
- No new npm dependencies.
- No line numbers, code execution, downloading, editing, or folding features.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Render fenced code blocks in a container with header and language label.

- Add per-block copy button with localized success feedback.

- Add syntax highlighting for common languages (JS, Python, Bash, JSON, XML).

- Support light and dark themes with separate syntax palettes.

- Update DOMPurify allowlist for copy button controls.

- Add tests for block container, copy behavior, styles, and themes.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Markdown input"] --> B["marked renderer"]
  B --> C["Code block container"]
  C --> D["Header with language label"]
  C --> E["Syntax highlighted code"]
  C --> F["Copy button"]
  F --> G["User clicks copy"]
  G --> H["copyToClipboard()"]
  H --> I["Success: set copied state"]
  H --> J["Failure: no change"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarkdownRenderer.vue</strong><dd><code>Enhance code blocks with container, copy, and themes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/MarkdownRenderer.vue

<ul><li>Added code block container (.markdown-code-block) with header and <br>language label.<br> <li> Added per-block copy button with localized success feedback and 1.8s <br>timer.<br> <li> Replaced dark terminal theme with light and dark syntax palettes (via <br>data-theme).<br> <li> Changed pre/code styles to preserve formatting, tab-size, and <br>horizontal scrolling.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/489/files#diff-8acab9a2284f91e2714ae018e98389ad38d85c55215ce785163b9cf790b4c5d3">+277/-12</a></td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitize.js</strong><dd><code>Extend DOMPurify allowlist for code copy controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/sanitize.js

<ul><li>Added button, type, aria-label, and data-markdown-code-copy to <br>DOMPurify allowlist.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/489/files#diff-0e695f4b793e507de5f17d378c483bc1a9f05c49fc81d917abf87cf7382ce4be">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>markdownRendererCodeBlocks.test.js</strong><dd><code>Add tests for code block rendering and copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/markdownRendererCodeBlocks.test.js

<ul><li>Added tests for block container markup, copy behavior, styles, themes, <br>and sanitizer.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/489/files#diff-1da750898ff817b488be91fb0aca9489491376618596a5b6103c6b0cf526f094">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>451.yaml</strong><dd><code>Add release note for Markdown code blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/451.yaml

- Added release note describing the improved code block experience.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/489/files#diff-54e25b007799271a9d727af9df3a66e1829c1ddd97518fb8b1c8bf24380b1c0c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

