### PR TITLE
Harden datasource lifecycle and Git workspace layout

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -2188,6 +2188,7 @@ class DataSourceSerializer(serializers.ModelSerializer):
                 status__in=[
                     TaskStatus.PENDING,
                     *TaskStatus.get_running_statuses(),
+                    "CANCELLING",
                 ],
             )
             .order_by("-created_at")

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -266,15 +266,17 @@ def register_datasource_sync_task(
 
     task_metadata = _datasource_task_metadata(datasource, trigger)
     task_metadata.update(metadata or {})
-    return TaskTracker.register_task(
-        task_id=task_id,
-        task_name=_datasource_sync_task_name(datasource),
-        module="lens_datasource",
-        task_args=[str(datasource.uuid)],
-        task_kwargs={"trigger": trigger},
-        created_by=created_by,
-        metadata=task_metadata,
-    )
+    with transaction.atomic():
+        DataSource.objects.select_for_update().get(pk=datasource.pk)
+        return TaskTracker.register_task(
+            task_id=task_id,
+            task_name=_datasource_sync_task_name(datasource),
+            module="lens_datasource",
+            task_args=[str(datasource.uuid)],
+            task_kwargs={"trigger": trigger},
+            created_by=created_by,
+            metadata=task_metadata,
+        )
 
 
 def register_datasource_conversion_task(

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -417,7 +417,10 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
     """Celery entrypoint for dispatching datasource sync to a LensNode."""
 
     from agentcore_task.adapters.django import TaskTracker
+    from agentcore_task.adapters.django.models import TaskExecution
     from agentcore_task.constants import TaskStatus
+
+    from .services import cancel_datasource_sync_on_lensnode
 
     # Track this run under a standalone id, not the Celery task id. The
     # Celery task returns SUCCESS right after dispatching to the LensNode,
@@ -426,42 +429,71 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
     # PENDING (unknown id) and the LensNode completion callback owns the
     # final status.
     task_id = task_id or uuid.uuid4().hex
-    datasource = DataSource.objects.select_related("lensnode").get(uuid=datasource_uuid)
-    if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
-        return 0
-    record = _get_or_create_source_sync_record(datasource)
-    if datasource.status == DataSource.Status.DISABLED:
-        if record.enabled:
-            record.enabled = False
-            record.save(update_fields=["enabled"])
-        return 0
+    with transaction.atomic():
+        datasource = DataSource.objects.select_for_update().get(
+            uuid=datasource_uuid
+        )
+        if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
+            return 0
+        record = _get_or_create_source_sync_record(datasource)
+        if datasource.status == DataSource.Status.DISABLED:
+            if record.enabled:
+                record.enabled = False
+                record.save(update_fields=["enabled"])
+            return 0
 
-    now = timezone.now()
-    record.last_status = ScheduledTask.Status.RUNNING
-    record.last_error = ""
-    record.last_run_at = now
-    record.save(update_fields=["last_status", "last_error", "last_run_at"])
-    register_datasource_sync_task(datasource, task_id, trigger)
-    TaskTracker.update_task_status(
-        task_id,
-        TaskStatus.PENDING,
-        metadata={
-            "queue_state": "QUEUED",
-            "execution_class": "exclusive",
-        },
-    )
-    _append_datasource_task_step(
-        task_id,
-        "prepare",
-        "queued",
-        "Datasource sync submitted to the LensNode queue.",
-    )
-
-    try:
-        acquire_datasource_lock(
-            datasource.uuid,
-            token=task_id,
-            ttl_s=get_datasource_sync_timeout_s(),
+        task_execution = register_datasource_sync_task(
+            datasource,
+            task_id,
+            trigger,
+        )
+        if task_execution.status in TaskStatus.get_completed_statuses():
+            return 0
+        now = timezone.now()
+        record.last_status = ScheduledTask.Status.RUNNING
+        record.last_error = ""
+        record.last_run_at = now
+        record.save(update_fields=["last_status", "last_error", "last_run_at"])
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.PENDING,
+            metadata={
+                "queue_state": "QUEUED",
+                "execution_class": "exclusive",
+            },
+        )
+        _append_datasource_task_step(
+            task_id,
+            "prepare",
+            "queued",
+            "Datasource sync submitted to the LensNode queue.",
+        )
+        try:
+            acquire_datasource_lock(
+                datasource.uuid,
+                token=task_id,
+                ttl_s=get_datasource_sync_timeout_s(),
+            )
+        except SourceSyncBusy as exc:
+            record.last_error = str(exc)
+            record.last_run_at = timezone.now()
+            record.save(update_fields=["last_error", "last_run_at"])
+            TaskTracker.update_task_status(
+                task_id,
+                TaskStatus.REVOKED,
+                error=str(exc),
+                metadata=_datasource_step_metadata(
+                    task_id,
+                    "lock",
+                    "skipped",
+                    str(exc),
+                ),
+            )
+            return 0
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.PENDING,
+            metadata={"lock_token": task_id},
         )
         _append_datasource_task_step(
             task_id,
@@ -469,38 +501,36 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
             "running",
             "Dispatching datasource sync to LensNode.",
         )
+
+    try:
         request_id = dispatch_datasource_sync_async(
             datasource,
             task_id=task_id,
             trigger=trigger,
         )
-        TaskTracker.update_task_status(
-            task_id,
-            TaskStatus.PENDING,
-            metadata={
-                "completion_source": "lensnode_callback",
-                "datasource_sync_request_id": request_id,
-                "lock_token": task_id,
-                "queue_state": "QUEUED",
-                "execution_class": "exclusive",
-            },
-        )
-    except SourceSyncBusy as exc:
-        record.last_error = str(exc)
-        record.last_run_at = timezone.now()
-        record.save(update_fields=["last_error", "last_run_at"])
-        TaskTracker.update_task_status(
-            task_id,
-            TaskStatus.REVOKED,
-            error=str(exc),
-            metadata=_datasource_step_metadata(
+        with transaction.atomic():
+            task_execution = TaskExecution.objects.select_for_update().get(
+                task_id=task_id
+            )
+            cancelling = (
+                task_execution.status == DATASOURCE_CANCELLING_STATUS
+            )
+            TaskTracker.update_task_status(
                 task_id,
-                "lock",
-                "skipped",
-                str(exc),
-            ),
-        )
-        return 0
+                task_execution.status if cancelling else TaskStatus.PENDING,
+                metadata={
+                    "completion_source": "lensnode_callback",
+                    "datasource_sync_request_id": request_id,
+                    "lock_token": task_id,
+                    "queue_state": "QUEUED",
+                    "execution_class": "exclusive",
+                },
+            )
+        if cancelling:
+            cancel_datasource_sync_on_lensnode(
+                datasource.lensnode,
+                task_id,
+            )
     except Exception as exc:
         release_datasource_lock(datasource.uuid, token=task_id)
         datasource.last_error = str(exc)

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -5498,6 +5498,36 @@ class LensApiTests(TestCase):
             "/workspace/scheduled",
         )
 
+    def test_datasource_list_filters_by_plugin_key(self):
+        self.datasource.plugin_key = "github"
+        self.datasource.save(update_fields=["plugin_key"])
+        DataSource.objects.create(
+            name="Feishu Docs",
+            plugin_key="feishu",
+            source_type="feishu",
+            lensnode=self.lensnode,
+            config={"folder_url": "https://example.com/folder"},
+            sync_policy={"interval_seconds": 3600},
+            target_path="/workspace/feishu-docs",
+        )
+
+        response = self.client.get(
+            "/api/lens/admin/datasources/",
+            {"plugin_key": "github", "page_size": 100},
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["plugin_key"], "github")
+
+        all_response = self.client.get(
+            "/api/lens/admin/datasources/",
+            {"plugin_key": "all", "page_size": 100},
+        )
+
+        self.assertEqual(all_response.status_code, 200, all_response.data)
+        self.assertEqual(all_response.data["count"], 2)
+
     def test_check_datasource_path_blocks_existing_datasource_path(self):
         response = self.client.post(
             f"/api/lens/admin/lensnodes/{self.lensnode.uuid}/" "check-datasource-path/",

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -82,6 +82,7 @@ from lens.skill_packages import package_zip_bytes
 from lens.tasks import (
     SourceSyncBusy,
     acquire_datasource_lock,
+    complete_datasource_sync_task,
     release_datasource_lock,
 )
 from lens.views.assistants import AssistantViewSet
@@ -6253,7 +6254,7 @@ class LensApiTests(TestCase):
         self.assertEqual(response.data["detail"], "DATASOURCE_DISABLED")
         apply_async.assert_not_called()
 
-    def test_cancel_datasource_sync_releases_lock(self):
+    def test_cancel_datasource_sync_waits_for_stop_confirmation(self):
         task = TaskExecution.objects.create(
             task_id="running-sync",
             task_name="datasource_sync:Repo Cache",
@@ -6287,13 +6288,34 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         revoke.assert_called_once_with(
             "celery-sync",
-            terminate=True,
-            signal="SIGTERM",
+            terminate=False,
         )
         cancel.assert_called_once_with(self.lensnode, "running-sync")
         task.refresh_from_db()
-        self.assertEqual(task.status, "REVOKED")
+        self.assertEqual(task.status, "CANCELLING")
 
+        delete_response = self.client.delete(
+            f"/api/lens/admin/datasources/{self.datasource.uuid}/"
+        )
+        self.assertEqual(delete_response.status_code, 409)
+
+        with self.assertRaises(SourceSyncBusy):
+            acquire_datasource_lock(
+                self.datasource.uuid,
+                token="new-sync",
+                ttl_s=60,
+            )
+
+        complete_datasource_sync_task(
+            task.task_id,
+            {
+                "status": "cancelled",
+                "error": "DATASOURCE_SYNC_CANCELLED",
+            },
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, "REVOKED")
         acquire_datasource_lock(
             self.datasource.uuid,
             token="new-sync",

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -38,18 +38,24 @@ from lens.models import (
     AssistantAccess,
     AssistantMCP,
     AssistantSkill,
+    Connection,
+    CredentialLease,
     DataSource,
     DataSourceCredential,
     EnvironmentVariableSet,
+    ExecutionSnapshot,
     GlobalSetting,
     LensNode,
     MCPServer,
     MessageAttachment,
+    PluginInvocation,
     Run,
     RunExecution,
     RunStep,
     ScheduledTask,
     Session,
+    SecretMaterial,
+    SecretVersion,
     SharedQA,
     Skill,
 )
@@ -6086,6 +6092,71 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertFalse(DataSource.objects.filter(pk=datasource.pk).exists())
         send.assert_not_called()
+
+    def test_datasource_delete_cleans_plugin_audit_records(self):
+        material = SecretMaterial.objects.create(name="Datasource PAT")
+        version = SecretVersion.objects.create(
+            material=material,
+            encrypted_value="encrypted",
+        )
+        connection_obj = Connection.objects.create(
+            name="Datasource GitHub",
+            plugin_key="github",
+            endpoint="https://github.com",
+            secret_version=version,
+        )
+        self.datasource.connection = connection_obj
+        self.datasource.plugin_key = "github"
+        self.datasource.save(update_fields=["connection", "plugin_key"])
+        snapshot = ExecutionSnapshot.objects.create(
+            kind=ExecutionSnapshot.Kind.DATASOURCE_SYNC,
+            connection=connection_obj,
+            datasource=self.datasource,
+            secret_version=version,
+            plugin_key="github",
+            plugin_version="1.0.0",
+            protocol_version=1,
+        )
+        invocation = PluginInvocation.objects.create(
+            snapshot=snapshot,
+            connection=connection_obj,
+            datasource=self.datasource,
+            lensnode=self.lensnode,
+            kind=ExecutionSnapshot.Kind.DATASOURCE_SYNC,
+            plugin_key="github",
+        )
+        lease = CredentialLease.objects.create(
+            snapshot=snapshot,
+            lensnode=self.lensnode,
+            expires_at=timezone.now() + timedelta(minutes=5),
+        )
+        schedule = ScheduledTask.objects.create(
+            name=f"source_sync:{self.datasource.uuid}",
+            task_type=ScheduledTask.TaskType.SOURCE_SYNC,
+            target_type="datasource",
+            target_id=self.datasource.uuid,
+        )
+
+        response = self.client.delete(
+            f"/api/lens/admin/datasources/{self.datasource.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            DataSource.objects.filter(pk=self.datasource.pk).exists()
+        )
+        self.assertFalse(
+            ExecutionSnapshot.objects.filter(pk=snapshot.pk).exists()
+        )
+        self.assertFalse(
+            PluginInvocation.objects.filter(pk=invocation.pk).exists()
+        )
+        self.assertFalse(
+            CredentialLease.objects.filter(pk=lease.pk).exists()
+        )
+        self.assertFalse(
+            ScheduledTask.objects.filter(pk=schedule.pk).exists()
+        )
 
     def test_datasource_manual_sync_registers_task(self):
         with patch(

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -5528,6 +5528,25 @@ class LensApiTests(TestCase):
         self.assertEqual(all_response.status_code, 200, all_response.data)
         self.assertEqual(all_response.data["count"], 2)
 
+    def test_datasource_delete_rejects_active_sync(self):
+        TaskExecution.objects.create(
+            task_id="running-datasource-sync",
+            task_name="source_sync:Repo Cache",
+            module="lens_datasource",
+            status="STARTED",
+            metadata={"datasource_uuid": str(self.datasource.uuid)},
+        )
+
+        response = self.client.delete(
+            f"/api/lens/admin/datasources/{self.datasource.uuid}/"
+        )
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(response.data["detail"], "DATASOURCE_SYNC_IN_PROGRESS")
+        self.assertTrue(
+            DataSource.objects.filter(pk=self.datasource.pk).exists()
+        )
+
     def test_check_datasource_path_blocks_existing_datasource_path(self):
         response = self.client.post(
             f"/api/lens/admin/lensnodes/{self.lensnode.uuid}/" "check-datasource-path/",

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -3089,6 +3089,47 @@ class LensServiceTests(TransactionTestCase):
             self.assertEqual(steps[0]["name"], "prepare")
             self.assertEqual(steps[-1]["name"], "dispatch")
 
+    def test_source_sync_task_rolls_back_schedule_when_registration_fails(self):
+        with patch(
+            "lens.tasks.register_datasource_sync_task",
+            side_effect=DataSource.DoesNotExist,
+        ):
+            with self.assertRaises(DataSource.DoesNotExist):
+                source_sync_task(str(self.datasource.uuid))
+
+        self.assertFalse(
+            ScheduledTask.objects.filter(
+                task_type=ScheduledTask.TaskType.SOURCE_SYNC,
+                target_type="datasource",
+                target_id=self.datasource.uuid,
+            ).exists()
+        )
+
+    def test_source_sync_task_reissues_cancel_after_dispatch_race(self):
+        def mark_cancelling(*args, **kwargs):
+            del args, kwargs
+            TaskExecution.objects.filter(module="lens_datasource").update(
+                status="CANCELLING"
+            )
+            return "request-1"
+
+        with (
+            patch(
+                "lens.tasks.dispatch_datasource_sync_async",
+                side_effect=mark_cancelling,
+            ),
+            patch("lens.services.cancel_datasource_sync_on_lensnode") as cancel,
+        ):
+            source_sync_task(str(self.datasource.uuid))
+
+        task = TaskExecution.objects.get(module="lens_datasource")
+        self.assertEqual(task.status, "CANCELLING")
+        self.assertEqual(
+            task.metadata["datasource_sync_request_id"],
+            "request-1",
+        )
+        cancel.assert_called_once_with(self.lensnode, task.task_id)
+
     def test_managed_workspace_sync_is_blocked_at_task_and_dispatch_layers(
         self,
     ):

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -176,6 +176,29 @@ class DataSourceViewSet(BaseAdminViewSet):
             response.data["initial_sync_task_id"] = task_id
         return response
 
+    def destroy(self, request, *args, **kwargs):
+        """Reject deletion while a datasource sync is still active."""
+
+        from agentcore_task.adapters.django.models import TaskExecution
+        from agentcore_task.constants import TaskStatus
+
+        datasource = self.get_object()
+        active_statuses = [
+            TaskStatus.PENDING,
+            *TaskStatus.get_running_statuses(),
+        ]
+        active_sync = TaskExecution.objects.filter(
+            module="lens_datasource",
+            metadata__datasource_uuid=str(datasource.uuid),
+            status__in=active_statuses,
+        ).exists()
+        if active_sync:
+            return Response(
+                {"detail": "DATASOURCE_SYNC_IN_PROGRESS"},
+                status=status.HTTP_409_CONFLICT,
+            )
+        return super().destroy(request, *args, **kwargs)
+
     def perform_destroy(self, instance):
         """Delete datasource audit records before the catalog row."""
 

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -15,7 +15,13 @@ from lens.datasource_services import (
     DataSourcePathError,
     check_datasource_path,
 )
-from lens.models import DataSource, ScheduledTask
+from lens.models import (
+    CredentialLease,
+    DataSource,
+    ExecutionSnapshot,
+    PluginInvocation,
+    ScheduledTask,
+)
 from lens.plugins.datasource_access import (
     datasource_access_failure_detail,
     validate_connection_datasource_access,
@@ -164,6 +170,43 @@ class DataSourceViewSet(BaseAdminViewSet):
         if task_id and isinstance(response.data, dict):
             response.data["initial_sync_task_id"] = task_id
         return response
+
+    def perform_destroy(self, instance):
+        """Delete datasource audit records before the catalog row."""
+
+        from django_celery_beat.models import PeriodicTask, PeriodicTasks
+
+        with transaction.atomic():
+            snapshot_ids = list(
+                ExecutionSnapshot.objects.filter(
+                    datasource=instance,
+                ).values_list("id", flat=True)
+            )
+            if snapshot_ids:
+                CredentialLease.objects.filter(
+                    snapshot_id__in=snapshot_ids,
+                ).delete()
+                PluginInvocation.objects.filter(
+                    snapshot_id__in=snapshot_ids,
+                ).delete()
+                ExecutionSnapshot.objects.filter(
+                    id__in=snapshot_ids,
+                ).delete()
+            PluginInvocation.objects.filter(datasource=instance).delete()
+
+            periodic_name = f"lens-source-sync-{instance.uuid}"
+            periodic_deleted, _ = PeriodicTask.objects.filter(
+                name=periodic_name,
+            ).delete()
+            ScheduledTask.objects.filter(
+                task_type=ScheduledTask.TaskType.SOURCE_SYNC,
+                target_type="datasource",
+                target_id=instance.uuid,
+            ).delete()
+            if periodic_deleted:
+                PeriodicTasks.update_changed()
+
+            instance.delete()
 
     def perform_create(self, serializer):
         """Create datasource, register schedule, and enqueue initial sync."""

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -183,21 +183,25 @@ class DataSourceViewSet(BaseAdminViewSet):
         from agentcore_task.constants import TaskStatus
 
         datasource = self.get_object()
-        active_statuses = [
-            TaskStatus.PENDING,
-            *TaskStatus.get_running_statuses(),
-        ]
-        active_sync = TaskExecution.objects.filter(
-            module="lens_datasource",
-            metadata__datasource_uuid=str(datasource.uuid),
-            status__in=active_statuses,
-        ).exists()
-        if active_sync:
-            return Response(
-                {"detail": "DATASOURCE_SYNC_IN_PROGRESS"},
-                status=status.HTTP_409_CONFLICT,
+        with transaction.atomic():
+            datasource = DataSource.objects.select_for_update().get(
+                pk=datasource.pk
             )
-        return super().destroy(request, *args, **kwargs)
+            active_statuses = [
+                TaskStatus.PENDING,
+                *TaskStatus.get_running_statuses(),
+            ]
+            active_sync = TaskExecution.objects.filter(
+                module="lens_datasource",
+                metadata__datasource_uuid=str(datasource.uuid),
+                status__in=active_statuses,
+            ).exists()
+            if active_sync:
+                return Response(
+                    {"detail": "DATASOURCE_SYNC_IN_PROGRESS"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            return super().destroy(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
         """Delete datasource audit records before the catalog row."""

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -81,6 +81,11 @@ class DataSourceViewSet(BaseAdminViewSet):
         filters = self._datasource_search_filters(
             self.request.query_params.get("filters")
         )
+        plugin_key = str(
+            self.request.query_params.get("plugin_key") or ""
+        ).strip()
+        if plugin_key and plugin_key.lower() != "all":
+            queryset = queryset.filter(plugin_key=plugin_key)
         for item in filters:
             queryset = queryset.filter(
                 self._datasource_search_query(

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -47,7 +47,6 @@ from lens.tasks import (
     register_datasource_conversion_task,
     register_datasource_sync_task,
     register_datasource_upload_task,
-    release_datasource_lock,
     source_sync_task,
 )
 from rest_framework import status
@@ -190,6 +189,7 @@ class DataSourceViewSet(BaseAdminViewSet):
             active_statuses = [
                 TaskStatus.PENDING,
                 *TaskStatus.get_running_statuses(),
+                DATASOURCE_CANCELLING_STATUS,
             ]
             active_sync = TaskExecution.objects.filter(
                 module="lens_datasource",
@@ -592,45 +592,65 @@ class DataSourceViewSet(BaseAdminViewSet):
         from core.celery import app
 
         datasource = self.get_object()
-        task = (
-            TaskExecution.objects.filter(
-                module="lens_datasource",
-                metadata__datasource_uuid=str(datasource.uuid),
-                status__in=[
-                    TaskStatus.PENDING,
-                    *TaskStatus.get_running_statuses(),
-                ],
+        with transaction.atomic():
+            datasource = DataSource.objects.select_for_update().get(
+                pk=datasource.pk
             )
-            .order_by("-created_at")
-            .first()
-        )
-        if task is None:
-            return Response(
-                {"detail": "No running datasource sync task."},
-                status=status.HTTP_404_NOT_FOUND,
+            task = (
+                TaskExecution.objects.select_for_update()
+                .filter(
+                    module="lens_datasource",
+                    metadata__datasource_uuid=str(datasource.uuid),
+                    status__in=[
+                        TaskStatus.PENDING,
+                        *TaskStatus.get_running_statuses(),
+                        DATASOURCE_CANCELLING_STATUS,
+                    ],
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            if task is None:
+                return Response(
+                    {"detail": "No running datasource sync task."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            metadata = dict(task.metadata or {})
+            celery_task_id = metadata.get("celery_task_id") or task.task_id
+            app.control.revoke(celery_task_id, terminate=False)
+            cancel_datasource_sync_on_lensnode(
+                datasource.lensnode,
+                task.task_id,
             )
 
-        metadata = dict(task.metadata or {})
-        celery_task_id = metadata.get("celery_task_id") or task.task_id
-        app.control.revoke(celery_task_id, terminate=True, signal="SIGTERM")
-        cancel_datasource_sync_on_lensnode(datasource.lensnode, task.task_id)
-
-        lock_token = metadata.get("lock_token") or task.task_id
-        release_datasource_lock(datasource.uuid, token=lock_token)
-        metadata["manual_revoked_at"] = timezone.now().isoformat()
-        metadata["manual_revoked_by"] = request.user.pk
-        task.status = TaskStatus.REVOKED
-        task.finished_at = timezone.now()
-        task.error = "Task manually revoked by operator."
-        task.metadata = metadata
-        task.save(
-            update_fields=[
-                "status",
-                "finished_at",
-                "error",
-                "metadata",
-            ]
-        )
+            metadata["manual_revoked_at"] = timezone.now().isoformat()
+            metadata["manual_revoked_by"] = request.user.pk
+            dispatched = bool(
+                metadata.get("lock_token")
+                or metadata.get("datasource_sync_request_id")
+                or task.status in TaskStatus.get_running_statuses()
+            )
+            task.status = (
+                DATASOURCE_CANCELLING_STATUS
+                if dispatched
+                else TaskStatus.REVOKED
+            )
+            task.finished_at = None if dispatched else timezone.now()
+            task.error = "" if dispatched else "DATASOURCE_SYNC_CANCELLED"
+            metadata["cancellation_state"] = task.status
+            if not dispatched:
+                metadata["completion_reason"] = "DATASOURCE_SYNC_CANCELLED"
+                metadata["stop_confirmation_source"] = "queued_before_dispatch"
+            task.metadata = metadata
+            task.save(
+                update_fields=[
+                    "status",
+                    "finished_at",
+                    "error",
+                    "metadata",
+                ]
+            )
         return Response(
             {
                 "uuid": str(datasource.uuid),

--- a/docs/multi-resource-datasources.md
+++ b/docs/multi-resource-datasources.md
@@ -13,11 +13,49 @@ sources.
 - GitLab datasource config accepts `projects` (1-50 values).
 - Existing singular `repository`/`project` configs remain readable during the
   expand phase.
-- Each resource is synchronized below the DataSource target path using a
-  deterministic resource-name subdirectory.
+- Plugin runtimes always emit a `repositories` collection, including for one
+  repository. LensNode uses the same synchronization path for singular and
+  plural configurations.
+- `target_path` is always the DataSource workspace root. A new repository is
+  stored at `target_path/<canonical-resource-id>`, for example
+  `target_path/HyperBDR/docs` or `target_path/group/subgroup/project`.
+- Canonical resource IDs are validated as safe POSIX-relative paths. Absolute
+  paths, traversal segments, empty segments, backslashes, and unsafe filename
+  characters are rejected before filesystem access.
 - Connection allowlists remain authoritative and are revalidated per resource.
+- Repository manifests retain stable Git source IDs based on repository URL,
+  branch, and repository-relative file path. DataSource-level paths include the
+  canonical resource ID so repositories with the same filename remain
+  distinguishable.
 
-## Migration
+## Existing workspace compatibility
+
+Deploying the canonical layout does not relocate production data. Before using
+the canonical target, LensNode recognizes an existing repository only when it
+contains `.git` and either a DataSource marker owned by the current
+`datasource_uuid` or, for an unmarked incomplete synchronization, an exact
+matching Git remote. Supported legacy layouts are:
+
+- a singular repository stored directly at `target_path`;
+- an organization repository stored at `target_path/<repository-name>`;
+- an encoded multi-resource directory such as
+  `target_path/group%2Frepository`.
+
+An owned legacy repository continues to synchronize in place. A missing or new
+repository uses the canonical layout. Cleanup walks nested namespace paths but
+only removes repository roots whose marker belongs to the current DataSource;
+foreign and unmarked directories are preserved.
+
+If a singular DataSource already has a root manifest but no canonical or owned
+legacy Git repository can be identified, synchronization stops with
+`LENS_SOURCE_GIT_LAYOUT_MIGRATION_REQUIRED`. It does not clone another copy or
+guess which existing directory should be reused.
+
+Workspace code search already scans recursively. Git history and recent-change
+tools also discover repositories recursively and stop at each Git root, so
+canonical namespace directories remain usable for code analysis.
+
+## Completed catalog consolidation
 
 - Keep the 5 GitHub and 9 Feishu DataSources unchanged.
 - Consolidate GitLab resources into two DataSources: `atomy` (10 projects) and
@@ -28,6 +66,15 @@ sources.
 - Replace old schedules with one schedule per consolidated DataSource.
 - Delete the 32 split GitLab DataSource rows only after references are moved in
   one transaction and a production backup is verified.
+
+## Pending storage migration
+
+Production storage remains on its current compatible layout after deployment.
+Moving an existing repository to the canonical path or rebuilding it with a
+fresh synchronization is a separate operational decision. Either operation
+must pause the affected schedule, verify repository identity and the DataSource
+marker, and validate synchronization and code analysis before legacy paths are
+removed.
 
 ## Verification
 

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -1236,6 +1236,8 @@
     },
     "datasourceSearch": {
       "all": "All",
+      "pluginType": "Plugin Type",
+      "allPlugins": "All plugins",
       "sourceType": "Source Type",
       "placeholder": "Type a field, e.g. status, path, repository...",
       "clear": "Clear search",

--- a/frontend/src/admin/locales/es.json
+++ b/frontend/src/admin/locales/es.json
@@ -1236,6 +1236,8 @@
     },
     "datasourceSearch": {
       "all": "Todos",
+      "pluginType": "Tipo de plugin",
+      "allPlugins": "Todos los plugins",
       "sourceType": "Tipo de fuente",
       "placeholder": "Escribe un campo, por ejemplo estado, ruta, repositorio...",
       "clear": "Borrar búsqueda",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -1236,6 +1236,8 @@
     },
     "datasourceSearch": {
       "all": "全部",
+      "pluginType": "插件类型",
+      "allPlugins": "全部插件",
       "sourceType": "数据源类型",
       "placeholder": "输入字段名，如 status、路径、仓库...",
       "clear": "清空搜索",

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -143,6 +143,23 @@
               </div>
             </div>
             <div class="flex shrink-0 items-center gap-3 text-xs text-ink-500">
+              <BaseSelect
+                v-model="pluginFilter"
+                class="w-44 text-sm"
+                :aria-label="t('lensAdmin.datasourceSearch.pluginType')"
+                @change="applyPluginFilter"
+              >
+                <option value="all">
+                  {{ t('lensAdmin.datasourceSearch.allPlugins') }}
+                </option>
+                <option
+                  v-for="plugin in datasourcePlugins"
+                  :key="plugin.key"
+                  :value="plugin.key"
+                >
+                  {{ pluginDisplayName(plugin, t, te) }}
+                </option>
+              </BaseSelect>
               <span
                 >{{ enabledDataSourceCount }}
                 {{ t('common.status.active') }}</span
@@ -432,6 +449,7 @@ import {
 import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
 import PaginationBar from '@/components/ui/PaginationBar.vue'
 import { pluginDisplayName } from '@/utils/pluginI18n'
 
@@ -474,6 +492,7 @@ const searchKey = ref('')
 const searchQuery = ref('')
 const searchFilters = ref([])
 const searchPickerOpen = ref(false)
+const pluginFilter = ref('all')
 const searchBoxRef = ref(null)
 const searchInputRef = ref(null)
 const searchValueInputRef = ref(null)
@@ -625,7 +644,15 @@ function datasourceListParams() {
   if (searchFilters.value.length) {
     params.filters = JSON.stringify(searchFilters.value)
   }
+  if (pluginFilter.value !== 'all') {
+    params.plugin_key = pluginFilter.value
+  }
   return params
+}
+
+function applyPluginFilter() {
+  currentPage.value = 1
+  load()
 }
 
 function applySearch() {

--- a/lensnode/lensnode/agent_tools.py
+++ b/lensnode/lensnode/agent_tools.py
@@ -3088,7 +3088,14 @@ def _resolve_repo_path(path, target_dirs):
 
     candidates = []
     if path:
-        candidates.append(Path(path).resolve())
+        requested = Path(path)
+        if requested.is_absolute():
+            candidates.append(requested.resolve())
+        else:
+            candidates.extend(
+                (Path(item.get("path", "")).resolve() / requested).resolve()
+                for item in target_dirs
+            )
     candidates.extend(Path(item.get("path", "")).resolve() for item in target_dirs)
     for candidate in candidates:
         for root_item in target_dirs:
@@ -3112,13 +3119,7 @@ def _discover_git_repositories(path, target_dirs, limit=20):
     if directory is None:
         return []
 
-    repos = []
-    for child in sorted(directory.iterdir(), key=lambda item: item.name):
-        if len(repos) >= limit:
-            break
-        if child.is_dir() and (child / ".git").exists():
-            repos.append(str(child))
-    return repos
+    return [str(repo) for repo in _iter_git_repositories(directory, limit)]
 
 
 def _matching_repositories(query, target_dirs):
@@ -3126,22 +3127,48 @@ def _matching_repositories(query, target_dirs):
 
     tokens = _query_tokens(query)
     repositories = []
+    seen = set()
     for item in target_dirs:
         root = Path(item.get("path", "")).resolve()
-        if (root / ".git").exists():
-            repositories.append(root)
-            continue
         if not root.is_dir():
             continue
-        for child in sorted(root.iterdir(), key=lambda item: item.name):
-            if not child.is_dir() or not (child / ".git").exists():
+        for repo in _iter_git_repositories(root, limit=20):
+            if repo in seen:
                 continue
-            name_tokens = set(_name_tokens(child.name))
+            seen.add(repo)
+            if repo == root:
+                repositories.append(repo)
+                continue
+            try:
+                identity = repo.relative_to(root).as_posix()
+            except ValueError:
+                identity = repo.name
+            name_tokens = set(_name_tokens(identity))
             if any(token in name_tokens for token in tokens):
-                repositories.append(child)
+                repositories.append(repo)
     if repositories:
         return repositories
     return []
+
+
+def _iter_git_repositories(directory, limit):
+    """Yield Git repositories recursively without scanning their contents."""
+
+    repositories = []
+    for current, dirnames, _filenames in os.walk(directory):
+        current = Path(current)
+        if (current / ".git").exists():
+            repositories.append(current)
+            dirnames[:] = []
+            if len(repositories) >= limit:
+                break
+            continue
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if not name.startswith(".") and not (current / name).is_symlink()
+        )
+    return repositories
 
 
 def _query_tokens(query):

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -1487,7 +1487,7 @@ def _sync_git(command, workspace_path, emit):
 
     config = command.get("config") or {}
     if config.get("scope_type") == "organization" or config.get("repositories"):
-        return _sync_git_organization(command, workspace_path, emit)
+        return _sync_git_repositories(command, workspace_path, emit)
 
     repo_url = config.get("repo_url")
     if not repo_url:
@@ -1628,8 +1628,8 @@ def _sync_git(command, workspace_path, emit):
     }
 
 
-def _sync_git_organization(command, workspace_path, emit):
-    """Synchronize multiple Git repositories under one datasource root."""
+def _sync_git_repositories(command, workspace_path, emit):
+    """Synchronize Git repositories under one datasource root."""
 
     config = command.get("config") or {}
     repositories = [
@@ -1641,14 +1641,33 @@ def _sync_git_organization(command, workspace_path, emit):
 
     root = normalize_target_path(command.get("target_path"), workspace_path)
     root.mkdir(parents=True, exist_ok=True)
-    repository_names = {
-        repo_target_subdir(repository) for repository in repositories
-    }
-    _cleanup_removed_git_repositories(
-        root,
-        repository_names,
-        command.get("datasource_uuid"),
-    )
+    repository_targets = [
+        (
+            repository,
+            *_resolve_git_repository_target(
+                root,
+                repository,
+                command.get("datasource_uuid"),
+                single_repository=len(repositories) == 1,
+            ),
+        )
+        for repository in repositories
+    ]
+    target_paths = [
+        target for _repository, _identity, target in repository_targets
+    ]
+    if len(set(target_paths)) != len(target_paths):
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+    if root.resolve() not in target_paths:
+        repository_names = {
+            target.relative_to(root.resolve()).as_posix()
+            for target in target_paths
+        }
+        _cleanup_removed_git_repositories(
+            root,
+            repository_names,
+            command.get("datasource_uuid"),
+        )
     totals = {
         "synced": 0,
         "files": 0,
@@ -1679,16 +1698,21 @@ def _sync_git_organization(command, workspace_path, emit):
         progress_percent=0,
         summary=totals,
     )
-    for index, repository in enumerate(repositories, start=1):
-        name = repo_target_subdir(repository)
-        repo_target = root / name
+    for index, (repository, identity, repo_target) in enumerate(
+        repository_targets,
+        start=1,
+    ):
+        relative_target = repo_target.relative_to(root.resolve()).as_posix()
+        path_prefix = "" if relative_target == "." else relative_target
         repo_command = {
             **command,
             "target_path": str(repo_target),
             "config": {
                 **config,
                 "repo_url": repository.get("repo_url") or "",
-                "branch": repository.get("branch") or config.get("branch") or "",
+                "branch": (
+                    repository.get("branch") or config.get("branch") or ""
+                ),
             },
         }
         repo_command["config"].pop("repositories", None)
@@ -1697,15 +1721,15 @@ def _sync_git_organization(command, workspace_path, emit):
             emit,
             "repository_started",
             "running",
-            f"Synchronizing Git repository {name}.",
+            f"Synchronizing Git repository {identity}.",
             category="repository",
             progress_total=total,
             progress_current=index - 1,
             progress_percent=int(((index - 1) / total) * 100),
-            current_file=name,
+            current_file=identity,
         )
         repository_event_status = "done"
-        repository_event_message = f"Finished Git repository {name}."
+        repository_event_message = f"Finished Git repository {identity}."
         repository_event_error = ""
         try:
             result = _sync_git(repo_command, workspace_path, emit)
@@ -1720,14 +1744,14 @@ def _sync_git_organization(command, workspace_path, emit):
                 repo_changed,
                 repo_deleted,
             )
-            prefixed_items = _prefix_sync_items(repo_items, name)
+            prefixed_items = _prefix_sync_items(repo_items, path_prefix)
             sync_items.extend(prefixed_items)
-            changed_paths.extend(_prefix_paths(repo_changed, name))
-            deleted_paths.extend(_prefix_paths(repo_deleted, name))
+            changed_paths.extend(_prefix_paths(repo_changed, path_prefix))
+            deleted_paths.extend(_prefix_paths(repo_deleted, path_prefix))
             _merge_git_summary(totals, result)
             totals["synced"] += 1
             repository_summaries.append(
-                _repository_summary(name, repository, "success", result)
+                _repository_summary(identity, repository, "success", result)
             )
         except Exception as exc:
             if str(exc) == "LENS_SOURCE_SYNC_CANCELLED":
@@ -1736,10 +1760,10 @@ def _sync_git_organization(command, workspace_path, emit):
             repository_event_status = "failed"
             repository_event_error = str(exc)
             repository_event_message = (
-                f"Failed Git repository {name}: {repository_event_error}"
+                f"Failed Git repository {identity}: {repository_event_error}"
             )
             failure = _repository_summary(
-                name,
+                identity,
                 repository,
                 "failed",
                 {"error": str(exc)},
@@ -1756,7 +1780,7 @@ def _sync_git_organization(command, workspace_path, emit):
             progress_current=index,
             progress_percent=int((index / total) * 100),
             summary=totals,
-            current_file=name,
+            current_file=identity,
             error=repository_event_error,
         )
 
@@ -1776,7 +1800,7 @@ def _sync_git_organization(command, workspace_path, emit):
 
 
 def repo_target_subdir(repository):
-    """Return a stable target subdirectory for a repository item."""
+    """Return a safe repository identity path below a datasource root."""
 
     raw = (
         repository.get("target_subdir")
@@ -1785,35 +1809,155 @@ def repo_target_subdir(repository):
         or _repo_name_from_url(repository.get("repo_url") or "")
         or "repository"
     )
-    return safe_filename(str(raw).strip()) or "repository"
+    value = str(raw).strip()
+    if not value or value.startswith("/") or "\\" in value:
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+    parts = value.split("/")
+    if any(
+        not part
+        or part in {".", ".."}
+        or safe_filename(part) != part
+        for part in parts
+    ):
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+    return "/".join(parts)
+
+
+def _resolve_git_repository_target(
+    root,
+    repository,
+    datasource_uuid,
+    *,
+    single_repository,
+):
+    """Return the canonical identity and compatible on-disk target."""
+
+    root = Path(root).resolve()
+    identity = repo_target_subdir(repository)
+    canonical = (root / identity).resolve()
+    try:
+        canonical.relative_to(root)
+    except ValueError as exc:
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID") from exc
+    if canonical.exists():
+        return identity, canonical
+
+    legacy_candidates = []
+    if single_repository:
+        legacy_candidates.append(root)
+    legacy_candidates.extend(
+        [
+            root / parse.quote(identity, safe=""),
+            root / safe_filename(identity),
+            root / identity.rsplit("/", 1)[-1],
+        ]
+    )
+    seen = set()
+    for candidate in legacy_candidates:
+        candidate = candidate.resolve()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if _is_compatible_git_repository(
+            candidate,
+            datasource_uuid,
+            repository.get("repo_url") or "",
+        ):
+            return identity, candidate
+    if single_repository and (root / manifest_store.MANIFEST_FILE).is_file():
+        raise DataSourceSyncError(
+            "LENS_SOURCE_GIT_LAYOUT_MIGRATION_REQUIRED"
+        )
+    return identity, canonical
+
+
+def _is_owned_git_repository(path, datasource_uuid):
+    """Return whether a Git directory marker belongs to the datasource."""
+
+    path = Path(path)
+    marker = path / manifest_store.MARKER_FILE
+    if not (path / ".git").exists() or not marker.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return str(payload.get("datasource_uuid") or "") == str(
+        datasource_uuid or ""
+    )
+
+
+def _is_compatible_git_repository(path, datasource_uuid, repo_url):
+    """Return whether an existing Git directory is safe to reuse."""
+
+    path = Path(path)
+    if not (path / ".git").exists():
+        return False
+    marker = path / manifest_store.MARKER_FILE
+    if marker.exists():
+        return _is_owned_git_repository(path, datasource_uuid)
+    if not repo_url:
+        return False
+    remote_url = _git_output(["remote", "get-url", "origin"], cwd=path)
+    return bool(remote_url) and _normalize_repo_url(
+        remote_url
+    ) == _normalize_repo_url(repo_url)
 
 
 def _cleanup_removed_git_repositories(root, repository_names, datasource_uuid):
-    """Remove child repositories no longer configured for a datasource."""
+    """Remove owned repositories no longer configured for a datasource."""
 
     datasource_uuid = str(datasource_uuid or "")
     if not datasource_uuid:
         return []
-    removed = []
-    for child in sorted(Path(root).iterdir(), key=lambda item: item.name):
-        if (
-            not child.is_dir()
-            or child.is_symlink()
-            or child.name in repository_names
-        ):
+    root = Path(root).resolve()
+    if (root / ".git").exists():
+        return []
+    stale = []
+    for current, dirnames, filenames in os.walk(root):
+        current = Path(current)
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if name != ".git" and not (current / name).is_symlink()
+        )
+        if current == root:
             continue
-        marker = child / manifest_store.MARKER_FILE
-        if not marker.is_file():
+        if manifest_store.MARKER_FILE not in filenames:
+            if (current / ".git").exists():
+                dirnames[:] = []
             continue
+        dirnames[:] = []
+        marker = current / manifest_store.MARKER_FILE
         try:
             marker_payload = json.loads(marker.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         if str(marker_payload.get("datasource_uuid") or "") != datasource_uuid:
             continue
-        shutil.rmtree(child)
-        removed.append(child.name)
+        name = current.relative_to(root).as_posix()
+        if name not in repository_names:
+            stale.append((name, current))
+
+    removed = []
+    for name, path in sorted(stale, key=lambda item: item[0]):
+        shutil.rmtree(path)
+        _remove_empty_git_namespace_dirs(path.parent, root)
+        removed.append(name)
     return removed
+
+
+def _remove_empty_git_namespace_dirs(path, root):
+    """Remove empty repository namespace directories below the root."""
+
+    path = Path(path)
+    root = Path(root)
+    while path != root:
+        try:
+            path.rmdir()
+        except OSError:
+            return
+        path = path.parent
 
 
 def _write_git_repository_manifest(
@@ -1838,6 +1982,8 @@ def _write_git_repository_manifest(
 
 
 def _prefix_sync_items(items, prefix):
+    if not prefix:
+        return list(items or [])
     result = []
     for item in items or []:
         local_path = f"{prefix}/{item.local_path}"
@@ -1860,6 +2006,8 @@ def _prefix_sync_items(items, prefix):
 
 
 def _prefix_paths(paths, prefix):
+    if not prefix:
+        return list(paths or [])
     return [f"{prefix}/{path}" for path in paths or []]
 
 

--- a/lensnode/tests/plugins/test_github_tools.py
+++ b/lensnode/tests/plugins/test_github_tools.py
@@ -43,7 +43,44 @@ def test_builds_multi_repository_datasource_command():
     ]
     assert [
         item["target_subdir"] for item in command["config"]["repositories"]
-    ] == ["oneprolabs%2Fa", "oneprolabs%2Fb"]
+    ] == ["oneprolabs/a", "oneprolabs/b"]
+
+
+def test_builds_single_repository_as_repository_collection():
+    command = GITHUB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://github.com",
+                "connection_scope": {
+                    "repositories": ["oneprolabs/a"]
+                },
+                "datasource_config": {
+                    "repository": "oneprolabs/a",
+                    "branch": "main",
+                },
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "github",
+            "endpoint": "https://github.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    assert "repo_url" not in command["config"]
+    assert command["config"]["repositories"] == [
+        {
+            "repo_url": "https://github.com/oneprolabs/a.git",
+            "branch": "main",
+            "directory": "",
+            "target_subdir": "oneprolabs/a",
+            "enabled": True,
+        }
+    ]
 
 
 def test_multi_repository_target_subdirs_remain_unique_for_same_names():
@@ -73,7 +110,7 @@ def test_multi_repository_target_subdirs_remain_unique_for_same_names():
     target_subdirs = [
         item["target_subdir"] for item in command["config"]["repositories"]
     ]
-    assert target_subdirs == ["team-a%2Fcommon", "team_b%2Fcommon"]
+    assert target_subdirs == ["team-a/common", "team_b/common"]
     assert len(set(target_subdirs)) == 2
 
 

--- a/lensnode/tests/plugins/test_gitlab_tools.py
+++ b/lensnode/tests/plugins/test_gitlab_tools.py
@@ -42,7 +42,42 @@ def test_builds_multi_project_datasource_command():
     ]
     assert [
         item["target_subdir"] for item in command["config"]["repositories"]
-    ] == ["platform%2Fa", "platform%2Fb"]
+    ] == ["platform/a", "platform/b"]
+
+
+def test_builds_single_project_as_repository_collection():
+    command = GITLAB_RUNTIME.build_datasource_command(
+        {
+            "datasource_uuid": "ds-1",
+            "resolved_config": {
+                "endpoint": "https://gitlab.example.com",
+                "connection_scope": {"projects": ["platform/a"]},
+                "datasource_config": {
+                    "project": "platform/a",
+                    "branch": "main",
+                },
+                "target_path": "/workspace/repos",
+                "sync_policy": {},
+            },
+        },
+        {
+            "plugin_key": "gitlab",
+            "endpoint": "https://gitlab.example.com",
+            "value": "secret",
+        },
+        "manual",
+    )
+
+    assert "repo_url" not in command["config"]
+    assert command["config"]["repositories"] == [
+        {
+            "repo_url": "https://gitlab.example.com/platform/a.git",
+            "branch": "main",
+            "directory": "",
+            "target_subdir": "platform/a",
+            "enabled": True,
+        }
+    ]
 
 
 def test_multi_project_datasource_resolves_each_default_branch():

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import subprocess
 import zipfile
 from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
 from threading import Event
@@ -33,9 +34,12 @@ from lensnode.datasource_sync import (
     _manifest_item_to_sync_item,
     _poll_feishu_export_task,
     _raise_feishu_business_error,
+    _resolve_git_repository_target,
+    repo_target_subdir,
     _sync_git,
     _sync_git_submodules,
     _sync_feishu_folder,
+    sync_datasource,
     upload_managed_workspace,
 )
 from lensnode.path_rules import source_sha256
@@ -245,15 +249,15 @@ def test_default_git_branch_prefers_main():
 def test_cleanup_removed_git_repositories_keeps_current_and_foreign(tmp_path):
     """Only stale child repositories owned by this datasource are removed."""
 
-    stale = tmp_path / "team%2Fstale"
-    current = tmp_path / "team%2Fcurrent"
-    foreign = tmp_path / "team%2Fforeign"
+    stale = tmp_path / "team" / "stale"
+    current = tmp_path / "team" / "current"
+    foreign = tmp_path / "other" / "foreign"
     for child, datasource_uuid in [
         (stale, "datasource-1"),
         (current, "datasource-1"),
         (foreign, "datasource-2"),
     ]:
-        child.mkdir()
+        child.mkdir(parents=True)
         (child / MARKER_FILE).write_text(
             json.dumps({"datasource_uuid": datasource_uuid}),
             encoding="utf-8",
@@ -261,14 +265,226 @@ def test_cleanup_removed_git_repositories_keeps_current_and_foreign(tmp_path):
 
     removed = _cleanup_removed_git_repositories(
         tmp_path,
-        {"team%2Fcurrent"},
+        {"team/current"},
         "datasource-1",
     )
 
-    assert removed == ["team%2Fstale"]
+    assert removed == ["team/stale"]
     assert not stale.exists()
     assert current.exists()
     assert foreign.exists()
+
+
+def test_repo_target_subdir_preserves_safe_resource_path():
+    assert repo_target_subdir({"target_subdir": "group/team/repo"}) == (
+        "group/team/repo"
+    )
+
+
+@pytest.mark.parametrize(
+    "target_subdir",
+    ["/absolute/repo", "../escape", "group//repo", "group/./repo"],
+)
+def test_repo_target_subdir_rejects_unsafe_resource_path(target_subdir):
+    with pytest.raises(
+        DataSourceSyncError,
+        match="LENS_SOURCE_CONFIG_INVALID",
+    ):
+        repo_target_subdir({"target_subdir": target_subdir})
+
+
+def test_repository_target_reuses_owned_legacy_encoded_path(tmp_path):
+    legacy = tmp_path / "group%2Frepo"
+    (legacy / ".git").mkdir(parents=True)
+    (legacy / MARKER_FILE).write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {"target_subdir": "group/repo"},
+        "datasource-1",
+        single_repository=False,
+    )
+
+    assert identity == "group/repo"
+    assert target == legacy.resolve()
+
+
+def test_repository_target_reuses_unmarked_matching_legacy_repo(
+    tmp_path,
+    monkeypatch,
+):
+    legacy = tmp_path / "group%2Frepo"
+    (legacy / ".git").mkdir(parents=True)
+    monkeypatch.setattr(
+        "lensnode.datasource_sync._git_output",
+        lambda *args, **kwargs: "https://git.example.com/group/repo.git",
+    )
+
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {
+            "repo_url": "https://git.example.com/group/repo.git",
+            "target_subdir": "group/repo",
+        },
+        "datasource-1",
+        single_repository=False,
+    )
+
+    assert identity == "group/repo"
+    assert target == legacy.resolve()
+
+
+def test_repository_target_does_not_reuse_foreign_marked_repo(
+    tmp_path,
+    monkeypatch,
+):
+    legacy = tmp_path / "group%2Frepo"
+    (legacy / ".git").mkdir(parents=True)
+    (legacy / MARKER_FILE).write_text(
+        json.dumps({"datasource_uuid": "datasource-2"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "lensnode.datasource_sync._git_output",
+        lambda *args, **kwargs: "https://git.example.com/group/repo.git",
+    )
+
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {
+            "repo_url": "https://git.example.com/group/repo.git",
+            "target_subdir": "group/repo",
+        },
+        "datasource-1",
+        single_repository=False,
+    )
+
+    assert identity == "group/repo"
+    assert target == (tmp_path / "group" / "repo").resolve()
+
+
+def test_repository_target_reuses_owned_single_repository_root(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / MARKER_FILE).write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {"target_subdir": "group/repo"},
+        "datasource-1",
+        single_repository=True,
+    )
+
+    assert identity == "group/repo"
+    assert target == tmp_path.resolve()
+
+
+def test_repository_target_reuses_owned_legacy_leaf_path(tmp_path):
+    legacy = tmp_path / "repo"
+    (legacy / ".git").mkdir(parents=True)
+    (legacy / MARKER_FILE).write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {"target_subdir": "group/repo"},
+        "datasource-1",
+        single_repository=True,
+    )
+
+    assert identity == "group/repo"
+    assert target == legacy.resolve()
+
+
+def test_repository_target_uses_canonical_path_for_new_repository(tmp_path):
+    identity, target = _resolve_git_repository_target(
+        tmp_path,
+        {"target_subdir": "group/team/repo"},
+        "datasource-1",
+        single_repository=True,
+    )
+
+    assert identity == "group/team/repo"
+    assert target == (tmp_path / "group" / "team" / "repo").resolve()
+
+
+def test_repository_target_blocks_unrecognized_existing_single_layout(tmp_path):
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"datasource_uuid": "datasource-1", "items": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        DataSourceSyncError,
+        match="LENS_SOURCE_GIT_LAYOUT_MIGRATION_REQUIRED",
+    ):
+        _resolve_git_repository_target(
+            tmp_path,
+            {"target_subdir": "group/repo"},
+            "datasource-1",
+            single_repository=True,
+        )
+
+
+def test_new_git_datasource_syncs_to_canonical_resource_path(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init"], cwd=source, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=source,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=source,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "branch", "-M", "main"],
+        cwd=source,
+        check=True,
+    )
+    (source / "README.md").write_text("hello", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=source, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=source, check=True)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "datasource"
+    result = sync_datasource(
+        {
+            "source_type": "git",
+            "datasource_uuid": "datasource-1",
+            "target_path": str(target),
+            "config": {
+                "repositories": [
+                    {
+                        "repo_url": str(source),
+                        "branch": "main",
+                        "target_subdir": "group/repo",
+                    }
+                ]
+            },
+        },
+        workspace_path=workspace,
+    )
+
+    repository = target / "group" / "repo"
+    manifest = json.loads((target / "manifest.json").read_text())
+    assert result["status"] == "success"
+    assert (repository / ".git").is_dir()
+    assert manifest["items"][0]["local_path"] == "group/repo/README.md"
+    assert manifest["items"][0]["source_id"] == (
+        f"git:{source}:main:README.md"
+    )
 
 
 def test_git_manifest_items_honors_repository_directory(tmp_path, monkeypatch):

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -1516,6 +1516,72 @@ def test_recent_changes_returns_no_match_instead_of_fallback_repo(tmp_path):
     assert str(repo) in data["candidate_repositories"]
 
 
+def test_recent_changes_uses_selected_repository_for_any_query(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+
+    tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {
+                "target_dirs": [{"path": str(repo)}],
+                "settings": {},
+            }
+        )
+    }
+
+    payload = tools["summarize_recent_changes"].invoke(
+        {
+            "query": "unrelated product changes",
+            "max_commits": 20,
+        }
+    )
+    data = json.loads(payload)
+
+    assert data["repositories"][0]["repository"] == str(repo)
+
+
+def test_recent_changes_discovers_namespaced_repository(tmp_path):
+    root = tmp_path / "workspace"
+    repo = root / "HyperBDR" / "docs"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo,
+        check=True,
+    )
+    (repo / "README.md").write_text("hello", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True)
+
+    tools = {
+        tool.name: tool
+        for tool in build_agent_tools(
+            {
+                "target_dirs": [{"path": str(root)}],
+                "settings": {},
+            }
+        )
+    }
+
+    payload = tools["summarize_recent_changes"].invoke(
+        {
+            "query": "docs recent changes",
+            "max_commits": 20,
+        }
+    )
+    data = json.loads(payload)
+
+    assert data["repositories"][0]["repository"] == str(repo)
+
+
 class BlockingExecutor:
     """Executor that blocks until cancelled."""
 

--- a/lensnode/tests/test_plugin_runtime.py
+++ b/lensnode/tests/test_plugin_runtime.py
@@ -474,6 +474,9 @@ def test_gitlab_plugin_sync_builds_git_command_from_snapshot(monkeypatch):
             "resolved_config": {
                 "endpoint": "https://gitlab.internal.example",
                 "target_path": "/workspace/repo",
+                "connection_scope": {
+                    "projects": ["platform/backend/sourcelens"]
+                },
                 "datasource_config": {
                     "project": "platform/backend/sourcelens",
                     "branch": "main",
@@ -508,9 +511,18 @@ def test_gitlab_plugin_sync_builds_git_command_from_snapshot(monkeypatch):
     )
 
     assert result["status"] == "success"
-    assert seen["config"]["repo_url"] == (
-        "https://gitlab.internal.example/platform/backend/sourcelens.git"
-    )
+    assert seen["config"]["repositories"] == [
+        {
+            "repo_url": (
+                "https://gitlab.internal.example/"
+                "platform/backend/sourcelens.git"
+            ),
+            "branch": "main",
+            "directory": "docs",
+            "target_subdir": "platform/backend/sourcelens",
+            "enabled": True,
+        }
+    ]
     assert seen["config"]["access_token"] == "gitlab-secret"
     assert material["value"] == ""
 

--- a/plugins/github/runtime.py
+++ b/plugins/github/runtime.py
@@ -912,19 +912,16 @@ def build_datasource_command(snapshot, material, trigger):
         "access_token": material["value"],
         "allow_submodules": False,
     }
-    if "repositories" in datasource:
-        config["repositories"] = [
-            {
-                "repo_url": f"{endpoint}/{repository}.git",
-                "branch": datasource.get("branch") or "",
-                "directory": datasource.get("directory") or "",
-                "target_subdir": quote(repository, safe=""),
-                "enabled": True,
-            }
-            for repository in repositories
-        ]
-    else:
-        config["repo_url"] = f"{endpoint}/{repositories[0]}.git"
+    config["repositories"] = [
+        {
+            "repo_url": f"{endpoint}/{repository}.git",
+            "branch": datasource.get("branch") or "",
+            "directory": datasource.get("directory") or "",
+            "target_subdir": repository,
+            "enabled": True,
+        }
+        for repository in repositories
+    ]
     return {
         "source_type": "git",
         "datasource_uuid": snapshot.get("datasource_uuid"),

--- a/plugins/gitlab/runtime.py
+++ b/plugins/gitlab/runtime.py
@@ -401,19 +401,16 @@ def build_datasource_command(snapshot, material, trigger):
         "auth_scheme": "token",
         "access_token": material["value"],
     }
-    if "projects" in datasource:
-        config["repositories"] = [
-            {
-                "repo_url": f"{endpoint}/{project}.git",
-                "branch": datasource.get("branch") or "",
-                "directory": datasource.get("directory") or "",
-                "target_subdir": quote(project, safe=""),
-                "enabled": True,
-            }
-            for project in projects
-        ]
-    else:
-        config["repo_url"] = f"{endpoint}/{projects[0]}.git"
+    config["repositories"] = [
+        {
+            "repo_url": f"{endpoint}/{project}.git",
+            "branch": datasource.get("branch") or "",
+            "directory": datasource.get("directory") or "",
+            "target_subdir": project,
+            "enabled": True,
+        }
+        for project in projects
+    ]
     return {
         "source_type": "git",
         "datasource_uuid": snapshot.get("datasource_uuid"),

--- a/release-notes/509.yaml
+++ b/release-notes/509.yaml
@@ -1,0 +1,8 @@
+type: improvement
+audience: admin
+en: >-
+  Improved datasource administration with plugin filtering, safer sync deletion,
+  and consistent Git repository workspace layouts.
+zh-CN: >-
+  优化数据源管理：支持按插件筛选，更安全地删除同步中的数据源，并统一 Git
+  仓库工作区布局。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Filter datasource lists by installed datasource-capable plugin type.
- Prevent datasource deletion from racing with queued or active synchronization and clean dependent Plugin audit records in dependency-safe order.
- Standardize Git datasource workspace roots and repository identities while retaining compatible legacy layouts until explicit production migration.

Closes #509

## Test plan
- [x] Frontend datasource and Plugin integration tests (40 passed)
- [x] Frontend lint
- [x] Frontend production build
- [x] LensNode targeted regression tests (153 passed)
- [ ] Resolve the existing LensNode exclusive-queue expectation failure
- [ ] Complete Django datasource API and service regression suite


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Filter datasources by plugin type

- Guard deletion during active sync, cleanup audits

- Standardize Git workspace layout with legacy support

- Revise sync cancellation for safer stop confirmation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Views"] --> B["Services / Tasks<br/>(atomic sync, cancellation)"]
  B --> C["LensNode Sync<br/>(canonical paths, nested repos)"]
  C --> D["Git Workspace<br/>(canonical layout, legacy compat)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Include CANCELLING status in sync check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>tasks.py</strong><dd><code>Add atomic transactions and cancel race handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+102/-70</a></td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Add plugin filter, safe destroy, revised cancel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+132/-37</a></td>

</tr>

<tr>
  <td><strong>agent_tools.py</strong><dd><code>Recursive Git discovery and relative path resolve</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-d7bdaa202ba0dcb44b0272760aaeed1bf42ed241b10914949454e94b0713a095">+42/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Canonical repo layout with legacy compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+187/-39</a></td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Always emit repositories collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-b080c820b95f34be4c9baaf2c5232a287db0bed19656bbefbb4ad295084a6767">+10/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Always emit repositories collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-53be8db070e937ced7fd3ec7acaa16c409ae2cce2f0efb579f9baff68a760ad4">+10/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DataSources.vue</strong><dd><code>Add plugin type filter dropdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-1a2dc840b5da820c7b8a16cb18fa4a424860f010974ced2df56948e3cde5c30a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for plugin filter, delete guard, cancel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+146/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_services.py</strong><dd><code>Test rollback and cancel-after-dispatch races</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_github_tools.py</strong><dd><code>Test single-repo collection and slash path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-1fff06e10039a30e673edc3717ac3f48bb686ac226ac3fdda6ab245b70481f5c">+39/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gitlab_tools.py</strong><dd><code>Test single-project collection and slash path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-964616fafb244f39b49d34ae9470d75d338ed89b1629fdda00bbc74696b64685">+36/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_datasource_sync.py</strong><dd><code>Test repo target resolution and canonical sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+222/-6</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Test recent changes with selected/namespaced repo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_plugin_runtime.py</strong><dd><code>Update snapshot test to use repositories list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-0f170425f7e5bf57146cd53e3454b526f8f7c964bf55d9350c2e1811fadfd34f">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>multi-resource-datasources.md</strong><dd><code>Document canonical layout and migration guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-30fbaf523fddde993854a3b02923965f0a5067b2c6a07441efd4338ab60b5b9b">+50/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>509.yaml</strong><dd><code>Add release note for datasource improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-e5b4122b8e22d6527ab7b38a393282f5d9142bbbabcb4f27b46247609ef6168f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add plugin type translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Add plugin type translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-fc5efacc2d4df9cfc4192f70e7478c9ac6da757a78b4543d46b34dd0638149d2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add plugin type translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/510/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

