### PR TITLE
Resume datasource conversions after LensNode reconnect

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -207,17 +207,17 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
     def _schedule_disconnect_grace_check(self, lensnode_uuid, disconnected_at):
         """Schedule the deferred grace check (delegates to the service)."""
 
-        schedule_lensnode_disconnect_grace_check(
-            lensnode_uuid, disconnected_at
-        )
+        schedule_lensnode_disconnect_grace_check(lensnode_uuid, disconnected_at)
 
     async def _handle_hello(self, content):
         active_runs = content.get("active_runs") or []
+        active_datasource_operations = content.get("active_datasource_operations")
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self._update_lensnode_report(content, require_versions=True)
         await database_sync_to_async(reconcile_orphaned_datasource_conversions)(
             self.lensnode.uuid,
             self.channel_name,
+            active_datasource_operations,
         )
         await database_sync_to_async(reconcile_lensnode_active_runs)(
             self.lensnode.uuid, active_runs
@@ -419,9 +419,9 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             citations=content.get("citations"),
             planned_evidence=content.get("planned_evidence"),
         )
-        parent_update = await database_sync_to_async(
-            self._delegation_done_payload
-        )(run.pk)
+        parent_update = await database_sync_to_async(self._delegation_done_payload)(
+            run.pk
+        )
         if parent_update is not None:
             await self.channel_layer.group_send(
                 lensnode_group_name(parent_update.pop("lensnode_uuid")),
@@ -467,9 +467,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             "outcome": run.outcome,
             "assistant_name": run.session.assistant.name,
             "answer": (
-                str(run.output_message.content or "")
-                if run.output_message_id
-                else ""
+                str(run.output_message.content or "") if run.output_message_id else ""
             ),
             "error": str(run.error or "")[:500],
             "lensnode_uuid": str(run.parent_run.lensnode.uuid),
@@ -489,13 +487,12 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         request_id = content.get("request_id") or ""
         dirs = content.get("dirs") or {}
         if request_id:
-            await database_sync_to_async(self._cache_list_dirs_result)(
-                request_id, dirs
-            )
+            await database_sync_to_async(self._cache_list_dirs_result)(request_id, dirs)
 
     @staticmethod
     def _cache_list_dirs_result(request_id, dirs):
         from django.core.cache import cache
+
         cache.set(f"lens:list_dirs:{request_id}", dirs, timeout=30)
 
     async def _handle_datasource_path_result(self, content):
@@ -511,6 +508,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
     @staticmethod
     def _cache_datasource_path_result(request_id, result):
         from django.core.cache import cache
+
         cache.set(f"lens:datasource_path:{request_id}", result, timeout=30)
 
     async def _handle_datasource_connection_result(self, content):
@@ -518,9 +516,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
 
         request_id = content.get("request_id") or ""
         if request_id:
-            await database_sync_to_async(
-                self._cache_datasource_connection_result
-            )(
+            await database_sync_to_async(self._cache_datasource_connection_result)(
                 request_id,
                 content.get("result") or {},
             )
@@ -528,6 +524,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
     @staticmethod
     def _cache_datasource_connection_result(request_id, result):
         from django.core.cache import cache
+
         cache.set(
             f"lens:datasource_connection:{request_id}",
             result,
@@ -543,10 +540,15 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         await database_sync_to_async(self._record_datasource_sync_event)(
             task_id,
             content,
+            self.channel_name,
         )
 
     @staticmethod
-    def _record_datasource_sync_event(task_id, content):
+    def _record_datasource_sync_event(
+        task_id,
+        content,
+        connection_id=None,
+    ):
         from agentcore_task.adapters.django import TaskTracker
         from agentcore_task.adapters.django.models import TaskExecution
         from agentcore_task.constants import TaskStatus
@@ -555,6 +557,14 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         if task and task.status in TaskStatus.get_completed_statuses():
             return
         metadata = dict(task.metadata or {}) if task else {}
+        owner_connection_id = metadata.get("lensnode_connection_id") or ""
+        if (
+            task
+            and connection_id
+            and owner_connection_id
+            and owner_connection_id != connection_id
+        ):
+            return
         progress_task_status = TaskStatus.STARTED
         queue_metadata = {}
         if task and content.get("step") == "queue":
@@ -575,9 +585,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             "name": content.get("step") or "sync",
             "status": content.get("status") or "running",
             "message": content.get("message") or "",
-            "timestamp": (
-                content.get("timestamp") or timezone.now().isoformat()
-            ),
+            "timestamp": (content.get("timestamp") or timezone.now().isoformat()),
         }
         for key in [
             "category",
@@ -598,11 +606,11 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             "phase_progress",
             "progress_counts",
             "substantive_progress",
-                    "conversion_summary",
-                    "repository_summaries",
-                    "failed_repositories",
-                    "partial_success",
-                    "current_file",
+            "conversion_summary",
+            "repository_summaries",
+            "failed_repositories",
+            "partial_success",
+            "current_file",
             "current_status",
             "current_reason",
             "current_stats",
@@ -656,9 +664,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             if summary:
                 metadata_update["sync_summary"] = summary
         if "conversion_summary" in content:
-            metadata_update["conversion_summary"] = content.get(
-                "conversion_summary"
-            )
+            metadata_update["conversion_summary"] = content.get("conversion_summary")
         for key in ["progress_total", "progress_current", "progress_percent"]:
             if key in content:
                 metadata_update[key] = content.get(key)
@@ -670,8 +676,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         if (
             queue_metadata
             and updated_task is not None
-            and updated_task.metadata.get("type")
-            == "datasource_conversion"
+            and updated_task.metadata.get("type") == "datasource_conversion"
         ):
             datasource_uuid = updated_task.metadata.get("datasource_uuid")
             if datasource_uuid:
@@ -786,9 +791,7 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             "status": status,
             "path": path,
             "name": path.rsplit("/", 1)[-1],
-            "extension": path.rsplit(".", 1)[-1].lower()
-            if "." in path
-            else "",
+            "extension": path.rsplit(".", 1)[-1].lower() if "." in path else "",
             "reason": content.get("current_reason") or "",
             "stats": content.get("current_stats") or {},
         }
@@ -887,19 +890,10 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
                     "documents": content.get("documents") or 0,
                     "by_extension": content.get("by_extension") or {},
                     "by_type": content.get("by_type") or {},
-                    "conversion_summary": content.get(
-                        "conversion_summary"
-                    )
-                    or {},
+                    "conversion_summary": content.get("conversion_summary") or {},
                     "warnings": content.get("warnings") or [],
-                    "repository_summaries": content.get(
-                        "repository_summaries"
-                    )
-                    or [],
-                    "failed_repositories": content.get(
-                        "failed_repositories"
-                    )
-                    or [],
+                    "repository_summaries": content.get("repository_summaries") or [],
+                    "failed_repositories": content.get("failed_repositories") or [],
                     "partial_success": bool(content.get("partial_success")),
                     "target_path": content.get("target_path") or "",
                     "error": content.get("error") or "",
@@ -917,9 +911,15 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         task_id = content.get("task_id") or ""
         if not request_id and not task_id:
             return
-        await database_sync_to_async(
-            self._complete_datasource_conversion_done
-        )(request_id, content, self.channel_name)
+        await database_sync_to_async(self._complete_datasource_conversion_done)(
+            request_id, content, self.channel_name
+        )
+        await self.send_json(
+            {
+                "type": "datasource_terminal_ack",
+                "task_id": task_id,
+            }
+        )
 
     async def _handle_datasource_upload_done(self, content):
         """Complete a Managed Workspace upload from LensNode."""
@@ -932,6 +932,12 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             request_id,
             content,
             self.channel_name,
+        )
+        await self.send_json(
+            {
+                "type": "datasource_terminal_ack",
+                "task_id": task_id,
+            }
         )
 
     @staticmethod

--- a/backend/lens/tasks.py
+++ b/backend/lens/tasks.py
@@ -430,9 +430,7 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
     # final status.
     task_id = task_id or uuid.uuid4().hex
     with transaction.atomic():
-        datasource = DataSource.objects.select_for_update().get(
-            uuid=datasource_uuid
-        )
+        datasource = DataSource.objects.select_for_update().get(uuid=datasource_uuid)
         if datasource.source_type == DataSource.SourceType.MANAGED_WORKSPACE:
             return 0
         record = _get_or_create_source_sync_record(datasource)
@@ -512,9 +510,7 @@ def source_sync_task(self, datasource_uuid, trigger="scheduled", task_id=None):
             task_execution = TaskExecution.objects.select_for_update().get(
                 task_id=task_id
             )
-            cancelling = (
-                task_execution.status == DATASOURCE_CANCELLING_STATUS
-            )
+            cancelling = task_execution.status == DATASOURCE_CANCELLING_STATUS
             TaskTracker.update_task_status(
                 task_id,
                 task_execution.status if cancelling else TaskStatus.PENDING,
@@ -957,9 +953,7 @@ def complete_datasource_sync_task(task_id, result):
     success = status_value == "success"
     cancelled = status_value == "cancelled"
     error = result.get("error") or (
-        "DATASOURCE_SYNC_CANCELLED"
-        if cancelled
-        else "LENS_SOURCE_SYNC_FAILED"
+        "DATASOURCE_SYNC_CANCELLED" if cancelled else "LENS_SOURCE_SYNC_FAILED"
     )
     changed = result.get("changed")
     if changed is None:
@@ -1037,9 +1031,7 @@ def complete_datasource_sync_task(task_id, result):
 
     if record is not None:
         record.last_status = (
-            ScheduledTask.Status.SUCCESS
-            if success
-            else ScheduledTask.Status.FAILED
+            ScheduledTask.Status.SUCCESS if success else ScheduledTask.Status.FAILED
         )
         record.last_error = "" if success or cancelled else error
         record.last_run_at = timezone.now()
@@ -1092,12 +1084,9 @@ def complete_datasource_sync_task(task_id, result):
                     "failed",
                     error,
                 ),
-                "completion_reason": str(
-                    result.get("completion_reason") or error
-                ),
+                "completion_reason": str(result.get("completion_reason") or error),
                 "stop_confirmation_source": str(
-                    result.get("stop_confirmation_source")
-                    or "lensnode_callback"
+                    result.get("stop_confirmation_source") or "lensnode_callback"
                 ),
             },
         )
@@ -1181,15 +1170,23 @@ def release_datasource_lock(datasource_uuid, token=None):
     return False
 
 
-def reconcile_orphaned_datasource_conversions(lensnode_uuid, connection_id):
-    """Fail conversions owned by a dead LensNode connection generation."""
+def reconcile_orphaned_datasource_conversions(
+    lensnode_uuid,
+    connection_id,
+    active_operations,
+):
+    """Rebind datasource work after a LensNode reconnect.
+
+    A missing active_operations report identifies a pre-protocol LensNode.
+    Preserve its reconnect behavior by rebinding its active work; an empty
+    report from a capable LensNode means the work is unreported instead.
+    """
 
     from agentcore_task.adapters.django.models import TaskExecution
     from agentcore_task.constants import TaskStatus
 
-    now = timezone.now()
     active_statuses = _datasource_active_statuses(TaskStatus)
-    orphaned = TaskExecution.objects.filter(
+    tasks = TaskExecution.objects.filter(
         module__in=[
             "lens_datasource_conversion",
             "lens_datasource_upload",
@@ -1199,50 +1196,130 @@ def reconcile_orphaned_datasource_conversions(lensnode_uuid, connection_id):
     ).exclude(
         metadata__lensnode_connection_id=str(connection_id),
     )
-    count = 0
-    for task in orphaned:
+    legacy_node = active_operations is None
+    operations = {
+        str(item.get("task_id")): item
+        for item in (active_operations or [])
+        if isinstance(item, dict) and item.get("task_id")
+    }
+    rebound_count = 0
+    for task in tasks:
         metadata = dict(task.metadata or {})
-        is_upload = task.module == "lens_datasource_upload"
-        datasource_uuid = metadata.get("datasource_uuid")
-        datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
-        if datasource is not None:
-            datasource.last_conversion_status = TaskStatus.FAILURE
-            datasource.last_conversion_at = now
-            datasource.save(
-                update_fields=[
-                    "last_conversion_status",
-                    "last_conversion_at",
-                    "updated_at",
-                ]
+        operation = operations.get(task.task_id)
+        expected_operation = (
+            "upload" if task.module == "lens_datasource_upload" else "conversion"
+        )
+        if legacy_node or (
+            operation
+            and str(operation.get("datasource_uuid"))
+            == str(metadata.get("datasource_uuid"))
+            and operation.get("operation") == expected_operation
+        ):
+            metadata["lensnode_connection_id"] = str(connection_id)
+            metadata["reconnected_at"] = timezone.now().isoformat()
+            if operation:
+                metadata["last_lensnode_operation"] = operation
+            metadata.pop("datasource_orphan_confirmation_connection_id", None)
+            task.metadata = metadata
+            task.save(update_fields=["metadata"])
+            rebound_count += 1
+            continue
+        if metadata.get("lensnode_connection_id") != str(connection_id):
+            # The operation may have completed while the socket was down. Its
+            # buffered terminal frame is sent after hello, so let the new
+            # connection deliver it during the confirmation window.
+            metadata["lensnode_connection_id"] = str(connection_id)
+            metadata["datasource_orphan_confirmation_connection_id"] = str(
+                connection_id
             )
-        release_datasource_lock(
-            datasource_uuid,
-            token=metadata.get("lock_token") or task.task_id,
+            task.metadata = metadata
+            task.save(update_fields=["metadata"])
+            _schedule_datasource_orphan_confirmation(
+                task.task_id,
+                connection_id,
+            )
+    return rebound_count
+
+
+def _schedule_datasource_orphan_confirmation(task_id, connection_id):
+    """Delay failure while LensNode delivers any buffered terminal frame."""
+
+    from .services import get_reconcile_confirm_grace_seconds
+
+    try:
+        confirm_orphaned_datasource_conversion.apply_async(
+            args=[task_id, str(connection_id)],
+            countdown=get_reconcile_confirm_grace_seconds(),
         )
-        metadata.update(
-            {
-                "recovery_reason": "LENSNODE_CONNECTION_GENERATION_EXPIRED",
-                "recovery_retryable": True,
-                "reconciled_at": now.isoformat(),
-                "completion_reason": (
-                    "DATASOURCE_UPLOAD_ORPHANED"
-                    if is_upload
-                    else "DATASOURCE_CONVERSION_ORPHANED"
-                ),
-                "stop_confirmation_source": "connection_generation_expired",
-            }
+    except Exception:
+        logger.exception(
+            "Failed to schedule datasource orphan confirmation for task %s",
+            task_id,
         )
-        task.status = TaskStatus.FAILURE
-        task.finished_at = now
-        task.error = (
-            "DATASOURCE_UPLOAD_ORPHANED"
-            if is_upload
-            else "DATASOURCE_CONVERSION_ORPHANED"
+
+
+@shared_task(
+    name="lens.confirm_orphaned_datasource_conversion",
+    queue="lens",
+    ignore_result=True,
+)
+def confirm_orphaned_datasource_conversion(task_id, connection_id):
+    """Fail unreported datasource work after the reconnect grace period."""
+
+    from agentcore_task.adapters.django.models import TaskExecution
+    from agentcore_task.constants import TaskStatus
+
+    task = TaskExecution.objects.filter(task_id=task_id).first()
+    if task is None:
+        return False
+    metadata = dict(task.metadata or {})
+    if metadata.get("datasource_orphan_confirmation_connection_id") != str(
+        connection_id
+    ):
+        return False
+    now = timezone.now()
+    is_upload = task.module == "lens_datasource_upload"
+    datasource_uuid = metadata.get("datasource_uuid")
+    error = (
+        "DATASOURCE_UPLOAD_ORPHANED" if is_upload else "DATASOURCE_CONVERSION_ORPHANED"
+    )
+    metadata.update(
+        {
+            "recovery_reason": "LENSNODE_ACTIVE_OPERATION_UNREPORTED",
+            "recovery_retryable": True,
+            "reconciled_at": now.isoformat(),
+            "completion_reason": error,
+            "stop_confirmation_source": "lensnode_active_operations_absent",
+        }
+    )
+    updated = TaskExecution.objects.filter(
+        pk=task.pk,
+        status__in=_datasource_active_statuses(TaskStatus),
+        metadata__datasource_orphan_confirmation_connection_id=str(connection_id),
+    ).update(
+        status=TaskStatus.FAILURE,
+        finished_at=now,
+        error=error,
+        metadata=metadata,
+    )
+    if not updated:
+        return False
+    datasource = DataSource.objects.filter(uuid=datasource_uuid).first()
+    if datasource is not None:
+        datasource.last_conversion_status = TaskStatus.FAILURE
+        datasource.last_conversion_at = now
+        datasource.save(
+            update_fields=[
+                "last_conversion_status",
+                "last_conversion_at",
+                "updated_at",
+            ]
         )
-        task.metadata = metadata
-        task.save(update_fields=["status", "finished_at", "error", "metadata"])
-        count += 1
-    return count
+    release_datasource_lock(
+        datasource_uuid,
+        token=metadata.get("lock_token") or task.task_id,
+    )
+    return True
 
 
 def cleanup_stale_datasource_sync_tasks(startup=False):
@@ -1264,11 +1341,6 @@ def cleanup_stale_datasource_sync_tasks(startup=False):
 
     now = timezone.now()
     orphaned_count = 0
-    for lensnode in LensNode.objects.all():
-        orphaned_count += reconcile_orphaned_datasource_conversions(
-            lensnode.uuid,
-            lensnode.connection_id,
-        )
     timeout_s = get_datasource_sync_timeout_s()
     conversion_cutoff = now - timedelta(seconds=get_datasource_conversion_timeout_s())
     upload_cutoff = now - timedelta(seconds=get_datasource_upload_timeout_s())
@@ -1600,6 +1672,11 @@ def check_lensnode_disconnect_grace_period(lensnode_uuid, disconnected_at_iso):
         lensnode_uuid,
     )
     mark_active_runs_awaiting_resume(lensnode_uuid)
+    reconcile_orphaned_datasource_conversions(
+        lensnode_uuid,
+        node.connection_id,
+        [],
+    )
 
 
 @shared_task(
@@ -1803,15 +1880,31 @@ def lensnode_health_task():
         key="lensnode.health.offline_threshold_s"
     ).first()
     threshold_s = int(setting.value if setting else 60)
-    cutoff = timezone.now() - timedelta(seconds=threshold_s)
-    updated = LensNode.objects.filter(
-        status=LensNode.Status.ONLINE,
-        last_heartbeat_at__lt=cutoff,
-    ).update(
-        status=LensNode.Status.OFFLINE,
-        connection_id="",
-        updated_at=timezone.now(),
+    now = timezone.now()
+    cutoff = now - timedelta(seconds=threshold_s)
+    stale_nodes = list(
+        LensNode.objects.filter(
+            status=LensNode.Status.ONLINE,
+            last_heartbeat_at__lt=cutoff,
+        ).only("pk", "uuid")
     )
+    updated = 0
+    from .services import schedule_lensnode_disconnect_grace_check
+
+    for node in stale_nodes:
+        transitioned = LensNode.objects.filter(
+            pk=node.pk,
+            status=LensNode.Status.ONLINE,
+            last_heartbeat_at__lt=cutoff,
+        ).update(
+            status=LensNode.Status.OFFLINE,
+            connection_id="",
+            disconnected_at=now,
+            updated_at=now,
+        )
+        if transitioned:
+            updated += 1
+            schedule_lensnode_disconnect_grace_check(node.uuid, now)
 
     record.last_status = ScheduledTask.Status.SUCCESS
     record.last_metrics = {

--- a/backend/lens/tests/test_disconnect_grace.py
+++ b/backend/lens/tests/test_disconnect_grace.py
@@ -10,6 +10,7 @@ from core.asgi import application
 from lens.lensnode_auth import issue_lensnode_token
 from lens.models import (
     Assistant,
+    DataSource,
     GlobalSetting,
     LensNode,
     Run,
@@ -24,7 +25,10 @@ from lens.services import (
     get_awaiting_resume_ttl_hours,
     get_reconcile_confirm_grace_seconds,
 )
-from lens.tasks import check_lensnode_disconnect_grace_period
+from lens.tasks import (
+    check_lensnode_disconnect_grace_period,
+    register_datasource_conversion_task,
+)
 
 User = get_user_model()
 
@@ -69,9 +73,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         )
 
     def _make_running_run(self):
-        run = create_execution_run(
-            session=self.session, question="q", enqueue=False
-        )
+        run = create_execution_run(session=self.session, question="q", enqueue=False)
         run.status = Run.Status.RUNNING
         run.started_at = timezone.now()
         run.save(update_fields=["status", "started_at"])
@@ -82,9 +84,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
             get_lensnode_disconnect_grace_seconds(),
             LENSNODE_DISCONNECT_GRACE_SECONDS_DEFAULT,
         )
-        GlobalSetting.objects.create(
-            key="lensnode.disconnect_grace_s", value=42
-        )
+        GlobalSetting.objects.create(key="lensnode.disconnect_grace_s", value=42)
         self.assertEqual(get_lensnode_disconnect_grace_seconds(), 42)
 
     def test_reconcile_confirm_grace_seconds_default_and_override(self):
@@ -93,9 +93,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
             get_reconcile_confirm_grace_seconds(),
             RECONCILE_CONFIRM_GRACE_SECONDS_DEFAULT,
         )
-        GlobalSetting.objects.create(
-            key="lensnode.reconcile_confirm_grace_s", value=7
-        )
+        GlobalSetting.objects.create(key="lensnode.reconcile_confirm_grace_s", value=7)
         self.assertEqual(get_reconcile_confirm_grace_seconds(), 7)
 
     def test_resume_ttl_is_capped_by_node_retention(self):
@@ -122,6 +120,42 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, Run.Status.RUNNING)
         self.assertIsNotNone(run.resume_by)
+
+    def test_check_confirms_active_conversion_when_node_stays_offline(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "offline-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata["lensnode_connection_id"] = "old-connection"
+        task.save(update_fields=["status", "metadata"])
+        stamp = timezone.now()
+        self.lensnode.status = LensNode.Status.OFFLINE
+        self.lensnode.connection_id = ""
+        self.lensnode.disconnected_at = stamp
+        self.lensnode.save(update_fields=["status", "connection_id", "disconnected_at"])
+
+        with patch(
+            "lens.tasks.confirm_orphaned_datasource_conversion.apply_async"
+        ) as apply_async:
+            check_lensnode_disconnect_grace_period(
+                str(self.lensnode.uuid),
+                stamp.isoformat(),
+            )
+
+        task.refresh_from_db()
+        self.assertEqual(
+            task.metadata["datasource_orphan_confirmation_connection_id"],
+            "",
+        )
+        apply_async.assert_called_once()
 
     def test_check_expires_run_past_original_wall_clock_budget(self):
         run = self._make_running_run()
@@ -152,9 +186,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         self.lensnode.status = LensNode.Status.OFFLINE
         self.lensnode.disconnected_at = stamp
         self.lensnode.labels = {}
-        self.lensnode.save(
-            update_fields=["status", "disconnected_at", "labels"]
-        )
+        self.lensnode.save(update_fields=["status", "disconnected_at", "labels"])
 
         check_lensnode_disconnect_grace_period(
             str(self.lensnode.uuid), stamp.isoformat()
@@ -187,9 +219,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         # A newer disconnect moved disconnected_at on; this stale check, pinned
         # to the earlier episode, must defer to the newer one and no-op.
         self.lensnode.status = LensNode.Status.OFFLINE
-        self.lensnode.disconnected_at = scheduled_stamp + timezone.timedelta(
-            seconds=5
-        )
+        self.lensnode.disconnected_at = scheduled_stamp + timezone.timedelta(seconds=5)
         self.lensnode.save(update_fields=["status", "disconnected_at"])
 
         check_lensnode_disconnect_grace_period(
@@ -224,9 +254,7 @@ class LensNodeDisconnectGraceTests(TransactionTestCase):
         self.assertIsNotNone(self.lensnode.disconnected_at)
         self.assertTrue(apply_async.called)
         kwargs = apply_async.call_args.kwargs
-        self.assertEqual(
-            kwargs["args"][0], str(self.lensnode.uuid)
-        )
+        self.assertEqual(kwargs["args"][0], str(self.lensnode.uuid))
         self.assertIn("countdown", kwargs)
 
     def test_disconnect_schedules_check_when_health_task_cleared_owner(self):

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -85,6 +85,7 @@ from lens.services import (
 from lens.tasks import (
     acquire_datasource_lock,
     cleanup_stale_datasource_sync_tasks,
+    confirm_orphaned_datasource_conversion,
     complete_datasource_conversion_task,
     complete_datasource_sync_task,
     datasource_conversion_task,
@@ -577,18 +578,14 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(run.execution.run_timeout_s, 3600)
 
     def test_build_run_history_returns_prior_turns_and_skips_empty(self):
-        run1 = create_execution_run(
-            session=self.session, question="q1", enqueue=False
-        )
+        run1 = create_execution_run(session=self.session, question="q1", enqueue=False)
         run1.output_message.content = "a1"
         run1.output_message.save(update_fields=["content"])
         run1.status = Run.Status.DONE
         run1.outcome = Run.Outcome.COMPLETED
         run1.save(update_fields=["status", "outcome"])
         # second turn left unanswered -> its empty answer must be skipped
-        create_execution_run(
-            session=self.session, question="q2", enqueue=False
-        )
+        create_execution_run(session=self.session, question="q2", enqueue=False)
         current = create_execution_run(
             session=self.session, question="q3", enqueue=False
         )
@@ -1256,9 +1253,7 @@ class LensServiceTests(TransactionTestCase):
     def test_execute_answer_run_creates_execution_snapshot(self):
         self.assistant.agent_rounds = "max"
         self.assistant.token_budget_profile = "deep"
-        self.assistant.save(
-            update_fields=["agent_rounds", "token_budget_profile"]
-        )
+        self.assistant.save(update_fields=["agent_rounds", "token_budget_profile"])
         run = create_execution_run(
             session=self.session,
             question="How does SSE work?",
@@ -1273,9 +1268,7 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(run.steps.count(), 3)
         self.assertTrue(run.output_message.content)
         self.assertEqual(run.execution.task, "knowledge_qa")
-        self.assertEqual(
-            run.execution.target_dirs, [{"path": "/workspace/repo"}]
-        )
+        self.assertEqual(run.execution.target_dirs, [{"path": "/workspace/repo"}])
         self.assertEqual(run.execution.agent_rounds, "max")
         self.assertEqual(run.execution.run_timeout_s, 3600)
         self.assertEqual(run.execution.token_budget_profile, "unlimited")
@@ -1320,9 +1313,7 @@ class LensServiceTests(TransactionTestCase):
         self.assistant.capability = Assistant.Capability.GENERAL_CHAT
         self.assistant.visibility = Assistant.Visibility.PUBLIC
         self.assistant.save(update_fields=["capability", "visibility"])
-        self.lensnode.tasks = [
-            {"name": "general_chat", "description": "Delegate work"}
-        ]
+        self.lensnode.tasks = [{"name": "general_chat", "description": "Delegate work"}]
         self.lensnode.save(update_fields=["tasks"])
         run = create_execution_run(
             session=self.session,
@@ -1687,9 +1678,7 @@ class LensServiceTests(TransactionTestCase):
         mock_attachment_data_url,
     ):
         sender = mock_async_to_sync.return_value
-        mock_attachment_data_url.return_value = (
-            "data:image/png;base64,encoded"
-        )
+        mock_attachment_data_url.return_value = "data:image/png;base64,encoded"
         self.assistant.multimodal_model_ref = uuid4()
         self.assistant.save(update_fields=["multimodal_model_ref"])
         attachment = MessageAttachment.objects.create(
@@ -1729,9 +1718,7 @@ class LensServiceTests(TransactionTestCase):
         sender = mock_async_to_sync.return_value
         self.assistant.agent_rounds = "deep"
         self.assistant.token_budget_profile = "unlimited"
-        self.assistant.save(
-            update_fields=["agent_rounds", "token_budget_profile"]
-        )
+        self.assistant.save(update_fields=["agent_rounds", "token_budget_profile"])
         run = create_execution_run(
             session=self.session,
             question="Analyze everything",
@@ -1741,9 +1728,7 @@ class LensServiceTests(TransactionTestCase):
 
         self.assistant.agent_rounds = "balanced"
         self.assistant.token_budget_profile = "standard"
-        self.assistant.save(
-            update_fields=["agent_rounds", "token_budget_profile"]
-        )
+        self.assistant.save(update_fields=["agent_rounds", "token_budget_profile"])
         dispatch_run_to_lensnode(run, "Analyze everything")
 
         payload = sender.call_args.args[1]["payload"]
@@ -1752,9 +1737,7 @@ class LensServiceTests(TransactionTestCase):
             {
                 "profile": "deep",
                 "max_tokens": execution.token_budget_max_tokens,
-                "final_reserve_tokens": (
-                    execution.token_budget_final_reserve_tokens
-                ),
+                "final_reserve_tokens": (execution.token_budget_final_reserve_tokens),
             },
         )
         self.assertEqual(execution.token_budget_profile, "deep")
@@ -1774,9 +1757,7 @@ class LensServiceTests(TransactionTestCase):
         sender = mock_async_to_sync.return_value
         self.assistant.agent_rounds = "max"
         self.assistant.token_budget_profile = "standard"
-        self.assistant.save(
-            update_fields=["agent_rounds", "token_budget_profile"]
-        )
+        self.assistant.save(update_fields=["agent_rounds", "token_budget_profile"])
         run = create_execution_run(
             session=self.session,
             question="Analyze without a token cap",
@@ -1840,9 +1821,7 @@ class LensServiceTests(TransactionTestCase):
     ):
         sender = mock_async_to_sync.return_value
         self.assistant.agent_model_ref = "11111111-1111-1111-1111-111111111111"
-        self.assistant.multimodal_model_ref = (
-            "22222222-2222-2222-2222-222222222222"
-        )
+        self.assistant.multimodal_model_ref = "22222222-2222-2222-2222-222222222222"
         self.assistant.settings = {"runtime_mode": "original"}
         self.user.profile.language = "zh-CN"
         self.user.profile.save(update_fields=["language"])
@@ -2935,6 +2914,40 @@ class LensServiceTests(TransactionTestCase):
         self.assertEqual(run.status, Run.Status.DONE)
         self.assertEqual(run.output_message.content, "answer")
 
+    def test_lensnode_reconnect_rebinds_active_conversion(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "reconnect-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata["lensnode_connection_id"] = "old-connection"
+        task.save(update_fields=["status", "metadata"])
+
+        token = issue_lensnode_token(self.lensnode)
+        async_to_sync(self._exercise_lensnode_conversion_reconnect)(
+            token,
+            task.task_id,
+            datasource.uuid,
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, "STARTED")
+        self.assertNotEqual(
+            task.metadata["lensnode_connection_id"],
+            "old-connection",
+        )
+        self.assertEqual(
+            task.metadata["last_lensnode_operation"]["operation"],
+            "conversion",
+        )
+
     def test_lensnode_websocket_rejects_revoked_token(self):
         token = issue_lensnode_token(self.lensnode)
         self.lensnode.token_revoked = True
@@ -3040,6 +3053,56 @@ class LensServiceTests(TransactionTestCase):
                     "unsupported": 0,
                 },
             }
+        )
+        self.assertEqual(
+            await communicator.receive_json_from(),
+            {
+                "type": "datasource_terminal_ack",
+                "task_id": task_id,
+            },
+        )
+        await communicator.disconnect()
+
+    async def _exercise_lensnode_conversion_reconnect(
+        self,
+        token,
+        task_id,
+        datasource_uuid,
+    ):
+        """Report a still-running conversion through a new WebSocket."""
+
+        communicator = WebsocketCommunicator(
+            application,
+            f"/ws/lens/lensnodes/?token={token}",
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        await communicator.receive_json_from()
+        await communicator.send_json_to(
+            {
+                "type": "hello",
+                "protocol_version": "v1",
+                "agent_version": "1.0.0",
+                "workspace_path": "/workspace",
+                "available_dirs": [{"path": "/workspace/repo"}],
+                "tasks": [{"name": "knowledge_qa"}],
+                "active_datasource_operations": [
+                    {
+                        "task_id": task_id,
+                        "datasource_uuid": str(datasource_uuid),
+                        "operation": "conversion",
+                        "phase": "conversion_progress",
+                        "last_progress": {
+                            "progress_current": 10,
+                            "progress_total": 100,
+                        },
+                    }
+                ],
+            }
+        )
+        self.assertEqual(
+            (await communicator.receive_json_from())["type"],
+            "hello_ack",
         )
         await communicator.disconnect()
 
@@ -3204,13 +3267,16 @@ class LensServiceTests(TransactionTestCase):
             },
         )
 
-        with patch.dict(
-            os.environ,
-            {
-                "LENSNODE_AI_GATEWAY_URL": "http://gateway.test",
-                "LENSNODE_TOKEN": "lensnode-token",
-            },
-        ), patch("lens.datasource_services._send_lensnode_command") as send:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LENSNODE_AI_GATEWAY_URL": "http://gateway.test",
+                    "LENSNODE_TOKEN": "lensnode-token",
+                },
+            ),
+            patch("lens.datasource_services._send_lensnode_command") as send,
+        ):
             request_id = dispatch_datasource_upload_async(
                 datasource,
                 task_id="managed-upload",
@@ -3240,9 +3306,7 @@ class LensServiceTests(TransactionTestCase):
         from lens.datasource_services import _send_lensnode_command
 
         self.lensnode.connection_id = "specific.connection!channel"
-        with patch(
-            "lens.datasource_services.get_channel_layer"
-        ) as get_layer:
+        with patch("lens.datasource_services.get_channel_layer") as get_layer:
             channel_layer = get_layer.return_value
             channel_layer.send = AsyncMock()
             _send_lensnode_command(
@@ -3273,9 +3337,7 @@ class LensServiceTests(TransactionTestCase):
             created_by=self.user,
         )
 
-        with patch(
-            "lens.tasks.dispatch_datasource_conversion_async"
-        ) as dispatch:
+        with patch("lens.tasks.dispatch_datasource_conversion_async") as dispatch:
             dispatch.return_value = "conversion-request"
             result = datasource_conversion_task(
                 str(datasource.uuid),
@@ -3373,7 +3435,7 @@ class LensServiceTests(TransactionTestCase):
             2,
         )
 
-    def test_reconnect_reconciles_orphaned_conversion_and_releases_owners(
+    def test_reconnect_rebinds_reported_conversion_to_new_connection(
         self,
     ):
         datasource = DataSource.objects.create(
@@ -3403,16 +3465,202 @@ class LensServiceTests(TransactionTestCase):
         count = reconcile_orphaned_datasource_conversions(
             self.lensnode.uuid,
             "new-connection",
+            [
+                {
+                    "task_id": task.task_id,
+                    "datasource_uuid": str(datasource.uuid),
+                    "operation": "conversion",
+                    "phase": "running",
+                    "last_progress": {
+                        "progress_current": 10,
+                        "progress_total": 100,
+                    },
+                }
+            ],
         )
 
         task.refresh_from_db()
         datasource.refresh_from_db()
         self.assertEqual(count, 1)
+        self.assertEqual(task.status, "STARTED")
+        self.assertEqual(
+            task.metadata["lensnode_connection_id"],
+            "new-connection",
+        )
+        self.assertEqual(
+            task.metadata["last_lensnode_operation"]["phase"],
+            "running",
+        )
+        self.assertEqual(datasource.last_conversion_status, "STARTED")
+        self.assertEqual(
+            cache.get(f"lens:datasource-sync:{datasource.uuid}"),
+            task.task_id,
+        )
+        LensNodeConsumer._record_datasource_sync_event(
+            task.task_id,
+            {
+                "step": "conversion_progress",
+                "status": "running",
+                "progress_percent": 99,
+            },
+            "old-connection",
+        )
+        task.refresh_from_db()
+        self.assertNotIn("progress_percent", task.metadata)
+
+    def test_legacy_reconnect_rebinds_conversion_without_operation_report(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "legacy-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata["lensnode_connection_id"] = "old-connection"
+        task.save(update_fields=["status", "metadata"])
+
+        with patch(
+            "lens.tasks.confirm_orphaned_datasource_conversion.apply_async"
+        ) as apply_async:
+            count = reconcile_orphaned_datasource_conversions(
+                self.lensnode.uuid,
+                "new-connection",
+                None,
+            )
+
+        task.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertEqual(task.status, "STARTED")
+        self.assertEqual(
+            task.metadata["lensnode_connection_id"],
+            "new-connection",
+        )
+        self.assertNotIn(
+            "datasource_orphan_confirmation_connection_id",
+            task.metadata,
+        )
+        apply_async.assert_not_called()
+
+    def test_reconnect_defers_failure_for_unreported_conversion(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "unreported-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata["lensnode_connection_id"] = "old-connection"
+        task.save(update_fields=["status", "metadata"])
+        cache.set(f"lens:datasource-sync:{datasource.uuid}", task.task_id)
+
+        with patch(
+            "lens.tasks.confirm_orphaned_datasource_conversion.apply_async"
+        ) as apply_async:
+            count = reconcile_orphaned_datasource_conversions(
+                self.lensnode.uuid,
+                "new-connection",
+                [],
+            )
+
+        task.refresh_from_db()
+        self.assertEqual(count, 0)
+        self.assertEqual(task.status, "STARTED")
+        self.assertEqual(
+            task.metadata["datasource_orphan_confirmation_connection_id"],
+            "new-connection",
+        )
+        self.assertEqual(
+            cache.get(f"lens:datasource-sync:{datasource.uuid}"),
+            task.task_id,
+        )
+        self.assertEqual(
+            task.metadata["lensnode_connection_id"],
+            "new-connection",
+        )
+        apply_async.assert_called_once()
+
+        self.assertTrue(
+            confirm_orphaned_datasource_conversion(
+                task.task_id,
+                "new-connection",
+            )
+        )
+        task.refresh_from_db()
         self.assertEqual(task.status, "FAILURE")
         self.assertEqual(task.error, "DATASOURCE_CONVERSION_ORPHANED")
-        self.assertTrue(task.metadata["recovery_retryable"])
-        self.assertEqual(datasource.last_conversion_status, "FAILURE")
-        self.assertIsNone(cache.get(f"lens:datasource-sync:{datasource.uuid}"))
+        self.assertEqual(
+            task.metadata["stop_confirmation_source"],
+            "lensnode_active_operations_absent",
+        )
+
+    def test_unreported_reconnect_accepts_buffered_completion(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "buffered-conversion",
+            {"document": True},
+        )
+        task.status = "STARTED"
+        task.metadata["lensnode_connection_id"] = "old-connection"
+        task.save(update_fields=["status", "metadata"])
+
+        with patch("lens.tasks.confirm_orphaned_datasource_conversion.apply_async"):
+            reconcile_orphaned_datasource_conversions(
+                self.lensnode.uuid,
+                "new-connection",
+                [],
+            )
+
+        complete_datasource_conversion_task(
+            task.task_id,
+            {"status": "success"},
+            connection_id="new-connection",
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.status, "SUCCESS")
+
+    def test_orphan_confirmation_does_not_replace_terminal_callback(self):
+        datasource = DataSource.objects.create(
+            name="Managed Snapshot",
+            source_type=DataSource.SourceType.MANAGED_WORKSPACE,
+            lensnode=self.lensnode,
+            target_path="/workspace/restores/finance",
+            last_conversion_status="SUCCESS",
+        )
+        task = register_datasource_conversion_task(
+            datasource,
+            "completed-conversion",
+            {"document": True},
+        )
+        task.status = "SUCCESS"
+        task.metadata["datasource_orphan_confirmation_connection_id"] = "new-connection"
+        task.save(update_fields=["status", "metadata"])
+
+        self.assertFalse(
+            confirm_orphaned_datasource_conversion(
+                task.task_id,
+                "new-connection",
+            )
+        )
+        task.refresh_from_db()
+        datasource.refresh_from_db()
+        self.assertEqual(task.status, "SUCCESS")
+        self.assertEqual(datasource.last_conversion_status, "SUCCESS")
 
     def test_complete_managed_workspace_conversion_persists_summary(self):
         datasource = DataSource.objects.create(
@@ -3541,9 +3789,7 @@ class LensServiceTests(TransactionTestCase):
         task.finished_at = timezone.now()
         task.save(update_fields=["status", "finished_at"])
 
-        with patch(
-            "lens.tasks.dispatch_datasource_conversion_async"
-        ) as dispatch:
+        with patch("lens.tasks.dispatch_datasource_conversion_async") as dispatch:
             result = datasource_conversion_task(
                 str(datasource.uuid),
                 {"document": True},
@@ -3583,8 +3829,7 @@ class LensServiceTests(TransactionTestCase):
                 side_effect=dispatch,
             ),
             patch(
-                "lens.services."
-                "cancel_datasource_conversion_on_lensnode"
+                "lens.services." "cancel_datasource_conversion_on_lensnode"
             ) as cancel,
         ):
             datasource_conversion_task(
@@ -4113,9 +4358,7 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
 
-        with patch(
-            "lens.services.cancel_datasource_sync_on_lensnode"
-        ) as cancel:
+        with patch("lens.services.cancel_datasource_sync_on_lensnode") as cancel:
             result = cleanup_stale_datasource_sync_tasks()
 
         task.refresh_from_db()
@@ -4160,9 +4403,7 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
 
-        with patch(
-            "lens.services.cancel_datasource_upload_on_lensnode"
-        ) as cancel:
+        with patch("lens.services.cancel_datasource_upload_on_lensnode") as cancel:
             result = cleanup_stale_datasource_sync_tasks()
 
         task.refresh_from_db()
@@ -4210,9 +4451,7 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
 
-        with patch(
-            "lens.services.cancel_datasource_conversion_on_lensnode"
-        ) as cancel:
+        with patch("lens.services.cancel_datasource_conversion_on_lensnode") as cancel:
             result = cleanup_stale_datasource_sync_tasks()
 
         task.refresh_from_db()
@@ -4280,9 +4519,7 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
 
-        with patch(
-            "lens.services.cancel_datasource_sync_on_lensnode"
-        ) as cancel:
+        with patch("lens.services.cancel_datasource_sync_on_lensnode") as cancel:
             result = cleanup_stale_datasource_sync_tasks(startup=True)
 
         task.refresh_from_db()
@@ -4319,9 +4556,7 @@ class LensServiceTests(TransactionTestCase):
             ttl_s=60,
         )
 
-        with patch(
-            "lens.services.cancel_datasource_sync_on_lensnode"
-        ) as cancel:
+        with patch("lens.services.cancel_datasource_sync_on_lensnode") as cancel:
             result = cleanup_stale_datasource_sync_tasks()
 
         self.assertEqual(result["failed"], 0)
@@ -4389,16 +4624,23 @@ class LensServiceTests(TransactionTestCase):
 
     def test_lensnode_health_marks_stale_lensnodes_offline(self):
         self.lensnode.status = LensNode.Status.ONLINE
-        self.lensnode.last_heartbeat_at = timezone.now() - timedelta(
-            seconds=120
-        )
+        self.lensnode.last_heartbeat_at = timezone.now() - timedelta(seconds=120)
         self.lensnode.save(update_fields=["status", "last_heartbeat_at"])
 
-        marked = lensnode_health_task()
+        with patch(
+            "lens.services.schedule_lensnode_disconnect_grace_check"
+        ) as schedule_check:
+            marked = lensnode_health_task()
 
         self.lensnode.refresh_from_db()
         self.assertEqual(marked, 1)
         self.assertEqual(self.lensnode.status, LensNode.Status.OFFLINE)
+        self.assertIsNotNone(self.lensnode.disconnected_at)
+        schedule_check.assert_called_once()
+        self.assertEqual(
+            str(schedule_check.call_args.args[0]),
+            str(self.lensnode.uuid),
+        )
 
     def test_register_periodic_tasks_adds_lens_entries(self):
         TASK_REGISTRY.clear()

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -114,6 +114,8 @@ class LensNodeClient:
             )
         )
         self.datasource_conversion_cancels = {}
+        self.active_datasource_operations = {}
+        self._datasource_operations_lock = threading.Lock()
         self.datasource_sync_cancels = {}
         self.running_commands = {}
         self._checkpoint_resume_ready = None
@@ -131,12 +133,11 @@ class LensNodeClient:
         # — better to drop the oldest frames of one run than to lose every run.
         self._outbox = collections.deque()
         self._outbox_ready = asyncio.Event()
-        self._outbox_max = int(
-            os.getenv("LENSNODE_OUTBOX_MAX_FRAMES", "10000")
-        )
+        self._outbox_max = int(os.getenv("LENSNODE_OUTBOX_MAX_FRAMES", "10000"))
         self._outbox_dropped = 0
         self._pending_trace_frames = collections.OrderedDict()
         self._pending_terminal_frames = collections.OrderedDict()
+        self._pending_datasource_terminal_frames = collections.OrderedDict()
 
     def _enqueue(self, payload):
         """Append an outbound frame to the durable outbox.
@@ -166,6 +167,15 @@ class LensNodeClient:
             self._pending_terminal_frames.move_to_end(run_uuid)
             while len(self._pending_terminal_frames) > self._outbox_max:
                 self._pending_terminal_frames.popitem(last=False)
+        if payload.get("type") in {
+            "datasource_convert_done",
+            "datasource_upload_done",
+        } and payload.get("task_id"):
+            task_id = str(payload["task_id"])
+            self._pending_datasource_terminal_frames[task_id] = payload
+            self._pending_datasource_terminal_frames.move_to_end(task_id)
+            while len(self._pending_datasource_terminal_frames) > self._outbox_max:
+                self._pending_datasource_terminal_frames.popitem(last=False)
         while len(self._outbox) >= self._outbox_max:
             self._outbox.popleft()
             self._outbox_dropped += 1
@@ -281,8 +291,7 @@ class LensNodeClient:
                 f"Draining LensNode {self.config.name} before shutdown.",
                 details=[
                     f"InFlightRuns: {len(self.running_tasks)}",
-                    "DrainTimeout: "
-                    f"{format_duration(self.config.drain_timeout_s)}",
+                    "DrainTimeout: " f"{format_duration(self.config.drain_timeout_s)}",
                 ],
             )
         )
@@ -329,9 +338,7 @@ class LensNodeClient:
         tasks = list(self.running_tasks.values())
         if not tasks:
             return
-        done, pending = await asyncio.wait(
-            tasks, timeout=self.config.drain_timeout_s
-        )
+        done, pending = await asyncio.wait(tasks, timeout=self.config.drain_timeout_s)
         if pending:
             LOGGER.warning(
                 task_log(
@@ -421,6 +428,7 @@ class LensNodeClient:
         await self._send_hello()
         self._restore_pending_trace_frames()
         self._restore_pending_terminal_frames()
+        self._restore_pending_datasource_terminal_frames()
 
     def _restore_pending_trace_frames(self):
         """Requeue unacknowledged trace events in per-run sequence order.
@@ -446,10 +454,7 @@ class LensNodeClient:
                 known_frame_ids.add(id(frame))
                 covered_sequences[run_uuid].update(sequences)
         for (run_uuid, sequence), frame in self._pending_trace_frames.items():
-            if (
-                id(frame) in known_frame_ids
-                or sequence in covered_sequences[run_uuid]
-            ):
+            if id(frame) in known_frame_ids or sequence in covered_sequences[run_uuid]:
                 continue
             key = (run_uuid, (sequence,))
             trace_frames.setdefault(key, frame)
@@ -462,8 +467,7 @@ class LensNodeClient:
         for frames in ordered_by_run.values():
             frames.sort(
                 key=lambda frame: min(
-                    event.get("sequence", 0)
-                    for event in frame.get("events") or []
+                    event.get("sequence", 0) for event in frame.get("events") or []
                 )
             )
 
@@ -494,6 +498,21 @@ class LensNodeClient:
         }
         for run_uuid, frame in self._pending_terminal_frames.items():
             if run_uuid not in queued_run_uuids:
+                self._outbox.append(frame)
+        if self._outbox:
+            self._outbox_ready.set()
+
+    def _restore_pending_datasource_terminal_frames(self):
+        """Requeue datasource terminal frames until the server receives them."""
+
+        queued_task_ids = {
+            str(frame.get("task_id") or "")
+            for frame in self._outbox
+            if frame.get("type")
+            in {"datasource_convert_done", "datasource_upload_done"}
+        }
+        for task_id, frame in self._pending_datasource_terminal_frames.items():
+            if task_id not in queued_task_ids:
                 self._outbox.append(frame)
         if self._outbox:
             self._outbox_ready.set()
@@ -602,10 +621,7 @@ class LensNodeClient:
                 )
             LOGGER.info(
                 task_log(
-                    (
-                        "Cancelled command run_start "
-                        f"{run_uuid} by control plane."
-                    )
+                    ("Cancelled command run_start " f"{run_uuid} by control plane.")
                 )
             )
         elif message_type == "run_done_ack":
@@ -627,6 +643,23 @@ class LensNodeClient:
             if not cleanup_deferred:
                 cleanup_run_checkpoint(run_uuid, workspace_path)
                 cleanup_run_runtime_resources(workspace_path, run_uuid)
+        elif message_type == "datasource_terminal_ack":
+            task_id = str(message.get("task_id") or "")
+            frame = self._pending_datasource_terminal_frames.get(task_id)
+            if frame is not None:
+                self._acknowledge_datasource_terminal_frame(frame)
+                self._outbox = collections.deque(
+                    item
+                    for item in self._outbox
+                    if not (
+                        item.get("type")
+                        in {
+                            "datasource_convert_done",
+                            "datasource_upload_done",
+                        }
+                        and str(item.get("task_id") or "") == task_id
+                    )
+                )
         elif message_type == "run_trace_events_ack":
             run_uuid = str(message.get("run_uuid") or "")
             last_sequence = message.get("last_sequence")
@@ -653,9 +686,7 @@ class LensNodeClient:
             )
         elif message_type == "hello_ack":
             LOGGER.info(
-                task_log(
-                    f"Confirmed LensNode capability report {self.config.name}."
-                )
+                task_log(f"Confirmed LensNode capability report {self.config.name}.")
             )
         elif message_type == "heartbeat_ack":
             LOGGER.debug("Received control frame: %s", message_type)
@@ -739,9 +770,7 @@ class LensNodeClient:
                 ],
             )
         )
-        task = asyncio.create_task(
-            self._execute_command(run_uuid, message)
-        )
+        task = asyncio.create_task(self._execute_command(run_uuid, message))
         self.running_commands[run_uuid] = message
         self.running_tasks[run_uuid] = task
         task.add_done_callback(lambda item: self._consume_task_exception(item))
@@ -778,11 +807,13 @@ class LensNodeClient:
                 except PermissionError:
                     pass
             result[path] = subdirs
-        self._enqueue({
-            "type": "list_dirs_result",
-            "request_id": request_id,
-            "dirs": result,
-        })
+        self._enqueue(
+            {
+                "type": "list_dirs_result",
+                "request_id": request_id,
+                "dirs": result,
+            }
+        )
 
     async def _handle_datasource_check_path(self, message):
         """Inspect a datasource path and reply to the control plane."""
@@ -843,9 +874,7 @@ class LensNodeClient:
         cancel_event = threading.Event()
         self.datasource_sync_cancels[task_id] = cancel_event
         message = {**message, "cancel_event": cancel_event}
-        task = asyncio.create_task(
-            self._execute_datasource_sync(message, plugin)
-        )
+        task = asyncio.create_task(self._execute_datasource_sync(message, plugin))
         self.running_tasks[task_key] = task
         task.add_done_callback(lambda item: self._consume_task_exception(item))
 
@@ -879,8 +908,7 @@ class LensNodeClient:
                             "step": "queue",
                             "status": "queued",
                             "message": (
-                                "Waiting for exclusive LensNode execution "
-                                "capacity."
+                                "Waiting for exclusive LensNode execution " "capacity."
                             ),
                         }
                     )
@@ -909,9 +937,7 @@ class LensNodeClient:
                     )
                 finally:
                     if slot_acquired:
-                        await self.execution_queue.release(
-                            ExecutionClass.EXCLUSIVE
-                        )
+                        await self.execution_queue.release(ExecutionClass.EXCLUSIVE)
                 if result.get("status") in {"failed", "cancelled"}:
                     self._enqueue(
                         {
@@ -939,9 +965,7 @@ class LensNodeClient:
                 "ai_gateway_url": self.config.ai_gateway_url,
                 "lensnode_token": self.config.token,
                 "gateway_http_client": self.gateway_http_client,
-                "tls_skip_verify": getattr(
-                    self.config, "tls_skip_verify", False
-                ),
+                "tls_skip_verify": getattr(self.config, "tls_skip_verify", False),
                 "tls_ca_file": getattr(self.config, "tls_ca_file", None),
             }
             slot_acquired = False
@@ -955,8 +979,7 @@ class LensNodeClient:
                         "step": "queue",
                         "status": "queued",
                         "message": (
-                            "Waiting for exclusive LensNode execution "
-                            "capacity."
+                            "Waiting for exclusive LensNode execution " "capacity."
                         ),
                     }
                 )
@@ -986,9 +1009,7 @@ class LensNodeClient:
                 )
             finally:
                 if slot_acquired:
-                    await self.execution_queue.release(
-                        ExecutionClass.EXCLUSIVE
-                    )
+                    await self.execution_queue.release(ExecutionClass.EXCLUSIVE)
             self._enqueue(
                 {
                     "type": "datasource_sync_done",
@@ -1143,9 +1164,7 @@ class LensNodeClient:
                 "plugin_http_pool",
                 None,
             )
-            if plugin_http_pool is not None and callable(
-                runtime.http_origins
-            ):
+            if plugin_http_pool is not None and callable(runtime.http_origins):
                 resolved = snapshot.get("resolved_config") or {}
                 endpoint = resolved.get("endpoint")
                 connection_scope = (
@@ -1195,6 +1214,12 @@ class LensNodeClient:
             return
         cancel_event = threading.Event()
         self.datasource_conversion_cancels[task_id] = cancel_event
+        self._record_datasource_operation(
+            task_id,
+            message.get("datasource_uuid"),
+            "conversion",
+            "starting",
+        )
         task = asyncio.create_task(
             self._execute_datasource_conversion(
                 {**message, "cancel_event": cancel_event}
@@ -1212,6 +1237,7 @@ class LensNodeClient:
         loop = asyncio.get_running_loop()
 
         def emit(event):
+            self._update_datasource_operation(task_id, event)
             payload = {
                 "type": "datasource_convert_event",
                 "request_id": request_id,
@@ -1248,8 +1274,7 @@ class LensNodeClient:
                         "step": "queue",
                         "status": "queued",
                         "message": (
-                            "Waiting for exclusive LensNode execution "
-                            "capacity."
+                            "Waiting for exclusive LensNode execution " "capacity."
                         ),
                     }
                 )
@@ -1279,9 +1304,7 @@ class LensNodeClient:
                 )
             finally:
                 if slot_acquired:
-                    await self.execution_queue.release(
-                        ExecutionClass.EXCLUSIVE
-                    )
+                    await self.execution_queue.release(ExecutionClass.EXCLUSIVE)
             self._enqueue(
                 {
                     "type": "datasource_convert_done",
@@ -1345,6 +1368,12 @@ class LensNodeClient:
         task_key = f"datasource-upload:{task_id}"
         if task_key in self.running_tasks:
             return
+        self._record_datasource_operation(
+            task_id,
+            message.get("datasource_uuid"),
+            "upload",
+            "starting",
+        )
         task = asyncio.create_task(self._execute_datasource_upload(message))
         self.running_tasks[task_key] = task
         task.add_done_callback(lambda item: self._consume_task_exception(item))
@@ -1380,9 +1409,7 @@ class LensNodeClient:
                 }
             )
         except Exception:
-            LOGGER.exception(
-                "Managed workspace upload failed task_id=%s", task_id
-            )
+            LOGGER.exception("Managed workspace upload failed task_id=%s", task_id)
             self._enqueue(
                 {
                     "type": "datasource_upload_done",
@@ -1423,8 +1450,7 @@ class LensNodeClient:
                         return_exceptions=True,
                     )
                     raise RunCancelledError(
-                        "Managed datasource conversion was cancelled while "
-                        "queued."
+                        "Managed datasource conversion was cancelled while " "queued."
                     )
                 await asyncio.wait((acquire_task,), timeout=0.1)
             return acquire_task.result()
@@ -1435,10 +1461,7 @@ class LensNodeClient:
                     acquire_task,
                     return_exceptions=True,
                 )
-            elif (
-                not acquire_task.cancelled()
-                and acquire_task.exception() is None
-            ):
+            elif not acquire_task.cancelled() and acquire_task.exception() is None:
                 await self.execution_queue.release(execution_class)
             raise
 
@@ -1483,6 +1506,7 @@ class LensNodeClient:
         completed = False
         slot_acquired = False
         try:
+
             def report_queued():
                 self._enqueue(
                     {
@@ -1492,9 +1516,7 @@ class LensNodeClient:
                         "status": "running",
                         "detail": {
                             "queue_state": "QUEUED",
-                            "message": (
-                                "Waiting for LensNode execution capacity."
-                            ),
+                            "message": ("Waiting for LensNode execution capacity."),
                         },
                     }
                 )
@@ -1549,6 +1571,73 @@ class LensNodeClient:
         except asyncio.CancelledError:
             return
 
+    def _record_datasource_operation(
+        self,
+        task_id,
+        datasource_uuid,
+        operation,
+        phase,
+    ):
+        """Record one datasource operation for reconnect reconciliation."""
+
+        with self._datasource_operations_lock:
+            self.active_datasource_operations[str(task_id)] = {
+                "task_id": str(task_id),
+                "datasource_uuid": str(datasource_uuid or ""),
+                "operation": operation,
+                "phase": phase,
+                "last_progress": {},
+            }
+
+    def _update_datasource_operation(self, task_id, event):
+        """Keep the reconnect report aligned with durable progress events."""
+
+        with self._datasource_operations_lock:
+            operation = self.active_datasource_operations.get(str(task_id))
+            if operation is None:
+                return
+            operation["phase"] = str(event.get("step") or "running")
+            operation["last_progress"] = {
+                key: event[key]
+                for key in [
+                    "progress_current",
+                    "progress_total",
+                    "progress_percent",
+                    "timestamp",
+                ]
+                if key in event
+            }
+
+    def _remove_datasource_operation(self, task_id):
+        """Stop reporting a datasource operation after terminal delivery."""
+
+        with self._datasource_operations_lock:
+            self.active_datasource_operations.pop(str(task_id), None)
+
+    def _acknowledge_datasource_terminal_frame(self, payload):
+        """Clear reconnect state after a datasource terminal frame is sent."""
+
+        if payload.get("type") not in {
+            "datasource_convert_done",
+            "datasource_upload_done",
+        }:
+            return
+        task_id = str(payload.get("task_id") or "")
+        if not task_id:
+            return
+        if self._pending_datasource_terminal_frames.get(task_id) is payload:
+            self._pending_datasource_terminal_frames.pop(task_id, None)
+            self._remove_datasource_operation(task_id)
+
+    def _reported_active_datasource_operations(self):
+        """Return a stable snapshot of live datasource operations."""
+
+        with self._datasource_operations_lock:
+            return [
+                dict(operation)
+                for operation in self.active_datasource_operations.values()
+            ]
+
     def _reported_active_runs(self):
         """Return runs executing or awaiting terminal-frame delivery."""
 
@@ -1560,8 +1649,7 @@ class LensNodeClient:
         active_runs.update(
             str(payload["run_uuid"])
             for payload in self._outbox
-            if payload.get("type") == "run_done"
-            and payload.get("run_uuid")
+            if payload.get("type") == "run_done" and payload.get("run_uuid")
         )
         active_runs.update(self._pending_terminal_frames)
         return sorted(active_runs)
@@ -1580,10 +1668,7 @@ class LensNodeClient:
         dirs = available_dirs(self.config.workspace_path)
         LOGGER.info(
             task_log(
-                (
-                    "Starting to report LensNode capabilities "
-                    f"{self.config.name}."
-                ),
+                ("Starting to report LensNode capabilities " f"{self.config.name}."),
                 details=[
                     f"WorkspacePath: {self.config.workspace_path}",
                     f"AvailableDirs: {len(dirs)}",
@@ -1592,6 +1677,7 @@ class LensNodeClient:
             )
         )
         active_runs = self._reported_active_runs()
+        active_datasource_operations = self._reported_active_datasource_operations()
         checkpoint_resume_ready = self._checkpoint_resume_available()
         await self.websocket.send(
             json.dumps(
@@ -1604,6 +1690,7 @@ class LensNodeClient:
                     "available_dirs": dirs,
                     "tasks": TASKS,
                     "active_runs": active_runs,
+                    "active_datasource_operations": active_datasource_operations,
                     "labels": {
                         "mode": "local",
                         "run_document_attachments": True,
@@ -1628,9 +1715,7 @@ class LensNodeClient:
         try:
             get_checkpoint_saver(workspace_path)
         except Exception:
-            LOGGER.exception(
-                "Disabling run checkpoint resume: storage is unavailable"
-            )
+            LOGGER.exception("Disabling run checkpoint resume: storage is unavailable")
             self._checkpoint_resume_ready = False
             return False
         self._checkpoint_resume_ready = True
@@ -1652,10 +1737,7 @@ class LensNodeClient:
                 tuple(task["name"] for task in TASKS),
             )
             self.heartbeat_count += 1
-            if (
-                self.heartbeat_count == 1
-                or signature != self.last_report_signature
-            ):
+            if self.heartbeat_count == 1 or signature != self.last_report_signature:
                 LOGGER.info(
                     task_log(
                         (
@@ -1699,9 +1781,7 @@ class LensNodeClient:
             while self._outbox:
                 payload = self._outbox.popleft()
                 try:
-                    await websocket.send(
-                        json.dumps(payload, ensure_ascii=False)
-                    )
+                    await websocket.send(json.dumps(payload, ensure_ascii=False))
                 except Exception:
                     self._outbox.appendleft(payload)
                     self._outbox_ready.set()
@@ -1732,9 +1812,7 @@ class LensNodeClient:
             f"CloseMessage: {message}",
         ]
         if self.connected_at:
-            details.append(
-                f"ConnectedDuration: {elapsed_since(self.connected_at)}"
-            )
+            details.append(f"ConnectedDuration: {elapsed_since(self.connected_at)}")
         LOGGER.info(
             task_log(
                 (
@@ -1783,12 +1861,9 @@ def _init_sentry():
         dsn=dsn,
         environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
         release=os.getenv("SENTRY_RELEASE", "") or None,
-        traces_sample_rate=float(
-            os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")
-        ),
-        send_default_pii=os.getenv(
-            "SENTRY_SEND_DEFAULT_PII", "false"
-        ).lower() in ("1", "true", "yes"),
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
+        send_default_pii=os.getenv("SENTRY_SEND_DEFAULT_PII", "false").lower()
+        in ("1", "true", "yes"),
     )
 
 

--- a/lensnode/tests/test_executor.py
+++ b/lensnode/tests/test_executor.py
@@ -157,12 +157,8 @@ def test_terminal_result_retains_checkpoint_until_acknowledged():
     executor.agent = FakeAgent()
 
     with (
-        patch(
-            "lensnode.executor.cleanup_run_checkpoint"
-        ) as checkpoint_cleanup,
-        patch(
-            "lensnode.executor.cleanup_run_runtime_resources"
-        ) as runtime_cleanup,
+        patch("lensnode.executor.cleanup_run_checkpoint") as checkpoint_cleanup,
+        patch("lensnode.executor.cleanup_run_runtime_resources") as runtime_cleanup,
     ):
         asyncio.run(
             executor.execute(
@@ -310,8 +306,7 @@ def test_duplicate_resume_for_active_run_is_idempotent():
         await client._handle_message(json.dumps(message))
 
         assert not any(
-            frame.get("error") == "LENSNODE_RUN_ACTIVE"
-            for frame in client._outbox
+            frame.get("error") == "LENSNODE_RUN_ACTIVE" for frame in client._outbox
         )
         client.running_tasks[run_uuid].cancel()
         await asyncio.gather(
@@ -360,9 +355,7 @@ def test_run_admission_echoes_dispatch_id_and_duplicate_is_idempotent():
         )
 
         admissions = [
-            frame
-            for frame in client._outbox
-            if frame.get("type") == "run_admitted"
+            frame for frame in client._outbox if frame.get("type") == "run_admitted"
         ]
         assert admissions == [
             {
@@ -377,8 +370,7 @@ def test_run_admission_echoes_dispatch_id_and_duplicate_is_idempotent():
             },
         ]
         assert not any(
-            frame.get("error") == "LENSNODE_RUN_ACTIVE"
-            for frame in client._outbox
+            frame.get("error") == "LENSNODE_RUN_ACTIVE" for frame in client._outbox
         )
         client.running_tasks[run_uuid].cancel()
         await asyncio.gather(
@@ -494,9 +486,7 @@ def test_control_plane_cancel_cleans_idle_checkpoint_and_runtime_files():
 
     with (
         patch("lensnode.main.cleanup_run_checkpoint") as checkpoint_cleanup,
-        patch(
-            "lensnode.main.cleanup_run_runtime_resources"
-        ) as runtime_cleanup,
+        patch("lensnode.main.cleanup_run_runtime_resources") as runtime_cleanup,
     ):
         asyncio.run(exercise())
 
@@ -666,9 +656,7 @@ def test_executor_watchdog_fails_stalled_run_and_mutes_late_emits(
     assert done[-1]["error"] == "NO_ACTIVITY_TIMEOUT"
     assert agent.cancel_event is not None
     assert agent.cancel_event.is_set()
-    assert not any(
-        event.get("content_delta") == "late output" for event in events
-    )
+    assert not any(event.get("content_delta") == "late output" for event in events)
 
 
 class HeartbeatOnlyAgent:
@@ -781,8 +769,7 @@ def test_executor_enforces_wall_clock_deadline_and_mutes_late_emits(
     assert agent.cancel_event is not None
     assert agent.cancel_event.is_set()
     assert not any(
-        event.get("content_delta") == "late deadline output"
-        for event in events
+        event.get("content_delta") == "late deadline output" for event in events
     )
 
 
@@ -976,9 +963,10 @@ def test_runtime_materializes_virtual_plugin_skill_references(tmp_path):
             "HyperBDR/sourcelens"
             in (package / "references" / "repositories.md").read_text()
         )
-        assert "do not grant access" in (
-            package / "references" / "repositories.md"
-        ).read_text()
+        assert (
+            "do not grant access"
+            in (package / "references" / "repositories.md").read_text()
+        )
         assert "virtual Skill" in resources.context_skill_contents[0]
     finally:
         cleanup_runtime_resources(resources)
@@ -1092,9 +1080,7 @@ def test_mcp_environment_expands_runtime_placeholders_only(tmp_path):
     try:
         runtime_mcp = resources.mcp_configs[0]
         assert runtime_mcp["endpoint"] == "https://mcp.example.com/api"
-        assert runtime_mcp["config"]["headers"] == {
-            "Authorization": f"Bearer {secret}"
-        }
+        assert runtime_mcp["config"]["headers"] == {"Authorization": f"Bearer {secret}"}
         runtime_text = resources.mcp_config_path.read_text(encoding="utf-8")
         assert secret not in runtime_text
         assert "MCP_TOKEN" not in runtime_text
@@ -1188,9 +1174,7 @@ def test_mcp_environment_preserves_legacy_placeholder_literals(tmp_path):
         assert resources.mcp_configs[0]["endpoint"] == (
             "https://mcp.example.com/${API_VERSION}"
         )
-        assert resources.mcp_configs[0]["config"] == {
-            "template": "${LITERAL}"
-        }
+        assert resources.mcp_configs[0]["config"] == {"template": "${LITERAL}"}
     finally:
         cleanup_runtime_resources(resources)
 
@@ -1266,10 +1250,7 @@ def test_system_prompt_injects_codegraph_guidance_when_available():
 
     assert "CodeGraph is available" in prompt
     assert "mcp__codegraph__codegraph_explore" in prompt
-    assert (
-        "MUST call mcp__codegraph__codegraph_explore before any"
-        in prompt
-    )
+    assert "MUST call mcp__codegraph__codegraph_explore before any" in prompt
     assert "mcp__codegraph__codegraph_trace" not in prompt
 
 
@@ -1327,8 +1308,7 @@ def test_code_analysis_paths_are_relative_to_resource_directories():
     )
 
     assert answer == (
-        "See backend/lens/views.py and "
-        "frontend/src/pages/lens/Chat.vue."
+        "See backend/lens/views.py and " "frontend/src/pages/lens/Chat.vue."
     )
 
 
@@ -1343,8 +1323,7 @@ def test_workspace_paths_are_relative_for_non_code_analysis_tasks():
     )
 
     assert answer == (
-        "The workspace is . and the file is "
-        "lensnode/lensnode/runtime.py."
+        "The workspace is . and the file is " "lensnode/lensnode/runtime.py."
     )
 
 
@@ -1376,9 +1355,12 @@ def test_general_chat_answers_hide_runtime_document_paths_and_tool_names():
 
 
 def test_code_analysis_has_bounded_default_agent_turns():
-    assert _resolve_agent_turn_limit(
-        {"task": "code_analysis"},
-    ) == 10
+    assert (
+        _resolve_agent_turn_limit(
+            {"task": "code_analysis"},
+        )
+        == 10
+    )
 
 
 @pytest.mark.parametrize(
@@ -1392,21 +1374,30 @@ def test_code_analysis_has_bounded_default_agent_turns():
     ],
 )
 def test_agent_rounds_resolve_to_model_turn_limits(agent_rounds, expected):
-    assert _resolve_agent_turn_limit(
-        {"task": "code_analysis", "agent_rounds": agent_rounds},
-    ) == expected
+    assert (
+        _resolve_agent_turn_limit(
+            {"task": "code_analysis", "agent_rounds": agent_rounds},
+        )
+        == expected
+    )
 
 
 def test_unknown_agent_rounds_keep_code_analysis_default():
-    assert _resolve_agent_turn_limit(
-        {"task": "code_analysis", "agent_rounds": "unknown"},
-    ) == 10
+    assert (
+        _resolve_agent_turn_limit(
+            {"task": "code_analysis", "agent_rounds": "unknown"},
+        )
+        == 10
+    )
 
 
 def test_explicit_agent_turn_limit_overrides_code_analysis_default():
-    assert _resolve_agent_turn_limit(
-        {"task": "code_analysis", "max_agent_turns": 7},
-    ) == 7
+    assert (
+        _resolve_agent_turn_limit(
+            {"task": "code_analysis", "max_agent_turns": 7},
+        )
+        == 7
+    )
 
 
 def test_other_tasks_keep_unset_agent_turn_limit():
@@ -1445,9 +1436,7 @@ def test_smart_collaboration_bypasses_capability_route():
 def test_vague_code_analysis_questions_are_detected_without_target():
     assert _vague_code_analysis_question("帮我分析一下") is True
     assert _vague_code_analysis_question("请描述一下") is True
-    assert _vague_code_analysis_question(
-        "分析 runtime.py 的 _build_agent"
-    ) is False
+    assert _vague_code_analysis_question("分析 runtime.py 的 _build_agent") is False
 
 
 def test_git_log_accepts_non_integer_max_count(tmp_path):
@@ -1935,6 +1924,7 @@ def test_lensnode_datasource_conversion_reports_safe_cancellation(
                     "type": "datasource_convert",
                     "request_id": "conversion-request",
                     "task_id": task_id,
+                    "datasource_uuid": "datasource-uuid",
                     "source_type": "managed_workspace",
                     "target_path": "/workspace/documents",
                     "conversion": {"document": True},
@@ -1945,6 +1935,15 @@ def test_lensnode_datasource_conversion_reports_safe_cancellation(
             asyncio.to_thread(started.wait),
             timeout=1,
         )
+        assert client._reported_active_datasource_operations() == [
+            {
+                "task_id": task_id,
+                "datasource_uuid": "datasource-uuid",
+                "operation": "conversion",
+                "phase": "starting",
+                "last_progress": {},
+            }
+        ]
 
         await client._handle_message(
             json.dumps(
@@ -1965,5 +1964,15 @@ def test_lensnode_datasource_conversion_reports_safe_cancellation(
         assert done[-1]["status"] == "cancelled"
         assert done[-1]["error"] == "DATASOURCE_CONVERSION_CANCELLED"
         assert f"datasource-convert:{task_id}" not in client.running_tasks
+        assert client._reported_active_datasource_operations()
+        await client._handle_message(
+            json.dumps(
+                {
+                    "type": "datasource_terminal_ack",
+                    "task_id": task_id,
+                }
+            )
+        )
+        assert client._reported_active_datasource_operations() == []
 
     asyncio.run(exercise())

--- a/release-notes/498.yaml
+++ b/release-notes/498.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Resumed managed workspace conversions and uploads after transient LensNode reconnects without losing completed results.
+zh-CN: 修复 LensNode 短暂重连后托管工作区转换和上传无法恢复，以及已完成结果可能丢失的问题。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Report active managed datasource conversions and uploads in the LensNode reconnect hello.
- Rebind reported and legacy work to the new WebSocket connection while deferring genuinely unreported work through a bounded confirmation window.
- Preserve terminal datasource frames until the control plane acknowledges their persisted completion, including reconnect recovery and heartbeat-detected disconnects.

Closes #498

## Test plan
- [x] Targeted Django reconnect, disconnect grace, orphan confirmation, and terminal acknowledgement tests
- [x] Python syntax and formatting checks
- [x] Automated uncommitted-change review


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Report active datasource operations in LensNode reconnect hello.

- Rebind reported operations to new WebSocket; defer unreported with grace period.

- Add pending datasource terminal frames and server acknowledgment.

- Add tests for reconnect rebinding, legacy rebind, and deferred failure.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LensNode["LensNode"] -- "WebSocket disconnect" --> Reconnect["Reconnect with new connection"]
  Reconnect -- "hello (active_datasource_operations)" --> Backend["Backend"]
  Backend -- "Rebind reported tasks" --> Rebound["Original TaskExecution remains active"]
  Backend -- "Defer unreported tasks" --> Grace["Confirm orphan after grace period"]
  LensNode -- "Buffered terminal frames" --> Ack["Server sends datasource_terminal_ack"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>main.py</strong><dd><code>Track active datasource operations for reconnect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+165/-90</a></td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Rebind or defer orphaned datasource conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-82180c2db81b93f0dd95ee09c609f435ff8221c15accdb379c377c7872b0136f">+166/-73</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>consumers.py</strong><dd><code>Handle active datasource ops and reject stale events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+53/-47</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_services.py</strong><dd><code>Add tests for datasource reconnect recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+316/-74</a></td>

</tr>

<tr>
  <td><strong>test_executor.py</strong><dd><code>Update tests for datasource conversion cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-a2b0b1e16d8c8522f440493e504c82f8fd8a46db737fa5c1c29366fcb28b9682">+62/-53</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_disconnect_grace.py</strong><dd><code>Add test for confirming active conversion offline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-4c30be79cc6bcad79aee8f4292034bf60ba45e1b95a1733ec8540c16b032949a">+47/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>498.yaml</strong><dd><code>Add release note for datasource reconnect fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/515/files#diff-e3ca701f0bd5f0d975384c587651bea7e4c84fd97d6da0adacfec3ac65c21560">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

