### PR TITLE
Fix cross-conversation message submission (#494)

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1853,7 +1853,10 @@ import {
   prependAssistantMentions,
   removeAssistantMentionToken
 } from '@/pages/lens/assistantMentions'
-import { prepareRunSubmission } from '@/pages/lens/chatSubmission'
+import {
+  prepareRunSubmission,
+  updateSessionSubmissionSet
+} from '@/pages/lens/chatSubmission'
 import { promptSuggestionKeys } from '@/pages/lens/chatPromptSuggestions'
 import { resolveChatViewport } from '@/pages/lens/chatViewport'
 import { createStreamTextBuffer } from '@/pages/lens/streamBuffer'
@@ -1957,7 +1960,8 @@ const currentRun = ref(null)
 const pendingRunSubmission = ref(null)
 const retryDraft = ref(null)
 const runStatusResolvingSessionUuid = ref('')
-const loading = ref({ run: false })
+const submittingSessionUuids = ref(new Set())
+const sessionCreationInProgress = ref(false)
 const streamController = ref(null)
 const sidebarOpen = ref(false)
 const sidebarCollapsed = ref(false)
@@ -2164,7 +2168,10 @@ const canSubmit = computed(() => {
   if (!canCompose.value) {
     return false
   }
-  if (loading.value.run) {
+  if (
+    sessionCreationInProgress.value ||
+    submittingSessionUuids.value.has(selectedSessionUuid.value)
+  ) {
     return false
   }
   if (hasUploadingAttachment.value) {
@@ -2175,6 +2182,14 @@ const canSubmit = computed(() => {
   )
   return !!question.value.trim() || hasReadyAttachment
 })
+
+function setSessionSubmitting(sessionUuid, submitting) {
+  submittingSessionUuids.value = updateSessionSubmissionSet(
+    submittingSessionUuids.value,
+    sessionUuid,
+    submitting
+  )
+}
 
 const hasAssistant = computed(() =>
   isAnonymous.value
@@ -3942,7 +3957,7 @@ async function submitClarification(message) {
     runUuid
   ])
   const sessionAtSubmit = selectedSessionUuid.value
-  loading.value.run = true
+  setSessionSubmitting(sessionAtSubmit, true)
   try {
     const continuation = await answerRunClarification(
       runUuid,
@@ -3976,9 +3991,7 @@ async function submitClarification(message) {
     const submitting = new Set(clarificationSubmitting.value)
     submitting.delete(runUuid)
     clarificationSubmitting.value = submitting
-    if (selectedSessionUuid.value === sessionAtSubmit) {
-      loading.value.run = false
-    }
+    setSessionSubmitting(sessionAtSubmit, false)
   }
 }
 
@@ -3988,7 +4001,10 @@ async function submit() {
     requireLogin()
     return
   }
-  if (loading.value.run) {
+  if (
+    sessionCreationInProgress.value ||
+    submittingSessionUuids.value.has(selectedSessionUuid.value)
+  ) {
     return
   }
   if (!canSubmit.value) {
@@ -4018,16 +4034,19 @@ async function submit() {
     showError(t('lens.chat.attachmentTooMany', { max: MAX_ATTACHMENTS }))
     return
   }
-  loading.value.run = true
   if (!selectedSessionUuid.value) {
-    const session = await createNewSession(
-      false,
-      routingScopeAssistantUuids.value
-    )
-    if (!session) {
-      question.value = draftTextAtSubmit
-      loading.value.run = false
-      return
+    sessionCreationInProgress.value = true
+    try {
+      const session = await createNewSession(
+        false,
+        routingScopeAssistantUuids.value
+      )
+      if (!session) {
+        question.value = draftTextAtSubmit
+        return
+      }
+    } finally {
+      sessionCreationInProgress.value = false
     }
     question.value = draftTextAtSubmit
   }
@@ -4036,9 +4055,10 @@ async function submit() {
   // not a failure, so we must not restore the draft, alarm the user, or write
   // into the now-current assistant's state.
   const sessionAtSubmit = selectedSessionUuid.value
+  setSessionSubmitting(sessionAtSubmit, true)
   if (isSmartCollaborationConversation.value && mentionToken.value) {
     showWarning(t('lens.chat.mentionAssistantRequired'))
-    loading.value.run = false
+    setSessionSubmitting(sessionAtSubmit, false)
     return
   }
   let submissionText = trimmedDraft
@@ -4046,7 +4066,7 @@ async function submit() {
   if (oversizedFile) {
     const uploaded = await addAttachment(oversizedFile)
     if (!uploaded || selectedSessionUuid.value !== sessionAtSubmit) {
-      loading.value.run = false
+      setSessionSubmitting(sessionAtSubmit, false)
       return
     }
     oversizedAttachment = uploaded
@@ -4205,9 +4225,7 @@ async function submit() {
         (item) => item.localUrl && URL.revokeObjectURL(item.localUrl)
       )
     }
-    if (selectedSessionUuid.value === sessionAtSubmit) {
-      loading.value.run = false
-    }
+    setSessionSubmitting(sessionAtSubmit, false)
   }
 }
 

--- a/frontend/src/pages/lens/chatSubmission.js
+++ b/frontend/src/pages/lens/chatSubmission.js
@@ -43,6 +43,14 @@ function isSameSubmission(pending, candidate) {
   )
 }
 
+export function updateSessionSubmissionSet(current, sessionUuid, submitting) {
+  if (!sessionUuid) return new Set(current)
+  const next = new Set(current)
+  if (submitting) next.add(sessionUuid)
+  else next.delete(sessionUuid)
+  return next
+}
+
 export function prepareRunSubmission({
   sessionUuid,
   question,

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -263,14 +263,20 @@ test('creates the first session only when the user submits a prompt', async () =
     'const sessionAtSubmit = selectedSessionUuid.value',
     submit
   )
-  const submitGuard = source.indexOf('if (loading.value.run)', submit)
-  const markSubmitting = source.indexOf('loading.value.run = true', submit)
+  const submitGuard = source.indexOf(
+    'submittingSessionUuids.value.has(selectedSessionUuid.value)',
+    submit
+  )
+  const markCreating = source.indexOf(
+    'sessionCreationInProgress.value = true',
+    submit
+  )
 
   assert.notEqual(createFirstSession, -1)
   assert.notEqual(bindSession, -1)
   assert.notEqual(submitGuard, -1)
   assert.ok(submitGuard < createFirstSession)
-  assert.ok(markSubmitting < createFirstSession)
+  assert.ok(markCreating < createFirstSession)
   assert.ok(createFirstSession < bindSession)
 })
 
@@ -287,7 +293,7 @@ test('lets Smart Collaboration select assistants before its first session', asyn
     'allowed_assistant_uuids: allowedAssistantUuids'
   )
   const selectedScope = source.indexOf(
-    'await createNewSession(\n      false,\n      routingScopeAssistantUuids.value',
+    'await createNewSession(\n        false,\n        routingScopeAssistantUuids.value',
     scopeCandidates
   )
 

--- a/frontend/tests/chatSubmission.test.js
+++ b/frontend/tests/chatSubmission.test.js
@@ -1,7 +1,21 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { prepareRunSubmission } from '../src/pages/lens/chatSubmission.js'
+import {
+  prepareRunSubmission,
+  updateSessionSubmissionSet
+} from '../src/pages/lens/chatSubmission.js'
+
+test('isolates submission locks by session', () => {
+  const first = updateSessionSubmissionSet(new Set(), 'session-1', true)
+  const both = updateSessionSubmissionSet(first, 'session-2', true)
+  const secondOnly = updateSessionSubmissionSet(both, 'session-1', false)
+
+  assert.deepEqual([...both], ['session-1', 'session-2'])
+  assert.deepEqual([...secondOnly], ['session-2'])
+  assert.equal(secondOnly.has('session-1'), false)
+  assert.equal(secondOnly.has('session-2'), true)
+})
 
 test('reuses the idempotency key for the same unknown-result replay', () => {
   const first = prepareRunSubmission({

--- a/release-notes/494.yaml
+++ b/release-notes/494.yaml
@@ -1,0 +1,10 @@
+type: fix
+audience: user
+en: >-
+  Fixed message submission being blocked in other conversations while a
+  response is still running.
+zh-CN: >-
+  修复一个会话正在运行时阻塞其他会话提交消息的问题。
+es: >-
+  Se corrigió el bloqueo del envío de mensajes en otras conversaciones
+  mientras una respuesta seguía ejecutándose.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Allow message submission independently in each conversation.
- Keep the session-creation guard separate from active Run submission state.
- Track normal and clarification submissions by session UUID so switching
  conversations does not inherit another session's loading lock.
- Add regression coverage and a release note for issue #494.

Closes #494

## User-visible problem

When a response was still running or streaming in one conversation, the chat
composer in another conversation became unavailable. The same happened when a
user switched to an existing session or attempted to start a new session while
the first response was in progress. This made independent conversations appear
to share one global submission lock.

## Root cause

The chat page represented submission progress with a single `loading.run`
boolean. That state was global to the component rather than scoped to the
session that owned the Run. After switching sessions, the selected conversation
could therefore still observe the previous conversation's loading state and
reject its own submission. Clarification submissions used the same global state
and could produce the same cross-conversation blocking behavior.

Session creation is a separate operation: it must be guarded while the first
session is being created, but creating a session should not make an unrelated
existing session wait for another session's Run to finish.

## Behavioral contract

| Scenario | Result after this PR |
| --- | --- |
| A Run is active in conversation A | Conversation B remains submit-capable. |
| Conversation B is a newly created session | Its first submission can create and bind the session while A is active. |
| Conversation A is switched away from and then revisited | Only A's own submission state can disable its composer. |
| A clarification is being submitted in A | B is unaffected; A remains locked until its clarification request settles. |
| A submission completes, fails, is cancelled, or exits early | The lock for that session is released in the existing cleanup path. |
| Two sessions submit concurrently | Each session retains an independent lock and Run lifecycle. |

## Implementation details

### Session-scoped submission state

- Replaced the component-wide Run loading flag with `submittingSessionUuids`, a
  set keyed by session UUID.
- Added `setSessionSubmitting` in `Chat.vue` to update the set immutably.
- Updated normal submissions and clarification submissions to capture the
  session UUID at submit time and release only that session's lock.
- Submission guards now check the selected session's UUID instead of a global
  boolean.

### Session creation isolation

- Added `sessionCreationInProgress` as a dedicated guard for the asynchronous
  first-session creation path.
- Preserved draft restoration and existing early-return behavior when session
  creation is unavailable.
- Kept attachment handling, mention validation, idempotency, streaming, and
  error cleanup behavior unchanged.

### Shared submission helper

- Added `updateSessionSubmissionSet` to centralize immutable session-lock
  updates and make the isolation behavior directly testable.

## Acceptance criteria mapping

- [x] A running response in one conversation no longer disables submission in
      another existing or newly created conversation.
- [x] Switching conversations does not leak the previous session's submission
      lock into the selected session.
- [x] Clarification submissions use the same session-scoped isolation.
- [x] Session creation has an independent in-progress guard.
- [x] Existing submission cleanup and error handling release the correct
      session lock.
- [x] Regression tests cover independent locks and first-session submission
      ordering.

## Test plan

### Automated validation

- [x] Frontend unit suite: **472 passed**.
- [x] Issue-focused chat tests: **36 passed**.
- [x] Frontend production build: passed.
- [x] ESLint: **0 errors**; six existing Prettier warnings remain outside the
      changed lines.
- [x] `git diff --check`: passed.

### Browser verification

- [x] Logged-in shared runtime at `http://localhost:8000`.
- [x] Submitted in a second newly created conversation while the first
      conversation was still running.
- [x] Submitted in an existing conversation while another conversation was
      still running.
- [x] API, PostgreSQL, and nginx services were healthy during verification.

## File walkthrough

| File | Purpose |
| --- | --- |
| `frontend/src/pages/lens/Chat.vue` | Scope normal and clarification submission locks by session and separate session creation from Run submission. |
| `frontend/src/pages/lens/chatSubmission.js` | Provide the immutable session-lock update helper. |
| `frontend/tests/chatBootstrap.test.js` | Verify first-session creation remains submit-triggered and guarded independently. |
| `frontend/tests/chatSubmission.test.js` | Verify locks for multiple sessions do not interfere with one another. |
| `release-notes/494.yaml` | Document the user-visible cross-conversation submission fix. |

## Compatibility and merge notes

- No database migration or API contract change is required.
- Existing conversation, attachment, streaming, retry, and clarification
  behavior is preserved apart from the incorrect cross-session blocking.
- The branch is based on the current `main` commit
  `4cc83456c99b9a6b4c612fb8b0b299431c0d7ce3`.
- PR #495 (issue #493) changes backend and LensNode files and does not overlap
  with this PR's five files.
- PR #475 is still open and shares two frontend files; a three-way merge was
  checked against its latest commit `eb168addbcda0b993a55d57dd498738ae52a1c45`
  and produced no textual conflict.
- Other open PRs reviewed for overlap (#490, #489, and #487) do not touch the
  files in this PR.

## Review guidance

The highest-value review points are:

1. The selected session UUID is captured before asynchronous submission work
   and used consistently for cleanup.
2. Session creation cannot be started twice, while an active Run in another
   session does not block it.
3. Clarification and ordinary submissions both release only their owning
   session's lock.
4. Existing attachment, mention, retry, streaming, and error paths remain
   unchanged.

## Merge policy

Do not merge automatically. Review and merge manually after required checks and
approvals are complete.


___

### **PR Type**
Bug fix


___

### **Description**
- Isolate submission locks per conversation session.

- Prevent session creation from blocking other sessions.

- Track submitting state via session UUID set.

- Add regression tests and release notes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Global loading.run"] --> new["Session-scoped submittingSessionUuids Set"]
  creation["sessionCreationInProgress flag"] --> release["Independent lock per session"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Scope submission state per session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Replaced global <code>loading.run</code> boolean with <code>submittingSessionUuids</code> Set.<br> <li> Added <code>sessionCreationInProgress</code> flag to separate session creation from <br>submission lock.<br> <li> Updated <code>canSubmit</code>, <code>submit</code>, and <code>submitClarification</code> to use <br>session-scoped lock.<br> <li> Lock release occurs in <code>finally</code> block using the session UUID at submit <br>time.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/496/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+40/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatSubmission.js</strong><dd><code>Export session-scoped lock helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/chatSubmission.js

<ul><li>Exported <code>updateSessionSubmissionSet</code> helper function.<br> <li> Function returns a new Set with session UUID added or removed.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/496/files#diff-e73e7f06403bf2928592a1a33440d3294cbc8dae81ffe7e2c23e12ba28a437e5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Adjust test for new submission guards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Updated test to check for new markers: <code>submittingSessionUuids</code> and <br><code>sessionCreationInProgress</code>.<br> <li> Adjusted assertion for session creation line indentation.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/496/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatSubmission.test.js</strong><dd><code>Add session lock isolation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatSubmission.test.js

<ul><li>Added test <code>isolates submission locks by session</code> to verify <br><code>updateSessionSubmissionSet</code> behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/496/files#diff-89187ab7c8cbc45d8e6f2fb7c61019968ae9453513344aa6d38ab844f0fc0d96">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>494.yaml</strong><dd><code>Add release note for #494</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/494.yaml

<ul><li>Added release note entry for the cross-conversation message submission <br>fix in English, Chinese, and Spanish.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/496/files#diff-8b139474ec0ddfc0e9aa3360e28afa21935582af43c23bf0211e9e0952fc3681">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

