### PR TITLE
Add guided AI model setup and detailed install progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,32 @@ After installation:
 - Installation details and the initial admin password:
   `<install-dir>/install-info.env`
 
+When no active system model exists during an interactive install or rerun, the
+installer offers to configure one before it prints the final summary. Select a
+provider and model with the arrow keys, enter the API key in the masked prompt,
+and the installer will test the connection before saving it as the system
+default. Existing model settings are preserved when the installer is run again.
+
+Use `--yes` to skip interactive model setup. You can configure or manage models
+later at `http://<host>:10080/management/llm/config`.
+
+When SourceLens is installed in a NAT virtual machine, forward host TCP port
+`10080` to guest TCP port `10080` before opening the site in the host browser.
+
+To test local changes, transfer the complete repository (including initialized
+submodules) to the target machine, then run:
+
+```bash
+sudo bash /tmp/sourcelens-source/install.sh \
+  --source /tmp/sourcelens-source \
+  --dir /opt/sourcelens-fixed-test
+```
+
+`--source` reads installer and deployment files from that source tree while
+application images are still pulled from the registry. A non-default install
+directory creates an isolated test environment so an existing installation is
+not replaced; the installer will ask for another port if `10080` is busy.
+
 The default installation directory is `/opt/sourcelens`. Re-running the
 installer with a newer tag upgrades the installation in place. Existing `.env`
 configuration and application data are preserved.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ SourceLens has two production deployment options. Use one per host:
 - **Standalone single instance**: installed and upgraded with `install.sh`.
 - **Zero-downtime blue/green**: deployed with `scripts/install.sh <tag>`.
 
-Default ports are HTTP 10080 and HTTPS 10443.
+The one-command installer defaults to HTTP 10083 and HTTPS 10443.
 
 ### One-command Installation
 
@@ -193,7 +193,7 @@ upgrade or install a specific release, add `--version <version>`. Run
 
 After installation:
 
-- Main site: `http://<host>:10080` (HTTPS: `https://<host>:10443`)
+- Main site: `http://<host>:10083` (HTTPS: `https://<host>:10443`)
 - Configuration: `<install-dir>/.env`
 - Installation details and the initial admin password:
   `<install-dir>/install-info.env`
@@ -205,10 +205,10 @@ and the installer will test the connection before saving it as the system
 default. Existing model settings are preserved when the installer is run again.
 
 Use `--yes` to skip interactive model setup. You can configure or manage models
-later at `http://<host>:10080/management/llm/config`.
+later at `http://<host>:10083/management/llm/config`.
 
 When SourceLens is installed in a NAT virtual machine, forward host TCP port
-`10080` to guest TCP port `10080` before opening the site in the host browser.
+`10083` to guest TCP port `10083` before opening the site in the host browser.
 
 To test local changes, transfer the complete repository (including initialized
 submodules) to the target machine, then run:
@@ -222,7 +222,7 @@ sudo bash /tmp/sourcelens-source/install.sh \
 `--source` reads installer and deployment files from that source tree while
 application images are still pulled from the registry. A non-default install
 directory creates an isolated test environment so an existing installation is
-not replaced; the installer will ask for another port if `10080` is busy.
+not replaced; the installer will ask for another port if `10083` is busy.
 
 The default installation directory is `/opt/sourcelens`. Re-running the
 installer with a newer tag upgrades the installation in place. Existing `.env`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,6 +195,29 @@ curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | \
 - 配置文件：`<install-dir>/.env`
 - 安装详情和初始管理员密码：`<install-dir>/install-info.env`
 
+交互式安装或重复运行时，如果没有已启用的系统模型，安装器会在最终摘要前引导
+配置。使用方向键选择模型服务商和模型，在显示星号掩码的输入框中填写 API Key 后，
+安装器会先测试连接，再将配置保存为系统默认模型。重复运行安装器不会覆盖已有模型
+配置。
+
+使用 `--yes` 可跳过交互式模型配置。之后可前往
+`http://<host>:10080/management/llm/config` 配置或管理模型。
+
+如果 SourceLens 安装在 NAT 虚拟机中，需要先将宿主机 TCP 端口 `10080` 转发到
+虚拟机 TCP 端口 `10080`，再从宿主机浏览器访问。
+
+测试本地修改时，将包含已初始化子模块的完整仓库传到目标机器，然后运行：
+
+```bash
+sudo bash /tmp/sourcelens-source/install.sh \
+  --source /tmp/sourcelens-source \
+  --dir /opt/sourcelens-fixed-test
+```
+
+`--source` 会从该目录读取安装和部署文件，应用镜像仍然从镜像仓库拉取。使用
+非默认安装目录时，安装器会创建隔离的测试环境，避免替换已有安装；如果 `10080`
+已占用，安装器会提示选择其他端口。
+
 默认安装目录为 `/opt/sourcelens`。使用新 tag 重复运行安装器即可原地升级，已有
 `.env` 配置和应用数据会被保留。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,7 +163,7 @@ SourceLens 有两种生产部署方式，每台主机选择一种：
 - **Standalone 单实例**：使用 `install.sh` 安装和升级。
 - **零停机蓝绿部署**：使用 `scripts/install.sh <tag>` 部署。
 
-默认端口为 HTTP 10080 和 HTTPS 10443。
+一键安装器的默认端口为 HTTP 10083 和 HTTPS 10443。
 
 ### 一键安装
 
@@ -191,7 +191,7 @@ curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | \
 
 安装完成后：
 
-- 主站：`http://<host>:10080`（HTTPS：`https://<host>:10443`）
+- 主站：`http://<host>:10083`（HTTPS：`https://<host>:10443`）
 - 配置文件：`<install-dir>/.env`
 - 安装详情和初始管理员密码：`<install-dir>/install-info.env`
 
@@ -201,10 +201,10 @@ curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | \
 配置。
 
 使用 `--yes` 可跳过交互式模型配置。之后可前往
-`http://<host>:10080/management/llm/config` 配置或管理模型。
+`http://<host>:10083/management/llm/config` 配置或管理模型。
 
-如果 SourceLens 安装在 NAT 虚拟机中，需要先将宿主机 TCP 端口 `10080` 转发到
-虚拟机 TCP 端口 `10080`，再从宿主机浏览器访问。
+如果 SourceLens 安装在 NAT 虚拟机中，需要先将宿主机 TCP 端口 `10083` 转发到
+虚拟机 TCP 端口 `10083`，再从宿主机浏览器访问。
 
 测试本地修改时，将包含已初始化子模块的完整仓库传到目标机器，然后运行：
 
@@ -215,7 +215,7 @@ sudo bash /tmp/sourcelens-source/install.sh \
 ```
 
 `--source` 会从该目录读取安装和部署文件，应用镜像仍然从镜像仓库拉取。使用
-非默认安装目录时，安装器会创建隔离的测试环境，避免替换已有安装；如果 `10080`
+非默认安装目录时，安装器会创建隔离的测试环境，避免替换已有安装；如果 `10083`
 已占用，安装器会提示选择其他端口。
 
 默认安装目录为 `/opt/sourcelens`。使用新 tag 重复运行安装器即可原地升级，已有

--- a/backend/core/management/commands/setup_ai_model.py
+++ b/backend/core/management/commands/setup_ai_model.py
@@ -318,14 +318,14 @@ class Command(BaseCommand):
     def _confirm(self, prompt, default):
         """Read a yes/no answer with an explicit default."""
 
-        suffix = " [Y/n]: " if default else " [y/N]: "
+        suffix = " [Yes/no]: " if default else " [yes/No]: "
         while True:
             answer = self._input(prompt + suffix).strip().lower()
             if not answer:
                 return default
-            if answer in {"y", "yes"}:
+            if answer == "yes":
                 return True
-            if answer in {"n", "no"}:
+            if answer == "no":
                 return False
             self.stdout.write(self.style.WARNING("Enter yes or no."))
 

--- a/backend/core/management/commands/setup_ai_model.py
+++ b/backend/core/management/commands/setup_ai_model.py
@@ -1,0 +1,376 @@
+"""Configure and validate the first system AI model interactively."""
+
+import sys
+import termios
+import tty
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from agentcore_metering.adapters.django.models import LLMConfig
+from agentcore_metering.adapters.django.services.config_source import (
+    get_default_llm_config_uuid,
+    set_default_llm_config,
+)
+from agentcore_metering.adapters.django.services.litellm_params import (
+    get_provider_params_schema,
+)
+from agentcore_metering.adapters.django.services.model_catalog import (
+    get_model_type_for_model_id,
+    get_providers_with_models,
+)
+from agentcore_metering.adapters.django.services.runtime_config import (
+    VALIDATION_MESSAGE_IDS,
+    get_validation_message,
+    validate_llm_config,
+)
+
+FIELD_LABELS = {
+    "api_base": "API endpoint",
+    "api_version": "API version",
+    "deployment": "Deployment name",
+}
+
+
+class Command(BaseCommand):
+    """Run the first-install AI model setup wizard."""
+
+    help = "Interactively configure and validate the system default AI model"
+    requires_system_checks = []
+
+    def add_arguments(self, parser):
+        """Add a status check used by the one-command installer."""
+
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help="Exit successfully only when an active system model exists.",
+        )
+
+    def handle(self, *args, **options):
+        """Run model setup or report whether setup is complete."""
+
+        if get_default_llm_config_uuid():
+            if not options["check"]:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "An active system AI model is already configured."
+                    )
+                )
+            return
+
+        if options["check"]:
+            raise CommandError("No active system AI model is configured.")
+
+        if not self._has_tty():
+            raise CommandError(
+                "Interactive model setup requires a terminal. Configure the "
+                "model later in the SourceLens management console."
+            )
+
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING("AI model setup"))
+        self.stdout.write(
+            "SourceLens needs an AI model before assistants can run."
+        )
+        if not self._confirm("Configure a model now?", default=True):
+            self.stdout.write(
+                self.style.WARNING(
+                    "AI model setup skipped. You can configure it later in "
+                    "the SourceLens management console."
+                )
+            )
+            return
+
+        try:
+            self._configure_until_complete()
+        except (EOFError, KeyboardInterrupt):
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING(
+                    "AI model setup skipped. The SourceLens installation is "
+                    "still available."
+                )
+            )
+
+    def _configure_until_complete(self):
+        """Retry the wizard until setup succeeds or the user stops."""
+
+        while True:
+            provider = self._select_provider()
+            config = self._collect_config(provider)
+            provider_id = provider["id"]
+            self.stdout.write("Testing the model connection...")
+            ok, message = validate_llm_config(
+                provider_id,
+                config,
+                user=None,
+            )
+            if ok:
+                self._save_default(provider_id, config)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Connection successful. The model was saved as the "
+                        "system default."
+                    )
+                )
+                return
+
+            self.stdout.write(self.style.ERROR(self._friendly_error(message)))
+            if not self._confirm("Try a different configuration?", True):
+                self.stdout.write(
+                    self.style.WARNING(
+                        "AI model setup skipped. You can configure it later "
+                        "in the SourceLens management console."
+                    )
+                )
+                return
+
+    def _select_provider(self):
+        """Return a provider id selected from the shared model catalog."""
+
+        schema = get_provider_params_schema().get("providers", {})
+        providers = [
+            provider
+            for provider in get_providers_with_models().get("providers", [])
+            if provider.get("id") in schema
+        ]
+        if not providers:
+            raise CommandError("No AI model providers are available.")
+        labels = [provider["label"] for provider in providers]
+        selected = self._select_option("Model providers", labels)
+        return providers[selected]
+
+    def _collect_config(self, provider):
+        """Collect only the model fields needed for first-time setup."""
+
+        provider_id = provider["id"]
+        schema = get_provider_params_schema()["providers"][provider_id]
+        config = {"model": self._select_model(provider, schema)}
+        required = set(schema.get("required") or [])
+        default_endpoint = schema.get("default_api_base") or ""
+
+        if "api_base" in required or default_endpoint:
+            endpoint = self._required_or_default(
+                FIELD_LABELS["api_base"],
+                default_endpoint,
+                required="api_base" in required,
+            )
+            if endpoint:
+                config["api_base"] = endpoint
+
+        if "deployment" in required:
+            config["deployment"] = self._required_or_default(
+                FIELD_LABELS["deployment"], "", required=True
+            )
+        if "api_version" in schema.get("editable_params", []):
+            api_version = self._required_or_default(
+                FIELD_LABELS["api_version"],
+                "2024-02-15-preview",
+                required=False,
+            )
+            if api_version:
+                config["api_version"] = api_version
+
+        while True:
+            api_key = self._secret_input("API key: ").strip()
+            if api_key:
+                config["api_key"] = api_key
+                break
+            self.stdout.write(self.style.WARNING("API key is required."))
+        return config
+
+    def _select_model(self, provider, schema):
+        """Select a chat model while still allowing custom model ids."""
+
+        models = [
+            model
+            for model in provider.get("models", [])
+            if model.get("mode", "chat") == "chat"
+        ]
+        default_model = schema.get("default_model") or ""
+        if not models:
+            return self._required_or_default(
+                "Model", default_model, required=not bool(default_model)
+            )
+
+        default_index = None
+        labels = []
+        for index, model in enumerate(models):
+            marker = " (default)" if model["id"] == default_model else ""
+            labels.append(f"{model['label']} [{model['id']}]{marker}")
+            if marker:
+                default_index = index
+        labels.append("Custom model")
+        selected = self._select_option(
+            f"Models from {provider['label']}",
+            labels,
+            selected=(
+                default_index if default_index is not None else len(models)
+            ),
+        )
+        if selected == len(models):
+            return self._required_or_default("Model", "", required=True)
+        return models[selected]["id"]
+
+    def _select_option(self, title, options, selected=0):
+        """Select one option using arrow keys and Enter."""
+
+        self.stdout.write("")
+        self.stdout.write(f"{title} (use ↑/↓ and press Enter):")
+        self._render_options(options, selected)
+        while True:
+            key = self._read_key()
+            if key == "up":
+                selected = (selected - 1) % len(options)
+            elif key == "down":
+                selected = (selected + 1) % len(options)
+            elif key == "enter":
+                return selected
+            else:
+                continue
+            self.stdout.write(
+                f"\033[{len(options)}A",
+                ending="",
+            )
+            self._render_options(options, selected)
+
+    def _render_options(self, options, selected):
+        """Render a terminal selection menu at the current cursor."""
+
+        for index, option in enumerate(options):
+            marker = ">" if index == selected else " "
+            self.stdout.write(
+                f"\r\033[2K  {marker} {option}",
+            )
+        self.stdout.flush()
+
+    @staticmethod
+    def _read_key():
+        """Read one navigation key without requiring Enter."""
+
+        fd = sys.stdin.fileno()
+        previous = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            char = sys.stdin.read(1)
+            if char == "\x03":
+                raise KeyboardInterrupt
+            if char in {"\r", "\n"}:
+                return "enter"
+            if char == "\x1b":
+                sequence = sys.stdin.read(2)
+                if sequence == "[A":
+                    return "up"
+                if sequence == "[B":
+                    return "down"
+            return ""
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, previous)
+
+    def _required_or_default(self, label, default, required):
+        """Prompt for a visible value with optional default handling."""
+
+        prompt = f"{label}"
+        if default:
+            prompt += f" [{default}]"
+        prompt += ": "
+        while True:
+            value = self._input(prompt).strip()
+            if value:
+                return value
+            if default:
+                return default
+            if not required:
+                return ""
+            self.stdout.write(self.style.WARNING(f"{label} is required."))
+
+    def _save_default(self, provider, config):
+        """Persist the validated model as the active global default."""
+
+        model_type = get_model_type_for_model_id(
+            provider,
+            config.get("model", ""),
+        )
+        if model_type != LLMConfig.MODEL_TYPE_LLM:
+            raise CommandError("The selected model is not a chat model.")
+        with transaction.atomic():
+            model_config = LLMConfig.objects.create(
+                scope=LLMConfig.Scope.GLOBAL,
+                user=None,
+                model_type=LLMConfig.MODEL_TYPE_LLM,
+                provider=provider,
+                config=config,
+                is_active=True,
+            )
+            set_default_llm_config(model_config)
+
+    @staticmethod
+    def _friendly_error(message):
+        """Return only sanitized, user-actionable validation text."""
+
+        if message in VALIDATION_MESSAGE_IDS:
+            detail = get_validation_message(message, language="en")
+        else:
+            detail = get_validation_message("unknown", language="en")
+        return f"Connection failed: {detail}"
+
+    def _confirm(self, prompt, default):
+        """Read a yes/no answer with an explicit default."""
+
+        suffix = " [Y/n]: " if default else " [y/N]: "
+        while True:
+            answer = self._input(prompt + suffix).strip().lower()
+            if not answer:
+                return default
+            if answer in {"y", "yes"}:
+                return True
+            if answer in {"n", "no"}:
+                return False
+            self.stdout.write(self.style.WARNING("Enter yes or no."))
+
+    @staticmethod
+    def _input(prompt):
+        """Read a non-secret answer from the attached terminal."""
+
+        return input(prompt)
+
+    @staticmethod
+    def _secret_input(prompt):
+        """Read a secret while displaying one mask per character."""
+
+        fd = sys.stdin.fileno()
+        previous = termios.tcgetattr(fd)
+        secret = []
+        sys.stdout.write(prompt)
+        sys.stdout.flush()
+        try:
+            tty.setraw(fd)
+            while True:
+                char = sys.stdin.read(1)
+                if char in {"\r", "\n"}:
+                    sys.stdout.write("\r\n")
+                    sys.stdout.flush()
+                    return "".join(secret)
+                if char == "\x03":
+                    raise KeyboardInterrupt
+                if char == "\x04":
+                    raise EOFError
+                if char in {"\x7f", "\b"}:
+                    if secret:
+                        secret.pop()
+                        sys.stdout.write("\b \b")
+                        sys.stdout.flush()
+                    continue
+                if char.isprintable():
+                    secret.append(char)
+                    sys.stdout.write("*")
+                    sys.stdout.flush()
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, previous)
+
+    @staticmethod
+    def _has_tty():
+        """Refuse secret entry when input cannot be hidden."""
+
+        return sys.stdin.isatty() and sys.stdout.isatty()

--- a/backend/tests/test_setup_ai_model_command.py
+++ b/backend/tests/test_setup_ai_model_command.py
@@ -1,0 +1,174 @@
+"""Tests for the interactive AI model setup command."""
+
+import sys
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from agentcore_metering.adapters.django.models import LLMConfig
+from core.management.commands.setup_ai_model import Command
+
+
+class FakeTerminalInput:
+    """Provide character-by-character terminal input for mask tests."""
+
+    def __init__(self, value):
+        self._characters = iter(value)
+
+    @staticmethod
+    def fileno():
+        """Return a harmless file descriptor for mocked terminal calls."""
+
+        return 0
+
+    def read(self, size):
+        """Return the next simulated terminal character."""
+
+        del size
+        return next(self._characters)
+
+
+@pytest.mark.django_db
+def test_check_fails_without_active_global_model():
+    """The installer can detect when model setup is still required."""
+
+    with pytest.raises(CommandError):
+        call_command(Command(), "--check", stdout=StringIO())
+
+
+@pytest.mark.django_db
+def test_existing_active_global_model_skips_prompts(monkeypatch):
+    """Rerunning the installer does not replace an existing model."""
+
+    LLMConfig.objects.create(
+        scope=LLMConfig.Scope.GLOBAL,
+        model_type=LLMConfig.MODEL_TYPE_LLM,
+        provider="openai",
+        config={"api_key": "existing-key", "model": "gpt-4o-mini"},
+        is_active=True,
+        is_default=True,
+    )
+    monkeypatch.setattr(
+        Command,
+        "_input",
+        lambda self, prompt: pytest.fail(f"Unexpected prompt: {prompt}"),
+    )
+    output = StringIO()
+
+    call_command(Command(), stdout=output)
+    call_command(Command(), "--check", stdout=StringIO())
+
+    assert "already configured" in output.getvalue()
+
+
+@pytest.mark.django_db
+def test_interactive_setup_tests_and_saves_default_model(monkeypatch):
+    """A successful connection creates one active system default model."""
+
+    answers = iter(["", ""])
+    secret = "test-api-key"
+    captured = {}
+
+    monkeypatch.setattr(Command, "_has_tty", lambda self: True)
+    monkeypatch.setattr(
+        Command,
+        "_input",
+        lambda self, prompt: next(answers),
+    )
+    monkeypatch.setattr(
+        Command,
+        "_select_option",
+        lambda self, title, options, selected=0: selected,
+    )
+    monkeypatch.setattr(
+        Command,
+        "_secret_input",
+        lambda self, prompt: secret,
+    )
+
+    def fake_validate(provider, config, user=None):
+        captured.update(provider=provider, config=config, user=user)
+        return True, ""
+
+    monkeypatch.setattr(
+        "core.management.commands.setup_ai_model.validate_llm_config",
+        fake_validate,
+    )
+    output = StringIO()
+
+    call_command(Command(), stdout=output)
+
+    config = LLMConfig.objects.get()
+    assert config.scope == LLMConfig.Scope.GLOBAL
+    assert config.model_type == LLMConfig.MODEL_TYPE_LLM
+    assert config.is_active is True
+    assert config.is_default is True
+    assert config.config["api_key"] == secret
+    assert captured["provider"] == config.provider
+    assert captured["config"] == config.config
+    assert captured["user"] is None
+    assert secret not in output.getvalue()
+    assert "saved as the system default" in output.getvalue()
+
+
+@pytest.mark.django_db
+def test_interactive_setup_can_be_skipped(monkeypatch):
+    """Skipping model setup leaves the working installation unchanged."""
+
+    monkeypatch.setattr(Command, "_has_tty", lambda self: True)
+    monkeypatch.setattr(Command, "_input", lambda self, prompt: "n")
+    output = StringIO()
+
+    call_command(Command(), stdout=output)
+
+    assert not LLMConfig.objects.exists()
+    assert "skipped" in output.getvalue().lower()
+
+
+def test_option_menu_uses_arrow_keys(monkeypatch):
+    """Arrow keys move the active option before Enter confirms it."""
+
+    keys = iter(["down", "down", "up", "enter"])
+    monkeypatch.setattr(Command, "_read_key", lambda self: next(keys))
+    output = StringIO()
+    command = Command(stdout=output)
+
+    selected = command._select_option(
+        "Providers",
+        ["OpenAI", "Anthropic", "DeepSeek"],
+    )
+
+    assert selected == 1
+    assert "use ↑/↓ and press Enter" in output.getvalue()
+    assert "> Anthropic" in output.getvalue()
+
+
+def test_secret_input_displays_masks_and_supports_backspace(monkeypatch):
+    """Typed and pasted secret characters are represented only by masks."""
+
+    terminal_input = FakeTerminalInput("abc\x7fd\r")
+    terminal_output = StringIO()
+    restored = []
+    monkeypatch.setattr(sys, "stdin", terminal_input)
+    monkeypatch.setattr(sys, "stdout", terminal_output)
+    monkeypatch.setattr(
+        "core.management.commands.setup_ai_model.termios.tcgetattr",
+        lambda fd: [fd],
+    )
+    monkeypatch.setattr(
+        "core.management.commands.setup_ai_model.termios.tcsetattr",
+        lambda fd, when, value: restored.append((fd, when, value)),
+    )
+    monkeypatch.setattr(
+        "core.management.commands.setup_ai_model.tty.setraw",
+        lambda fd: None,
+    )
+
+    secret = Command._secret_input("API key: ")
+
+    assert secret == "abd"
+    assert "abc" not in terminal_output.getvalue()
+    assert terminal_output.getvalue().count("*") == 4
+    assert restored

--- a/backend/tests/test_setup_ai_model_command.py
+++ b/backend/tests/test_setup_ai_model_command.py
@@ -118,7 +118,7 @@ def test_interactive_setup_can_be_skipped(monkeypatch):
     """Skipping model setup leaves the working installation unchanged."""
 
     monkeypatch.setattr(Command, "_has_tty", lambda self: True)
-    monkeypatch.setattr(Command, "_input", lambda self, prompt: "n")
+    monkeypatch.setattr(Command, "_input", lambda self, prompt: "no")
     output = StringIO()
 
     call_command(Command(), stdout=output)

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -58,9 +58,9 @@ services:
       # Gate dependent services on API readiness only. Full Celery readiness is
       # checked by install.sh after worker and scheduler have started.
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      interval: 5s
+      timeout: 5s
+      retries: 12
       start_period: 120s
 
   frontend:

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ GITEE_REPO="oneprolabs/sourcelens"
 GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
 GITEE_RAW_BASE="https://gitee.com/${GITEE_REPO}/raw"
 DEFAULT_INSTALL_DIR="/opt/${APP_NAME}"
-DEFAULT_HTTP_PORT=10080
+DEFAULT_HTTP_PORT=10083
 DEFAULT_HTTPS_PORT=10443
 # Image registry prefixes. Docker Hub uses just the namespace; Aliyun ACR uses
 # host/namespace. Both carry sourcelens-{backend,frontend,lensnode}.

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,8 @@
 #      cn/gitee channel, rewrites the image registry to Aliyun ACR.
 #   4. Generates a self-signed TLS certificate if missing, creates the data
 #      directory layout, pulls images, starts the stack and health-checks it.
+#   5. When no active system model exists, offers an interactive AI model
+#      setup with hidden API-key input and a connection test.
 #
 # Channels: the download source (github/gitee) selects where release files come
 # from AND which registry the application images are pulled from:
@@ -32,8 +34,8 @@
 # (docker-compose 1.x) is NOT supported — the compose files use V2-only features
 # (top-level `name`, `depends_on.condition`).
 #
-# --source mode — for testing this script itself, or running the whole flow from
-# a local checkout without touching GitHub/Gitee:
+# --source mode — test local installer/deployment files while still pulling
+# released application images from the selected registry:
 #
 #   ./install.sh --source /path/to/sourcelens-repo [tag]
 # =============================================================================
@@ -58,8 +60,10 @@ DEFAULT_HTTPS_PORT=10443
 REGISTRY_GITHUB="oneprolabs"
 REGISTRY_CN="registry.cn-beijing.aliyuncs.com/oneprolabs"
 COMPOSE_FILE="docker-compose.standalone.yml"
+MODEL_SETUP_OVERRIDE="docker-compose.model-setup.yml"
 INSTALLER_VERSION="0.1.0"
 HEALTH_TIMEOUT=240
+PULL_PARALLELISM=4
 
 # Release files fetched directly from the repository tag. Only what
 # docker-compose.standalone.yml actually mounts/needs is included.
@@ -113,6 +117,8 @@ ASSUME_YES=0
 FORCE=0
 SOURCE_DIR=""
 INSTALL_ARGS=()
+MODEL_CONFIGURED=0
+MODEL_SETUP_UNAVAILABLE=0
 
 SCHEME="http"
 PORT_SUFFIX=""
@@ -170,15 +176,15 @@ Options:
                              (default: auto; also selects the image registry:
                              github -> Docker Hub, gitee -> Aliyun ACR)
   -v, --version VER        Release version to install (default: latest tag)
-      --source DIR         Use a local repository directory instead of
-                           downloading release files (testing/offline)
+      --source DIR         Use local installer/deployment files while still
+                           pulling application images from the registry
   -r, --registry REG       Override the application image registry prefix
       --domain HOST        Public hostname / IP (default: auto-detect)
       --admin-user USER    Initial admin username (default: admin)
       --admin-email EMAIL  Initial admin email (default: admin@<domain>)
       --https              Configure URLs for HTTPS behind a TLS proxy
       --docker-mirror URL  Configure a Docker Hub registry mirror (linux)
-  -y, --yes                Non-interactive: accept defaults, no prompts
+  -y, --yes                Accept install defaults and skip model setup
       --force              Upgrade without confirmation
   -h, --help               Show this help
 
@@ -438,6 +444,9 @@ check_compose() {
 # stack; refuse to run on a host where blue/green is already active.
 check_no_bluegreen() {
   local c=""
+  if [[ -n "${SOURCE_DIR}" && "${INSTALL_DIR}" != "${DEFAULT_INSTALL_DIR}" ]]; then
+    return 0
+  fi
   for c in sourcelens-api-blue sourcelens-api-green; do
     if [[ "$(docker inspect -f '{{.State.Running}}' "${c}" 2>/dev/null)" == "true" ]]; then
       abort "blue/green stack is active on this host (${c} is running). The standalone installer shares project 'sourcelens' with it; use scripts/install.sh instead, or install on a separate host."
@@ -622,15 +631,21 @@ download_release_file() {
 
 fetch_release_files() {
   log_step "Installing release files (source: ${DOWNLOAD_SOURCE})"
-  local rel="" src="" dir="" http="" done=0
+  local rel="" src="" dir="" target="" http="" done=0
   local total="${#RELEASE_FILES[@]}"
   for rel in "${RELEASE_FILES[@]}"; do
     dir="${INSTALL_DIR}/$(dirname "${rel}")"
+    target="${INSTALL_DIR}/${rel}"
     mkdir -p "${dir}"
+    if [[ -d "${target}" ]]; then
+      rmdir "${target}" 2>/dev/null \
+        || abort "expected release file but found a non-empty directory: ${target}"
+      log_warn "replacing an empty directory with release file ${rel}"
+    fi
     if [[ -n "${SOURCE_DIR}" ]]; then
       src="${SOURCE_DIR%/}/${rel}"
       [[ -f "${src}" ]] || abort "source directory ${SOURCE_DIR} is missing ${rel}"
-      cp -f "${src}" "${INSTALL_DIR}/${rel}"
+      cp -f "${src}" "${target}"
       done=$((done + 1))
     else
       download_release_file "${rel}" || true
@@ -666,6 +681,26 @@ fetch_release_files() {
   # Postgres initdb shell scripts must stay executable for the official image.
   chmod +x "${INSTALL_DIR}/docker/postgresql/initdb.d"/*.sh 2>/dev/null || true
   log_ok "Release files installed"
+}
+
+prepare_model_setup_overlay() {
+  local command_rel="backend/core/management/commands/setup_ai_model.py"
+  local command_src="${SOURCE_DIR%/}/${command_rel}"
+  local overlay_dir="${INSTALL_DIR}/docker/model-setup"
+  local overlay="${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}"
+  rm -f "${overlay}" "${overlay_dir}/setup_ai_model.py"
+  [[ -n "${SOURCE_DIR}" && -f "${command_src}" ]] || return 0
+
+  mkdir -p "${overlay_dir}"
+  cp -f "${command_src}" "${overlay_dir}/setup_ai_model.py"
+  {
+    printf 'services:\n'
+    printf '  backend-api:\n'
+    printf '    volumes:\n'
+    printf '      - ./docker/model-setup/setup_ai_model.py:'
+    printf '/opt/backend/core/management/commands/setup_ai_model.py:ro\n'
+  } >"${overlay}"
+  log_info "Model setup is enabled for this local installer test"
 }
 
 # ---------------------------------------------------------------------------
@@ -794,6 +829,19 @@ patch_compose() {
   if ! grep -q "image: ${REGISTRY}/sourcelens-backend:${VERSION}" "${compose}"; then
     abort "failed to pin image references in ${compose}"
   fi
+  if [[ -n "${SOURCE_DIR}" && "${INSTALL_DIR}" != "${DEFAULT_INSTALL_DIR}" ]]; then
+    local project_name=""
+    project_name="$(basename "${INSTALL_DIR}" \
+      | tr '[:upper:]' '[:lower:]' \
+      | tr -cs 'a-z0-9_-' '-')"
+    project_name="${project_name#-}"
+    project_name="${project_name%-}"
+    [[ -n "${project_name}" ]] \
+      || abort "could not derive a test project name from ${INSTALL_DIR}"
+    sed_inplace "${compose}" -E "s/^name:.*$/name: ${project_name}/"
+    sed_inplace "${compose}" -E '/^[[:space:]]*container_name:/d'
+    log_info "Local test environment is isolated from the existing installation"
+  fi
   log_ok "Compose patched (registry: ${REGISTRY}, images tagged :${VERSION})"
 }
 
@@ -835,82 +883,142 @@ create_dirs() {
 # Docker Compose lifecycle
 # ---------------------------------------------------------------------------
 run_compose() {
+  local -a compose_files=(-f "${INSTALL_DIR}/${COMPOSE_FILE}")
+  if [[ -n "${SOURCE_DIR}" && \
+        -f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}" ]]; then
+    compose_files+=(-f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")
+  fi
   "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
-    -f "${INSTALL_DIR}/${COMPOSE_FILE}" "$@" 2>&1 | tee -a "${LOG_FILE}"
+    "${compose_files[@]}" "$@" 2>&1 | tee -a "${LOG_FILE}"
 }
 
 run_compose_quiet() {
+  local -a compose_files=(-f "${INSTALL_DIR}/${COMPOSE_FILE}")
+  if [[ -n "${SOURCE_DIR}" && \
+        -f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}" ]]; then
+    compose_files+=(-f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")
+  fi
   "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
-    -f "${INSTALL_DIR}/${COMPOSE_FILE}" "$@"
+    "${compose_files[@]}" "$@"
 }
 
 pull_one() {
-  local img="$1" rc=0
-  if [[ -t 1 ]]; then
-    docker pull "${img}" 2>&1 | tee -a "${LOG_FILE:-/dev/null}" | docker_pull_progress "${img}" || rc=$?
-  else
-    docker pull "${img}" >>"${LOG_FILE:-/dev/null}" 2>&1 || rc=$?
-  fi
-  return "${rc}"
+  local img="$1"
+  printf '[PULL] %s\n' "${img}" >>"${LOG_FILE:-/dev/null}"
+  docker pull "${img}" >>"${LOG_FILE:-/dev/null}" 2>&1
 }
 
-docker_pull_progress() {
-  local img="${1##*/}" line="" frac="" msg="" prev=""
-  local total=0 ready=0 done=0
-  [[ -t 1 ]] || { cat >/dev/null 2>&1 || true; return 0; }
-  while IFS= read -r line; do
-    line="${line//$'\r'/}"
-    case "${line}" in
-      *": Pulling fs layer") total=$((total + 1));;
-      *": Layer already exists") total=$((total + 1)); ready=$((ready + 1));;
-      *": Download complete") ready=$((ready + 1));;
-      *": Pull complete") done=$((done + 1));;
-    esac
-    frac=""
-    if [[ "${line}" =~ \:[[:space:]]*(Downloading|Extracting)[[:space:]]*\[[^]]*\][[:space:]]*([0-9][0-9.]*[kMG]?B/[0-9][0-9.]*[kMG]?B) ]]; then
-      frac="${BASH_REMATCH[2]}"
-    fi
-    msg="${img}: ${ready}/${total} layers ready"
-    ((done > 0)) && msg+=", ${done} complete"
-    [[ -n "${frac}" ]] && msg+=" (${frac})"
-    printf '\r\033[K%s' "${msg}"
-    prev=1
-  done
-  [[ -n "${prev}" ]] && printf '\r\033[K'
-  return 0
+show_pull_progress() {
+  local completed="$1" total="$2" started="$3" tick="$4"
+  local chars='/-\|' elapsed=0 minutes=0 seconds=0 char=""
+  [[ -t 1 ]] || return 0
+  elapsed=$((SECONDS - started))
+  minutes=$((elapsed / 60))
+  seconds=$((elapsed % 60))
+  char="${chars:$((tick % 4)):1}"
+  printf '\r\033[K%sDownloading SourceLens components  %s  %s/%s completed  %02d:%02d%s' \
+    "${c_cyan}" "${char}" "${completed}" "${total}" \
+    "${minutes}" "${seconds}" "${c_reset}"
 }
 
 pull_images() {
-  log_step "Pulling container images (registry: ${REGISTRY})"
+  log_step "Downloading SourceLens components"
   run_compose config --quiet || abort "invalid docker-compose configuration; see ${LOG_FILE}"
 
-  local -a images=() img=""
+  local -a images=()
+  local img=""
   while IFS= read -r img; do
     [[ -n "${img}" ]] && images+=("${img}")
   done < <(run_compose_quiet config --images 2>/dev/null | sort -u)
+  if [[ ! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.crt" || \
+        ! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.key" ]]; then
+    images+=("alpine/openssl")
+  fi
 
-  local total="${#images[@]}" idx=1 attempt=1 max_attempts=3
+  local total="${#images[@]}" attempt=1 max_attempts=3
+  local completed=0 cursor=0 job=0 img="" running=0 found=0
+  local started="${SECONDS}" tick=0 rc=0 status_file=""
+  local failure_message="" retry_message=""
+  local status_dir="${INSTALL_DIR}/logs/.pull-status-$$"
+  local -a pending=() failed=() pids=() batch=() statuses=()
   if ((total == 0)); then
-    log_warn "no container images to pull"
+    log_warn "No components need to be downloaded"
     return 0
   fi
-  for img in "${images[@]}"; do
-    attempt=1
-    while :; do
-      if pull_one "${img}"; then
-        break
-      fi
-      if ((attempt >= max_attempts)); then
-        abort "failed to pull ${img} after ${max_attempts} attempts; check network access to the registry (see ${LOG_FILE})"
-      fi
-      log_warn "pull of ${img} failed (attempt ${attempt}/${max_attempts}); retrying in 10s"
-      sleep 10
-      attempt=$((attempt + 1))
+  pending=("${images[@]}")
+  log_info \
+    "Downloading ${total} components, up to ${PULL_PARALLELISM} in parallel"
+  mkdir -p "${status_dir}"
+  show_pull_progress "${completed}" "${total}" "${started}" "${tick}"
+
+  while ((${#pending[@]} > 0)); do
+    failed=()
+    cursor=0
+    running=0
+    pids=()
+    batch=()
+    statuses=()
+    while ((cursor < ${#pending[@]} || running > 0)); do
+      while ((running < PULL_PARALLELISM && cursor < ${#pending[@]})); do
+        img="${pending[cursor]}"
+        status_file="${status_dir}/${attempt}-${cursor}"
+        (
+          if pull_one "${img}"; then
+            printf '0\n' >"${status_file}"
+          else
+            printf '1\n' >"${status_file}"
+          fi
+        ) &
+        pids+=("$!")
+        batch+=("${img}")
+        statuses+=("${status_file}")
+        cursor=$((cursor + 1))
+        running=$((running + 1))
+      done
+
+      found=0
+      for ((job = 0; job < ${#pids[@]}; job++)); do
+        status_file="${statuses[job]:-}"
+        if [[ -n "${status_file}" && -f "${status_file}" ]]; then
+          rc="$(head -n 1 "${status_file}")"
+          wait "${pids[job]}" || true
+          if [[ "${rc}" == "0" ]]; then
+            completed=$((completed + 1))
+            log_line "[PROGRESS] ${completed}/${total} components downloaded"
+          else
+            failed+=("${batch[job]}")
+          fi
+          rm -f "${status_file}"
+          statuses[job]=""
+          running=$((running - 1))
+          found=1
+        fi
+      done
+      tick=$((tick + 1))
+      show_pull_progress "${completed}" "${total}" "${started}" "${tick}"
+      ((found == 1)) || sleep 0.2
     done
-    log_ok "[${idx}/${total}] pulled ${img}"
-    idx=$((idx + 1))
+
+    if ((${#failed[@]} == 0)); then
+      break
+    fi
+    [[ -t 1 ]] && printf '\n'
+    if ((attempt >= max_attempts)); then
+      failure_message="failed to download ${#failed[@]} component(s) after "
+      failure_message+="${max_attempts} attempts; check registry access "
+      failure_message+="(see ${LOG_FILE})"
+      abort "${failure_message}"
+    fi
+    retry_message="${#failed[@]} component download(s) failed on attempt "
+    retry_message+="${attempt}/${max_attempts}; retrying in 10s"
+    log_warn "${retry_message}"
+    sleep 10
+    pending=("${failed[@]}")
+    attempt=$((attempt + 1))
   done
-  log_ok "All ${total} images pulled"
+  [[ -t 1 ]] && printf '\n'
+  rmdir "${status_dir}" 2>/dev/null || true
+  log_ok "All ${total} components downloaded"
 }
 
 _spinner_pid=""
@@ -920,10 +1028,15 @@ spinner_start() {
   [[ -t 1 ]] || return 0
   _spinner_on=1
   (
-    local label="$1" chars='/-\|' i=0 c=""
+    local label="$1" chars='/-\|' i=0 c="" started="${SECONDS}"
+    local elapsed=0 minutes=0 seconds=0
     while :; do
       c="${chars:$((i % 4)):1}"
-      printf '\r\033[K%s %s' "${label}" "${c}"
+      elapsed=$((SECONDS - started))
+      minutes=$((elapsed / 60))
+      seconds=$((elapsed % 60))
+      printf '\r\033[K%s  %s  %02d:%02d' \
+        "${label}" "${c}" "${minutes}" "${seconds}"
       i=$((i + 1))
       sleep 0.2
     done
@@ -940,53 +1053,132 @@ spinner_stop() {
 }
 
 start_stack() {
-  log_step "Starting Docker Compose stack"
+  log_step "Starting SourceLens"
   local attempt=1 max_attempts=5 backoff=20
   if [[ -t 1 ]]; then
-    log_info "Starting stack (details logged to ${LOG_FILE})"
-    spinner_start "Starting Docker Compose stack"
+    log_info "Starting SourceLens (details logged to ${LOG_FILE})"
+    spinner_start "Starting SourceLens"
   fi
   until run_compose_quiet up -d --no-build --remove-orphans >>"${LOG_FILE}" 2>&1; do
     spinner_stop
     if ((attempt >= max_attempts)); then
-      log_error "docker compose up failed after ${max_attempts} attempts"
-      log_error "container status:"
-      run_compose ps || true
-      log_error "recent container logs:"
-      run_compose logs --tail=100 --no-color || true
-      abort "docker compose up failed; see ${LOG_FILE} and the container logs above"
+      log_error "SourceLens failed to start after ${max_attempts} attempts"
+      run_compose_quiet ps >>"${LOG_FILE}" 2>&1 || true
+      run_compose_quiet logs --tail=100 --no-color \
+        >>"${LOG_FILE}" 2>&1 || true
+      abort "SourceLens failed to start; see ${LOG_FILE}"
     fi
     log_info "dependencies still warming up; retrying in ${backoff}s (attempt ${attempt}/${max_attempts})"
     sleep "${backoff}"
     ((backoff < 120)) && backoff=$((backoff * 2))
     attempt=$((attempt + 1))
-    spinner_start "Starting Docker Compose stack"
+    spinner_start "Starting SourceLens"
   done
   spinner_stop
-  log_ok "Stack started"
-  log_info "Container status:"
-  run_compose_quiet ps --format 'table {{.Name}}\t{{.Status}}' || true
+  log_ok "SourceLens started"
 }
 
 # ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
-health_check() {
-  log_step "Waiting for system health endpoint (timeout: ${HEALTH_TIMEOUT}s)"
-  local deadline=$((SECONDS + HEALTH_TIMEOUT))
-  local url="http://127.0.0.1:${HTTP_PORT}/health/celery"
-  until curl -fsS --max-time 5 "${url}" >/dev/null 2>&1; do
-    if ((SECONDS >= deadline)); then
-      log_error "health check timed out after ${HEALTH_TIMEOUT}s"
-      log_error "container status:"
-      run_compose ps || true
-      log_error "recent container logs:"
-      run_compose logs --tail=100 --no-color || true
-      abort "health check failed — see ${LOG_FILE} and the container logs above"
-    fi
-    sleep 5
+background_services_ready() {
+  local url="$1" payload="" services="" service=""
+  payload="$(curl -sS --max-time 3 "${url}/health/celery" 2>/dev/null)" \
+    || return 1
+  [[ "${payload}" == *'"missing_consumers": []'* ]] || return 1
+  [[ "${payload}" == *'"overloaded_queues": []'* ]] || return 1
+  [[ "${payload}" != *'"broker_error"'* ]] || return 1
+
+  services="$(run_compose_quiet ps --status running --services 2>/dev/null)" \
+    || return 1
+  for service in backend-worker backend-scheduler frontend lensnode nginx; do
+    printf '%s\n' "${services}" | grep -qx "${service}" || return 1
   done
-  log_ok "Health check passed: ${url}"
+}
+
+health_check() {
+  log_step "Checking SourceLens health"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local url="http://127.0.0.1:${HTTP_PORT}"
+  local web_ready=0
+  spinner_start "Preparing SourceLens web service"
+  while :; do
+    if [[ "${web_ready}" == "0" ]] && \
+       curl -fsS --max-time 5 "${url}/health" >/dev/null 2>&1; then
+      web_ready=1
+      spinner_stop
+      log_ok "SourceLens web service is ready"
+      spinner_start "Preparing SourceLens background services"
+    fi
+    if [[ "${web_ready}" == "1" ]] && \
+       background_services_ready "${url}"; then
+      break
+    fi
+    if ((SECONDS >= deadline)); then
+      spinner_stop
+      log_error "health check timed out after ${HEALTH_TIMEOUT}s"
+      run_compose_quiet ps >>"${LOG_FILE}" 2>&1 || true
+      run_compose_quiet logs --tail=100 --no-color \
+        >>"${LOG_FILE}" 2>&1 || true
+      abort "SourceLens health check failed; see ${LOG_FILE}"
+    fi
+    sleep 3
+  done
+  spinner_stop
+  log_ok "SourceLens is healthy"
+}
+
+# ---------------------------------------------------------------------------
+# First-time AI model setup
+# ---------------------------------------------------------------------------
+model_setup_is_available() {
+  run_compose_quiet exec -T backend-api \
+    python manage.py help setup_ai_model >/dev/null 2>&1
+}
+
+model_is_configured() {
+  run_compose_quiet exec -T backend-api \
+    python manage.py setup_ai_model --check >/dev/null 2>&1
+}
+
+configure_ai_model() {
+  local skip_message="" unavailable_message=""
+  log_step "AI model setup"
+  if ! model_setup_is_available; then
+    MODEL_SETUP_UNAVAILABLE=1
+    unavailable_message="The installed SourceLens release does not include "
+    unavailable_message+="the AI model setup wizard; existing model settings "
+    unavailable_message+="were left unchanged"
+    log_warn "${unavailable_message}"
+    return 0
+  fi
+  if model_is_configured; then
+    MODEL_CONFIGURED=1
+    log_ok "An active system AI model is already configured"
+    return 0
+  fi
+
+  if [[ "${ASSUME_YES}" == "1" ]]; then
+    skip_message="AI model setup needs an interactive terminal and was "
+    skip_message+="skipped because --yes is enabled"
+    log_warn "${skip_message}"
+    return 0
+  fi
+  if [[ ! -r /dev/tty || ! -w /dev/tty ]]; then
+    log_warn "No interactive terminal is available; AI model setup was skipped"
+    return 0
+  fi
+
+  if ! run_compose_quiet exec backend-api \
+    python manage.py setup_ai_model </dev/tty >/dev/tty 2>/dev/tty; then
+    log_warn "Interactive AI model setup did not complete"
+  fi
+  if model_is_configured; then
+    MODEL_CONFIGURED=1
+    log_ok "System AI model is ready"
+  else
+    log_warn "No active system AI model is configured yet"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1020,7 +1212,6 @@ show_summary() {
   log_step "Installation summary"
   log_info "  Platform:     ${OS_NAME} (${PLATFORM}/${ARCH})"
   log_info "  Version:      v${VERSION}"
-  log_info "  Channel:      ${CHANNEL} (source: ${DOWNLOAD_SOURCE}, registry: ${REGISTRY})"
   log_info "  Install dir:  ${INSTALL_DIR}"
   log_info "  URL:          ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
   log_info "  HTTP port:    ${HTTP_PORT}"
@@ -1030,15 +1221,31 @@ show_summary() {
 }
 
 final_summary() {
+  local local_url="${SCHEME}://localhost${PORT_SUFFIX}"
+  local model_url="${SCHEME}://${DOMAIN}${PORT_SUFFIX}/management/llm/config"
+  local local_model_url="${local_url}/management/llm/config"
+  local model_warning="" vm_hint=""
   log_step "Installation complete"
   log_ok "SourceLens v${VERSION} installed at ${INSTALL_DIR}"
   log_info "URL:              ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
   log_info "Email:            ${ADMIN_EMAIL}"
-  log_info "Initial password: ${ADMIN_PASSWORD}"
+  printf '%sInitial password: %s%s\n' \
+    "${c_cyan}" "${ADMIN_PASSWORD}" "${c_reset}"
   log_info "Install dir:      ${INSTALL_DIR}"
   log_info "Config file:      ${INSTALL_DIR}/.env"
   log_info "Install info:     ${INSTALL_DIR}/install-info.env"
   log_info "Install log:      ${LOG_FILE}"
+  log_info "AI model settings: ${model_url}"
+  if [[ "${MODEL_CONFIGURED}" != "1" && \
+        "${MODEL_SETUP_UNAVAILABLE}" != "1" ]]; then
+    model_warning="AI model setup is incomplete; assistants cannot run "
+    model_warning+="until a model is configured"
+    log_warn "${model_warning}"
+  fi
+  vm_hint="NAT virtual machine: forward host TCP port ${HTTP_PORT} to guest "
+  vm_hint+="TCP port ${HTTP_PORT}, then open ${local_url}"
+  log_info "${vm_hint}"
+  log_info "NAT virtual machine AI model settings: ${local_model_url}"
   if [[ "${ENV_EXISTS}" == "1" ]]; then
     log_warn "An existing .env was preserved; the admin password above is the one stored in it"
   fi
@@ -1082,6 +1289,12 @@ main() {
     esac
   done
 
+  if [[ -n "${SOURCE_DIR}" ]]; then
+    [[ -d "${SOURCE_DIR}" ]] \
+      || abort "source directory does not exist: ${SOURCE_DIR}"
+    SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd -P)"
+  fi
+
   trap 'log_line "=== install failed at line ${LINENO} (exit $?) ==="' ERR
 
   # Preflight
@@ -1093,6 +1306,8 @@ main() {
 
   mkdir -p "${INSTALL_DIR}/logs"
   LOG_FILE="${INSTALL_DIR}/logs/install.log"
+  touch "${LOG_FILE}"
+  chmod 600 "${LOG_FILE}"
   log_line "=== install.sh v${INSTALLER_VERSION} started ($(date -u '+%Y-%m-%dT%H:%M:%SZ')) ==="
   log_line "argv: $*"
 
@@ -1120,12 +1335,14 @@ main() {
     log_info "Using local release files from ${SOURCE_DIR%/}"
   fi
   fetch_release_files
+  prepare_model_setup_overlay
   generate_env
   patch_compose
-  generate_certs
   pull_images
+  generate_certs
   start_stack
   health_check
+  configure_ai_model
   write_install_info
   final_summary
 }

--- a/install.sh
+++ b/install.sh
@@ -202,19 +202,31 @@ EOF
 confirm() {
   local prompt="$1" answer=""
   [[ "${ASSUME_YES}" == "1" ]] && return 0
-  if [[ ! -t 0 ]]; then
-    if [[ -e /dev/tty ]]; then
-      printf '%s [y/N] ' "${prompt}" >/dev/tty
-      read -r answer </dev/tty || answer="n"
+  while :; do
+    if [[ ! -t 0 ]]; then
+      if [[ -e /dev/tty ]]; then
+        printf '%s [yes/No] ' "${prompt}" >/dev/tty
+        read -r answer </dev/tty || answer="no"
+      else
+        return 0 # fully non-interactive: proceed with defaults
+      fi
     else
-      return 0 # fully non-interactive: proceed with defaults
+      printf '%s [yes/No] ' "${prompt}"
+      read -r answer || answer="no"
     fi
-  else
-    printf '%s [y/N] ' "${prompt}"
-    read -r answer || answer="n"
-  fi
-  answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
-  [[ "${answer}" == "y" || "${answer}" == "yes" ]]
+    answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
+    case "${answer}" in
+      yes) return 0 ;;
+      ""|no) return 1 ;;
+      *)
+        if [[ ! -t 0 && -e /dev/tty ]]; then
+          printf 'Enter yes or no.\n' >/dev/tty
+        else
+          printf 'Enter yes or no.\n'
+        fi
+        ;;
+    esac
+  done
 }
 
 prompt_value() {
@@ -903,22 +915,130 @@ run_compose_quiet() {
 }
 
 pull_one() {
-  local img="$1"
-  printf '[PULL] %s\n' "${img}" >>"${LOG_FILE:-/dev/null}"
-  docker pull "${img}" >>"${LOG_FILE:-/dev/null}" 2>&1
+  local img="$1" output_file="$2"
+  printf '[PULL] %s\n' "${img}" >"${output_file}"
+  docker pull "${img}" >>"${output_file}" 2>&1
 }
 
-show_pull_progress() {
-  local completed="$1" total="$2" started="$3" tick="$4"
-  local chars='/-\|' elapsed=0 minutes=0 seconds=0 char=""
+pull_image_label() {
+  case "$1" in
+    *sourcelens-backend*) printf 'SourceLens Backend' ;;
+    *sourcelens-frontend*) printf 'SourceLens Frontend' ;;
+    *sourcelens-lensnode*) printf 'SourceLens LensNode' ;;
+    postgres:*) printf 'PostgreSQL' ;;
+    redis:*) printf 'Redis' ;;
+    nginx:*) printf 'Nginx' ;;
+    alpine/openssl*) printf 'TLS Helper' ;;
+    *) printf '%s' "${1##*/}" ;;
+  esac
+}
+
+pull_layer_progress() {
+  local output_file="$1"
+  [[ -f "${output_file}" ]] || { printf '0 0'; return 0; }
+  awk '
+    {
+      gsub(/\r/, "")
+      layer = $1
+      sub(/:$/, "", layer)
+      if ($0 ~ /: Pulling fs layer$/) total[layer] = 1
+      if ($0 ~ /: (Download complete|Pull complete)$/ ||
+          $0 ~ /: (Already exists|Layer already exists)$/) {
+        total[layer] = 1
+        done[layer] = 1
+      }
+    }
+    END {
+      total_count = 0
+      done_count = 0
+      for (layer in total) total_count++
+      for (layer in done) done_count++
+      printf "%d %d", done_count, total_count
+    }
+  ' "${output_file}"
+}
+
+pull_progress_bar() {
+  local percent="$1" width=16 filled=0 index=0 bar=""
+  filled=$((percent * width / 100))
+  for ((index = 0; index < width; index++)); do
+    if ((index < filled)); then
+      bar+="█"
+    else
+      bar+="░"
+    fi
+  done
+  printf '%s' "${bar}"
+}
+
+_pull_dashboard_cursor_hidden=0
+
+pull_dashboard_hide_cursor() {
   [[ -t 1 ]] || return 0
+  printf '\033[?25l'
+  _pull_dashboard_cursor_hidden=1
+}
+
+pull_dashboard_show_cursor() {
+  [[ "${_pull_dashboard_cursor_hidden}" == "1" ]] || return 0
+  printf '\033[?25h'
+  _pull_dashboard_cursor_hidden=0
+}
+
+render_pull_dashboard() {
+  local total="$1" started="$2" tick="$3"
+  local index=0 state="" output_file="" metrics="" detail=""
+  local done_layers=0 total_layers=0 percent=0 elapsed=0
+  local minutes=0 seconds=0 indicator="" color="" bar=""
+  local chars='/-\|'
+  [[ -t 1 ]] || return 0
+
+  if [[ "${_pull_dashboard_rendered}" == "1" ]]; then
+    printf '\033[%sA' "${total}"
+  fi
   elapsed=$((SECONDS - started))
   minutes=$((elapsed / 60))
   seconds=$((elapsed % 60))
-  char="${chars:$((tick % 4)):1}"
-  printf '\r\033[K%sDownloading SourceLens components  %s  %s/%s completed  %02d:%02d%s' \
-    "${c_cyan}" "${char}" "${completed}" "${total}" \
-    "${minutes}" "${seconds}" "${c_reset}"
+
+  for ((index = 0; index < total; index++)); do
+    state="${image_states[index]}"
+    output_file="${image_logs[index]:-}"
+    percent=0
+    indicator="·"
+    color="${c_cyan}"
+    detail="waiting"
+    if [[ "${state}" == "active" ]]; then
+      indicator="${chars:$((tick % 4)):1}"
+      metrics="$(pull_layer_progress "${output_file}")"
+      done_layers="${metrics%% *}"
+      total_layers="${metrics##* }"
+      if ((total_layers > 0)); then
+        percent=$((done_layers * 100 / total_layers))
+        ((percent >= 100)) && percent=95
+        detail="${done_layers}/${total_layers} layers"
+      else
+        detail="starting"
+      fi
+    elif [[ "${state}" == "done" ]]; then
+      indicator="✓"
+      color="${c_green}"
+      percent=100
+      detail="complete"
+    elif [[ "${state}" == "retrying" ]]; then
+      indicator="!"
+      color="${c_yellow}"
+      detail="retrying"
+    elif [[ "${state}" == "failed" ]]; then
+      indicator="✗"
+      color="${c_red}"
+      detail="failed"
+    fi
+    bar="$(pull_progress_bar "${percent}")"
+    printf '\r\033[K%s%s  %-20s [%s]  %3d%%  %-12s  %02d:%02d%s\n' \
+      "${color}" "${indicator}" "${image_labels[index]}" "${bar}" \
+      "${percent}" "${detail}" "${minutes}" "${seconds}" "${c_reset}"
+  done
+  _pull_dashboard_rendered=1
 }
 
 pull_images() {
@@ -936,20 +1056,28 @@ pull_images() {
   fi
 
   local total="${#images[@]}" attempt=1 max_attempts=3
-  local completed=0 cursor=0 job=0 img="" running=0 found=0
-  local started="${SECONDS}" tick=0 rc=0 status_file=""
+  local completed=0 cursor=0 job=0 image_index=0 img=""
+  local running=0 found=0 started="${SECONDS}" tick=0 rc=0
+  local status_file="" output_file=""
   local failure_message="" retry_message=""
   local status_dir="${INSTALL_DIR}/logs/.pull-status-$$"
   local -a pending=() failed=() pids=() batch=() statuses=()
+  local -a image_states=() image_logs=() image_labels=()
   if ((total == 0)); then
     log_warn "No components need to be downloaded"
     return 0
   fi
-  pending=("${images[@]}")
+  for ((image_index = 0; image_index < total; image_index++)); do
+    pending+=("${image_index}")
+    image_states+=("waiting")
+    image_logs+=("")
+    image_labels+=("$(pull_image_label "${images[image_index]}")")
+  done
   log_info \
     "Downloading ${total} components, up to ${PULL_PARALLELISM} in parallel"
   mkdir -p "${status_dir}"
-  show_pull_progress "${completed}" "${total}" "${started}" "${tick}"
+  _pull_dashboard_rendered=0
+  pull_dashboard_hide_cursor
 
   while ((${#pending[@]} > 0)); do
     failed=()
@@ -960,17 +1088,21 @@ pull_images() {
     statuses=()
     while ((cursor < ${#pending[@]} || running > 0)); do
       while ((running < PULL_PARALLELISM && cursor < ${#pending[@]})); do
-        img="${pending[cursor]}"
-        status_file="${status_dir}/${attempt}-${cursor}"
+        image_index="${pending[cursor]}"
+        img="${images[image_index]}"
+        status_file="${status_dir}/${attempt}-${image_index}.status"
+        output_file="${status_dir}/${attempt}-${image_index}.log"
+        image_states[image_index]="active"
+        image_logs[image_index]="${output_file}"
         (
-          if pull_one "${img}"; then
+          if pull_one "${img}" "${output_file}"; then
             printf '0\n' >"${status_file}"
           else
             printf '1\n' >"${status_file}"
           fi
         ) &
         pids+=("$!")
-        batch+=("${img}")
+        batch+=("${image_index}")
         statuses+=("${status_file}")
         cursor=$((cursor + 1))
         running=$((running + 1))
@@ -980,30 +1112,41 @@ pull_images() {
       for ((job = 0; job < ${#pids[@]}; job++)); do
         status_file="${statuses[job]:-}"
         if [[ -n "${status_file}" && -f "${status_file}" ]]; then
+          image_index="${batch[job]}"
           rc="$(head -n 1 "${status_file}")"
           wait "${pids[job]}" || true
+          output_file="${image_logs[image_index]}"
+          [[ -f "${output_file}" ]] \
+            && cat "${output_file}" >>"${LOG_FILE:-/dev/null}"
           if [[ "${rc}" == "0" ]]; then
+            image_states[image_index]="done"
             completed=$((completed + 1))
             log_line "[PROGRESS] ${completed}/${total} components downloaded"
           else
-            failed+=("${batch[job]}")
+            image_states[image_index]="retrying"
+            failed+=("${image_index}")
           fi
-          rm -f "${status_file}"
+          rm -f "${status_file}" "${output_file}"
+          image_logs[image_index]=""
           statuses[job]=""
           running=$((running - 1))
           found=1
         fi
       done
       tick=$((tick + 1))
-      show_pull_progress "${completed}" "${total}" "${started}" "${tick}"
+      render_pull_dashboard "${total}" "${started}" "${tick}"
       ((found == 1)) || sleep 0.2
     done
 
     if ((${#failed[@]} == 0)); then
       break
     fi
-    [[ -t 1 ]] && printf '\n'
     if ((attempt >= max_attempts)); then
+      for image_index in "${failed[@]}"; do
+        image_states[image_index]="failed"
+      done
+      render_pull_dashboard "${total}" "${started}" "${tick}"
+      pull_dashboard_show_cursor
       failure_message="failed to download ${#failed[@]} component(s) after "
       failure_message+="${max_attempts} attempts; check registry access "
       failure_message+="(see ${LOG_FILE})"
@@ -1011,14 +1154,20 @@ pull_images() {
     fi
     retry_message="${#failed[@]} component download(s) failed on attempt "
     retry_message+="${attempt}/${max_attempts}; retrying in 10s"
-    log_warn "${retry_message}"
+    log_line "[WARN]  ${retry_message}"
+    render_pull_dashboard "${total}" "${started}" "${tick}"
     sleep 10
     pending=("${failed[@]}")
     attempt=$((attempt + 1))
   done
-  [[ -t 1 ]] && printf '\n'
   rmdir "${status_dir}" 2>/dev/null || true
-  log_ok "All ${total} components downloaded"
+  render_pull_dashboard "${total}" "${started}" "${tick}"
+  pull_dashboard_show_cursor
+  if [[ -t 1 ]]; then
+    log_line "[OK]    All ${total} components downloaded"
+  else
+    log_ok "All ${total} components downloaded"
+  fi
 }
 
 _spinner_pid=""
@@ -1295,6 +1444,7 @@ main() {
     SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd -P)"
   fi
 
+  trap 'pull_dashboard_show_cursor' EXIT
   trap 'log_line "=== install failed at line ${LINENO} (exit $?) ==="' ERR
 
   # Preflight

--- a/release-notes/guided-standalone-model-setup.yaml
+++ b/release-notes/guided-standalone-model-setup.yaml
@@ -1,0 +1,9 @@
+type: improvement
+audience: admin
+en: >-
+  Added guided AI model setup to standalone installation, with provider and
+  model selection, masked API key entry, connection validation, and safe
+  preservation of existing model settings.
+zh-CN: >-
+  为 standalone 安装新增 AI 模型配置向导，支持服务商和模型选择、API Key
+  星号输入、连接验证，并安全保留已有模型配置。


### PR DESCRIPTION
## Summary

- Add an interactive first-install AI model setup wizard with provider and model selection, masked API-key input, connection validation, and safe skip behavior.
- Pull the seven standalone installation images with four-way bounded concurrency, per-image layer progress bars, failed-image-only retries, and terminal cursor cleanup.
- Require explicit `yes` or `no` answers for installation and model confirmation prompts.
- Use browser-safe host port `10083` for new one-command installations while leaving container ports and existing installations unchanged.
- Improve standalone startup feedback while preserving existing installations, model settings, and the separate blue/green deployment workflow.

## Test plan

- [x] AI model setup command tests (`6 passed`)
- [x] Bash syntax, Python compilation, Black, isort, and diff checks
- [x] TTY confirmation checks for full `yes` and `no` input
- [x] Seven-image progress simulation with a measured maximum concurrency of four
- [x] Successful pull, transient retry, permanent failure, and cursor restoration paths
- [x] Fresh Ubuntu 24.04 standalone installation from the packaged local source
- [x] Installed health endpoint and unauthenticated login-page loading through an SSH port forward
- [x] New-install port resolution and Compose mapping (`10083` host to nginx port `80`)
- [x] Existing-install port preservation (`10080` remains unchanged on upgrade)
- [ ] Repository-wide pytest remains blocked by pre-existing multi-settings collection conflicts and unrelated response-wrapper/OTP test failures
