### PR TITLE
Support robust multi-resource Git datasources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ WORKDIR /opt/backend
 
 COPY --from=backend-builder /opt/venv /opt/venv
 COPY --from=backend-builder /opt/backend /opt/backend
+COPY --from=backend-builder /opt/plugins /opt/plugins
 
 # Verify neither the system install nor the copied venv resurrected pip.
 RUN set -eux; \

--- a/backend/lens/tests/plugins/test_github_provider.py
+++ b/backend/lens/tests/plugins/test_github_provider.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from lens.plugins.providers import get_datasource_provider
 from lens.plugins.registry import installed_plugin
 from lens.plugins.tool_providers import ToolProviderError, get_tool_provider
 
@@ -217,3 +218,27 @@ class GitHubToolProviderTests(TestCase):
                     "path": "/user",
                 },
             )
+
+
+class GitHubDatasourceProviderTests(TestCase):
+    """Verify GitHub datasource resource lists stay within scope."""
+
+    def setUp(self):
+        self.provider = get_datasource_provider("github", "1.0.0")
+
+    def test_accepts_multiple_repositories(self):
+        config = self.provider.validate_datasource_config(
+            {"repositories": ["oneprolabs/a", "oneprolabs/b"]},
+            {
+                "repositories": ["oneprolabs/a", "oneprolabs/b"],
+                "branch": "main",
+            },
+        )
+
+        self.assertEqual(
+            config,
+            {
+                "repositories": ["oneprolabs/a", "oneprolabs/b"],
+                "branch": "main",
+            },
+        )

--- a/backend/lens/tests/plugins/test_gitlab_provider.py
+++ b/backend/lens/tests/plugins/test_gitlab_provider.py
@@ -60,6 +60,23 @@ class GitLabDatasourceProviderTests(TestCase):
         self.assertEqual(config["project"], "platform/backend/sourcelens")
         self.assertEqual(config["directory"], "docs")
 
+    def test_accepts_multiple_projects(self):
+        config = self.provider.validate_datasource_config(
+            {"projects": ["platform/a", "platform/b"]},
+            {
+                "projects": ["platform/a", "platform/b"],
+                "branch": "main",
+            },
+        )
+
+        self.assertEqual(
+            config,
+            {
+                "projects": ["platform/a", "platform/b"],
+                "branch": "main",
+            },
+        )
+
     def test_rejects_project_outside_connection_scope(self):
         with self.assertRaisesMessage(DatasourceProviderError, "scope"):
             self.provider.validate_datasource_config(

--- a/backend/lens/tests/test_plugin_registry.py
+++ b/backend/lens/tests/test_plugin_registry.py
@@ -132,12 +132,12 @@ class PluginRegistryTests(TestCase):
         self.assertEqual(plugin.connection_schema["type"], "object")
         self.assertEqual(plugin.datasource_schema["type"], "object")
         self.assertEqual(
-            plugin.datasource_schema["properties"]["repository"]["resource"],
+            plugin.datasource_schema["properties"]["repositories"]["resource"],
             "repositories",
         )
-        self.assertEqual(
-            plugin.datasource_schema["properties"]["branch"]["depends_on"],
-            "repository",
+        self.assertIn(
+            "shared by all repositories",
+            plugin.datasource_schema["properties"]["branch"]["description"],
         )
         self.assertEqual(
             plugin.connection_schema["properties"]["repositories"]["write_to"],

--- a/docs/multi-resource-datasources.md
+++ b/docs/multi-resource-datasources.md
@@ -1,0 +1,37 @@
+# Multi-resource Git DataSources
+
+## Objective
+
+Allow one GitHub or GitLab DataSource to synchronize multiple authorized
+repositories/projects. Preserve the current workspace layout and reduce the
+production catalog from 48 split GitLab rows to the original 16 logical data
+sources.
+
+## Contract
+
+- GitHub datasource config accepts `repositories` (1-50 values).
+- GitLab datasource config accepts `projects` (1-50 values).
+- Existing singular `repository`/`project` configs remain readable during the
+  expand phase.
+- Each resource is synchronized below the DataSource target path using a
+  deterministic resource-name subdirectory.
+- Connection allowlists remain authoritative and are revalidated per resource.
+
+## Migration
+
+- Keep the 5 GitHub and 9 Feishu DataSources unchanged.
+- Consolidate GitLab resources into two DataSources: `atomy` (10 projects) and
+  `hypermotion` (24 projects), retaining their existing sync policies and
+  workspace paths.
+- Repoint historical ExecutionSnapshot and PluginInvocation rows to the
+  consolidated DataSource while retaining resolved resource and target data.
+- Replace old schedules with one schedule per consolidated DataSource.
+- Delete the 32 split GitLab DataSource rows only after references are moved in
+  one transaction and a production backup is verified.
+
+## Verification
+
+- Provider/unit tests cover singular compatibility, multi-resource validation,
+  scope rejection, and deterministic target paths.
+- Production audit reports 16 active DataSources, no protected references,
+  unique target paths, and complete schedules.

--- a/frontend/src/pages/lens/DataSourceDetailDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceDetailDrawer.vue
@@ -501,6 +501,7 @@ import {
   dataSourceBranch,
   dataSourceRepositories,
   dataSourceRepositoryUrl,
+  isOrganizationDataSource,
   isDataSourceSyncing
 } from './datasourceHelpers'
 import { useShortDateTime } from './useShortDateTime'
@@ -975,7 +976,7 @@ const datasourceResourceDetails = computed(() => {
           : authSchemeLabel(config.auth_scheme)
       )
     ]
-    if (!repositories.length) {
+    if (!isOrganizationDataSource(row)) {
       items.splice(
         1,
         0,

--- a/frontend/src/pages/lens/DataSourceFormDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceFormDrawer.vue
@@ -1547,16 +1547,22 @@ const sourceTypes = computed(() => {
       }
     }),
     {
-      value: 'gitlab',
-      label: 'GitLab',
-      description: t('lensAdmin.datasourceWizard.gitlabDesc')
-    },
-    {
       value: 'managed_workspace',
       label: t('lensAdmin.datasourceWizard.managedWorkspace'),
       description: t('lensAdmin.datasourceWizard.managedWorkspaceDesc')
     }
   ]
+  if (
+    props.mode === 'edit' &&
+    props.form.source_type === 'gitlab' &&
+    !props.form.connection_uuid
+  ) {
+    types.splice(types.length - 1, 0, {
+      value: 'gitlab',
+      label: 'GitLab',
+      description: t('lensAdmin.datasourceWizard.gitlabDesc')
+    })
+  }
   if (props.mode === 'edit' && props.form.source_type === 'feishu') {
     types.splice(types.length - 1, 0, {
       value: 'feishu',

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -1147,7 +1147,24 @@ function formFromRow(row) {
 
 function datasourceConfigFromRow(row) {
   if (row.plugin_key && row.connection) {
-    return { ...(row.datasource_config || {}) }
+    const config = { ...(row.datasource_config || {}) }
+    if (
+      row.plugin_key === 'github' &&
+      config.repository &&
+      !Array.isArray(config.repositories)
+    ) {
+      config.repositories = [config.repository]
+      delete config.repository
+    }
+    if (
+      row.plugin_key === 'gitlab' &&
+      config.project &&
+      !Array.isArray(config.projects)
+    ) {
+      config.projects = [config.project]
+      delete config.project
+    }
+    return config
   }
   if (row.source_type === 'feishu') {
     return {

--- a/frontend/src/pages/lens/datasourceHelpers.js
+++ b/frontend/src/pages/lens/datasourceHelpers.js
@@ -18,14 +18,22 @@ export function formatDocIds(docIds) {
 export function dataSourceRepository(row) {
   const config = row.config || {}
   const datasourceConfig = row.datasource_config || {}
+  const resources = Array.isArray(datasourceConfig.repositories)
+    ? datasourceConfig.repositories
+    : Array.isArray(datasourceConfig.projects)
+      ? datasourceConfig.projects
+      : []
+  const firstResource = resources[0]
   if (
     row.source_type === 'git' ||
     datasourceConfig.repository ||
-    datasourceConfig.project
+    datasourceConfig.project ||
+    firstResource
   ) {
     return (
       datasourceConfig.repository ||
       datasourceConfig.project ||
+      firstResource ||
       config.organization_url ||
       config.repo_url ||
       EMPTY_VALUE
@@ -55,12 +63,29 @@ export function dataSourceRepositoryUrl(row, connectionEndpoint = '') {
 }
 
 export function dataSourceRepositories(row) {
+  const datasourceConfig = row?.datasource_config || {}
+  const pluginResources = Array.isArray(datasourceConfig.repositories)
+    ? datasourceConfig.repositories
+    : Array.isArray(datasourceConfig.projects)
+      ? datasourceConfig.projects
+      : []
+  if (pluginResources.length) {
+    return pluginResources.map((resource) =>
+      typeof resource === 'string'
+        ? {
+            name: resource,
+            path: resource,
+            branch: datasourceConfig.branch || ''
+          }
+        : resource
+    )
+  }
   const repositories = row?.config?.repositories
   return Array.isArray(repositories) ? repositories : []
 }
 
 export function isOrganizationDataSource(row) {
-  return dataSourceRepositories(row).length > 0
+  return dataSourceRepositories(row).length > 1
 }
 
 export function dataSourceBranch(row) {

--- a/frontend/tests/datasourceHelpers.test.js
+++ b/frontend/tests/datasourceHelpers.test.js
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  dataSourceBranch,
+  dataSourceRepositories,
   dataSourceRepository,
-  dataSourceRepositoryUrl
+  dataSourceRepositoryUrl,
+  isOrganizationDataSource
 } from '../src/pages/lens/datasourceHelpers.js'
 
 test('plugin repository fields are used as the datasource resource', () => {
@@ -48,6 +51,39 @@ test('plugin repository URLs include the Connection endpoint', () => {
     ),
     'http://gitlab.example.com:20080/hypermotion/mass'
   )
+})
+
+test('multi-resource Plugin datasources expose their first resource and count', () => {
+  const row = {
+    plugin_key: 'gitlab',
+    datasource_config: {
+      projects: ['hypermotion/alpha', 'hypermotion/beta']
+    },
+    config: {}
+  }
+  assert.equal(dataSourceRepository(row), 'hypermotion/alpha')
+  assert.equal(
+    dataSourceRepositoryUrl(row, 'https://gitlab.example.com'),
+    'https://gitlab.example.com/hypermotion/alpha'
+  )
+  assert.equal(dataSourceRepositories(row).length, 2)
+  assert.equal(isOrganizationDataSource(row), true)
+})
+
+test('single-resource Plugin datasources preserve branch details', () => {
+  const row = {
+    source_type: 'git',
+    plugin_key: 'gitlab',
+    datasource_config: {
+      projects: ['hypermotion/alpha'],
+      branch: 'develop'
+    },
+    config: {}
+  }
+
+  assert.equal(isOrganizationDataSource(row), false)
+  assert.equal(dataSourceBranch(row), 'develop')
+  assert.equal(dataSourceRepositories(row)[0].branch, 'develop')
 })
 
 test('legacy and Feishu datasource URLs remain directly readable', () => {

--- a/frontend/tests/pluginIntegrations.test.js
+++ b/frontend/tests/pluginIntegrations.test.js
@@ -254,6 +254,11 @@ test('Feishu datasource creation uses the Plugin while legacy rows remain editab
   )
   assert.match(
     drawer,
+    /props\.mode === 'edit' &&\s*props\.form\.source_type === 'gitlab'/
+  )
+  assert.match(drawer, /!props\.form\.connection_uuid/)
+  assert.match(
+    drawer,
     /if \(isPluginSourceType\(props\.form\.source_type\)\) \{\s*return Boolean\([\s\S]*schemaRequiredFieldsHaveValues/
   )
 })

--- a/frontend/tests/pluginIntegrations.test.js
+++ b/frontend/tests/pluginIntegrations.test.js
@@ -17,6 +17,8 @@ test('Plugin data sources use installed manifests and Connections', async () => 
   assert.match(page, /payload\.plugin_key = form\.value\.plugin_key/)
   assert.match(page, /payload\.connection_uuid = form\.value\.connection_uuid/)
   assert.match(page, /payload\.datasource_config = buildPluginDatasourceConfig/)
+  assert.match(page, /config\.repositories = \[config\.repository\]/)
+  assert.match(page, /config\.projects = \[config\.project\]/)
   assert.match(page, /payload\.credential_uuid = null/)
   assert.match(page, /getConnectionResources/)
   assert.doesNotMatch(page, /GitHub resources are available/)

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -1641,6 +1641,14 @@ def _sync_git_organization(command, workspace_path, emit):
 
     root = normalize_target_path(command.get("target_path"), workspace_path)
     root.mkdir(parents=True, exist_ok=True)
+    repository_names = {
+        repo_target_subdir(repository) for repository in repositories
+    }
+    _cleanup_removed_git_repositories(
+        root,
+        repository_names,
+        command.get("datasource_uuid"),
+    )
     totals = {
         "synced": 0,
         "files": 0,
@@ -1778,6 +1786,34 @@ def repo_target_subdir(repository):
         or "repository"
     )
     return safe_filename(str(raw).strip()) or "repository"
+
+
+def _cleanup_removed_git_repositories(root, repository_names, datasource_uuid):
+    """Remove child repositories no longer configured for a datasource."""
+
+    datasource_uuid = str(datasource_uuid or "")
+    if not datasource_uuid:
+        return []
+    removed = []
+    for child in sorted(Path(root).iterdir(), key=lambda item: item.name):
+        if (
+            not child.is_dir()
+            or child.is_symlink()
+            or child.name in repository_names
+        ):
+            continue
+        marker = child / manifest_store.MARKER_FILE
+        if not marker.is_file():
+            continue
+        try:
+            marker_payload = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if str(marker_payload.get("datasource_uuid") or "") != datasource_uuid:
+            continue
+        shutil.rmtree(child)
+        removed.append(child.name)
+    return removed
 
 
 def _write_git_repository_manifest(

--- a/lensnode/tests/plugins/test_github_tools.py
+++ b/lensnode/tests/plugins/test_github_tools.py
@@ -41,6 +41,40 @@ def test_builds_multi_repository_datasource_command():
         "https://github.com/oneprolabs/a.git",
         "https://github.com/oneprolabs/b.git",
     ]
+    assert [
+        item["target_subdir"] for item in command["config"]["repositories"]
+    ] == ["oneprolabs%2Fa", "oneprolabs%2Fb"]
+
+
+def test_multi_repository_target_subdirs_remain_unique_for_same_names():
+    command = GITHUB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://github.com",
+                "connection_scope": {
+                    "repositories": ["team-a/common", "team_b/common"]
+                },
+                "datasource_config": {
+                    "repositories": ["team-a/common", "team_b/common"]
+                },
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "github",
+            "endpoint": "https://github.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    target_subdirs = [
+        item["target_subdir"] for item in command["config"]["repositories"]
+    ]
+    assert target_subdirs == ["team-a%2Fcommon", "team_b%2Fcommon"]
+    assert len(set(target_subdirs)) == 2
 
 
 def _execute(tool_key, arguments, handler):

--- a/lensnode/tests/plugins/test_github_tools.py
+++ b/lensnode/tests/plugins/test_github_tools.py
@@ -12,6 +12,37 @@ from lensnode.plugin_runtime import PluginRuntimeError
 GITHUB_RUNTIME = load_runtime_contract("github", "1.0.0")
 
 
+def test_builds_multi_repository_datasource_command():
+    command = GITHUB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://github.com",
+                "connection_scope": {
+                    "repositories": ["oneprolabs/a", "oneprolabs/b"]
+                },
+                "datasource_config": {
+                    "repositories": ["oneprolabs/a", "oneprolabs/b"],
+                    "branch": "main",
+                },
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "github",
+            "endpoint": "https://github.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    assert [item["repo_url"] for item in command["config"]["repositories"]] == [
+        "https://github.com/oneprolabs/a.git",
+        "https://github.com/oneprolabs/b.git",
+    ]
+
+
 def _execute(tool_key, arguments, handler):
     with httpx.Client(transport=httpx.MockTransport(handler)) as client:
         return GITHUB_RUNTIME.execute_tool(

--- a/lensnode/tests/plugins/test_gitlab_tools.py
+++ b/lensnode/tests/plugins/test_gitlab_tools.py
@@ -40,6 +40,33 @@ def test_builds_multi_project_datasource_command():
         "https://gitlab.example.com/platform/a.git",
         "https://gitlab.example.com/platform/b.git",
     ]
+    assert [
+        item["target_subdir"] for item in command["config"]["repositories"]
+    ] == ["platform%2Fa", "platform%2Fb"]
+
+
+def test_multi_project_datasource_resolves_each_default_branch():
+    command = GITLAB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://gitlab.example.com",
+                "connection_scope": {"projects": ["platform/a"]},
+                "datasource_config": {"projects": ["platform/a"]},
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "gitlab",
+            "endpoint": "https://gitlab.example.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    assert command["config"]["branch"] == ""
+    assert command["config"]["repositories"][0]["branch"] == ""
 
 
 def _command(tool_key):

--- a/lensnode/tests/plugins/test_gitlab_tools.py
+++ b/lensnode/tests/plugins/test_gitlab_tools.py
@@ -5,6 +5,41 @@ from types import SimpleNamespace
 import httpx
 
 from lensnode.plugin_tools import build_plugin_tools
+from lensnode.plugin_package_loader import load_runtime_contract
+
+
+GITLAB_RUNTIME = load_runtime_contract("gitlab", "1.0.0")
+
+
+def test_builds_multi_project_datasource_command():
+    command = GITLAB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://gitlab.example.com",
+                "connection_scope": {
+                    "projects": ["platform/a", "platform/b"]
+                },
+                "datasource_config": {
+                    "projects": ["platform/a", "platform/b"],
+                    "branch": "main",
+                },
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "gitlab",
+            "endpoint": "https://gitlab.example.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    assert [item["repo_url"] for item in command["config"]["repositories"]] == [
+        "https://gitlab.example.com/platform/a.git",
+        "https://gitlab.example.com/platform/b.git",
+    ]
 
 
 def _command(tool_key):

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -8,8 +8,10 @@ from threading import Event
 import httpx
 import pytest
 
+from lensnode.datasource_manifest import MARKER_FILE
 from lensnode.datasource_sync import (
     DataSourceSyncError,
+    _cleanup_removed_git_repositories,
     datasource_sync_workers,
     inspect_datasource_path,
     _default_git_branch,
@@ -238,6 +240,35 @@ def test_default_git_branch_prefers_main():
     assert _default_git_branch(["dev", "main"]) == "main"
     assert _default_git_branch(["dev", "master"]) == "master"
     assert _default_git_branch(["release"]) == "release"
+
+
+def test_cleanup_removed_git_repositories_keeps_current_and_foreign(tmp_path):
+    """Only stale child repositories owned by this datasource are removed."""
+
+    stale = tmp_path / "team%2Fstale"
+    current = tmp_path / "team%2Fcurrent"
+    foreign = tmp_path / "team%2Fforeign"
+    for child, datasource_uuid in [
+        (stale, "datasource-1"),
+        (current, "datasource-1"),
+        (foreign, "datasource-2"),
+    ]:
+        child.mkdir()
+        (child / MARKER_FILE).write_text(
+            json.dumps({"datasource_uuid": datasource_uuid}),
+            encoding="utf-8",
+        )
+
+    removed = _cleanup_removed_git_repositories(
+        tmp_path,
+        {"team%2Fcurrent"},
+        "datasource-1",
+    )
+
+    assert removed == ["team%2Fstale"]
+    assert not stale.exists()
+    assert current.exists()
+    assert foreign.exists()
 
 
 def test_git_manifest_items_honors_repository_directory(tmp_path, monkeypatch):

--- a/plugins/github/control.py
+++ b/plugins/github/control.py
@@ -28,7 +28,9 @@ SENSITIVE_CONFIG_KEYS = frozenset(
         "token",
     }
 )
-ALLOWED_CONFIG_KEYS = frozenset({"repository", "branch", "directory"})
+ALLOWED_CONFIG_KEYS = frozenset(
+    {"repository", "repositories", "branch", "directory"}
+)
 ALLOWED_SCOPE_KEYS = frozenset({"repositories"})
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_API_VERSION = "2022-11-28"
@@ -370,13 +372,28 @@ class GitHubDatasourceProvider(DatasourceProvider):
             raise DatasourceProviderError(
                 "datasource config contains unsupported fields"
             )
-        repository = _repository_name(datasource_config.get("repository"))
         allowed_repositories = _allowed_repositories(connection_scope)
-        if repository.casefold() not in allowed_repositories:
+        raw_repositories = datasource_config.get("repositories")
+        if raw_repositories is None:
+            raw_repositories = [datasource_config.get("repository")]
+        if (
+            not isinstance(raw_repositories, list)
+            or not raw_repositories
+            or len(raw_repositories) > GITHUB_MAX_REPOSITORIES
+        ):
+            raise DatasourceProviderError(
+                "repositories must contain 1 through 50 items"
+            )
+        repositories = [_repository_name(value) for value in raw_repositories]
+        if len({item.casefold() for item in repositories}) != len(repositories):
+            raise DatasourceProviderError("repositories must be unique")
+        if any(item.casefold() not in allowed_repositories for item in repositories):
             raise DatasourceProviderError(
                 "repository is outside connection scope"
             )
-        normalized = {"repository": repository}
+        normalized = {"repositories": repositories}
+        if "repository" in datasource_config and "repositories" not in datasource_config:
+            normalized = {"repository": repositories[0]}
         branch = _optional_nonempty_string(
             datasource_config.get("branch"), "branch"
         )

--- a/plugins/github/plugin.json
+++ b/plugins/github/plugin.json
@@ -113,18 +113,19 @@
   "datasource_schema": {
     "type": "object",
     "properties": {
-      "repository": {
-        "type": "string",
+      "repositories": {
+        "type": "array",
+        "items": {"type": "string"},
         "format": "provider-resource",
         "resource": "repositories",
-        "title": "Repository"
+        "title": "Repositories",
+        "minItems": 1,
+        "maxItems": 50
       },
       "branch": {
         "type": "string",
-        "format": "provider-resource-option",
-        "resource": "branches",
-        "depends_on": "repository",
-        "title": "Branch"
+        "title": "Branch",
+        "description": "Optional branch, tag, or commit ref shared by all repositories."
       },
       "directory": {
         "type": "string",
@@ -133,7 +134,7 @@
         "description": "Optional repository-relative directory to sync."
       }
     },
-    "required": ["repository"],
+    "required": ["repositories"],
     "additionalProperties": false
   },
   "tools": [

--- a/plugins/github/runtime.py
+++ b/plugins/github/runtime.py
@@ -892,24 +892,46 @@ def build_datasource_command(snapshot, material, trigger):
     endpoint = _endpoint(resolved.get("endpoint"))
     _material(material, endpoint)
     datasource = resolved.get("datasource_config") or {}
-    repository = datasource.get("repository") if isinstance(datasource, dict) else ""
-    if not isinstance(repository, str) or not repository:
+    if not isinstance(datasource, dict):
         raise PluginRuntimeError("PLUGIN_CONFIG_INVALID")
-    _validate_repository_scope(repository, resolved.get("connection_scope"))
+    repositories = datasource.get("repositories")
+    if repositories is None:
+        repositories = [datasource.get("repository")]
+    if (
+        not isinstance(repositories, list)
+        or not repositories
+        or any(not isinstance(item, str) or not item for item in repositories)
+    ):
+        raise PluginRuntimeError("PLUGIN_CONFIG_INVALID")
+    for repository in repositories:
+        _validate_repository_scope(repository, resolved.get("connection_scope"))
+    config = {
+        "branch": datasource.get("branch") or "",
+        "directory": datasource.get("directory") or "",
+        "auth_scheme": "token",
+        "access_token": material["value"],
+        "allow_submodules": False,
+    }
+    if "repositories" in datasource:
+        config["repositories"] = [
+            {
+                "repo_url": f"{endpoint}/{repository}.git",
+                "branch": datasource.get("branch") or "",
+                "directory": datasource.get("directory") or "",
+                "target_subdir": repository.rsplit("/", 1)[-1],
+                "enabled": True,
+            }
+            for repository in repositories
+        ]
+    else:
+        config["repo_url"] = f"{endpoint}/{repositories[0]}.git"
     return {
         "source_type": "git",
         "datasource_uuid": snapshot.get("datasource_uuid"),
         "target_path": resolved.get("target_path"),
         "sync_policy": resolved.get("sync_policy") or {},
         "trigger": trigger,
-        "config": {
-            "repo_url": f"{endpoint}/{repository}.git",
-            "branch": datasource.get("branch") or "",
-            "directory": datasource.get("directory") or "",
-            "auth_scheme": "token",
-            "access_token": material["value"],
-            "allow_submodules": False,
-        },
+        "config": config,
     }
 
 

--- a/plugins/github/runtime.py
+++ b/plugins/github/runtime.py
@@ -918,7 +918,7 @@ def build_datasource_command(snapshot, material, trigger):
                 "repo_url": f"{endpoint}/{repository}.git",
                 "branch": datasource.get("branch") or "",
                 "directory": datasource.get("directory") or "",
-                "target_subdir": repository.rsplit("/", 1)[-1],
+                "target_subdir": quote(repository, safe=""),
                 "enabled": True,
             }
             for repository in repositories

--- a/plugins/gitlab/control.py
+++ b/plugins/gitlab/control.py
@@ -27,7 +27,9 @@ SENSITIVE_CONFIG_KEYS = frozenset(
         "token",
     }
 )
-ALLOWED_CONFIG_KEYS = frozenset({"project", "branch", "directory"})
+ALLOWED_CONFIG_KEYS = frozenset(
+    {"project", "projects", "branch", "directory"}
+)
 ALLOWED_SCOPE_KEYS = frozenset({"projects"})
 GITLAB_MAX_PROJECTS = 50
 GITLAB_MAX_BRANCHES = 100
@@ -296,16 +298,31 @@ class GitLabDatasourceProvider(DatasourceProvider):
             raise DatasourceProviderError(
                 "datasource config contains unsupported fields"
             )
-        project = _project_name(datasource_config.get("project"))
+        raw_projects = datasource_config.get("projects")
+        if raw_projects is None:
+            raw_projects = [datasource_config.get("project")]
+        if (
+            not isinstance(raw_projects, list)
+            or not raw_projects
+            or len(raw_projects) > GITLAB_MAX_PROJECTS
+        ):
+            raise DatasourceProviderError(
+                "projects must contain 1 through 50 items"
+            )
+        projects = [_project_name(value) for value in raw_projects]
+        if len({item.casefold() for item in projects}) != len(projects):
+            raise DatasourceProviderError("projects must be unique")
         allowed = {
             item.casefold()
             for item in self.validate_connection_scope(
                 connection_scope
             )["projects"]
         }
-        if project.casefold() not in allowed:
+        if any(item.casefold() not in allowed for item in projects):
             raise DatasourceProviderError("project is outside connection scope")
-        normalized = {"project": project}
+        normalized = {"projects": projects}
+        if "project" in datasource_config and "projects" not in datasource_config:
+            normalized = {"project": projects[0]}
         branch = _optional_text(
             datasource_config.get("branch"),
             "branch",

--- a/plugins/gitlab/plugin.json
+++ b/plugins/gitlab/plugin.json
@@ -91,18 +91,19 @@
   "datasource_schema": {
     "type": "object",
     "properties": {
-      "project": {
-        "type": "string",
+      "projects": {
+        "type": "array",
+        "items": {"type": "string"},
         "format": "provider-resource",
         "resource": "projects",
-        "title": "Project"
+        "title": "Projects",
+        "minItems": 1,
+        "maxItems": 50
       },
       "branch": {
         "type": "string",
-        "format": "provider-resource-option",
-        "resource": "branches",
-        "depends_on": "project",
-        "title": "Branch"
+        "title": "Branch",
+        "description": "Optional branch, tag, or commit ref shared by all projects."
       },
       "directory": {
         "type": "string",
@@ -111,7 +112,7 @@
         "description": "Optional project-relative directory to sync."
       }
     },
-    "required": ["project"],
+    "required": ["projects"],
     "additionalProperties": false
   },
   "tools": [

--- a/plugins/gitlab/runtime.py
+++ b/plugins/gitlab/runtime.py
@@ -396,7 +396,7 @@ def build_datasource_command(snapshot, material, trigger):
     if any(item.casefold() not in allowed for item in projects):
         raise PluginRuntimeError("PLUGIN_SCOPE_VIOLATION")
     config = {
-        "branch": datasource.get("branch") or "main",
+        "branch": datasource.get("branch") or "",
         "directory": datasource.get("directory") or "",
         "auth_scheme": "token",
         "access_token": material["value"],
@@ -405,9 +405,9 @@ def build_datasource_command(snapshot, material, trigger):
         config["repositories"] = [
             {
                 "repo_url": f"{endpoint}/{project}.git",
-                "branch": datasource.get("branch") or "main",
+                "branch": datasource.get("branch") or "",
                 "directory": datasource.get("directory") or "",
-                "target_subdir": project.rsplit("/", 1)[-1],
+                "target_subdir": quote(project, safe=""),
                 "enabled": True,
             }
             for project in projects

--- a/plugins/gitlab/runtime.py
+++ b/plugins/gitlab/runtime.py
@@ -378,9 +378,50 @@ def build_datasource_command(snapshot, material, trigger):
     if not isinstance(material, dict) or material.get("plugin_key") != PLUGIN_KEY or str(material.get("endpoint") or "").rstrip("/") != endpoint or not material.get("value"):
         raise PluginRuntimeError("PLUGIN_MATERIAL_MISMATCH")
     datasource = resolved.get("datasource_config") or {}
-    project = datasource.get("project") if isinstance(datasource, dict) else ""
-    if not isinstance(project, str) or not project: raise PluginRuntimeError("PLUGIN_CONFIG_INVALID")
-    return {"source_type": "git", "datasource_uuid": snapshot.get("datasource_uuid"), "target_path": resolved.get("target_path"), "sync_policy": resolved.get("sync_policy") or {}, "trigger": trigger, "config": {"repo_url": f"{endpoint}/{project}.git", "branch": datasource.get("branch") or "main", "directory": datasource.get("directory") or "", "auth_scheme": "token", "access_token": material["value"]}}
+    if not isinstance(datasource, dict):
+        raise PluginRuntimeError("PLUGIN_CONFIG_INVALID")
+    projects = datasource.get("projects")
+    if projects is None:
+        projects = [datasource.get("project")]
+    if (
+        not isinstance(projects, list)
+        or not projects
+        or any(not isinstance(item, str) or not item for item in projects)
+    ):
+        raise PluginRuntimeError("PLUGIN_CONFIG_INVALID")
+    scope = resolved.get("connection_scope") or {}
+    allowed = {
+        str(item).casefold() for item in scope.get("projects", [])
+    }
+    if any(item.casefold() not in allowed for item in projects):
+        raise PluginRuntimeError("PLUGIN_SCOPE_VIOLATION")
+    config = {
+        "branch": datasource.get("branch") or "main",
+        "directory": datasource.get("directory") or "",
+        "auth_scheme": "token",
+        "access_token": material["value"],
+    }
+    if "projects" in datasource:
+        config["repositories"] = [
+            {
+                "repo_url": f"{endpoint}/{project}.git",
+                "branch": datasource.get("branch") or "main",
+                "directory": datasource.get("directory") or "",
+                "target_subdir": project.rsplit("/", 1)[-1],
+                "enabled": True,
+            }
+            for project in projects
+        ]
+    else:
+        config["repo_url"] = f"{endpoint}/{projects[0]}.git"
+    return {
+        "source_type": "git",
+        "datasource_uuid": snapshot.get("datasource_uuid"),
+        "target_path": resolved.get("target_path"),
+        "sync_policy": resolved.get("sync_policy") or {},
+        "trigger": trigger,
+        "config": config,
+    }
 
 
 def _endpoint(value):


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Add multi-resource GitHub and GitLab datasource configuration and runtime support.
- Keep repository/project target directories unique across namespaces and clean up stale directories owned by the datasource.
- Resolve GitLab default branches per project and preserve accurate single-resource versus multi-resource details in the admin UI.
- Include plugin runtime image, provider validation, synchronization, and frontend regression coverage.

Closes #505

## Test plan
- [x] `./.venv/bin/pytest -q tests/plugins/test_github_tools.py tests/plugins/test_gitlab_tools.py tests/test_datasource_sync.py` (64 passed)
- [x] `node --test frontend/tests/datasourceHelpers.test.js` (5 passed)
- [ ] Run the full backend and frontend suites in CI


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Backend providers validate multi-repository/project configs

- LensNode sync removes stale directories owned by the datasource

- Frontend displays single and multi-resource details correctly

- GitHub and GitLab plugins build multi-resource sync commands


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>test_github_provider.py</strong><dd><code>Test multi-repository validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-e1ffa45e57c35ec910bf39f36ee2dd651b905bee19f683d72f11794c771a03c9">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gitlab_provider.py</strong><dd><code>Test multi-project validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-7df9693fc7da5d4e6170b89ffe8215659a8d73db5436cebf83ff99ac6fea65d7">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_github_tools.py</strong><dd><code>Test multi-repository command building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-1fff06e10039a30e673edc3717ac3f48bb686ac226ac3fdda6ab245b70481f5c">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gitlab_tools.py</strong><dd><code>Test multi-project and default branch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-964616fafb244f39b49d34ae9470d75d338ed89b1629fdda00bbc74696b64685">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_datasource_sync.py</strong><dd><code>Test cleanup of stale directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasourceHelpers.test.js</strong><dd><code>Add tests for multi-resource helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-2fe4dc987b2731632a7a67a43d99167d6bbf25abd6b655500c3b32ea1466ad04">+37/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pluginIntegrations.test.js</strong><dd><code>Update regex matchers for new code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-4f7b0be18b55449fe0931d2293fcaa8e993946339d6914638e4c0d2a627cf462">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Add cleanup for removed repositories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>control.py</strong><dd><code>Validate multi-repository datasource config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-01ca9b85d661b644b2d5d7baa9b51df0319278a411ad6e91cf6478d08e62e864">+21/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Build multi-repository sync command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-b080c820b95f34be4c9baaf2c5232a287db0bed19656bbefbb4ad295084a6767">+33/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>control.py</strong><dd><code>Validate multi-project datasource config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-482b7bbb6b90a5907cf1e4ae2953c81d6c48ea946167be7ba76fff81105eba16">+21/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Build multi-project sync command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-53be8db070e937ced7fd3ec7acaa16c409ae2cce2f0efb579f9baff68a760ad4">+44/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceDetailDrawer.vue</strong><dd><code>Show details for multi-resource datasources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-b0769411d4535ce440e95fe367c2d0996579d7fc5a79c1d0a6ff8475d210a523">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceFormDrawer.vue</strong><dd><code>Conditionally show GitLab source type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-0b2ea6040d7c458a234eb3d290500ddb300a087019b6b58d947883cda373ec42">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasourceHelpers.js</strong><dd><code>Support multi-resource in helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-2a4e96e3cf92d92f5e8ef916aa558e50b9ae852b47b7888e185b50169c26ca5e">+27/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DataSources.vue</strong><dd><code>Normalize legacy config to array format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-1a2dc840b5da820c7b8a16cb18fa4a424860f010974ced2df56948e3cde5c30a">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>Copy plugins directory into runtime image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>multi-resource-datasources.md</strong><dd><code>Document multi-resource datasource feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-30fbaf523fddde993854a3b02923965f0a5067b2c6a07441efd4338ab60b5b9b">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>plugin.json</strong><dd><code>Update schema for multi-repository input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-94013ae13c060306042c69005e9e355f7fae801b79b87221311ab2b20b6fc41c">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin.json</strong><dd><code>Update schema for multi-project input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-533b3b63b34f1969f68939aceae563c81e5cffec615cde512dad3288fbb130f2">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_plugin_registry.py</strong></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/506/files#diff-631c7d8259d2c0277683319744d9d7c79aaa9a6ec6f71d801916b2e5bac63f54">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

