### PR TITLE
Enforce Run-level tool-call budgets

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -2220,6 +2220,22 @@ def max_agent_turns_for_rounds(agent_rounds):
     )
 
 
+def tool_budget_for_assistant(assistant):
+    """Return an explicit Assistant tool-call budget override, if configured."""
+
+    settings_payload = assistant.settings
+    if not isinstance(settings_payload, dict):
+        return None
+    tool_budget = settings_payload.get("tool_budget")
+    if not isinstance(tool_budget, dict) or "max_calls" not in tool_budget:
+        return None
+    try:
+        max_calls = int(tool_budget["max_calls"])
+    except (TypeError, ValueError):
+        return None
+    return {"max_calls": max(max_calls, 0)}
+
+
 @transaction.atomic
 def create_run_execution_snapshot(
     run,
@@ -2243,6 +2259,9 @@ def create_run_execution_snapshot(
         routing_assistant_uuids,
         routing_assistant_explicit,
     )
+    tool_budget = tool_budget_for_assistant(assistant)
+    if tool_budget is not None:
+        runtime_snapshot["tool_budget"] = tool_budget
     loaded_plugins = build_loaded_plugins(assistant)
     loaded_skills = build_loaded_skills(assistant)
     loaded_skills.extend(
@@ -3016,6 +3035,7 @@ def dispatch_run_to_lensnode(
                         execution.token_budget_final_reserve_tokens
                     ),
                 },
+                "tool_budget": runtime_snapshot.get("tool_budget"),
                 "trace_cursor": last_trace_sequence,
                 "trace_attempt": max(
                     last_trace_attempt + (1 if resume else 0),

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -1749,6 +1749,29 @@ class LensServiceTests(TransactionTestCase):
 
     @patch("lens.services.async_to_sync")
     @patch("lens.services.get_channel_layer")
+    def test_dispatch_sends_frozen_tool_budget_override(
+        self,
+        get_channel_layer,
+        mock_async_to_sync,
+    ):
+        sender = mock_async_to_sync.return_value
+        self.assistant.settings = {"tool_budget": {"max_calls": 12}}
+        self.assistant.save(update_fields=["settings"])
+        run = create_execution_run(
+            session=self.session,
+            question="Analyze everything",
+            enqueue=False,
+        )
+
+        self.assistant.settings = {"tool_budget": {"max_calls": 64}}
+        self.assistant.save(update_fields=["settings"])
+        dispatch_run_to_lensnode(run, "Analyze everything")
+
+        payload = sender.call_args.args[1]["payload"]
+        self.assertEqual(payload["tool_budget"], {"max_calls": 12})
+
+    @patch("lens.services.async_to_sync")
+    @patch("lens.services.get_channel_layer")
     def test_dispatch_sends_unlimited_profile_budget(
         self,
         get_channel_layer,

--- a/env.sample
+++ b/env.sample
@@ -134,6 +134,8 @@ LENSNODE_TOKEN_BUDGET_HARD_MAX_TOKENS=500000
 # tool-free synthesis before the ceiling.
 LENSNODE_TOKEN_BUDGET_FINAL_RESERVE_TOKENS=40000
 LENSNODE_TOKEN_BUDGET_WARN_RATIO=0.8
+# Maximum actual Tool calls per Run; 0 disables this safety limit.
+LENSNODE_TOOL_BUDGET_MAX_CALLS=64
 # Initial plan generation is coordination work; restore the Assistant's normal
 # reasoning effort immediately after write_todos succeeds.
 LENSNODE_PLANNING_REASONING_EFFORT=none

--- a/lensnode/lensnode/agent_runtime/capabilities.py
+++ b/lensnode/lensnode/agent_runtime/capabilities.py
@@ -22,12 +22,15 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
         require_initial_plan=False,
         planning_reasoning_effort=None,
         on_state_change=None,
+        max_tool_calls=0,
     ):
         self.emit_event = emit_event
         self.required_capabilities = set(required_capabilities or [])
         self.require_initial_plan = require_initial_plan
         self.planning_reasoning_effort = planning_reasoning_effort
         self.on_state_change = on_state_change
+        self.max_tool_calls = max(int(max_tool_calls or 0), 0)
+        self.tool_call_count = 0
         self.planning_started_at = time.monotonic()
         self.initial_plan_exists = False
         self.blocked_tools = set()
@@ -98,6 +101,7 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
                 [*key, detail]
                 for key, detail in self.failure_records.items()
             ],
+            "tool_call_count": self.tool_call_count,
         }
 
     def restore_state(self, state):
@@ -179,6 +183,10 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
                 tuple(item[:3]): dict(item[3])
                 for item in state.get("failure_records") or []
             }
+            self.tool_call_count = max(
+                int(state.get("tool_call_count") or 0),
+                0,
+            )
         except (TypeError, ValueError, IndexError) as exc:
             raise CheckpointResumeError(
                 "Resume checkpoint has invalid execution-gate state."
@@ -683,6 +691,8 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
                 )
 
     def _filter_tools(self, tools):
+        if self._tool_budget_reached():
+            return []
         remaining = []
         for tool in tools:
             tool_name = getattr(tool, "name", None)
@@ -701,6 +711,23 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
                 continue
             remaining.append(tool)
         return remaining
+
+    def _tool_budget_reached(self):
+        return (
+            self.max_tool_calls > 0
+            and self.tool_call_count >= self.max_tool_calls
+        )
+
+    def _record_tool_call(self):
+        self.tool_call_count += 1
+        if self._tool_budget_reached() and self.emit_event is not None:
+            self.emit_event(
+                "deepagents.tool_budget.reached",
+                {
+                    "max_tool_calls": self.max_tool_calls,
+                    "tool_call_count": self.tool_call_count,
+                },
+            )
 
     def _is_blocked(self, request):
         tool_name = self._tool_name(request)
@@ -757,6 +784,10 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             return self._deny_unplanned_call(request)
         if self._is_blocked(request):
             return self._deny_blocked_call(request)
+        if self._tool_budget_reached():
+            return self._deny_tool_budget_call(request)
+        self._record_tool_call()
+        self._notify_state_change()
         result = handler(request)
         self._observe_plan_call(request, result)
         result = self._record_result(request, result)
@@ -771,8 +802,32 @@ class CapabilityBoundaryMiddleware(AgentMiddleware):
             return self._deny_unplanned_call(request)
         if self._is_blocked(request):
             return self._deny_blocked_call(request)
+        if self._tool_budget_reached():
+            return self._deny_tool_budget_call(request)
+        self._record_tool_call()
+        self._notify_state_change()
         result = await handler(request)
         self._observe_plan_call(request, result)
         result = self._record_result(request, result)
         self._notify_state_change()
         return result
+
+    def _deny_tool_budget_call(self, request):
+        """Prevent a same-step call from exceeding the Run budget."""
+
+        tool_call = request.tool_call or {}
+        return ToolMessage(
+            content=json.dumps(
+                {
+                    "ok": False,
+                    "error": "TOOL_BUDGET_EXHAUSTED",
+                    "message": (
+                        "The Run tool-call budget is exhausted. Use the "
+                        "existing evidence and finish the answer."
+                    ),
+                }
+            ),
+            name=self._tool_name(request),
+            status="error",
+            tool_call_id=tool_call.get("id") or "tool-budget-exhausted",
+        )

--- a/lensnode/lensnode/agent_runtime/limits.py
+++ b/lensnode/lensnode/agent_runtime/limits.py
@@ -38,3 +38,20 @@ def resolve_token_budget(config, command):
         "max_tokens": fallback_max,
         "final_reserve_tokens": min(fallback_reserve, fallback_max),
     }
+
+
+def resolve_tool_call_budget(config, command):
+    """Return the maximum actual tool calls permitted for one run.
+
+    The control plane may provide an explicit per-run budget. Otherwise the
+    LensNode setting applies. A value of zero disables the limit.
+    """
+
+    run_budget = (command or {}).get("tool_budget")
+    fallback_max = max(
+        int(getattr(config, "tool_budget_max_calls", 64) or 0),
+        0,
+    )
+    if isinstance(run_budget, dict):
+        return max(int(run_budget.get("max_calls") or 0), 0)
+    return fallback_max

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -70,7 +70,10 @@ from .execution import (
     _strip_dangling_tool_call,
     _synthesize_wrapup_answer,
 )
-from .limits import resolve_token_budget as _resolve_token_budget
+from .limits import (
+    resolve_token_budget as _resolve_token_budget,
+    resolve_tool_call_budget as _resolve_tool_call_budget,
+)
 from .messages import (
     activity_from_event as _activity_from_event,
     build_initial_messages as _build_initial_messages,
@@ -738,6 +741,10 @@ class LensDeepAgentRuntime:
             self.config,
             state.command,
         )
+        state.tool_call_budget = _resolve_tool_call_budget(
+            self.config,
+            state.command,
+        )
         budget_gates_enabled = (
             state.runtime_mode.execution_gates
             or bool(state.command.get("parent_run_uuid"))
@@ -1104,6 +1111,11 @@ class LensDeepAgentRuntime:
                 "none",
             ),
             on_state_change=state.persist_execution_state,
+            max_tool_calls=getattr(
+                state,
+                "tool_call_budget",
+                _resolve_tool_call_budget(self.config, state.command),
+            ),
         )
         if state.resume_state is not None:
             state.capability_middleware.restore_state(
@@ -1331,6 +1343,7 @@ class LensDeepAgentRuntime:
                     "token_budget_final_reserve_tokens": state.token_budget[
                         "final_reserve_tokens"
                     ],
+                    "tool_budget_max_calls": state.tool_call_budget,
                 }
             )
         state.emit_agent_event(

--- a/lensnode/lensnode/config.py
+++ b/lensnode/lensnode/config.py
@@ -26,6 +26,7 @@ class LensNodeConfig:
     summary_keep_tokens: int
     offload_tool_tokens: int
     offload_human_tokens: int | None
+    tool_budget_max_calls: int = 64
     context_window_tokens: int = 128000
     summary_trigger_ratio: float = 0.75
     token_budget_max_tokens: int = 200000
@@ -233,6 +234,9 @@ def load_config():
         ),
         offload_human_tokens=_optional_int(
             os.getenv("LENSNODE_OFFLOAD_HUMAN_TOKENS")
+        ),
+        tool_budget_max_calls=int(
+            os.getenv("LENSNODE_TOOL_BUDGET_MAX_CALLS", "64")
         ),
         stream_recovery_attempts=int(
             os.getenv("LENSNODE_STREAM_RECOVERY_ATTEMPTS", "3")

--- a/lensnode/tests/test_history.py
+++ b/lensnode/tests/test_history.py
@@ -30,6 +30,7 @@ from lensnode.agent_runtime import (
     _strip_dangling_tool_call,
     _synthesize_wrapup_answer,
 )
+from lensnode.agent_runtime.limits import resolve_tool_call_budget
 from lensnode.agent_runtime.prompts import command_answer_language
 from lensnode.agent_runtime.system_prompts import _smart_collaboration_system_prompt
 from lensnode.checkpoint import CheckpointResumeError, ResumeState
@@ -131,6 +132,16 @@ def test_plan_route_requires_initial_plan_before_business_tool():
         require_initial_plan=True,
     )
     assert middleware._requires_initial_plan("github_repository_get") is True
+
+
+def test_tool_call_budget_accepts_per_run_override():
+    config = SimpleNamespace(tool_budget_max_calls=64)
+
+    assert resolve_tool_call_budget(config, {}) == 64
+    assert resolve_tool_call_budget(
+        config,
+        {"tool_budget": {"max_calls": 12}},
+    ) == 12
 
 
 def test_plan_outcome_uses_required_capability_failures():
@@ -934,6 +945,7 @@ def test_capability_boundary_state_round_trips_for_resume():
     original.blocked_requests = {("run_skill", "digest")}
     original.failed_sources = {"skill:github-cli"}
     original.recovered_sources = {"skill:income"}
+    original.tool_call_count = 7
 
     restored = agent_runtime.CapabilityBoundaryMiddleware(
         required_capabilities=["skill"]
@@ -959,6 +971,7 @@ def test_capability_boundary_state_round_trips_for_resume():
     assert restored.blocked_requests == {("run_skill", "digest")}
     assert restored.failed_sources == {"skill:github-cli"}
     assert restored.recovered_sources == {"skill:income"}
+    assert restored.tool_call_count == 7
     assert restored.successful_evidence == original.successful_evidence
     assert outcome == "completed"
     assert detail == {}
@@ -3932,6 +3945,36 @@ def test_capability_boundary_blocks_only_repeated_transient_request():
     )
     assert json.loads(denied.content)["error"] == "CAPABILITY_BLOCKED"
     assert middleware.termination_detail["capability"] == "mcp"
+
+
+def test_capability_boundary_stops_exposing_tools_at_run_budget():
+    events = []
+    middleware = agent_runtime.CapabilityBoundaryMiddleware(
+        emit_event=lambda name, detail: events.append((name, detail)),
+        max_tool_calls=1,
+    )
+    request = SimpleNamespace(
+        tool=SimpleNamespace(name="mcp__orders"),
+        tool_call={"name": "mcp__orders", "id": "call-1"},
+    )
+
+    middleware.wrap_tool_call(
+        request,
+        lambda _request: ToolMessage(
+            content='{"ok":true}',
+            name="mcp__orders",
+            tool_call_id="call-1",
+        ),
+    )
+
+    assert middleware.tool_call_count == 1
+    assert middleware._filter_tools([request.tool]) == []
+    assert events == [
+        (
+            "deepagents.tool_budget.reached",
+            {"max_tool_calls": 1, "tool_call_count": 1},
+        )
+    ]
 
 
 def test_request_failures_are_isolated_by_normalized_arguments():

--- a/release-notes/518.yaml
+++ b/release-notes/518.yaml
@@ -1,0 +1,7 @@
+type: improvement
+audience: user
+en: >-
+  Improved long-running assistant reliability with per-Run tool-call budgets
+  that preserve completed evidence and safely finish answers after the limit.
+zh-CN: >-
+  优化长时间运行助手的稳定性：支持按 Run 限制工具调用次数，在达到上限后保留已有证据并安全完成回答。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- enforce a bounded count of actual tool calls and hide tools once exhausted
- persist the counter across checkpoint recovery and publish budget events
- freeze and dispatch optional Assistant-level `tool_budget.max_calls` overrides
- retain the LensNode environment default when no Run override is configured

Closes #518

## Test plan

- [x] Python compilation for changed backend and LensNode modules
- [x] Django setup smoke check for Assistant tool-budget snapshot parsing
- [x] LensNode budget-resolution smoke checks for default, override, and disabled values
- [x] `git diff --check`
- [ ] Focused Django and LensNode pytest suites (blocked locally: missing WeasyPrint system library / pytest dependency)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add lensnode environment default and per-assistant override

- Count tool calls and enforce budget in capability middleware

- Persist count across checkpoint state

- Release note for tool call budgets


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Assistant settings: tool_budget.max_calls"] --> B["Backend snapshot"]
  B --> C["Runtime config: tool_budget"]
  C --> D["Capability middleware: max_tool_calls"]
  D --> E["Track count & enforce limit"]
  E --> F["Emit tool_budget.reached event"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Add tool_budget_for_assistant helper and snapshot integration</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>capabilities.py</strong><dd><code>Enforce tool budget in wrap_tool_call and filter tools</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-781d84476cc95d3f9cc4f535b0debe9626d57da89921bbcd02e1b93909d8c18c">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>limits.py</strong><dd><code>Add resolve_tool_call_budget function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-d4abc6d1713b0514c1516174eef43ebca566e8c601c936454691449c8d90b687">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Wire tool budget resolution and middleware creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_services.py</strong><dd><code>Test frozen tool budget dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_history.py</strong><dd><code>Add budget resolution and enforcement tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-007a96622714293126e634989e9bb3ff2363977edf6b93acc2cb23a3525a6038">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Add tool_budget_max_calls config and env var</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-cea4701e537631f9ac76849759faa4aa6bbe8d02d2c90c45681eb9ccf2c23d86">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.sample</strong><dd><code>Document LENSNODE_TOOL_BUDGET_MAX_CALLS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-ed437ec74dc075f03baddfbafa70f1520b4b02580b871044ae39838e004004f6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>518.yaml</strong><dd><code>Release note for tool call budgets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/519/files#diff-78543f8fa4fa611bf3ecec6e906542c32cc910ecd0becd11377232c359362ce8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

