### PR TITLE
Delegate datasource sync to plugin handlers

### DIFF
--- a/docs/design-plugin-integrations.md
+++ b/docs/design-plugin-integrations.md
@@ -746,12 +746,15 @@ PLUGIN_VERSION = "1.0.0"
 http_origins(endpoint)
 build_tool(definition, executor)
 execute_tool(tool_key, client, arguments, secret, endpoint, config)
-# Optional; required only when the Manifest declares Datasource support.
+# Required as a pair when the Manifest declares Datasource support.
 build_datasource_command(snapshot, material, trigger)
+sync_datasource(command, workspace_path, emit, execute)
 ```
 
 LensNode 保留通用的快照、lease、材料读取、审计和 finally 清理职责；Provider API
-调用、endpoint 策略、工具签名、结果上限及同步命令规范化均由 Plugin runtime 承担。
+调用、endpoint 策略、工具签名、结果上限、同步命令规范化与同步编排均由 Plugin
+runtime 承担。Plugin handler 可调用 LensNode 提供的受限共享执行器，但执行器不得
+根据 provider key 推断供应商规则。
 新 Plugin 或新版本因此不需要向 SourceLens/LensNode 增加供应商 key 分支。V1 仍是
 企业管理员安装的受信任 Python 代码；进程隔离、制品签名和外部第三方 Plugin 运行权
 限是后续安全发布工作。

--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -142,7 +142,7 @@ Plugin 专属的 `plugin_help` Tool；详细说明统一通过虚拟 Skill 文�
 HTTPS origin。宿主据此注入受限客户端；Provider 不得自行创建或关闭客户端。
 
 `runtime.py` 必须导出 Tool 相关固定符号；只有 Manifest 声明 DataSource 能力时，
-才必须额外导出 `build_datasource_command`：
+才必须成对导出 `build_datasource_command` 和 `sync_datasource`：
 
 ```python
 PLUGIN_API_VERSION = 1
@@ -159,9 +159,16 @@ def execute_tool(key, client, arguments, secret, endpoint, config):
     """Execute one bounded operation and return JSON-safe data."""
 
 # Required only for Plugins with a declared Datasource capability.
-def build_datasource_command(config, output_dir, options):
+def build_datasource_command(snapshot, material, trigger):
     """Build one controlled Datasource synchronization command."""
+
+def sync_datasource(command, workspace_path, emit, execute):
+    """Apply Plugin sync policy, then call the shared executor."""
 ```
+
+LensNode 负责快照、lease、材料读取、取消、进度上报和结果生命周期；Plugin handler
+负责 provider 专属的同步策略与执行编排。共享 `execute` 仅执行 Plugin 已准备好的
+通用命令，不得根据 provider key 推断地址、认证或资源规则。
 
 宿主会校验入口文件是受控目录中的普通文件，且入口身份与 Manifest 的
 `key + version` 一致，并按 `plugin_key + plugin_version + 内容哈希` 缓存加载

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -1576,7 +1576,11 @@ def _sync_git(command, workspace_path, emit):
         )
 
     if config.get("allow_submodules", True):
-        _sync_git_submodules(target, git_options=git_options)
+        _sync_git_submodules(
+            target,
+            config=config,
+            git_options=git_options,
+        )
 
     _validate_git_tree_size(target)
 
@@ -2041,19 +2045,22 @@ def _repository_summary(name, repository, status, result):
     }
 
 
-def _sync_git_submodules(target, git_options=None):
-    """Synchronize Git submodules when the repository declares them."""
+def _sync_git_submodules(target, config=None, git_options=None):
+    """Synchronize Git submodules using a Plugin-provided URL rewrite plan."""
 
     if not (target / ".gitmodules").exists():
         return
+    rewrites = _resolve_submodule_url_rewrites(target, config)
+    git_args = _submodule_git_config_args(rewrites)
     _run_git(
-        ["submodule", "sync", "--recursive"],
+        [*git_args, "submodule", "sync", "--recursive"],
         cwd=target,
         detail_prefix="LENS_SOURCE_GIT_SUBMODULE_SYNC_FAILED",
         **(git_options or {}),
     )
     _run_git(
         [
+            *git_args,
             "submodule",
             "update",
             "--init",
@@ -2065,6 +2072,61 @@ def _sync_git_submodules(target, git_options=None):
         detail_prefix="LENS_SOURCE_GIT_SUBMODULE_UPDATE_FAILED",
         **(git_options or {}),
     )
+
+
+def _resolve_submodule_url_rewrites(target, config):
+    """Resolve a bounded, Plugin-owned list of Git URL rewrites."""
+
+    resolver = (config or {}).get("submodule_url_resolver")
+    if resolver is None:
+        return []
+    if not callable(resolver):
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+    try:
+        rewrites = resolver(target, config)
+    except Exception as exc:
+        raise DataSourceSyncError(
+            "LENS_SOURCE_GIT_SUBMODULE_PLAN_FAILED"
+        ) from exc
+    if not isinstance(rewrites, list) or len(rewrites) > 20:
+        raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+    return rewrites
+
+
+def _submodule_git_config_args(rewrites):
+    """Serialize validated Plugin URL rewrites as process-local Git config."""
+
+    args = []
+    seen = set()
+    for rewrite in rewrites:
+        if not isinstance(rewrite, dict):
+            raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+        source = rewrite.get("from")
+        destination = rewrite.get("to")
+        parsed = parse.urlsplit(str(destination or ""))
+        if (
+            not isinstance(source, str)
+            or not source
+            or len(source) > 512
+            or parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise DataSourceSyncError("LENS_SOURCE_CONFIG_INVALID")
+        identity = (source, destination)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        args.extend(
+            [
+                "-c",
+                f'url.{json.dumps(destination)}.insteadOf={source}',
+            ]
+        )
+    return args
 
 
 def _git_manifest_items(target, repo_url, branch, directory=""):

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -1106,7 +1106,10 @@ class LensNodeClient:
             plugin_key = str(snapshot.get("plugin_key") or "")
             plugin_version = str(snapshot.get("plugin_version") or "")
             runtime = load_runtime_contract(plugin_key, plugin_version)
-            if not callable(runtime.build_datasource_command):
+            if (
+                not callable(runtime.build_datasource_command)
+                or not callable(runtime.sync_datasource)
+            ):
                 return {
                     "status": "failed",
                     "error": "PLUGIN_DATASOURCE_UNSUPPORTED",
@@ -1157,10 +1160,11 @@ class LensNodeClient:
                 )
             if message.get("cancel_event") is not None:
                 command["cancel_event"] = message["cancel_event"]
-            return sync_datasource(
+            return runtime.sync_datasource(
                 command,
                 self.config.workspace_path,
                 emit,
+                sync_datasource,
             )
         except PluginRuntimeError as exc:
             return {"status": "failed", "error": str(exc)}

--- a/lensnode/lensnode/plugin_package_loader.py
+++ b/lensnode/lensnode/plugin_package_loader.py
@@ -28,6 +28,7 @@ class PluginRuntimeContract:
     build_tool: object
     execute_tool: object
     build_datasource_command: object
+    sync_datasource: object
 
 
 def load_runtime_contract(plugin_key, plugin_version, roots=None):
@@ -113,12 +114,17 @@ def _runtime_contract(path, plugin_key, plugin_version):
         "build_datasource_command",
         None,
     )
+    sync_datasource = getattr(module, "sync_datasource", None)
     if not callable(build_tool) or not callable(execute_tool):
         raise PluginPackageLoadError("plugin runtime contract is invalid")
     if build_datasource_command is not None and not callable(
         build_datasource_command
     ):
         raise PluginPackageLoadError("plugin runtime contract is invalid")
+    if sync_datasource is not None and not callable(sync_datasource):
+        raise PluginPackageLoadError("plugin runtime contract is invalid")
+    if (build_datasource_command is None) != (sync_datasource is None):
+        raise PluginPackageLoadError("plugin datasource contract is invalid")
     http_origins = getattr(module, "http_origins", None)
     if http_origins is not None and not callable(http_origins):
         raise PluginPackageLoadError("plugin runtime contract is invalid")
@@ -129,6 +135,7 @@ def _runtime_contract(path, plugin_key, plugin_version):
         build_tool=build_tool,
         execute_tool=execute_tool,
         build_datasource_command=build_datasource_command,
+        sync_datasource=sync_datasource,
     )
 
 

--- a/lensnode/tests/plugins/test_gitlab_tools.py
+++ b/lensnode/tests/plugins/test_gitlab_tools.py
@@ -43,6 +43,62 @@ def test_builds_multi_project_datasource_command():
     assert [
         item["target_subdir"] for item in command["config"]["repositories"]
     ] == ["platform/a", "platform/b"]
+    assert command["config"]["allow_submodules"] is True
+    assert callable(GITLAB_RUNTIME.sync_datasource)
+
+
+def test_gitlab_datasource_handler_owns_submodule_sync():
+    """GitLab injects its submodule behavior before executing Git sync."""
+
+    command = {"config": {"gitlab_endpoint": "http://gitlab.example"}}
+    seen = {}
+
+    def execute(value, workspace_path, emit):
+        seen.update(value)
+        assert workspace_path == "/workspace"
+        assert emit is None
+        return {"status": "success"}
+
+    result = GITLAB_RUNTIME.sync_datasource(
+        command,
+        "/workspace",
+        None,
+        execute,
+    )
+
+    assert result == {"status": "success"}
+    assert callable(seen["config"]["submodule_url_resolver"])
+
+
+def test_gitlab_submodule_resolver_rewrites_ssh_origins(tmp_path):
+    """GitLab owns SSH-to-HTTP submodule origin translation."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".gitmodules").write_text(
+        "[submodule \"api\"]\n"
+        "\tpath = api\n"
+        "\turl = ssh://git@office.internal:20022/team/api.git\n"
+        "[submodule \"web\"]\n"
+        "\tpath = web\n"
+        "\turl = git@office.internal:team/web.git\n",
+        encoding="utf-8",
+    )
+
+    resolver = GITLAB_RUNTIME.build_datasource_command.__globals__[
+        "_gitlab_submodule_url_rewrites"
+    ]
+
+    assert resolver(repo, {"gitlab_endpoint": "http://gitlab.example"}) == [
+        {
+            "from": "ssh://git@office.internal:20022/",
+            "to": "http://gitlab.example/",
+        },
+        {
+            "from": "git@office.internal:",
+            "to": "http://gitlab.example/",
+        },
+    ]
 
 
 def test_builds_single_project_as_repository_collection():

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -828,6 +828,36 @@ def test_sync_git_submodules_runs_when_declared(tmp_path, monkeypatch):
     assert calls[1][2] == "LENS_SOURCE_GIT_SUBMODULE_UPDATE_FAILED"
 
 
+def test_sync_git_submodules_uses_plugin_url_rewrites(tmp_path, monkeypatch):
+    """The generic executor applies a Plugin-provided URL rewrite plan."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".gitmodules").write_text("", encoding="utf-8")
+    calls = []
+
+    def run_git(args, cwd=None, timeout=600, detail_prefix=""):
+        del timeout
+        calls.append((args, cwd, detail_prefix))
+        return None
+
+    monkeypatch.setattr("lensnode.datasource_sync._run_git", run_git)
+
+    _sync_git_submodules(
+        repo,
+        config={
+            "submodule_url_resolver": lambda _target, _config: [
+                {"from": "git@example:", "to": "https://example/"},
+            ],
+        },
+    )
+
+    assert calls[0][0][:2] == [
+        "-c",
+        'url."https://example/".insteadOf=git@example:',
+    ]
+
+
 def test_feishu_folder_token_from_drive_url():
     """Feishu folder URLs can be normalized to folder tokens."""
 

--- a/lensnode/tests/test_plugin_package_loader.py
+++ b/lensnode/tests/test_plugin_package_loader.py
@@ -22,6 +22,9 @@ def execute_tool(tool_key, client, arguments, secret, endpoint, config):
 
 def build_datasource_command(snapshot, material, trigger):
     return {"source_type": "git"}
+
+def sync_datasource(command, workspace_path, emit, execute):
+    return execute(command, workspace_path, emit)
 '''
 
 
@@ -46,6 +49,7 @@ def test_loads_runtime_contract_from_configured_root(tmp_path):
     assert callable(contract.build_tool)
     assert callable(contract.execute_tool)
     assert callable(contract.build_datasource_command)
+    assert callable(contract.sync_datasource)
     assert contract.http_origins("https://example.com") == (
         "https://example.com",
     )
@@ -55,6 +59,10 @@ def test_loads_tool_only_runtime_without_datasource_command(tmp_path):
     source = RUNTIME_SOURCE.replace(
         '\ndef build_datasource_command(snapshot, material, trigger):\n'
         '    return {"source_type": "git"}\n',
+        "",
+    ).replace(
+        '\ndef sync_datasource(command, workspace_path, emit, execute):\n'
+        '    return execute(command, workspace_path, emit)\n',
         "",
     )
     _package(tmp_path, source)
@@ -66,6 +74,7 @@ def test_loads_tool_only_runtime_without_datasource_command(tmp_path):
     )
 
     assert contract.build_datasource_command is None
+    assert contract.sync_datasource is None
 
 
 def test_rejects_runtime_identity_mismatch(tmp_path):

--- a/plugins/feishu/runtime.py
+++ b/plugins/feishu/runtime.py
@@ -82,6 +82,12 @@ def build_datasource_command(snapshot, material, trigger):
     }
 
 
+def sync_datasource(command, workspace_path, emit, execute):
+    """Execute the Feishu datasource policy through the shared executor."""
+
+    return execute(command, workspace_path, emit)
+
+
 def _endpoint(value):
     """Require the fixed Feishu API origin from the snapshot."""
 

--- a/plugins/github/runtime.py
+++ b/plugins/github/runtime.py
@@ -932,6 +932,12 @@ def build_datasource_command(snapshot, material, trigger):
     }
 
 
+def sync_datasource(command, workspace_path, emit, execute):
+    """Execute the GitHub datasource policy through the shared executor."""
+
+    return execute(command, workspace_path, emit)
+
+
 def _validate_definition(value):
     if (
         not isinstance(value, dict)

--- a/plugins/gitlab/runtime.py
+++ b/plugins/gitlab/runtime.py
@@ -1,8 +1,11 @@
 """GitLab LensNode runtime entrypoint."""
 
+import configparser
 import json
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Annotated
 from urllib.parse import quote, urlsplit, urlunsplit
 
@@ -23,6 +26,7 @@ ACTIVITY_RESOURCE_MAX = {
     "merge_requests": 20,
     "issues": 20,
 }
+GITLAB_MAX_SUBMODULE_CONFIG_BYTES = 64 * 1024
 
 
 def http_origins(endpoint):
@@ -400,6 +404,8 @@ def build_datasource_command(snapshot, material, trigger):
         "directory": datasource.get("directory") or "",
         "auth_scheme": "token",
         "access_token": material["value"],
+        "allow_submodules": True,
+        "gitlab_endpoint": endpoint,
     }
     config["repositories"] = [
         {
@@ -419,6 +425,75 @@ def build_datasource_command(snapshot, material, trigger):
         "trigger": trigger,
         "config": config,
     }
+
+
+def sync_datasource(command, workspace_path, emit, execute):
+    """Execute GitLab synchronization with GitLab-owned submodule policy."""
+
+    config = dict((command or {}).get("config") or {})
+    config["submodule_url_resolver"] = _gitlab_submodule_url_rewrites
+    return execute(
+        {**command, "config": config},
+        workspace_path,
+        emit,
+    )
+
+
+def _gitlab_submodule_url_rewrites(target, config):
+    """Return GitLab-owned SSH-to-HTTP submodule origin rewrites."""
+
+    endpoint = _endpoint((config or {}).get("gitlab_endpoint"))
+    modules_path = Path(target) / ".gitmodules"
+    if not modules_path.is_file():
+        return []
+    if modules_path.stat().st_size > GITLAB_MAX_SUBMODULE_CONFIG_BYTES:
+        raise PluginRuntimeError("GITLAB_SUBMODULE_CONFIG_TOO_LARGE")
+    parser = configparser.RawConfigParser(interpolation=None)
+    try:
+        parser.read(modules_path, encoding="utf-8")
+    except (configparser.Error, OSError, UnicodeDecodeError) as exc:
+        raise PluginRuntimeError("GITLAB_SUBMODULE_CONFIG_INVALID") from exc
+    rewrites = []
+    seen = set()
+    for section in parser.sections():
+        if not section.startswith("submodule ") or not parser.has_option(
+            section,
+            "url",
+        ):
+            continue
+        rewrite = _gitlab_submodule_url_rewrite(
+            parser.get(section, "url"),
+            endpoint,
+        )
+        if rewrite is None:
+            continue
+        identity = (rewrite["from"], rewrite["to"])
+        if identity not in seen:
+            seen.add(identity)
+            rewrites.append(rewrite)
+    return rewrites
+
+
+def _gitlab_submodule_url_rewrite(url, endpoint):
+    """Map one GitLab SSH URL origin to the approved HTTP endpoint."""
+
+    value = str(url or "").strip()
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme == "ssh"
+        and parsed.username == "git"
+        and parsed.hostname
+        and parsed.path.startswith("/")
+        and not parsed.query
+        and not parsed.fragment
+    ):
+        source = urlunsplit(("ssh", parsed.netloc, "/", "", ""))
+    else:
+        match = re.fullmatch(r"git@([^/:]+):.+", value)
+        if match is None:
+            return None
+        source = f"git@{match.group(1)}:"
+    return {"from": source, "to": f"{endpoint}/"}
 
 
 def _endpoint(value):


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Require datasource Plugins to provide paired command-building and sync handlers
- Delegate GitLab submodule URL policy to the GitLab Plugin
- Document the handler contract and cover it with focused tests

Closes #511

## Test plan

- [x] 116 focused LensNode and Plugin tests pass
- [x] review-it against origin/main...HEAD returned no actionable findings


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Delegate GitLab submodule URL policy to the GitLab plugin

- Require paired datasource handlers (build_datasource_command + sync_datasource)

- Add plugin-injectable submodule URL rewrites in generic sync executor

- Update documentation and test coverage for the new contract


___

### Diagram Walkthrough


```mermaid
flowchart TD
  LensNode["LensNode"] --> SyncCmd["sync_datasource(command, workspace, emit, execute)"]
  SyncCmd --> Plugin["Plugin.sync_datasource"]
  Plugin --> Resolve["inject submodule_url_resolver"]
  Resolve --> Exec["shared execute"]
  Exec --> GitSync["_sync_git_submodules"]
  GitSync --> Rewrite["_resolve_submodule_url_rewrites"]
  Rewrite --> GitArgs["_submodule_git_config_args"]
  GitArgs --> GitCmd["git submodule sync / update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Accept plugin URL rewrites in submodule sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+66/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Validate sync_datasource callable in plugin runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin_package_loader.py</strong><dd><code>Add sync_datasource to runtime contract with pair validation</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-6e021193a704cb994e55905e0f5c862530154327c22763e4bf8b2bd27fbeed0d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Add sync_datasource handler for Feishu plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-807236df47b96730beab1aa1d6773d69335ea1d8996150bbd3ca2a085e61144a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Add sync_datasource handler for GitHub plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-b080c820b95f34be4c9baaf2c5232a287db0bed19656bbefbb4ad295084a6767">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Add sync_datasource with SSH-to-HTTP submodule rewrites</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-53be8db070e937ced7fd3ec7acaa16c409ae2cce2f0efb579f9baff68a760ad4">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_gitlab_tools.py</strong><dd><code>Test GitLab submodule URL rewrites and sync handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-964616fafb244f39b49d34ae9470d75d338ed89b1629fdda00bbc74696b64685">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_datasource_sync.py</strong><dd><code>Test generic executor applies plugin URL rewrites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_plugin_package_loader.py</strong><dd><code>Test sync_datasource contract loading and pair validation</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-72f7dee20890be2446d38dd97c847948d0b11097191d333d65d715018ee29f7e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>design-plugin-integrations.md</strong><dd><code>Update design docs for paired datasource handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-363c281c5d8cc6c206ced943a2d95bb33f6289ef3afeec66cf914dd653162b6c">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin-protocol.md</strong><dd><code>Update protocol docs for sync_datasource contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/512/files#diff-19360a806393bf32adb3da6e6f0b02ebe9d355c9a4c6fffce2924eef597b31b0">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

