### PR TITLE
Improve email verification code login errors

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -228,14 +228,22 @@ class VerifyLoginCodeSerializer(serializers.Serializer):
     )
     code = serializers.CharField(
         required=True,
-        min_length=4,
-        max_length=8,
+        min_length=6,
+        max_length=6,
         help_text=_("Verification code from email")
     )
 
     def validate_email(self, value):
         """Normalize the email address."""
         return value.lower().strip()
+
+    def validate_code(self, value):
+        """Require the six-digit numeric code issued by the service."""
+        if not re.fullmatch(r'[0-9]{6}', value):
+            raise serializers.ValidationError(
+                _("The verification code is incorrect.")
+            )
+        return value
 
 
 class VirtualEmailUsernameSerializer(serializers.Serializer):

--- a/backend/accounts/tests/test_login.py
+++ b/backend/accounts/tests/test_login.py
@@ -1,6 +1,10 @@
 """Password login identifier tests."""
 
+import json
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.test import TestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -93,3 +97,91 @@ class EmailPasswordLoginTests(TestCase):
         )
         self.assertEqual(unknown_email.status_code, wrong_password.status_code)
         self.assertEqual(unknown_email.data, wrong_password.data)
+
+
+@override_settings(ROOT_URLCONF="accounts.tests.urls")
+class EmailCodeLoginTests(TestCase):
+    """Return actionable errors for invalid email login codes."""
+
+    verify_url = "/api/v1/auth/login/verify-code"
+
+    def setUp(self):
+        """Use DRF's JSON-aware API client."""
+        self.client = APIClient()
+        cache.clear()
+
+    def _post_code(self, code="000000"):
+        return self.client.post(
+            self.verify_url,
+            {
+                "email": "code-login@example.com",
+                "code": code,
+            },
+            format="json",
+        )
+
+    def test_malformed_code_returns_incorrect_code_message(self):
+        """A code rejected by validation must not become generic failed."""
+        response = self.client.post(
+            self.verify_url,
+            {
+                "email": "code-login@example.com",
+                "code": "not-a-valid-code",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_code"], "INVALID")
+        self.assertEqual(
+            str(response.data["message"]),
+            "The verification code is incorrect.",
+        )
+
+    def test_missing_short_and_long_codes_return_invalid(self):
+        payloads = (
+            {"email": "code-login@example.com"},
+            {"email": "code-login@example.com", "code": "12"},
+            {"email": "code-login@example.com", "code": "1234567"},
+        )
+        for payload in payloads:
+            response = self.client.post(
+                self.verify_url, payload, format="json"
+            )
+            self.assertEqual(response.data["error_code"], "INVALID")
+            self.assertNotEqual(response.data["message"], "failed")
+
+    def test_six_digit_non_numeric_code_returns_invalid(self):
+        response = self._post_code("abcdef")
+        self.assertEqual(response.data["error_code"], "INVALID")
+        self.assertNotEqual(response.data["message"], "failed")
+
+    @patch("accounts.views.login_otp.otp.verify_code")
+    def test_expired_code_returns_expired(self, verify_code):
+        verify_code.return_value = (False, "expired")
+        response = self._post_code()
+        self.assertEqual(response.data["error_code"], "EXPIRED")
+        self.assertIn("expired", str(response.data["message"]).lower())
+
+    @patch("accounts.views.login_otp.otp.verify_code")
+    def test_too_many_attempts_returns_stable_error(self, verify_code):
+        verify_code.return_value = (False, "too_many_attempts")
+        response = self._post_code()
+        self.assertEqual(response.data["error_code"], "TOO_MANY_ATTEMPTS")
+        self.assertIn("new code", str(response.data["message"]).lower())
+
+    @patch("accounts.views.login_otp.otp.verify_code")
+    def test_invalid_code_returns_invalid(self, verify_code):
+        verify_code.return_value = (False, "invalid")
+        response = self._post_code()
+        self.assertEqual(response.data["error_code"], "INVALID")
+
+    def test_renderer_keeps_error_code_inside_data(self):
+        response = self._post_code("not-a-valid-code")
+        response.render()
+        rendered = json.loads(response.content)
+        self.assertEqual(rendered["data"]["error_code"], "INVALID")
+        self.assertEqual(
+            rendered["data"]["message"],
+            "The verification code is incorrect.",
+        )

--- a/backend/accounts/tests/urls.py
+++ b/backend/accounts/tests/urls.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from accounts.urls import CustomLoginView
-from accounts.views import CustomUserDetailsView
+from accounts.views import CustomUserDetailsView, VerifyLoginCodeView
 from accounts.views.management import (
     ManagementGroupBulkDeleteView,
     ManagementGroupListView,
@@ -30,6 +30,10 @@ class AuthenticatedProbeView(APIView):
 
 urlpatterns = [
     path("api/v1/auth/login", CustomLoginView.as_view()),
+    path(
+        "api/v1/auth/login/verify-code",
+        VerifyLoginCodeView.as_view(),
+    ),
     path("api/v1/auth/user", CustomUserDetailsView.as_view()),
     path(
         "api/v1/auth/password/reset",

--- a/backend/accounts/views/login_otp.py
+++ b/backend/accounts/views/login_otp.py
@@ -115,12 +115,13 @@ class VerifyLoginCodeView(APIView):
     """
     permission_classes = [AllowAny]
 
+    _INVALID_CODE_MESSAGE = _('The verification code is incorrect.')
     _ERROR_MESSAGES = {
         'expired': _('The verification code has expired.'),
         'too_many_attempts': _(
             'Too many incorrect attempts. Request a new code.'
         ),
-        'invalid': _('The verification code is incorrect.'),
+        'invalid': _INVALID_CODE_MESSAGE,
     }
 
     @extend_schema(
@@ -133,8 +134,19 @@ class VerifyLoginCodeView(APIView):
         """Verify the code and issue JWT tokens."""
         serializer = VerifyLoginCodeSerializer(data=request.data)
         if not serializer.is_valid():
+            response_data = {
+                'success': False,
+                'errors': serializer.errors,
+            }
+            if 'code' in serializer.errors:
+                response_data.update(
+                    {
+                        'error_code': 'INVALID',
+                        'message': self._INVALID_CODE_MESSAGE,
+                    }
+                )
             return Response(
-                {'success': False, 'errors': serializer.errors},
+                response_data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -148,7 +160,11 @@ class VerifyLoginCodeView(APIView):
             return Response(
                 {
                     'success': False,
-                    'error_code': reason.upper(),
+                    'error_code': {
+                        'invalid': 'INVALID',
+                        'expired': 'EXPIRED',
+                        'too_many_attempts': 'TOO_MANY_ATTEMPTS',
+                    }.get(reason, 'INVALID'),
                     'message': self._ERROR_MESSAGES.get(
                         reason, _('Verification failed.')
                     ),

--- a/frontend/src/components/auth/EmailCodeLogin.vue
+++ b/frontend/src/components/auth/EmailCodeLogin.vue
@@ -92,6 +92,7 @@ import { authApi } from '@/api/auth'
 import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import TurnstileWidget from '@/components/TurnstileWidget.vue'
+import { getVerificationErrorMessage } from '@/utils/verificationError'
 
 const emit = defineEmits(['success'])
 
@@ -179,8 +180,8 @@ const handleVerifyCode = async () => {
     })
     emit('success')
   } catch (error) {
-    errorMessage.value =
-      error.response?.data?.message || t('auth.codeLogin.verifyFailed')
+    errorMessage.value = getVerificationErrorMessage(error, t)
+  } finally {
     loading.value = false
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -529,6 +529,9 @@
       "switchToCode": "Use email code",
       "turnstileRequired": "Please complete the human verification",
       "sendFailed": "Failed to send the code, please try again later",
+      "invalidCode": "Incorrect verification code. Please try again.",
+      "expiredCode": "This verification code has expired. Request a new code.",
+      "tooManyAttempts": "Too many failed attempts. Request a new code.",
       "verifyFailed": "The code is incorrect or expired",
       "invalidEmail": "Please enter a valid email address"
     },

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -529,6 +529,9 @@
       "switchToCode": "Usa código de correo electrónico",
       "turnstileRequired": "Por favor complete la verificación humana",
       "sendFailed": "Error al enviar el código, por favor intente más tarde",
+      "invalidCode": "El código de verificación no es correcto. Inténtalo de nuevo.",
+      "expiredCode": "Este código de verificación ha caducado. Solicita uno nuevo.",
+      "tooManyAttempts": "Demasiados intentos fallidos. Solicita un código nuevo.",
       "verifyFailed": "El código es incorrecto o ha expirado.",
       "invalidEmail": "Por favor ingrese una dirección de correo electrónico válida"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -529,6 +529,9 @@
       "switchToCode": "使用邮箱验证码登录",
       "turnstileRequired": "请先完成人机验证",
       "sendFailed": "验证码发送失败，请稍后重试",
+      "invalidCode": "验证码错误，请重新输入",
+      "expiredCode": "验证码已过期，请重新获取",
+      "tooManyAttempts": "验证码错误次数过多，请重新获取",
       "verifyFailed": "验证码错误或已过期",
       "invalidEmail": "请输入有效的邮箱地址"
     },

--- a/frontend/src/utils/verificationError.js
+++ b/frontend/src/utils/verificationError.js
@@ -1,0 +1,17 @@
+const ERROR_TRANSLATIONS = {
+  INVALID: 'auth.codeLogin.invalidCode',
+  EXPIRED: 'auth.codeLogin.expiredCode',
+  TOO_MANY_ATTEMPTS: 'auth.codeLogin.tooManyAttempts'
+}
+
+export const getVerificationErrorMessage = (error, translate) => {
+  const response = error?.response?.data || {}
+  const details = response?.data || response
+  const errorCode = details?.error_code || response?.error_code
+
+  if (ERROR_TRANSLATIONS[errorCode]) {
+    return translate(ERROR_TRANSLATIONS[errorCode])
+  }
+
+  return translate('auth.codeLogin.verifyFailed')
+}

--- a/frontend/tests/login.test.js
+++ b/frontend/tests/login.test.js
@@ -46,3 +46,68 @@ test('email code verification submits the detected UI language', async () => {
     /loginWithCode\(\{[\s\S]*language: locale\.value[\s\S]*\}\)/
   )
 })
+
+test('email code verification maps actionable errors in every locale', async () => {
+  const [component, utility, english, chinese, spanish] = await Promise.all([
+    source('components/auth/EmailCodeLogin.vue'),
+    source('utils/verificationError.js'),
+    source('locales/en.json'),
+    source('locales/zh-CN.json'),
+    source('locales/es.json')
+  ])
+
+  assert.match(component, /getVerificationErrorMessage\(error, t\)/)
+  assert.match(utility, /data \|\| response/)
+
+  const module = await import(
+    new URL('../src/utils/verificationError.js', import.meta.url)
+  )
+  const translate = (key) => key
+  for (const [code, key] of [
+    ['INVALID', 'auth.codeLogin.invalidCode'],
+    ['EXPIRED', 'auth.codeLogin.expiredCode'],
+    ['TOO_MANY_ATTEMPTS', 'auth.codeLogin.tooManyAttempts']
+  ]) {
+    assert.equal(
+      module.getVerificationErrorMessage(
+        { response: { data: { error_code: code } } },
+        translate
+      ),
+      key
+    )
+    assert.equal(
+      module.getVerificationErrorMessage(
+        { response: { data: { data: { error_code: code } } } },
+        translate
+      ),
+      key
+    )
+  }
+  assert.equal(
+    module.getVerificationErrorMessage(
+      { response: { data: { message: 'failed' } } },
+      translate
+    ),
+    'auth.codeLogin.verifyFailed'
+  )
+  assert.equal(
+    module.getVerificationErrorMessage(
+      { response: { data: { data: { errors: { code: ['invalid'] } } } } },
+      translate
+    ),
+    'auth.codeLogin.verifyFailed'
+  )
+  assert.equal(
+    module.getVerificationErrorMessage(
+      { response: { data: { detail: 'internal error' } } },
+      translate
+    ),
+    'auth.codeLogin.verifyFailed'
+  )
+
+  for (const messages of [english, chinese, spanish].map(JSON.parse)) {
+    assert.ok(messages.auth.codeLogin.invalidCode)
+    assert.ok(messages.auth.codeLogin.expiredCode)
+    assert.ok(messages.auth.codeLogin.tooManyAttempts)
+  }
+})

--- a/release-notes/403.yaml
+++ b/release-notes/403.yaml
@@ -1,0 +1,11 @@
+type: fix
+audience: user
+en: >-
+  Improved email verification code login errors with clear, localized guidance
+  for incorrect, expired, and exhausted codes.
+zh-CN: >-
+  优化邮箱验证码登录错误提示，为验证码错误、过期及尝试次数过多提供清晰的本地化指引。
+es: >-
+  Se mejoraron los errores de inicio de sesión con código de verificación por
+  correo con indicaciones claras y localizadas para códigos incorrectos,
+  caducados o con demasiados intentos.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Return stable, actionable error codes for invalid, expired, and rate-limited email login verification codes.
- Parse both direct and unified renderer error envelopes without exposing generic or internal backend messages.
- Show localized recovery guidance in English, Simplified Chinese, and Spanish while preserving the active verification flow.
- Add backend and frontend regression coverage for validation, renderer wrapping, localization, and fallback behavior.

Closes #403

## Root cause

The verification endpoint returned field validation errors without a stable verification error code. The global renderer then wrapped those errors under `data` while the frontend only read the top-level `message`, which could be the generic value `failed`.

The frontend also treated backend messages as user-facing text instead of mapping known verification states to the current UI locale.

## Error contract

- `INVALID`: incorrect or malformed six-digit verification code
- `EXPIRED`: missing or expired verification code
- `TOO_MANY_ATTEMPTS`: maximum incorrect attempts reached

The existing global renderer and `FAILED_MESSAGE` remain unchanged. The frontend supports both direct responses and `{ code, message, data }` envelopes.

## User experience

- Incorrect codes ask the user to try again.
- Expired codes and exhausted attempts explicitly ask the user to request a new code.
- Email and code input state remain available after verification failures.
- Loading state always resets after verification.
- Unknown, serializer, DRF, empty, and generic `failed` errors use a localized safe fallback.

## Security and compatibility

- No verification code, cache record, internal exception, or account-existence information is exposed.
- Successful login responses and the global response renderer are unchanged.
- No database migration is required.
- Sending codes, resend cooldowns, password login, and Turnstile flows are unchanged.

## Test plan

- [x] `docker exec sourcelens-api-dev python manage.py test accounts.tests.test_login --verbosity 1` (11 passed)
- [x] `npm run test:unit` (472 passed)
- [x] `npm run build`
- [x] ESLint on the changed frontend component, utility, and login tests
- [x] `git diff --check`
- [x] `ego-browser` verification at `http://localhost:8000` in English, Simplified Chinese, and Spanish
- [x] Verified email/code preservation and loading recovery after invalid submissions


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add stable error codes (INVALID, EXPIRED, TOO_MANY_ATTEMPTS) for verification code failures.

- Provide localized error messages in English, Chinese, and Spanish.

- Frontend maps backend error codes to user-friendly translations.

- Add comprehensive backend and frontend tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend validation"] --> B["Stable error code"]
  B --> C["Frontend getVerificationErrorMessage"]
  C --> D["Localized user message"]
  D --> E["Display in UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Enforce six-digit numeric code and add validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-0b33c4345668293e42e86aa38a1de86a9f7088a07d1c47eb1d65b24905280f90">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>login_otp.py</strong><dd><code>Return stable error codes and localized messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-d2cb08d9494ed4d20cb66457b2ac210fe8df7f1a1f81d8426498810e845068dc">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_login.py</strong><dd><code>Add tests for verification code error cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-281733996dbc045a7a2a50e6cb66b6a32f142467b6f4b35a99aee95e41d1ad18">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>urls.py</strong><dd><code>Register verify-code endpoint for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-0f73c409b352fce6d361da13735321f013677ea6918c7f50cac2ef7c1a0841d6">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>login.test.js</strong><dd><code>Add frontend tests for error mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-5ed856f7d1985f943e3b1e3721cbeed24968add3d7c9be9d532722a459b71107">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>EmailCodeLogin.vue</strong><dd><code>Use utility function to map error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-5d40e3200c89b7a54d6458c5ae60f8acdcc831e4e66638a582e528990c61e1f7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>verificationError.js</strong><dd><code>Add utility for verification error mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-5b5b0b9baeb0973f1672116fc0cf58995336e29f25ee6f3f6438d59fe4c73405">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English localized error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Add Spanish localized error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-ba529cd8e421586279be00c1310ca7d73e9279c6738cd47b4228566944ef2bd2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese localized error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>403.yaml</strong><dd><code>Add release note for the fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/490/files#diff-68500c68a90b0fec92ef94430e4478092e8b36ae79d3c372395f516611666802">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

