### PR TITLE
Fix conflicting lens migration leaf nodes

### DIFF
--- a/backend/lens/migrations/0048_sharedqa_content_language.py
+++ b/backend/lens/migrations/0048_sharedqa_content_language.py
@@ -25,7 +25,7 @@ def populate_content_languages(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    dependencies = [("lens", "0046_assistant_fixed_collaboration")]
+    dependencies = [("lens", "0047_plugin_integrations")]
 
     operations = [
         migrations.AddField(


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Rename the SharedQA content language migration from `0047` to `0048`.
- Make the migration depend on `0047_plugin_integrations` so Django has one linear migration path.
- Prevent the deployment startup failure caused by conflicting migration leaf nodes.

Closes #501

## Test plan
- [x] Python migration syntax check
- [x] Migration numbering and dependency check
- [x] Full migration application from an empty SQLite database in the backend container
- [x] `git diff --check`


___

### **PR Type**
Bug fix


___

### **Description**
- Rename lens migration dependency to resolve leaf conflict.

- Ensure single linear migration path for deployment.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    0046["0046_assistant_fixed_collaboration"] --> 0047["0047_plugin_integrations"] --> 0048["0048_sharedqa_content_language"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0048_sharedqa_content_language.py</strong><dd><code>Update migration dependency to 0047</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/migrations/0048_sharedqa_content_language.py

Changed migration dependency from <code>0046_assistant_fixed_collaboration</code> <br>to <code>0047_plugin_integrations</code> to resolve conflicting leaf nodes and <br>ensure a linear migration path.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/502/files#diff-7ff457a9cb8ebdd8812968db98d51c7bf2966c2fa0403ee65d105c571bccbeee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

