### PR TITLE
Fix stuck session deletion flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ WORKDIR /opt/backend
 
 COPY --from=backend-builder /opt/venv /opt/venv
 COPY --from=backend-builder /opt/backend /opt/backend
+COPY --from=backend-builder /opt/plugins /opt/plugins
 
 # Verify neither the system install nor the copied venv resurrected pip.
 RUN set -eux; \

--- a/backend/lens/tests/test_session_management.py
+++ b/backend/lens/tests/test_session_management.py
@@ -4,15 +4,22 @@ import uuid
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from django.utils import timezone
 from PIL import Image
 from rest_framework.test import APIClient
 
 from lens.models import (
     Assistant,
+    Connection,
+    CredentialLease,
+    ExecutionSnapshot,
     LensNode,
+    PluginInvocation,
     Run,
     RunDiagnostic,
     RunDiagnosticEvidence,
+    SecretMaterial,
+    SecretVersion,
     Session,
     SharedQA,
 )
@@ -233,6 +240,67 @@ class SessionManagementTests(TestCase):
         self.assertFalse(
             RunDiagnosticEvidence.objects.filter(pk=evidence.pk).exists()
         )
+
+    def test_delete_session_with_plugin_tool_snapshot(self):
+        run = create_execution_run(
+            self.first,
+            "Plugin question",
+            enqueue=False,
+            user=self.user,
+        )
+        material = SecretMaterial.objects.create(name="Plugin secret")
+        secret_version = SecretVersion.objects.create(
+            material=material,
+            encrypted_value="encrypted",
+        )
+        connection = Connection.objects.create(
+            name="Plugin connection",
+            plugin_key="github",
+            endpoint="https://github.com",
+            secret_version=secret_version,
+        )
+        snapshot = ExecutionSnapshot.objects.create(
+            kind=ExecutionSnapshot.Kind.TOOL_INVOKE,
+            connection=connection,
+            run=run,
+            secret_version=secret_version,
+            plugin_key="github",
+            plugin_version="1.0.0",
+            protocol_version=1,
+            tool_key="github_read_file",
+            invocation_id="tool-call-1",
+            resolved_config={},
+        )
+        invocation = PluginInvocation.objects.create(
+            snapshot=snapshot,
+            connection=connection,
+            run=run,
+            actor=self.user,
+            lensnode=self.node,
+            kind=ExecutionSnapshot.Kind.TOOL_INVOKE,
+            plugin_key="github",
+            tool_key="github_read_file",
+        )
+        lease = CredentialLease.objects.create(
+            snapshot=snapshot,
+            lensnode=self.node,
+            expires_at=timezone.now(),
+        )
+
+        response = self.client.delete(
+            f"/api/lens/sessions/{self.first.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 204, response.data)
+        self.assertFalse(Session.objects.filter(pk=self.first.pk).exists())
+        self.assertFalse(Run.objects.filter(pk=run.pk).exists())
+        self.assertFalse(
+            ExecutionSnapshot.objects.filter(pk=snapshot.pk).exists()
+        )
+        self.assertFalse(
+            PluginInvocation.objects.filter(pk=invocation.pk).exists()
+        )
+        self.assertFalse(CredentialLease.objects.filter(pk=lease.pk).exists())
 
     def test_other_users_cannot_manage_sessions_they_do_not_own(self):
         self.client.force_authenticate(self.other)

--- a/backend/lens/views/sessions.py
+++ b/backend/lens/views/sessions.py
@@ -41,8 +41,11 @@ from lens.document_attachments import (
 )
 from lens.models import (
     Assistant,
+    CredentialLease,
+    ExecutionSnapshot,
     Message,
     MessageAttachment,
+    PluginInvocation,
     Run,
     RunDiagnostic,
     RunExecution,
@@ -231,13 +234,32 @@ class SessionViewSet(BaseAuthenticatedViewSet):
         """Delete protected dependents in dependency order.
 
         Django's deletion collector checks PROTECT constraints while it
-        collects related objects. Delete diagnostics before their evidence
-        cascades from Run, then delete Runs before Messages cascade from the
-        Session.
+        collects related objects. Delete Plugin execution audit records and
+        diagnostics before their evidence cascades from Run, then delete Runs
+        before Messages cascade from the Session.
         """
         session_uuid = instance.uuid
         user_id = instance.user_id
         with transaction.atomic():
+            run_ids = list(
+                instance.run_set.values_list("id", flat=True)
+            )
+            snapshot_ids = list(
+                ExecutionSnapshot.objects.filter(
+                    run_id__in=run_ids,
+                ).values_list("id", flat=True)
+            )
+            if snapshot_ids:
+                CredentialLease.objects.filter(
+                    snapshot_id__in=snapshot_ids,
+                ).delete()
+                PluginInvocation.objects.filter(
+                    snapshot_id__in=snapshot_ids,
+                ).delete()
+                ExecutionSnapshot.objects.filter(
+                    id__in=snapshot_ids,
+                ).delete()
+            PluginInvocation.objects.filter(run_id__in=run_ids).delete()
             RunDiagnostic.objects.filter(run__session=instance).delete()
             instance.run_set.all().delete()
             instance.delete()

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -3443,7 +3443,9 @@ async function handleSessionAction(session, action) {
   else if (action === 'unpin') await setSessionPinned(session, false)
   else if (action === 'archive') await archiveManagedSession(session)
   else if (action === 'restore') await restoreManagedSession(session)
-  else if (action === 'delete') deleteSessionTarget.value = session
+  else if (action === 'delete' && !deletingSession.value) {
+    deleteSessionTarget.value = session
+  }
 }
 
 async function setSessionPinned(session, pinned) {
@@ -4547,6 +4549,8 @@ async function doDeleteSession() {
     if (clearUnreadSession(window.localStorage, session.uuid)) {
       refreshUnreadSessions()
     }
+    deleteSessionTarget.value = null
+    showSuccess(t('lens.chat.sessionDeleted'))
     if (selectedSessionUuid.value === session.uuid) {
       const next = sessions.value[0]
       if (next) {
@@ -4555,8 +4559,6 @@ async function doDeleteSession() {
         clearSessionSelection()
       }
     }
-    deleteSessionTarget.value = null
-    showSuccess(t('lens.chat.sessionDeleted'))
   } catch {
     showError(t('lens.chat.deleteFailed'))
   } finally {

--- a/frontend/tests/chatBootstrap.test.js
+++ b/frontend/tests/chatBootstrap.test.js
@@ -67,6 +67,28 @@ test('guards restored run state with the current session load', async () => {
   )
 })
 
+test('closes the delete dialog before loading the replacement session', async () => {
+  const source = await chatSource()
+  const deleteHandler = source.indexOf('async function doDeleteSession()')
+  const deleteHandlerEnd = source.indexOf('\n}\n\nwatch(', deleteHandler)
+  const handlerSource = source.slice(deleteHandler, deleteHandlerEnd)
+  const closeDialog = handlerSource.indexOf('deleteSessionTarget.value = null')
+  const replacementLoad = handlerSource.indexOf('await selectSession(next)')
+
+  assert.notEqual(deleteHandler, -1)
+  assert.notEqual(closeDialog, -1)
+  assert.notEqual(replacementLoad, -1)
+  assert.ok(closeDialog < replacementLoad)
+})
+
+test('does not reopen the delete dialog during replacement loading', async () => {
+  const source = await chatSource()
+  assert.match(
+    source,
+    /action === 'delete' && !deletingSession\.value\)\s*\{\s*deleteSessionTarget\.value = session/
+  )
+})
+
 test('shows a retryable node-offline error when run creation is unavailable', async () => {
   const source = await chatSource()
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Close the session deletion dialog immediately after the delete request succeeds, before loading the replacement session.
- Clean up protected Plugin Tool leases, invocations, and execution snapshots before deleting session runs.
- Include bundled plugins in the backend runtime image.
- Add frontend and backend regression coverage for the deletion paths.

Closes #500

## Test plan
- [x] Frontend deletion regression tests
- [x] Frontend ESLint
- [x] Frontend production build
- [x] Dockerfile build check
- [x] Python syntax compilation
- [ ] Full backend Django test suite (local environment lacks `daphne`)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Close delete dialog before loading replacement session

- Clean up protected Plugin records before deleting runs

- Guard delete action to prevent re-entry during loading

- Include bundled plugins in runtime image


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User clicks delete"] --> B["Guard: !deletingSession.value"]
  B --> C["Set deleteSessionTarget"]
  C --> D["doDeleteSession()"]
  D --> E["deleteSession(session.uuid)"]
  E --> F["Delete dialog cleared (deleteSessionTarget = null)"]
  F --> G["Show success message"]
  G --> H["Select next session"]
  H --> I["Cleanup: delete Plugin records before runs"]
  I --> J["Delete runs and session"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_session_management.py</strong><dd><code>Add regression test for plugin session deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_session_management.py

<ul><li>Added test for deleting session with plugin tool snapshot<br> <li> Verifies cleanup of ExecutionSnapshot, PluginInvocation, <br>CredentialLease</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/504/files#diff-388fe1a422b63d03d261be45bec2e25e874834faa7f3bd702680421e62a35171">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatBootstrap.test.js</strong><dd><code>Add frontend regression tests for delete flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatBootstrap.test.js

<ul><li>Test that delete dialog is closed before replacement load<br> <li> Test that delete dialog does not reopen during loading</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/504/files#diff-2135b75e8914c7558e50e47a57486bfd5cdc6b37cc97fac25aa7dfdee9d2d4fd">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Clean up protected plugin records before delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/views/sessions.py

<ul><li>Delete CredentialLease, PluginInvocation, ExecutionSnapshot before <br>runs<br> <li> Also delete PluginInvocation without snapshot by run_id</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/504/files#diff-5271360df826bc1230406d5a73425315af7aafd55724812d08e243956049a6ed">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Fix stuck delete dialog and re-entry guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Guard delete action to ignore if already deleting<br> <li> Close delete dialog before loading next session</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/504/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Include plugins in backend runtime image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Copy plugins from builder to runtime image


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/504/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

