### PR TITLE
Support cross-platform standalone installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,19 +172,49 @@ health.
 
 Requirements:
 
-- Docker with Compose V2 (`docker compose`)
+- Docker with Compose V2 (`docker compose`) must already be installed and
+  running. The SourceLens installer does not install Docker.
+- Supported platforms: Linux, macOS, and Windows through Git Bash
+- Linux uses Docker Engine and does not require a desktop environment; macOS
+  and Windows use Docker Desktop
+- `amd64` or `arm64` CPU architecture
+- At least 4 GB available memory and 20 GB free disk space
+
+Run on Linux or macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | \
-  sudo bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | sudo bash
 ```
 
-For networks with limited GitHub access, use the China distribution channel:
+On Windows, run the equivalent command in Git Bash. Docker Desktop must be
+installed and running:
 
 ```bash
-curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | \
-  sudo bash -s -- --channel cn --download-source gitee
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | bash
 ```
+
+If access to GitHub is slow or restricted, use the China distribution channel:
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | sudo bash -s -- --channel cn --download-source gitee
+```
+
+When running the China-channel command in Windows Git Bash, replace
+`sudo bash` with `bash`. Do not run this Bash installer directly in PowerShell
+or Command Prompt.
+
+The SourceLens repository is published as `oneprolabs/sourcelens` on both
+GitHub and Gitee. The installer automatically selects an available download
+source and its corresponding image registry. The China channel downloads
+release files from Gitee and pulls SourceLens application images from Aliyun
+ACR. To accept all defaults and skip interactive model setup, add `--yes`:
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | sudo bash -s -- --channel cn --download-source gitee --yes
+```
+
+Common options include `--dir /srv/sourcelens`, `--port 10083`,
+`--https-port 10443`, `--domain lens.example.com`, and `--version 0.49.6`.
 
 For a fresh installation, the installer selects the latest available release
 tag. An existing installation reuses its current version by default; to
@@ -224,9 +254,10 @@ application images are still pulled from the registry. A non-default install
 directory creates an isolated test environment so an existing installation is
 not replaced; the installer will ask for another port if `10083` is busy.
 
-The default installation directory is `/opt/sourcelens`. Re-running the
-installer with a newer tag upgrades the installation in place. Existing `.env`
-configuration and application data are preserved.
+The default installation directory is `/opt/sourcelens` on Linux,
+`/Users/Shared/sourcelens` on macOS, and `$HOME/sourcelens` on Windows Git
+Bash. Re-running the installer with a newer tag upgrades the installation in
+place. Existing `.env` configuration and application data are preserved.
 
 For zero-downtime upgrades, see
 [`docs/blue-green-deployment.md`](docs/blue-green-deployment.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,19 +171,47 @@ SourceLens 有两种生产部署方式，每台主机选择一种：
 
 前置要求：
 
-- Docker + Docker Compose V2（`docker compose`）
+- 必须预先安装并启动 Docker + Docker Compose V2（`docker compose`）；
+  SourceLens 安装器不会自动安装 Docker
+- Linux 服务器不需要桌面环境，使用 Docker Engine；macOS 和 Windows 使用
+  Docker Desktop
+- Linux、macOS，或安装了 Git Bash 的 Windows
+- `amd64` 或 `arm64` CPU 架构
+- 至少 4 GB 可用内存和 20 GB 可用磁盘空间
+
+在 Linux 或 macOS 上运行：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | \
-  sudo bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | sudo bash
+```
+
+Windows 用户从 Git Bash 运行对应命令，并确保 Docker Desktop 已安装并启动：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/main/install.sh | bash
 ```
 
 网络无法稳定访问 GitHub 时，使用中国分发通道：
 
 ```bash
-curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | \
-  sudo bash -s -- --channel cn --download-source gitee
+curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | sudo bash -s -- --channel cn --download-source gitee
 ```
+
+Windows Git Bash 使用中国分发通道时，将同一条命令中的 `sudo bash` 替换为
+`bash`。不要直接在 PowerShell 或命令提示符中运行这个 Bash 安装器。
+
+GitHub 和 Gitee 都使用 `oneprolabs/sourcelens` 作为源代码仓库。安装程序会自动选择
+可用的下载源和对应的镜像仓库。中国分发通道从 Gitee 下载发布文件，并从阿里云 ACR
+拉取 SourceLens 应用镜像。使用 `--yes` 可按默认配置非交互式安装，并跳过交互式模型
+配置：
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/main/install.sh | sudo bash -s -- --channel cn --download-source gitee --yes
+```
+
+常用选项包括 `--dir /srv/sourcelens`、`--port 10083`、
+`--https-port 10443`、`--domain lens.example.com` 和 `--version 0.49.6`。
+运行 `install.sh --help` 查看完整列表。
 
 全新安装时，安装器会选择当前可用的最新 release tag。已有安装默认沿用当前版本；
 如需升级或安装指定版本，增加 `--version <version>`。完整选项见
@@ -218,8 +246,9 @@ sudo bash /tmp/sourcelens-source/install.sh \
 非默认安装目录时，安装器会创建隔离的测试环境，避免替换已有安装；如果 `10083`
 已占用，安装器会提示选择其他端口。
 
-默认安装目录为 `/opt/sourcelens`。使用新 tag 重复运行安装器即可原地升级，已有
-`.env` 配置和应用数据会被保留。
+Linux 默认安装目录为 `/opt/sourcelens`，macOS 默认为
+`/Users/Shared/sourcelens`，Windows Git Bash 默认为 `$HOME/sourcelens`。使用新
+tag 重复运行安装器即可原地升级，已有 `.env` 配置和应用数据会被保留。
 
 如需零停机升级，请参阅
 [`docs/blue-green-deployment.md`](docs/blue-green-deployment.md)。

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -248,7 +248,8 @@ services:
     image: redis:alpine
     container_name: sourcelens-redis
     restart: unless-stopped
-    command: redis-server
+    working_dir: /tmp
+    command: redis-server --dir /data
     volumes:
       - ./data/redis:/data
       - ./data/logs/redis:/var/log/redis

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,7 @@
 # docker-compose.yml. Pick ONE production shape per host: both share the
 # "sourcelens" compose project.
 #
-#   curl -fsSL https://raw.githubusercontent.com/oneprolabs/sourcelens/<tag>/install.sh \
-#       -o install.sh && chmod +x install.sh && ./install.sh <tag>
+# See README.md for the Linux, macOS, and Windows Git Bash commands.
 #
 # What it does, every single run (idempotent; re-running upgrades):
 #   1. Fetches the small set of declarative deploy files (docker-compose
@@ -52,7 +51,6 @@ GITHUB_RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPO}"
 GITEE_REPO="oneprolabs/sourcelens"
 GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
 GITEE_RAW_BASE="https://gitee.com/${GITEE_REPO}/raw"
-DEFAULT_INSTALL_DIR="/opt/${APP_NAME}"
 DEFAULT_HTTP_PORT=10083
 DEFAULT_HTTPS_PORT=10443
 # Image registry prefixes. Docker Hub uses just the namespace; Aliyun ACR uses
@@ -78,14 +76,29 @@ RELEASE_FILES=(
   docker/postgresql/initdb.d/002-setup-log-permissions.sh
 )
 
-# Detect host platform early: macOS and Linux differ in memory detection and
-# networking helpers.
+# Detect the host platform before selecting platform-specific paths and
+# preflight checks.
 case "$(uname -s)" in
   Darwin)                PLATFORM="macos" ;;
   Linux)                 PLATFORM="linux" ;;
   MINGW*|MSYS*|CYGWIN*)  PLATFORM="windows" ;;
   *)                     PLATFORM="unknown" ;;
 esac
+
+default_install_dir_for_platform() {
+  case "$1" in
+    macos) printf '/Users/Shared/%s' "${APP_NAME}" ;;
+    windows) printf '%s/%s' "${HOME}" "${APP_NAME}" ;;
+    *) printf '/opt/%s' "${APP_NAME}" ;;
+  esac
+}
+
+DEFAULT_INSTALL_DIR="$(default_install_dir_for_platform "${PLATFORM}")"
+LEGACY_DEFAULT_INSTALL_DIR="/opt/${APP_NAME}"
+if [[ "${PLATFORM}" == "macos" && \
+      -f "${LEGACY_DEFAULT_INSTALL_DIR}/${COMPOSE_FILE}" ]]; then
+  DEFAULT_INSTALL_DIR="${LEGACY_DEFAULT_INSTALL_DIR}"
+fi
 
 # ---------------------------------------------------------------------------
 # Defaults (overridable via SOURCELENS_* environment variables / CLI flags)
@@ -164,8 +177,8 @@ usage() {
 Usage: install.sh [options] [tag]
 
 Installs/upgrades the standalone (single-instance) SourceLens stack by driving
-docker-compose.standalone.yml. Supported platforms: Linux, macOS. Requires
-Docker and Docker Compose V2 (\`docker compose\`).
+docker-compose.standalone.yml. Supported platforms: Linux, macOS, and Windows
+through Git Bash. Requires Docker and Docker Compose V2 (\`docker compose\`).
 
 Options:
   -d, --dir DIR            Install directory (default: ${DEFAULT_INSTALL_DIR})
@@ -244,6 +257,10 @@ prompt_value() {
 # Preflight checks
 # ---------------------------------------------------------------------------
 require_root() {
+  if [[ "${PLATFORM}" == "windows" ]]; then
+    log_info "Running in Windows Git Bash; Docker Desktop provides the engine"
+    return 0
+  fi
   if [[ "$(id -u)" -eq 0 ]]; then return 0; fi
   if command -v sudo >/dev/null 2>&1 && [[ -f "$0" && "$0" != "bash" && "$0" != "-bash" ]]; then
     log_warn "not running as root, re-executing with sudo"
@@ -256,13 +273,18 @@ detect_os() {
   OS_ID="unknown"; OS_NAME="unknown"
   if [[ "${PLATFORM}" == "macos" ]]; then
     OS_ID="macos"; OS_NAME="macOS $(sw_vers -productVersion 2>/dev/null)"
+  elif [[ "${PLATFORM}" == "windows" ]]; then
+    OS_ID="windows"; OS_NAME="Windows (Git Bash)"
   elif [[ -r /etc/os-release ]]; then
     OS_ID=$(. /etc/os-release; printf '%s' "${ID:-unknown}")
     OS_NAME=$(. /etc/os-release; printf '%s' "${PRETTY_NAME:-unknown}")
   fi
   log_info "OS: ${OS_NAME} (${OS_ID})"
-  if [[ "${PLATFORM}" != "macos" && "${PLATFORM}" != "linux" ]]; then
-    abort "unsupported platform '${PLATFORM}'; supported: Linux, macOS"
+  if [[ "${PLATFORM}" != "macos" && "${PLATFORM}" != "linux" && \
+        "${PLATFORM}" != "windows" ]]; then
+    local message="unsupported platform '${PLATFORM}'; supported: Linux, "
+    message+="macOS, Windows Git Bash"
+    abort "${message}"
   fi
 }
 
@@ -285,6 +307,9 @@ check_memory() {
     ps="$(vm_stat 2>/dev/null | awk '/Pages speculative/ {print $3}' | tr -d '.')"
     pf="${pf:-0}"; pi="${pi:-0}"; ps="${ps:-0}"
     mem_kb="$(( (pf + pi + ps) * pagesize / 1024 ))"
+  elif [[ "${PLATFORM}" == "windows" ]]; then
+    log_warn "memory detection is unavailable in Git Bash; skipping check"
+    return 0
   else
     mem_kb="$(awk '/MemAvailable/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)"
   fi
@@ -320,6 +345,10 @@ check_tools() {
   for tool in curl tar gzip openssl; do
     command -v "${tool}" >/dev/null 2>&1 || abort "required tool not found: ${tool}"
   done
+  if [[ "${PLATFORM}" == "windows" ]] && \
+     ! command -v cygpath >/dev/null 2>&1; then
+    abort "cygpath not found; run this installer from Windows Git Bash"
+  fi
   log_ok "Required tools present (curl, tar, gzip, openssl)"
 }
 
@@ -474,8 +503,10 @@ configure() {
     if [[ "${PLATFORM}" == "linux" ]]; then
       DOMAIN="$(ip route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}' | head -n1)"
       [[ -z "${DOMAIN}" ]] && DOMAIN="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
-    else
+    elif [[ "${PLATFORM}" == "macos" ]]; then
       DOMAIN="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)"
+    else
+      DOMAIN="127.0.0.1"
     fi
     [[ -z "${DOMAIN}" ]] && DOMAIN="$(hostname -f 2>/dev/null || hostname)"
     [[ -z "${DOMAIN}" ]] && DOMAIN="127.0.0.1"
@@ -492,6 +523,16 @@ port_in_use() {
   local port="$1"
   if [[ "${PLATFORM}" == "macos" ]] && command -v lsof >/dev/null 2>&1; then
     lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  if [[ "${PLATFORM}" == "windows" ]] && \
+     command -v netstat >/dev/null 2>&1; then
+    local netstat_program=""
+    netstat_program='$1 ~ /^TCP/ && $4 == "LISTENING" && $2 ~ p '
+    netstat_program+='{found=1} END {exit !found}'
+    netstat -ano 2>/dev/null \
+      | awk -v p=":${port}$" \
+          "${netstat_program}"
     return $?
   fi
   if command -v ss >/dev/null 2>&1; then
@@ -841,6 +882,7 @@ patch_compose() {
   if ! grep -q "image: ${REGISTRY}/sourcelens-backend:${VERSION}" "${compose}"; then
     abort "failed to pin image references in ${compose}"
   fi
+  patch_platform_compose "${compose}"
   if [[ -n "${SOURCE_DIR}" && "${INSTALL_DIR}" != "${DEFAULT_INSTALL_DIR}" ]]; then
     local project_name=""
     project_name="$(basename "${INSTALL_DIR}" \
@@ -857,6 +899,46 @@ patch_compose() {
   log_ok "Compose patched (registry: ${REGISTRY}, images tagged :${VERSION})"
 }
 
+patch_platform_compose() {
+  local compose="$1"
+  if [[ "${PLATFORM}" == "windows" ]]; then
+    local pg_pattern="" redis_pattern="" log_pattern=""
+    pg_pattern='s#^([[:space:]]*)-[[:space:]]+\./data/postgresql/'
+    pg_pattern+='data:/var/lib/postgresql/data[[:space:]]*$#'
+    pg_pattern+='\1- postgresql_data:/var/lib/postgresql/data#'
+    redis_pattern='s#^([[:space:]]*)-[[:space:]]+\./data/redis:'
+    redis_pattern+='/data[[:space:]]*$#\1- redis_data:/data#'
+    log_pattern='/^[[:space:]]*-[[:space:]]+\.\/data\/logs\/'
+    log_pattern+='(postgresql|redis):\/var\/log\/'
+    log_pattern+='(postgresql|redis)[[:space:]]*$/d'
+    sed_inplace "${compose}" -E "${pg_pattern}"
+    sed_inplace "${compose}" -E "${redis_pattern}"
+    sed_inplace "${compose}" -E "${log_pattern}"
+    {
+      printf '\nvolumes:\n'
+      printf '  postgresql_data:\n'
+      printf '  redis_data:\n'
+    } >>"${compose}"
+    grep -q 'postgresql_data:/var/lib/postgresql/data' "${compose}" \
+      || abort "failed to configure PostgreSQL storage on Windows"
+    grep -q 'redis_data:/data' "${compose}" \
+      || abort "failed to configure Redis storage on Windows"
+    log_info "PostgreSQL and Redis use Docker volumes on Windows"
+    return 0
+  fi
+  [[ "${PLATFORM}" == "macos" ]] || return 0
+  local log_pattern=""
+  log_pattern='^[[:space:]]*-[[:space:]]+\.\/data\/logs\/postgresql:'
+  log_pattern+='\/var\/log\/postgresql[[:space:]]*$'
+  sed_inplace "${compose}" -E "/${log_pattern}/d"
+  if grep -qE "${log_pattern}" "${compose}"; then
+    abort "failed to disable the PostgreSQL log bind mount on macOS"
+  fi
+  local message="PostgreSQL logs use container storage on macOS"
+  message+=" (view with: docker logs sourcelens-postgres)"
+  log_info "${message}"
+}
+
 # ---------------------------------------------------------------------------
 # TLS certificate (self-signed for the nginx HTTPS server block)
 # ---------------------------------------------------------------------------
@@ -866,15 +948,36 @@ generate_certs() {
   mkdir -p "${certs_dir}"
   if [[ ! -f "${certs_dir}/nginx-selfsigned.crt" || ! -f "${certs_dir}/nginx-selfsigned.key" ]]; then
     log_info "Generating self-signed certificate for ${DOMAIN} (replace with a real certificate for production)"
-    docker run --rm -v "${certs_dir}:/certs" alpine/openssl req -x509 \
-      -newkey rsa:2048 -nodes -days 3650 \
-      -keyout /certs/nginx-selfsigned.key -out /certs/nginx-selfsigned.crt \
-      -subj "/CN=${DOMAIN}" \
-      -addext "subjectAltName=DNS:${DOMAIN},DNS:localhost,IP:127.0.0.1" 2>/dev/null \
-      || docker run --rm -v "${certs_dir}:/certs" alpine/openssl req -x509 \
-           -newkey rsa:2048 -nodes -days 3650 \
-           -keyout /certs/nginx-selfsigned.key -out /certs/nginx-selfsigned.crt \
-           -subj "/CN=${DOMAIN}"
+    if [[ "${PLATFORM}" == "windows" ]]; then
+      (
+        cd "${certs_dir}"
+        MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 \
+          -nodes -days 3650 \
+          -keyout nginx-selfsigned.key \
+          -out nginx-selfsigned.crt \
+          -subj "/CN=${DOMAIN}" \
+          -addext \
+          "subjectAltName=DNS:${DOMAIN},DNS:localhost,IP:127.0.0.1" \
+          2>/dev/null \
+          || MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 \
+               -nodes -days 3650 \
+               -keyout nginx-selfsigned.key \
+               -out nginx-selfsigned.crt \
+               -subj "/CN=${DOMAIN}"
+      )
+    else
+      docker run --rm -v "${certs_dir}:/certs" \
+        alpine/openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+        -keyout /certs/nginx-selfsigned.key \
+        -out /certs/nginx-selfsigned.crt -subj "/CN=${DOMAIN}" \
+        -addext \
+        "subjectAltName=DNS:${DOMAIN},DNS:localhost,IP:127.0.0.1" \
+        2>/dev/null \
+        || docker run --rm -v "${certs_dir}:/certs" \
+             alpine/openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+             -keyout /certs/nginx-selfsigned.key \
+             -out /certs/nginx-selfsigned.crt -subj "/CN=${DOMAIN}"
+    fi
     chmod 600 "${certs_dir}/nginx-selfsigned.key"
   fi
   log_ok "TLS certificate ready"
@@ -891,26 +994,72 @@ create_dirs() {
   log_ok "Directories created under ${INSTALL_DIR}"
 }
 
+macos_docker_owner() {
+  local uid="${SUDO_UID:-}" gid="${SUDO_GID:-}" console_owner=""
+  if [[ "${uid}" =~ ^[0-9]+$ && "${gid}" =~ ^[0-9]+$ && \
+        "${uid}" != "0" ]]; then
+    printf '%s:%s' "${uid}" "${gid}"
+    return 0
+  fi
+  console_owner="$(stat -f '%u:%g' /dev/console 2>/dev/null || true)"
+  if [[ "${console_owner}" =~ ^[1-9][0-9]*:[0-9]+$ ]]; then
+    printf '%s' "${console_owner}"
+    return 0
+  fi
+  return 1
+}
+
+prepare_macos_mount_permissions() {
+  [[ "${PLATFORM}" == "macos" ]] || return 0
+  [[ ! -f "${INSTALL_DIR}/install-info.env" ]] || return 0
+  local owner=""
+  owner="$(macos_docker_owner)" \
+    || abort "could not identify the macOS Docker Desktop user"
+  chown -R "${owner}" "${INSTALL_DIR}/data" \
+    "${INSTALL_DIR}/docker/nginx/certs" \
+    || abort "could not prepare macOS bind-mount permissions"
+  log_info "Docker Desktop bind mounts prepared for macOS user ${owner}"
+}
+
 # ---------------------------------------------------------------------------
 # Docker Compose lifecycle
 # ---------------------------------------------------------------------------
+docker_host_path() {
+  if [[ "${PLATFORM}" == "windows" ]] && \
+     command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
 run_compose() {
-  local -a compose_files=(-f "${INSTALL_DIR}/${COMPOSE_FILE}")
+  local project_dir=""
+  local -a compose_files
+  project_dir="$(docker_host_path "${INSTALL_DIR}")"
+  compose_files=(-f \
+    "$(docker_host_path "${INSTALL_DIR}/${COMPOSE_FILE}")")
   if [[ -n "${SOURCE_DIR}" && \
         -f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}" ]]; then
-    compose_files+=(-f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")
+    compose_files+=(-f \
+      "$(docker_host_path "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")")
   fi
-  "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
+  "${COMPOSE_CMD[@]}" --project-directory "${project_dir}" \
     "${compose_files[@]}" "$@" 2>&1 | tee -a "${LOG_FILE}"
 }
 
 run_compose_quiet() {
-  local -a compose_files=(-f "${INSTALL_DIR}/${COMPOSE_FILE}")
+  local project_dir=""
+  local -a compose_files
+  project_dir="$(docker_host_path "${INSTALL_DIR}")"
+  compose_files=(-f \
+    "$(docker_host_path "${INSTALL_DIR}/${COMPOSE_FILE}")")
   if [[ -n "${SOURCE_DIR}" && \
         -f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}" ]]; then
-    compose_files+=(-f "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")
+    compose_files+=(-f \
+      "$(docker_host_path "${INSTALL_DIR}/${MODEL_SETUP_OVERRIDE}")")
   fi
-  "${COMPOSE_CMD[@]}" --project-directory "${INSTALL_DIR}" \
+  "${COMPOSE_CMD[@]}" --project-directory "${project_dir}" \
     "${compose_files[@]}" "$@"
 }
 
@@ -931,6 +1080,12 @@ pull_image_label() {
     alpine/openssl*) printf 'TLS Helper' ;;
     *) printf '%s' "${1##*/}" ;;
   esac
+}
+
+tls_helper_image_required() {
+  [[ "${PLATFORM}" != "windows" && \
+     (! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.crt" || \
+      ! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.key") ]]
 }
 
 pull_layer_progress() {
@@ -1050,8 +1205,7 @@ pull_images() {
   while IFS= read -r img; do
     [[ -n "${img}" ]] && images+=("${img}")
   done < <(run_compose_quiet config --images 2>/dev/null | sort -u)
-  if [[ ! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.crt" || \
-        ! -f "${INSTALL_DIR}/docker/nginx/certs/nginx-selfsigned.key" ]]; then
+  if tls_helper_image_required; then
     images+=("alpine/openssl")
   fi
 
@@ -1201,14 +1355,47 @@ spinner_stop() {
   _spinner_on=0
 }
 
+stale_mount_namespace_detected() {
+  local container="" health_output=""
+  while IFS= read -r container; do
+    [[ -n "${container}" ]] || continue
+    health_output="$(
+      docker inspect --format \
+        '{{if .State.Health}}{{range .State.Health.Log}}'\
+'{{println .Output}}{{end}}{{end}}' \
+        "${container}" 2>/dev/null || true
+    )"
+    local stale_message="current working directory is outside of container "
+    stale_message+="mount namespace root"
+    if [[ "${health_output}" == *"${stale_message}"* ]]; then
+      return 0
+    fi
+  done < <(run_compose_quiet ps -aq 2>/dev/null || true)
+  return 1
+}
+
 start_stack() {
   log_step "Starting SourceLens"
   local attempt=1 max_attempts=5 backoff=20
+  local -a up_args
+  up_args=(up -d --no-build --remove-orphans)
+  if [[ "${EXISTING}" == "0" || \
+        ! -f "${INSTALL_DIR}/install-info.env" ]]; then
+    up_args+=(--force-recreate)
+    log_info "Fresh or incomplete install will recreate stale containers"
+  elif stale_mount_namespace_detected; then
+    up_args+=(--force-recreate)
+    local stale_warning="Docker reported a stale bind-mount working "
+    stale_warning+="directory; "
+    stale_warning+="recreating containers while preserving SourceLens data"
+    log_warn "${stale_warning}"
+  fi
   if [[ -t 1 ]]; then
     log_info "Starting SourceLens (details logged to ${LOG_FILE})"
     spinner_start "Starting SourceLens"
   fi
-  until run_compose_quiet up -d --no-build --remove-orphans >>"${LOG_FILE}" 2>&1; do
+  until run_compose_quiet "${up_args[@]}" >>"${LOG_FILE}" 2>&1; do
+    up_args=(up -d --no-build --remove-orphans)
     spinner_stop
     if ((attempt >= max_attempts)); then
       log_error "SourceLens failed to start after ${max_attempts} attempts"
@@ -1490,6 +1677,7 @@ main() {
   patch_compose
   pull_images
   generate_certs
+  prepare_macos_mount_permissions
   start_stack
   health_check
   configure_ai_model

--- a/release-notes/cross-platform-standalone-install.yaml
+++ b/release-notes/cross-platform-standalone-install.yaml
@@ -1,0 +1,9 @@
+type: improvement
+audience: admin
+en: >-
+  Improved standalone installation across Linux, macOS, and Windows Git Bash,
+  including platform-appropriate storage, paths, permissions, and recovery from
+  stale Docker bind mounts.
+zh-CN: >-
+  改进 Linux、macOS 和 Windows Git Bash 上的 standalone 安装流程，包括适配
+  各平台的存储、路径和权限，并支持从失效的 Docker bind mount 中自动恢复。

--- a/tests/test_installer_platform.py
+++ b/tests/test_installer_platform.py
@@ -1,0 +1,368 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+COMPOSE = ROOT / "docker-compose.standalone.yml"
+
+
+def run_installer_function(body, *args):
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            f'source "$1"; {body}',
+            "installer-test",
+            str(INSTALLER),
+            *map(str, args),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class InstallerPlatformTests(unittest.TestCase):
+    def test_readmes_use_single_line_platform_install_commands(self):
+        readmes = [ROOT / "README.md", ROOT / "README.zh-CN.md"]
+        commands = [
+            "curl -fsSL https://raw.githubusercontent.com/oneprolabs/"
+            "sourcelens/main/install.sh | sudo bash",
+            "curl -fsSL https://gitee.com/oneprolabs/sourcelens/raw/"
+            "main/install.sh | sudo bash -s -- --channel cn "
+            "--download-source gitee",
+            "curl -fsSL https://raw.githubusercontent.com/oneprolabs/"
+            "sourcelens/main/install.sh | bash",
+        ]
+        for readme in readmes:
+            content = readme.read_text()
+            for command in commands:
+                with self.subTest(readme=readme.name, command=command):
+                    self.assertIn(command, content)
+
+    def test_readmes_explain_windows_china_channel_without_sudo(self):
+        readmes = [ROOT / "README.md", ROOT / "README.zh-CN.md"]
+        for readme in readmes:
+            content = readme.read_text()
+            with self.subTest(readme=readme.name):
+                self.assertIn("`sudo bash`", content)
+                self.assertIn("`bash`", content)
+
+    def test_readmes_document_noninteractive_install_and_options(self):
+        readmes = [ROOT / "README.md", ROOT / "README.zh-CN.md"]
+        expected = [
+            "oneprolabs/sourcelens",
+            "--download-source gitee --yes",
+            "--dir /srv/sourcelens",
+            "--port 10083",
+            "--https-port 10443",
+            "--domain lens.example.com",
+            "install.sh --help",
+        ]
+        for readme in readmes:
+            content = readme.read_text()
+            for text in expected:
+                with self.subTest(readme=readme.name, text=text):
+                    self.assertIn(text, content)
+
+    def test_readmes_document_recommended_resources_as_requirements(self):
+        requirements = {
+            ROOT / "README.md": (
+                "At least 4 GB available memory and 20 GB free disk space"
+            ),
+            ROOT / "README.zh-CN.md": (
+                "至少 4 GB 可用内存和 20 GB 可用磁盘空间"
+            ),
+        }
+        for readme, requirement in requirements.items():
+            with self.subTest(readme=readme.name):
+                self.assertIn(requirement, readme.read_text())
+
+    def test_default_install_dir_is_platform_appropriate(self):
+        cases = [
+            ("linux", "/opt/sourcelens"),
+            ("macos", "/Users/Shared/sourcelens"),
+        ]
+        for platform, expected in cases:
+            with self.subTest(platform=platform):
+                result = run_installer_function(
+                    'default_install_dir_for_platform "$2"', platform
+                )
+                self.assertEqual(result.stdout, expected)
+
+        result = run_installer_function(
+            'HOME=/c/Users/test; default_install_dir_for_platform windows'
+        )
+        self.assertEqual(result.stdout, "/c/Users/test/sourcelens")
+
+    def test_windows_does_not_require_root(self):
+        result = run_installer_function(
+            'PLATFORM=windows; LOG_FILE=""; require_root'
+        )
+
+        self.assertIn("Windows Git Bash", result.stdout)
+
+    def test_macos_compose_avoids_postgresql_log_bind_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            compose = Path(directory) / "docker-compose.standalone.yml"
+            shutil.copyfile(COMPOSE, compose)
+
+            run_installer_function(
+                'PLATFORM=macos; patch_platform_compose "$2"', compose
+            )
+
+            content = compose.read_text()
+            self.assertNotIn(
+                "./data/logs/postgresql:/var/log/postgresql", content
+            )
+            self.assertIn(
+                "./data/postgresql/data:/var/lib/postgresql/data", content
+            )
+
+    def test_linux_compose_keeps_postgresql_log_bind_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            compose = Path(directory) / "docker-compose.standalone.yml"
+            shutil.copyfile(COMPOSE, compose)
+
+            run_installer_function(
+                'PLATFORM=linux; patch_platform_compose "$2"', compose
+            )
+
+            content = compose.read_text()
+            self.assertIn(
+                "./data/logs/postgresql:/var/log/postgresql", content
+            )
+
+    def test_windows_compose_uses_docker_volumes_for_databases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            compose = Path(directory) / "docker-compose.standalone.yml"
+            shutil.copyfile(COMPOSE, compose)
+
+            run_installer_function(
+                'PLATFORM=windows; patch_platform_compose "$2"', compose
+            )
+
+            content = compose.read_text()
+            self.assertNotIn(
+                "./data/postgresql/data:/var/lib/postgresql/data", content
+            )
+            self.assertNotIn("./data/redis:/data", content)
+            self.assertNotIn("./data/logs/postgresql", content)
+            self.assertNotIn("./data/logs/redis", content)
+            self.assertIn(
+                "postgresql_data:/var/lib/postgresql/data", content
+            )
+            self.assertIn("redis_data:/data", content)
+            self.assertIn("\nvolumes:\n", content)
+
+    def test_redis_healthcheck_uses_stable_working_directory(self):
+        content = COMPOSE.read_text()
+
+        self.assertIn("working_dir: /tmp", content)
+        self.assertIn("command: redis-server --dir /data", content)
+
+    def test_windows_compose_paths_use_cygpath(self):
+        result = run_installer_function(
+            'PLATFORM=windows; '
+            'cygpath() { printf "C:\\\\sourcelens"; }; '
+            'docker_host_path /c/sourcelens'
+        )
+
+        self.assertEqual(result.stdout, "C:\\sourcelens")
+
+    def test_windows_generates_certificate_without_docker_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            run_installer_function(
+                'PLATFORM=windows; INSTALL_DIR="$2"; DOMAIN=127.0.0.1; '
+                'LOG_FILE="$3"; '
+                'docker() { return 1; }; generate_certs',
+                install_dir,
+                install_dir / "install.log",
+            )
+
+            certs = install_dir / "docker/nginx/certs"
+            self.assertTrue((certs / "nginx-selfsigned.crt").is_file())
+            self.assertTrue((certs / "nginx-selfsigned.key").is_file())
+
+    def test_windows_does_not_require_tls_helper_image(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_installer_function(
+                'PLATFORM=windows; INSTALL_DIR="$2"; '
+                "! tls_helper_image_required",
+                directory,
+            )
+
+    def test_linux_requires_tls_helper_image_when_certificate_is_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_installer_function(
+                'PLATFORM=linux; INSTALL_DIR="$2"; '
+                "tls_helper_image_required",
+                directory,
+            )
+
+    def test_windows_disables_msys_path_conversion_for_openssl(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            run_installer_function(
+                'PLATFORM=windows; INSTALL_DIR="$2"; DOMAIN=127.0.0.1; '
+                'LOG_FILE="$3"; '
+                'openssl() { '
+                '[[ "${MSYS_NO_PATHCONV:-}" == "1" ]] || return 2; '
+                'while [[ "$#" -gt 0 ]]; do '
+                'case "$1" in -keyout|-out) shift; '
+                '[[ "$1" != /* ]] || return 3; : >"$1" ;; esac; '
+                'shift; done; '
+                '}; generate_certs',
+                install_dir,
+                install_dir / "install.log",
+            )
+
+            certs = install_dir / "docker/nginx/certs"
+            self.assertTrue((certs / "nginx-selfsigned.crt").is_file())
+            self.assertTrue((certs / "nginx-selfsigned.key").is_file())
+
+    def test_macos_prepares_mounts_for_sudo_user(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            (install_dir / "data").mkdir()
+            (install_dir / "docker/nginx/certs").mkdir(parents=True)
+            calls = install_dir / "chown-calls"
+            run_installer_function(
+                'PLATFORM=macos; INSTALL_DIR="$2"; LOG_FILE="$3"; '
+                'SUDO_UID=501; SUDO_GID=20; '
+                'CHOWN_CALLS="$4"; '
+                'chown() { printf "%s\\n" "$*" >>"$CHOWN_CALLS"; }; '
+                "prepare_macos_mount_permissions",
+                install_dir,
+                install_dir / "install.log",
+                calls,
+            )
+
+            content = calls.read_text()
+            self.assertIn("-R 501:20", content)
+            self.assertIn(str(install_dir / "data"), content)
+            self.assertIn(str(install_dir / "docker/nginx/certs"), content)
+
+    def test_completed_macos_install_keeps_existing_ownership(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            (install_dir / "install-info.env").write_text("complete\n")
+            run_installer_function(
+                'PLATFORM=macos; INSTALL_DIR="$2"; LOG_FILE="$3"; '
+                'chown() { return 1; }; prepare_macos_mount_permissions',
+                install_dir,
+                install_dir / "install.log",
+            )
+
+    def test_linux_does_not_change_mount_ownership(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            run_installer_function(
+                'PLATFORM=linux; INSTALL_DIR="$2"; '
+                'chown() { return 1; }; prepare_macos_mount_permissions',
+                install_dir,
+            )
+
+    def test_fresh_install_recreates_stale_containers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_file = Path(directory) / "install.log"
+            run_installer_function(
+                'LOG_FILE="$2"; INSTALL_DIR="$3"; EXISTING=0; '
+                'run_compose_quiet() { printf "%s\\n" "$*"; }; '
+                "start_stack",
+                log_file,
+                directory,
+            )
+
+            content = log_file.read_text()
+            self.assertIn("--force-recreate", content)
+
+    def test_existing_install_does_not_force_recreate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            log_file = install_dir / "install.log"
+            (install_dir / "install-info.env").write_text("complete\n")
+            run_installer_function(
+                'LOG_FILE="$2"; INSTALL_DIR="$3"; EXISTING=1; '
+                'stale_mount_namespace_detected() { return 1; }; '
+                'run_compose_quiet() { printf "%s\\n" "$*"; }; '
+                "start_stack",
+                log_file,
+                install_dir,
+            )
+
+            content = log_file.read_text()
+            self.assertNotIn("--force-recreate", content)
+
+    def test_stale_mount_namespace_forces_container_recreation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            log_file = install_dir / "install.log"
+            (install_dir / "install-info.env").write_text("complete\n")
+            result = run_installer_function(
+                'LOG_FILE="$2"; INSTALL_DIR="$3"; EXISTING=1; '
+                'stale_mount_namespace_detected() { return 0; }; '
+                'run_compose_quiet() { printf "%s\\n" "$*"; }; '
+                "start_stack",
+                log_file,
+                install_dir,
+            )
+
+            content = log_file.read_text()
+            self.assertIn("--force-recreate", content)
+            self.assertIn("stale bind-mount working directory", result.stdout)
+
+    def test_stale_mount_namespace_error_is_detected(self):
+        run_installer_function(
+            'run_compose_quiet() { printf "redis-id\\n"; }; '
+            'docker() { '
+            'printf "current working directory is outside of container "'
+            '"mount namespace root\\n"; '
+            '}; stale_mount_namespace_detected'
+        )
+
+    def test_incomplete_existing_install_recreates_stale_containers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            log_file = install_dir / "install.log"
+            run_installer_function(
+                'LOG_FILE="$2"; INSTALL_DIR="$3"; EXISTING=1; '
+                'run_compose_quiet() { printf "%s\\n" "$*"; }; '
+                "start_stack",
+                log_file,
+                install_dir,
+            )
+
+            content = log_file.read_text()
+            self.assertIn("--force-recreate", content)
+
+    def test_retry_does_not_recreate_containers_again(self):
+        with tempfile.TemporaryDirectory() as directory:
+            install_dir = Path(directory)
+            log_file = install_dir / "install.log"
+            run_installer_function(
+                'LOG_FILE="$2"; INSTALL_DIR="$3"; EXISTING=0; calls=0; '
+                'sleep() { :; }; '
+                'run_compose_quiet() { calls=$((calls + 1)); '
+                'printf "%s\\n" "$*"; [[ "$calls" -gt 1 ]]; }; '
+                "start_stack",
+                log_file,
+                install_dir,
+            )
+
+            calls = [
+                line
+                for line in log_file.read_text().splitlines()
+                if line.startswith("up -d")
+            ]
+            self.assertEqual(len(calls), 2)
+            self.assertIn("--force-recreate", calls[0])
+            self.assertNotIn("--force-recreate", calls[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Support standalone installation on Linux, macOS, and Windows through Git Bash with platform-appropriate defaults, Docker paths, port checks, and privilege handling.
- Use Docker volumes and host OpenSSL on Windows, and prepare Docker Desktop bind mounts safely on macOS.
- Recover from stale Docker bind-mount working directories and keep Redis health checks independent of its data mount.
- Document platform commands, distribution channels, resource requirements, and common installer options in English and Chinese.
- Add a release-note fragment and focused regression coverage for platform-specific installer behavior.

## Test plan

- [x] Installer platform regressions (`24 passed`)
- [x] Release-note regressions (`7 passed`)
- [x] Release-note PR validation (`1 fragment validated`)
- [x] Bash syntax, Python compilation, and diff checks
- [x] Linux, macOS, and Windows-patched Docker Compose configuration validation
- [ ] Fresh end-to-end installation on physical or virtual Linux, macOS, and Windows hosts


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Support Linux, macOS, and Windows Git Bash installation.
  - Platform‑appropriate default paths, Docker volume handling, and privilege checks.

- Update READMEs (EN/CN) with installation commands and options for all platforms.

- Improve Docker Compose patches for Windows volumes and macOS mount permissions.

- Add regression tests for platform‑specific installer recovery and behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  install_sh["install.sh"] --> PLATFORM{"Platform"}
  PLATFORM -->|Linux| Linux["/opt/sourcelens, bind mounts, root"]
  PLATFORM -->|macOS| macOS["/Users/Shared, prepare_macos_permissions"]
  PLATFORM -->|Windows| Windows["$HOME/sourcelens, Docker volumes, OpenSSL cert"]
  install_sh --> README["README updates"]
  install_sh --> TESTS["Platform regression tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_installer_platform.py</strong><dd><code>Add platform installer regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_installer_platform.py

<ul><li>Verify platform‑specific default install directories, permission <br>handling, and compose patches.<br> <li> Test Windows certificate generation without Docker, stale mount <br>recovery, and compose idempotency.<br> <li> Check README contents contain correct platform install commands and <br>resource requirements.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-dee5b70b6f64dea345f52db8b4c458bc1cbd656f8f9ad7e99720753328a0b841">+368/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Cross‑platform installer logic and compose patching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

install.sh

<ul><li>Add PLATFORM detection and default_install_dir_for_platform function <br>for Linux/macOS/Windows.<br> <li> Implement patch_platform_compose to replace bind mounts with Docker <br>volumes on Windows and disable PostgreSQL log mount on macOS.<br> <li> Add macOS mount permission preparation <br>(prepare_macos_mount_permissions) and stale mount namespace recovery.<br> <li> Use host OpenSSL on Windows (MSYS_NO_PATHCONV) and skip docker TLS <br>helper image when not needed.<br> <li> Convert compose paths via cygpath on Windows for Docker Desktop <br>compatibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+216/-28</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.standalone.yml</strong><dd><code>Stable Redis working directory and data directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.standalone.yml

<ul><li>Add working_dir: /tmp and command –dir /data to Redis service for <br>stable health checks.<br> <li> No structural changes; volume declarations remain for Linux, patched <br>at runtime for other platforms.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-9ce448f74e566e43c1699bd469713bd9cd36e5f11ffccd6b824cd840f3077228">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Linux/macOS/Windows install commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document supported platforms (Linux, macOS, Windows Git Bash) and <br>resource requirements.<br> <li> Provide separate install commands for Linux/macOS (with sudo) and <br>Windows (without sudo).<br> <li> Explain China channel usage, common options, and default install <br>directories per platform.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+40/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>Chinese translation of platform install instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh-CN.md

<ul><li>Translate platform support and install instructions to Chinese.<br> <li> Add Windows Git Bash‑specific notes and China channel usage.<br> <li> State per‑platform default install directories and resource minimums.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+36/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cross-platform-standalone-install.yaml</strong><dd><code>Add release note for cross‑platform support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/cross-platform-standalone-install.yaml

<ul><li>Add release note fragment for the cross‑platform installer improvement <br>in English and Chinese.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/520/files#diff-50a6e71090e8800612416538b93cf2d91b9b160cfa6e0bda9a48fb83ac2eb2da">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

