### PR TITLE
Improve datasource sync catalog and history performance

### DIFF
--- a/backend/lens/consumers.py
+++ b/backend/lens/consumers.py
@@ -96,6 +96,8 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
             await self._handle_list_dirs_result(content)
         elif frame_type == "datasource_path_result":
             await self._handle_datasource_path_result(content)
+        elif frame_type == "datasource_files_result":
+            await self._handle_datasource_files_result(content)
         elif frame_type == "datasource_connection_result":
             await self._handle_datasource_connection_result(content)
         elif frame_type == "datasource_sync_event":
@@ -510,6 +512,22 @@ class LensNodeConsumer(AsyncJsonWebsocketConsumer):
         from django.core.cache import cache
 
         cache.set(f"lens:datasource_path:{request_id}", result, timeout=30)
+
+    async def _handle_datasource_files_result(self, content):
+        """Store one datasource file catalog response for the HTTP request."""
+
+        request_id = content.get("request_id") or ""
+        if request_id:
+            await database_sync_to_async(self._cache_datasource_files_result)(
+                request_id,
+                content.get("result") or {},
+            )
+
+    @staticmethod
+    def _cache_datasource_files_result(request_id, result):
+        from django.core.cache import cache
+
+        cache.set(f"lens:datasource_files:{request_id}", result, timeout=30)
 
     async def _handle_datasource_connection_result(self, content):
         """Store datasource connection test result for the waiting request."""

--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -222,6 +222,38 @@ def check_datasource_path(lensnode, target_path, source_type, config=None):
     )
 
 
+def list_datasource_files(datasource, page=1, page_size=20, **filters):
+    """Return a paginated, safe datasource file catalog from its LensNode."""
+
+    datasource = DataSource.objects.select_related("lensnode").get(
+        pk=datasource.pk
+    )
+    target_path = normalize_workspace_target_path(
+        datasource.target_path,
+        datasource.lensnode.workspace_path,
+    )
+    request_id = uuid.uuid4().hex
+    _send_lensnode_command(
+        datasource.lensnode,
+        {
+            "type": "datasource_list_files",
+            "request_id": request_id,
+            "datasource_uuid": str(datasource.uuid),
+            "source_type": datasource.source_type,
+            "target_path": target_path,
+            "page": page,
+            "page_size": page_size,
+            "query": filters.get("query") or "",
+            "sync_status": filters.get("sync_status") or "",
+            "conversion_status": filters.get("conversion_status") or "",
+        },
+    )
+    return _wait_cache_result(
+        f"lens:datasource_files:{request_id}",
+        timeout_s=15,
+    )
+
+
 def test_datasource_connection(
     lensnode,
     source_type,

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -6237,6 +6237,40 @@ class LensApiTests(TestCase):
         self.assertEqual(task.created_by, self.user)
         self.assertEqual(task.metadata["celery_task_id"], celery_task_id)
 
+    @patch("lens.views.datasources.list_datasource_files")
+    def test_datasource_files_returns_manifest_catalog(self, list_files):
+        list_files.return_value = {
+            "count": 1,
+            "page": 1,
+            "page_size": 20,
+            "results": [
+                {
+                    "path": "MIW Production Export/report.pdf",
+                    "name": "report.pdf",
+                    "extension": "pdf",
+                    "sync_status": "synced",
+                    "conversion_status": "success",
+                    "source_updated_at": "2026-09-09T00:00:00Z",
+                    "converted_at": "2026-09-09T00:01:00Z",
+                    "conversion_error": "",
+                }
+            ],
+        }
+
+        response = self.client.get(
+            f"/api/lens/admin/datasources/{self.datasource.uuid}/files/",
+            {"query": "MIW", "page": 1, "page_size": 20},
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["path"],
+            "MIW Production Export/report.pdf",
+        )
+        self.assertNotIn("/workspace", response.data["results"][0]["path"])
+        list_files.assert_called_once()
+
     def test_disabled_datasource_rejects_manual_sync(self):
         self.datasource.status = DataSource.Status.DISABLED
         self.datasource.save(update_fields=["status", "updated_at"])

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -6237,6 +6237,33 @@ class LensApiTests(TestCase):
         self.assertEqual(task.created_by, self.user)
         self.assertEqual(task.metadata["celery_task_id"], celery_task_id)
 
+    def test_datasource_sync_tasks_uses_a_fixed_query_count(self):
+        for index in range(10):
+            TaskExecution.objects.create(
+                task_id=f"datasource-sync-history-{index}",
+                task_name="datasource_sync:Repo Cache",
+                module="lens_datasource",
+                status="SUCCESS",
+                created_by=self.user,
+                metadata={
+                    "datasource_uuid": str(self.datasource.uuid),
+                    "trigger": "scheduled",
+                },
+            )
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(
+                f"/api/lens/admin/datasources/{self.datasource.uuid}/sync-tasks/",
+                {"page": 1, "page_size": 10, "metadata_fields": "trigger"},
+            )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertLessEqual(len(queries), 3)
+        self.assertEqual(len(response.data["results"]), 10)
+        self.assertEqual(response.data["results"][0]["metadata"], {
+            "trigger": "scheduled",
+        })
+
     @patch("lens.views.datasources.list_datasource_files")
     def test_datasource_files_returns_manifest_catalog(self, list_files):
         list_files.return_value = {

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -591,15 +591,41 @@ class DataSourceViewSet(BaseAdminViewSet):
         )
 
         datasource = self.get_object()
-        queryset = TaskExecution.objects.filter(
-            module="lens_datasource",
-            metadata__datasource_uuid=str(datasource.uuid),
-        ).order_by("-created_at")
+        queryset = (
+            TaskExecution.objects.filter(
+                module="lens_datasource",
+                metadata__datasource_uuid=str(datasource.uuid),
+            )
+            .select_related("created_by")
+            .only(
+                "id",
+                "task_id",
+                "task_name",
+                "module",
+                "status",
+                "created_at",
+                "started_at",
+                "finished_at",
+                "metadata",
+                "created_by_id",
+                "created_by__id",
+                "created_by__username",
+            )
+            .order_by("-created_at")
+        )
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = TaskExecutionListSerializer(page, many=True)
+            serializer = TaskExecutionListSerializer(
+                page,
+                many=True,
+                context={"request": request},
+            )
             return self.get_paginated_response(serializer.data)
-        serializer = TaskExecutionListSerializer(queryset, many=True)
+        serializer = TaskExecutionListSerializer(
+            queryset,
+            many=True,
+            context={"request": request},
+        )
         return Response(serializer.data)
 
     @action(detail=True, methods=["get"], url_path="conversion-tasks")

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -14,6 +14,7 @@ from lens.datasource_services import (
     DataSourceDispatchError,
     DataSourcePathError,
     check_datasource_path,
+    list_datasource_files,
 )
 from lens.models import (
     CredentialLease,
@@ -540,6 +541,45 @@ class DataSourceViewSet(BaseAdminViewSet):
             ]
         )
         return Response(DataSourceSerializer(datasource).data)
+
+    @action(detail=True, methods=["get"], url_path="files")
+    def files(self, request, uuid=None):
+        """Return the current manifest-backed datasource file catalog."""
+
+        datasource = self.get_object()
+        try:
+            page = max(1, int(request.query_params.get("page") or 1))
+            page_size = min(
+                100,
+                max(1, int(request.query_params.get("page_size") or 20)),
+            )
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "DATASOURCE_FILE_QUERY_INVALID"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            result = list_datasource_files(
+                datasource,
+                page=page,
+                page_size=page_size,
+                query=request.query_params.get("query") or "",
+                sync_status=request.query_params.get("sync_status") or "",
+                conversion_status=(
+                    request.query_params.get("conversion_status") or ""
+                ),
+            )
+        except (DataSourcePathError, DataSourceDispatchError) as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        if result.get("error"):
+            return Response(
+                {"detail": result["error"]},
+                status=status.HTTP_409_CONFLICT,
+            )
+        return Response(result)
 
     @action(detail=True, methods=["get"], url_path="sync-tasks")
     def sync_tasks(self, request, uuid=None):

--- a/docs/design-incremental-datasource-sync.md
+++ b/docs/design-incremental-datasource-sync.md
@@ -1,0 +1,56 @@
+# Incremental datasource sync and conversion
+
+## Objective
+
+Separate datasource discovery and download from document conversion so a
+long-running conversion cannot retain the exclusive datasource-sync lease.
+The design preserves current user-visible paths and existing workspaces while
+making changed-file conversion, retries, and deletion safe.
+
+## Confirmed behaviour
+
+- A complete upstream scan marks an absent item as `missing` on its first
+  observation. It remains available locally.
+- Only a second consecutive complete scan that still does not contain the
+  item marks it `deleted` and removes its source file and conversion sidecar.
+- An incomplete scan never increments the missing counter or deletes data.
+- The existing `delete_missing` option remains the explicit opt-in for source
+  deletion. When disabled, absent items are retained as today.
+- Conversion retries at most three times. A fourth failure is retained for an
+  explicit retry or a later source-content change.
+
+## Compatibility boundary
+
+The initial rollout retains the current datasource root and sidecars. New
+layout metadata may describe `source/`, `derived/`, and `.sourcelens/`, but
+no historical workspace is physically moved in this change. Answers and UI
+citations always use the original relative source path.
+
+## Target workflow
+
+```text
+exclusive sync: discover -> diff -> download changed -> write manifest
+                                                        -> enqueue conversion
+
+bounded conversion: convert changed -> checkpoint -> update conversion state
+```
+
+The sync task completes after durable discovery/download state is written.
+Conversion is a separate, non-exclusive task with its own recovery lifecycle.
+
+## Delivery slices
+
+1. Add two-complete-scan deletion semantics and regression tests.
+2. Persist conversion work independently and allow sync to skip inline
+   conversion behind a safe default/feature flag.
+3. Add plugin conversion task dispatch, progress, recovery, and a separate
+   conversion lease.
+4. Add retry state, no-progress timeout, and failure retry API.
+5. Introduce the physical source/derived layout only after read compatibility
+   is verified.
+
+## Verification
+
+- `pytest lensnode/tests/plugins/test_feishu_datasource.py`
+- Relevant Django `lens` task and consumer tests for slices 2--4.
+- Existing workspaces continue to resolve source paths and sidecars unchanged.

--- a/docs/design-incremental-datasource-sync.md
+++ b/docs/design-incremental-datasource-sync.md
@@ -48,6 +48,9 @@ Conversion is a separate, non-exclusive task with its own recovery lifecycle.
 4. Add retry state, no-progress timeout, and failure retry API.
 5. Introduce the physical source/derived layout only after read compatibility
    is verified.
+6. Expose a paginated, read-only file catalog from the LensNode manifest.
+   The catalog uses original relative paths and never returns internal
+   directories or absolute workspace paths.
 
 ## Verification
 

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -1565,7 +1565,25 @@
       "basicInfo": "Basic Information",
       "tabs": {
         "basic": "Basic Information",
-        "details": "Sync history"
+        "details": "Sync history",
+        "files": "Files"
+      },
+      "files": {
+        "searchPlaceholder": "Search paths",
+        "allSync": "All sync states",
+        "allConversion": "All conversion states",
+        "path": "Path",
+        "type": "Type",
+        "syncStatus": "Sync status",
+        "conversionStatus": "Conversion status",
+        "syncSynced": "Synced",
+        "syncMissing": "Pending deletion",
+        "syncFailed": "Sync failed",
+        "conversionSuccess": "Converted",
+        "conversionFailed": "Conversion failed",
+        "conversionSkipped": "Skipped",
+        "notConverted": "Not converted",
+        "empty": "No files are available for this data source."
       },
       "connection": "Connection",
       "resourceAndTarget": "Resource and target",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -1565,7 +1565,25 @@
       "basicInfo": "基本信息",
       "tabs": {
         "basic": "基本信息",
-        "details": "同步记录"
+        "details": "同步记录",
+        "files": "文件清单"
+      },
+      "files": {
+        "searchPlaceholder": "按路径搜索",
+        "allSync": "全部同步状态",
+        "allConversion": "全部转换状态",
+        "path": "路径",
+        "type": "类型",
+        "syncStatus": "同步状态",
+        "conversionStatus": "转换状态",
+        "syncSynced": "已同步",
+        "syncMissing": "待确认删除",
+        "syncFailed": "同步失败",
+        "conversionSuccess": "转换成功",
+        "conversionFailed": "转换失败",
+        "conversionSkipped": "已跳过",
+        "notConverted": "未转换",
+        "empty": "当前数据源没有可展示的文件。"
       },
       "connection": "连接信息",
       "resourceAndTarget": "资源与目标",

--- a/frontend/src/pages/lens/DataSourceDetailDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceDetailDrawer.vue
@@ -3,7 +3,7 @@
     :show="show"
     :title="t('lensAdmin.datasourceDetail.title')"
     :subtitle="datasource?.name || ''"
-    width="2xl"
+    width="5xl"
     @close="$emit('close')"
   >
     <template v-if="datasource" #tabs>

--- a/frontend/src/pages/lens/DataSourceDetailDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceDetailDrawer.vue
@@ -25,6 +25,14 @@
           >
             {{ t('lensAdmin.datasourceDetail.tabs.details') }}
           </button>
+          <button
+            type="button"
+            class="detail-tab"
+            :class="activeTab === 'files' ? 'detail-tab-active' : ''"
+            @click="activeTab = 'files'"
+          >
+            {{ t('lensAdmin.datasourceDetail.tabs.files') }}
+          </button>
         </div>
       </div>
     </template>
@@ -430,6 +438,135 @@
           </div>
         </div>
       </div>
+      <div v-show="activeTab === 'files'" class="space-y-4">
+        <div class="flex flex-wrap gap-2">
+          <input
+            v-model="fileQuery"
+            class="min-w-48 flex-1 rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-900 outline-none placeholder:text-ink-400 focus:border-primary-500"
+            :placeholder="
+              t('lensAdmin.datasourceDetail.files.searchPlaceholder')
+            "
+            type="search"
+            @keyup.enter="loadFiles"
+          />
+          <select
+            v-model="fileSyncStatus"
+            class="rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-700"
+            @change="loadFiles"
+          >
+            <option value="">
+              {{ t('lensAdmin.datasourceDetail.files.allSync') }}
+            </option>
+            <option value="synced">
+              {{ t('lensAdmin.datasourceDetail.files.syncSynced') }}
+            </option>
+            <option value="missing">
+              {{ t('lensAdmin.datasourceDetail.files.syncMissing') }}
+            </option>
+            <option value="failed">
+              {{ t('lensAdmin.datasourceDetail.files.syncFailed') }}
+            </option>
+          </select>
+          <select
+            v-model="fileConversionStatus"
+            class="rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-700"
+            @change="loadFiles"
+          >
+            <option value="">
+              {{ t('lensAdmin.datasourceDetail.files.allConversion') }}
+            </option>
+            <option value="success">
+              {{ t('lensAdmin.datasourceDetail.files.conversionSuccess') }}
+            </option>
+            <option value="failed">
+              {{ t('lensAdmin.datasourceDetail.files.conversionFailed') }}
+            </option>
+            <option value="skipped">
+              {{ t('lensAdmin.datasourceDetail.files.conversionSkipped') }}
+            </option>
+            <option value="not_converted">
+              {{ t('lensAdmin.datasourceDetail.files.notConverted') }}
+            </option>
+          </select>
+        </div>
+        <div class="overflow-hidden rounded-lg border border-line bg-surface">
+          <div
+            class="hidden grid-cols-[minmax(0,1fr)_90px_110px_110px] gap-3 bg-surface-sunken px-4 py-2 text-xs font-semibold uppercase tracking-wider text-ink-600 sm:grid"
+          >
+            <span>{{ t('lensAdmin.datasourceDetail.files.path') }}</span>
+            <span>{{ t('lensAdmin.datasourceDetail.files.type') }}</span>
+            <span>{{ t('lensAdmin.datasourceDetail.files.syncStatus') }}</span>
+            <span>{{
+              t('lensAdmin.datasourceDetail.files.conversionStatus')
+            }}</span>
+          </div>
+          <div
+            v-if="filesLoading"
+            class="px-4 py-8 text-center text-sm text-ink-500"
+          >
+            {{ t('common.loading') }}
+          </div>
+          <div
+            v-else-if="filesError"
+            class="px-4 py-8 text-center text-sm text-danger-600"
+          >
+            {{ filesError }}
+          </div>
+          <div
+            v-else-if="!files.length"
+            class="px-4 py-8 text-center text-sm text-ink-500"
+          >
+            {{ t('lensAdmin.datasourceDetail.files.empty') }}
+          </div>
+          <ul v-else class="divide-y divide-line">
+            <li
+              v-for="file in files"
+              :key="file.path"
+              class="grid gap-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_90px_110px_110px] sm:items-center sm:gap-3"
+            >
+              <p
+                class="truncate font-mono text-xs text-ink-800"
+                :title="file.path"
+              >
+                {{ file.path }}
+              </p>
+              <span class="text-xs text-ink-500">{{
+                file.extension || emptyValue
+              }}</span>
+              <span class="text-xs text-ink-700">{{ file.sync_status }}</span>
+              <span class="text-xs text-ink-700" :title="file.conversion_error">
+                {{ file.conversion_status }}
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          v-if="filesCount > 0"
+          class="flex items-center justify-between gap-2"
+        >
+          <p class="text-sm text-ink-500">
+            {{ t('common.pagination.showing', filesPaginationShowing) }}
+          </p>
+          <div class="flex gap-2">
+            <BaseButton
+              variant="outline"
+              size="sm"
+              :disabled="filesLoading || filePage <= 1"
+              @click="goPrevFilePage"
+            >
+              {{ t('common.pagination.previous') }}
+            </BaseButton>
+            <BaseButton
+              variant="outline"
+              size="sm"
+              :disabled="filesLoading || filePage >= filesTotalPages"
+              @click="goNextFilePage"
+            >
+              {{ t('common.pagination.next') }}
+            </BaseButton>
+          </div>
+        </div>
+      </div>
     </div>
     <div v-else class="py-12 text-center text-sm text-ink-500">
       {{ t('lensAdmin.datasourceDetail.selectHint') }}
@@ -537,6 +674,17 @@ const tasksLoadInFlight = ref(false)
 const taskRequestSeq = ref(0)
 const taskListContextKey = ref('')
 
+const files = ref([])
+const filesLoading = ref(false)
+const filesError = ref('')
+const filesCount = ref(0)
+const filePage = ref(1)
+const filesTotalPages = ref(1)
+const fileQuery = ref('')
+const fileSyncStatus = ref('')
+const fileConversionStatus = ref('')
+const fileListContextKey = ref('')
+
 const expandedTaskId = ref(null)
 const expandedTask = ref(null)
 const expandedTaskDetailLoading = ref(false)
@@ -565,6 +713,12 @@ const paginationShowing = computed(() => ({
   from: (currentPage.value - 1) * pageSize + 1,
   to: Math.min(currentPage.value * pageSize, totalCount.value),
   total: totalCount.value
+}))
+
+const filesPaginationShowing = computed(() => ({
+  from: (filePage.value - 1) * pageSize + 1,
+  to: Math.min(filePage.value * pageSize, filesCount.value),
+  total: filesCount.value
 }))
 
 function mapTaskStatus(status) {
@@ -598,6 +752,55 @@ function resetTaskList() {
   totalPages.value = 1
   expandedTaskId.value = null
   expandedTask.value = null
+}
+
+function resetFileList() {
+  files.value = []
+  filesCount.value = 0
+  filesTotalPages.value = 1
+  filesError.value = ''
+}
+
+async function loadFiles() {
+  const uuid = props.datasource?.uuid
+  if (!uuid) {
+    resetFileList()
+    return
+  }
+  filesLoading.value = true
+  filesError.value = ''
+  try {
+    const res = await api.get(`/lens/admin/datasources/${uuid}/files/`, {
+      params: {
+        page: filePage.value,
+        page_size: pageSize,
+        query: fileQuery.value,
+        sync_status: fileSyncStatus.value,
+        conversion_status: fileConversionStatus.value
+      }
+    })
+    const data = extractResponseData(res) || {}
+    files.value = Array.isArray(data.results) ? data.results : []
+    filesCount.value = Number(data.count) || 0
+    filesTotalPages.value = Math.max(1, Math.ceil(filesCount.value / pageSize))
+  } catch (error) {
+    resetFileList()
+    filesError.value = extractErrorMessage(error, t('common.error'))
+  } finally {
+    filesLoading.value = false
+  }
+}
+
+function goPrevFilePage() {
+  if (filesLoading.value || filePage.value <= 1) return
+  filePage.value -= 1
+  loadFiles()
+}
+
+function goNextFilePage() {
+  if (filesLoading.value || filePage.value >= filesTotalPages.value) return
+  filePage.value += 1
+  loadFiles()
 }
 
 function hasProcessingTasks() {
@@ -809,6 +1012,23 @@ watch(
         stopProcessingRefresh()
       }
     })
+  },
+  { immediate: true }
+)
+
+watch(
+  () => [props.datasource?.uuid, props.show, activeTab.value],
+  ([uuid, visible, tab]) => {
+    if (!visible || !uuid || tab !== 'files') {
+      fileListContextKey.value = ''
+      resetFileList()
+      return
+    }
+    const contextKey = `${uuid}:${tab}`
+    if (fileListContextKey.value === contextKey) return
+    fileListContextKey.value = contextKey
+    filePage.value = 1
+    loadFiles()
   },
   { immediate: true }
 )

--- a/frontend/src/pages/lens/DataSourceDetailDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceDetailDrawer.vue
@@ -447,12 +447,12 @@
               t('lensAdmin.datasourceDetail.files.searchPlaceholder')
             "
             type="search"
-            @keyup.enter="loadFiles"
+            @keyup.enter="searchFiles"
           />
           <select
             v-model="fileSyncStatus"
             class="rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-700"
-            @change="loadFiles"
+            @change="searchFiles"
           >
             <option value="">
               {{ t('lensAdmin.datasourceDetail.files.allSync') }}
@@ -470,7 +470,7 @@
           <select
             v-model="fileConversionStatus"
             class="rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink-700"
-            @change="loadFiles"
+            @change="searchFiles"
           >
             <option value="">
               {{ t('lensAdmin.datasourceDetail.files.allConversion') }}
@@ -684,6 +684,7 @@ const fileQuery = ref('')
 const fileSyncStatus = ref('')
 const fileConversionStatus = ref('')
 const fileListContextKey = ref('')
+const fileRequestSeq = ref(0)
 
 const expandedTaskId = ref(null)
 const expandedTask = ref(null)
@@ -762,6 +763,8 @@ function resetFileList() {
 }
 
 async function loadFiles() {
+  const requestSeq = fileRequestSeq.value + 1
+  fileRequestSeq.value = requestSeq
   const uuid = props.datasource?.uuid
   if (!uuid) {
     resetFileList()
@@ -780,15 +783,34 @@ async function loadFiles() {
       }
     })
     const data = extractResponseData(res) || {}
+    if (
+      requestSeq !== fileRequestSeq.value ||
+      uuid !== props.datasource?.uuid
+    ) {
+      return
+    }
     files.value = Array.isArray(data.results) ? data.results : []
     filesCount.value = Number(data.count) || 0
     filesTotalPages.value = Math.max(1, Math.ceil(filesCount.value / pageSize))
   } catch (error) {
+    if (
+      requestSeq !== fileRequestSeq.value ||
+      uuid !== props.datasource?.uuid
+    ) {
+      return
+    }
     resetFileList()
     filesError.value = extractErrorMessage(error, t('common.error'))
   } finally {
-    filesLoading.value = false
+    if (requestSeq === fileRequestSeq.value) {
+      filesLoading.value = false
+    }
   }
+}
+
+function searchFiles() {
+  filePage.value = 1
+  loadFiles()
 }
 
 function goPrevFilePage() {
@@ -1020,6 +1042,7 @@ watch(
   () => [props.datasource?.uuid, props.show, activeTab.value],
   ([uuid, visible, tab]) => {
     if (!visible || !uuid || tab !== 'files') {
+      fileRequestSeq.value += 1
       fileListContextKey.value = ''
       resetFileList()
       return

--- a/lensnode/lensnode/datasource_manifest.py
+++ b/lensnode/lensnode/datasource_manifest.py
@@ -60,6 +60,7 @@ class SyncResult:
     changed_paths: list = field(default_factory=list)
     deleted_paths: list = field(default_factory=list)
     stats: dict = field(default_factory=dict)
+    changed_only: bool = False
 
 
 def write_datasource_marker(target, context):

--- a/lensnode/lensnode/datasource_manifest.py
+++ b/lensnode/lensnode/datasource_manifest.py
@@ -22,6 +22,7 @@ class SyncItem:
     status: str
     metadata: dict = field(default_factory=dict)
     remote: dict = field(default_factory=dict)
+    missing_scans: int = 0
 
     def get(self, key, default=None):
         """Return a manifest value using dict-compatible access."""
@@ -49,6 +50,8 @@ class SyncItem:
         token = self.remote.get("token")
         if token:
             payload["token"] = token
+        if self.missing_scans:
+            payload["missing_scans"] = self.missing_scans
         return payload
 
 

--- a/lensnode/lensnode/datasource_manifest.py
+++ b/lensnode/lensnode/datasource_manifest.py
@@ -80,6 +80,19 @@ def write_datasource_marker(target, context):
     )
 
 
+def read_manifest_marker(target):
+    """Read a datasource root marker file."""
+
+    path = Path(target) / MARKER_FILE
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 def read_manifest(target):
     """Read a datasource manifest file."""
 
@@ -180,12 +193,8 @@ def should_skip_dir(path, current_datasource_uuid, excluded_roots):
     path = Path(path)
     if is_sidecar_dir(path) or is_excluded_path(path, excluded_roots):
         return True
-    marker = path / MARKER_FILE
-    if not marker.is_file():
-        return False
-    try:
-        payload = json.loads(marker.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    payload = read_manifest_marker(path)
+    if not payload:
         return False
     return payload.get("datasource_uuid") != current_datasource_uuid
 

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -24,6 +24,7 @@ from .path_rules import is_excluded_path
 from .path_rules import normalize_excluded_roots
 from .path_rules import relative_path
 from .path_rules import safe_filename
+from .path_rules import sidecar_path
 from .path_rules import source_sha256
 from .path_rules import stable_suffix
 from .path_rules import unique_child_path
@@ -253,6 +254,150 @@ def sync_datasource(command, workspace_path=WORKSPACE_ROOT, emit=None):
     conversion_summary["deleted_sidecars"] = deleted_sidecars
     result["conversion_summary"] = conversion_summary
     return result
+
+
+def list_datasource_files(command, workspace_path=WORKSPACE_ROOT):
+    """Return one safe, paginated view of a datasource manifest."""
+
+    target = normalize_target_path(command.get("target_path"), workspace_path)
+    datasource_uuid = str(command.get("datasource_uuid") or "")
+    source_type = str(command.get("source_type") or "")
+    marker = manifest_store.read_manifest_marker(target)
+    if (
+        source_type != "managed_workspace"
+        and (
+            not datasource_uuid
+            or marker.get("datasource_uuid") != datasource_uuid
+        )
+    ):
+        raise DataSourceSyncError("DATASOURCE_MANIFEST_NOT_FOUND")
+
+    query = str(command.get("query") or "").strip().lower()
+    sync_status = str(command.get("sync_status") or "").strip().lower()
+    conversion_status = str(
+        command.get("conversion_status") or ""
+    ).strip().lower()
+    try:
+        page = max(1, int(command.get("page") or 1))
+        page_size = min(100, max(1, int(command.get("page_size") or 20)))
+    except (TypeError, ValueError) as exc:
+        raise DataSourceSyncError("DATASOURCE_FILE_QUERY_INVALID") from exc
+
+    files = []
+    if source_type == "managed_workspace":
+        manifest_items = _managed_workspace_catalog_items(target)
+    else:
+        manifest_items = manifest_store.manifest_items(
+            manifest_store.read_manifest(target)
+        )
+    for item in manifest_items:
+        entry = _datasource_file_entry(target, item)
+        if entry is None:
+            continue
+        if query and query not in entry["path"].lower():
+            continue
+        if sync_status and entry["sync_status"].lower() != sync_status:
+            continue
+        if (
+            conversion_status
+            and entry["conversion_status"].lower() != conversion_status
+        ):
+            continue
+        files.append(entry)
+    files.sort(key=lambda item: item["path"].lower())
+    start = (page - 1) * page_size
+    return {
+        "count": len(files),
+        "page": page,
+        "page_size": page_size,
+        "results": files[start : start + page_size],
+    }
+
+
+def _managed_workspace_catalog_items(target):
+    """Return manifest-compatible items from a managed workspace directory."""
+
+    target = Path(target)
+    items = []
+    for path in target.rglob("*"):
+        if (
+            not path.is_file()
+            or _is_datasource_catalog_internal_path(target, path)
+        ):
+            continue
+        local_path = relative_path(target, path)
+        items.append(
+            {
+                "local_path": local_path,
+                "name": path.name,
+                "file_extension": path.suffix.lstrip(".").lower(),
+                "status": "synced",
+                "metadata": {
+                    "modified_time": datetime.fromtimestamp(
+                        path.stat().st_mtime,
+                        timezone.utc,
+                    ).isoformat(),
+                },
+            }
+        )
+    return items
+
+
+def _is_datasource_catalog_internal_path(target, path):
+    """Return whether a path is internal datasource bookkeeping content."""
+
+    relative = path.resolve().relative_to(Path(target).resolve())
+    if relative.name in {
+        manifest_store.MANIFEST_FILE,
+        manifest_store.MARKER_FILE,
+    }:
+        return True
+    return any(part.endswith(".sourcelens") for part in relative.parts)
+
+
+def _datasource_file_entry(target, item):
+    """Return safe catalog data for one manifest item."""
+
+    local_path = manifest_store.manifest_local_path(item)
+    if not local_path:
+        return None
+    path = (Path(target) / local_path).resolve()
+    try:
+        path.relative_to(Path(target).resolve())
+    except ValueError:
+        return None
+    conversion = _read_datasource_conversion(path)
+    metadata = item.get("metadata") or {}
+    return {
+        "path": Path(local_path).as_posix(),
+        "name": str(item.get("name") or Path(local_path).name),
+        "extension": str(
+            item.get("extension")
+            or item.get("file_extension")
+            or Path(local_path).suffix.lstrip(".")
+        ).lower(),
+        "sync_status": str(item.get("status") or "synced"),
+        "conversion_status": conversion["status"],
+        "source_updated_at": str(metadata.get("modified_time") or ""),
+        "converted_at": conversion["generated_at"],
+        "conversion_error": conversion["error"],
+    }
+
+
+def _read_datasource_conversion(path):
+    """Return the public conversion state for one source file."""
+
+    meta_path = sidecar_path(path) / "meta.json"
+    try:
+        payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    conversion = payload.get("conversion") or {}
+    return {
+        "status": str(conversion.get("status") or "not_converted"),
+        "generated_at": str(conversion.get("generated_at") or ""),
+        "error": str(conversion.get("error") or ""),
+    }
 
 
 def convert_managed_workspace(

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -223,6 +223,7 @@ def sync_datasource(command, workspace_path=WORKSPACE_ROOT, emit=None):
         changed_paths=changed_paths,
         deleted_paths=deleted_paths,
         stats=_sync_summary_from_result(result),
+        changed_only=True,
     )
     sync_details = _sync_details_by_metric(
         sync_items,

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -3113,6 +3113,17 @@ def _finalize_feishu_missing_items(
             manifest_items.append({**item, "status": "skipped"})
             stats["skipped"] += 1
             continue
+        missing_scans = int(item.get("missing_scans") or 0) + 1
+        if missing_scans < 2:
+            manifest_items.append(
+                {
+                    **item,
+                    "status": "missing",
+                    "missing_scans": missing_scans,
+                }
+            )
+            stats["skipped"] += 1
+            continue
         deleted_item = {**item, "status": "deleted"}
         manifest_items.append(deleted_item)
         stats["deleted"] += 1
@@ -3388,17 +3399,16 @@ def _sync_feishu_folder(config, target, headers, emit, max_workers=1):
                 summary=stats,
             )
 
-    for token, item in previous_items.items():
-        if token in seen_tokens:
-            continue
-        deleted_item = {**item, "status": "deleted"}
-        manifest_items.append(deleted_item)
-        stats["deleted"] += 1
-        local_path = _manifest_local_path(item)
-        if local_path:
-            deleted_paths.append(local_path)
-        if delete_missing and local_path:
-            _delete_manifest_file(target, local_path)
+    _finalize_feishu_missing_items(
+        target,
+        previous_items,
+        seen_tokens,
+        manifest_items,
+        deleted_paths,
+        stats,
+        delete_missing=delete_missing,
+        scan_complete=True,
+    )
     _write_manifest(
         target,
         {
@@ -4411,6 +4421,7 @@ def _feishu_manifest_item_from_previous(
         "metadata": _feishu_item_sync_metadata(item),
         "remote": {"token": token, "type": item_type},
         "status": "skipped",
+        "missing_scans": 0,
     }
 
 

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -283,7 +283,7 @@ def list_datasource_files(command, workspace_path=WORKSPACE_ROOT):
     except (TypeError, ValueError) as exc:
         raise DataSourceSyncError("DATASOURCE_FILE_QUERY_INVALID") from exc
 
-    files = []
+    candidates = []
     if source_type == "managed_workspace":
         manifest_items = _managed_workspace_catalog_items(target)
     else:
@@ -291,26 +291,35 @@ def list_datasource_files(command, workspace_path=WORKSPACE_ROOT):
             manifest_store.read_manifest(target)
         )
     for item in manifest_items:
-        entry = _datasource_file_entry(target, item)
+        local_path = manifest_store.manifest_local_path(item)
+        if not local_path:
+            continue
+        display_path = Path(local_path).as_posix()
+        public_status = _public_sync_status(item.get("status"))
+        if query and query not in display_path.lower():
+            continue
+        if sync_status and public_status != sync_status:
+            continue
+        entry = _datasource_file_entry(target, item, public_status)
         if entry is None:
             continue
-        if query and query not in entry["path"].lower():
-            continue
-        if sync_status and entry["sync_status"].lower() != sync_status:
-            continue
-        if (
-            conversion_status
-            and entry["conversion_status"].lower() != conversion_status
-        ):
-            continue
-        files.append(entry)
-    files.sort(key=lambda item: item["path"].lower())
+        candidates.append((display_path, entry))
+    candidates.sort(key=lambda item: item[0].lower())
+    if conversion_status:
+        candidates = [
+            candidate
+            for candidate in candidates
+            if candidate[1]["conversion_status"].lower() == conversion_status
+        ]
     start = (page - 1) * page_size
+    page_items = candidates[start : start + page_size]
     return {
-        "count": len(files),
+        "count": len(candidates),
         "page": page,
         "page_size": page_size,
-        "results": files[start : start + page_size],
+        "results": [
+            entry for _path, entry in page_items
+        ],
     }
 
 
@@ -325,7 +334,10 @@ def _managed_workspace_catalog_items(target):
             or _is_datasource_catalog_internal_path(target, path)
         ):
             continue
-        local_path = relative_path(target, path)
+        try:
+            local_path = relative_path(target, path)
+        except ValueError:
+            continue
         items.append(
             {
                 "local_path": local_path,
@@ -355,7 +367,7 @@ def _is_datasource_catalog_internal_path(target, path):
     return any(part.endswith(".sourcelens") for part in relative.parts)
 
 
-def _datasource_file_entry(target, item):
+def _datasource_file_entry(target, item, sync_status=None):
     """Return safe catalog data for one manifest item."""
 
     local_path = manifest_store.manifest_local_path(item)
@@ -376,12 +388,19 @@ def _datasource_file_entry(target, item):
             or item.get("file_extension")
             or Path(local_path).suffix.lstrip(".")
         ).lower(),
-        "sync_status": str(item.get("status") or "synced"),
+        "sync_status": sync_status or _public_sync_status(item.get("status")),
         "conversion_status": conversion["status"],
         "source_updated_at": str(metadata.get("modified_time") or ""),
         "converted_at": conversion["generated_at"],
         "conversion_error": conversion["error"],
     }
+
+
+def _public_sync_status(value):
+    """Return the catalog's stable public sync state."""
+
+    status = str(value or "synced").lower()
+    return "synced" if status in {"cataloged", "skipped"} else status
 
 
 def _read_datasource_conversion(path):
@@ -4605,6 +4624,7 @@ def _manifest_item_to_sync_item(item, target):
         status=item.get("status") or "synced",
         metadata=item.get("metadata") or {},
         remote=item.get("remote") or {"token": token, "type": item.get("type")},
+        missing_scans=int(item.get("missing_scans") or 0),
     )
 
 

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -332,6 +332,9 @@ def post_process_documents(context, sync_result, emit=None):
         context.get("datasource_uuid") or "",
         excluded_roots,
         conversion,
+        changed_paths=(
+            sync_result.changed_paths if sync_result.changed_only else None
+        ),
     )
     total = len(candidates)
     summary = {
@@ -792,15 +795,19 @@ def conversion_candidates(
     datasource_uuid,
     excluded_roots,
     conversion,
+    changed_paths=None,
 ):
     """Return manifest items eligible for conversion."""
 
     candidates = []
+    changed = set(changed_paths) if changed_paths is not None else None
     for item in items or []:
         if item.get("status") == "deleted":
             continue
         local_path = manifest_local_path(item)
         if not local_path:
+            continue
+        if changed is not None and local_path not in changed:
             continue
         path = (target / local_path).resolve()
         if not path.is_file() or is_excluded_path(path, excluded_roots):

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -44,6 +44,7 @@ DEFAULT_TOKEN_CHARS = 4
 DETAIL_ITEMS_LIMIT = 200
 DEFAULT_MAX_SPREADSHEET_CELLS = 100000
 DEFAULT_MAX_SPREADSHEET_XML_BYTES = 50 * 1024 * 1024
+MAX_AUTOMATIC_CONVERSION_ATTEMPTS = 3
 
 
 def _check_runtime_cancelled(context):
@@ -335,6 +336,7 @@ def post_process_documents(context, sync_result, emit=None):
         changed_paths=(
             sync_result.changed_paths if sync_result.changed_only else None
         ),
+        force=bool(context.get("force")),
     )
     total = len(candidates)
     summary = {
@@ -796,6 +798,7 @@ def conversion_candidates(
     excluded_roots,
     conversion,
     changed_paths=None,
+    force=False,
 ):
     """Return manifest items eligible for conversion."""
 
@@ -807,9 +810,13 @@ def conversion_candidates(
         local_path = manifest_local_path(item)
         if not local_path:
             continue
-        if changed is not None and local_path not in changed:
-            continue
         path = (target / local_path).resolve()
+        if (
+            changed is not None
+            and local_path not in changed
+            and not _conversion_needs_recheck(path, conversion, force)
+        ):
+            continue
         if not path.is_file() or is_excluded_path(path, excluded_roots):
             continue
         if not is_convertible(path, conversion):
@@ -823,6 +830,31 @@ def conversion_candidates(
             continue
         candidates.append(item)
     return candidates
+
+
+def _conversion_needs_recheck(path, conversion, force=False):
+    """Return whether an unchanged source still needs conversion evaluation."""
+
+    payload = read_json(sidecar_path(path) / "meta.json")
+    previous = payload.get("conversion") or {}
+    if force or previous.get("options") != conversion:
+        return True
+    if previous.get("status") == "success":
+        return False
+    if previous.get("status") == "failed":
+        return _conversion_attempts(previous) < (
+            MAX_AUTOMATIC_CONVERSION_ATTEMPTS
+        )
+    return True
+
+
+def _conversion_attempts(conversion):
+    """Return a safe persisted conversion attempt count."""
+
+    try:
+        return max(0, int(conversion.get("attempts") or 0))
+    except (AttributeError, TypeError, ValueError):
+        return 0
 
 
 def has_foreign_marker(parent, target, datasource_uuid, excluded_roots):
@@ -2383,6 +2415,21 @@ def write_success_meta(
 def write_failed_meta(target, path, item, context, error):
     """Write failed conversion metadata."""
 
+    previous = read_json(sidecar_path(path) / "meta.json")
+    previous_conversion = previous.get("conversion") or {}
+    previous_source = previous.get("source") or {}
+    source_digest = source_sha256(path) if path.is_file() else ""
+    retrying_same_conversion = (
+        previous_conversion.get("status") == "failed"
+        and previous_conversion.get("options")
+        == (context.get("conversion") or {})
+        and previous_source.get("sha256") == source_digest
+    )
+    attempts = (
+        _conversion_attempts(previous_conversion) + 1
+        if retrying_same_conversion
+        else 1
+    )
     write_meta(
         target,
         path,
@@ -2393,7 +2440,8 @@ def write_failed_meta(target, path, item, context, error):
             "error": error,
             "fingerprint": "",
             "stats": {},
-            "source_sha256": "",
+            "source_sha256": source_digest,
+            "attempts": attempts,
         },
     )
 
@@ -2444,6 +2492,7 @@ def write_meta(target, path, item, context, conversion):
             "status": conversion.get("status"),
             "error": conversion.get("error", ""),
             "fingerprint": conversion.get("fingerprint", ""),
+            "attempts": _conversion_attempts(conversion),
             "generated_at": time.strftime(
                 "%Y-%m-%dT%H:%M:%SZ",
                 time.gmtime(),

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -21,7 +21,8 @@ from .checkpoint import (
 from .config import load_config
 from .datasource_sync import DataSourceSyncError
 from .datasource_sync import convert_managed_workspace
-from .datasource_sync import inspect_datasource_path, sync_datasource
+from .datasource_sync import inspect_datasource_path, list_datasource_files
+from .datasource_sync import sync_datasource
 from .datasource_sync import test_datasource_connection
 from .datasource_sync import upload_managed_workspace
 from .delegation_events import delegation_events
@@ -557,6 +558,8 @@ class LensNodeClient:
             await self._handle_list_dirs(message)
         elif message_type == "datasource_check_path":
             await self._handle_datasource_check_path(message)
+        elif message_type == "datasource_list_files":
+            await self._handle_datasource_list_files(message)
         elif message_type == "datasource_test_connection":
             await self._handle_datasource_test_connection(message)
         elif message_type == "datasource_sync":
@@ -834,6 +837,26 @@ class LensNodeClient:
         self._enqueue(
             {
                 "type": "datasource_path_result",
+                "request_id": request_id,
+                "result": result,
+            }
+        )
+
+    async def _handle_datasource_list_files(self, message):
+        """Read one datasource manifest and reply with safe file metadata."""
+
+        request_id = str(message.get("request_id") or "")
+        try:
+            result = await asyncio.to_thread(
+                list_datasource_files,
+                message,
+                self.config.workspace_path,
+            )
+        except DataSourceSyncError as exc:
+            result = {"error": str(exc)}
+        self._enqueue(
+            {
+                "type": "datasource_files_result",
                 "request_id": request_id,
                 "result": result,
             }

--- a/lensnode/tests/plugins/test_feishu_datasource.py
+++ b/lensnode/tests/plugins/test_feishu_datasource.py
@@ -396,6 +396,76 @@ def test_delete_missing_false_keeps_local_file_and_sidecar(
     assert result["_deleted_paths"] == []
 
 
+def test_delete_missing_requires_two_complete_scans(tmp_path, monkeypatch):
+    old_path = tmp_path / "folders" / "old" / "Old.docx"
+    sidecar = Path(f"{old_path}.sourcelens")
+    old_path.parent.mkdir(parents=True)
+    old_path.write_bytes(b"old")
+    sidecar.mkdir()
+    (tmp_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "kind": "document",
+                        "token": "doc_old",
+                        "name": "Old",
+                        "file": "folders/old/Old.docx",
+                        "local_path": "folders/old/Old.docx",
+                        "type": "docx",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "lensnode.datasource_sync._list_feishu_folder_children",
+        lambda _folder_token, _headers: [],
+    )
+    config = {
+        "resources": [{"kind": "folder", "token": "fld_one"}],
+        "recursive": True,
+        "max_depth": 10,
+        "incremental": True,
+        "delete_missing": True,
+    }
+
+    first = _sync_feishu_resources(
+        config,
+        Path(tmp_path),
+        {"Authorization": "Bearer tenant-token"},
+        None,
+        max_workers=2,
+    )
+    first_manifest = json.loads(
+        (tmp_path / "manifest.json").read_text(encoding="utf-8")
+    )
+    first_item = first_manifest["items"][0]
+
+    assert first["_deleted_paths"] == []
+    assert old_path.is_file()
+    assert sidecar.is_dir()
+    assert first_item["status"] == "missing"
+    assert first_item["missing_scans"] == 1
+
+    second = _sync_feishu_resources(
+        config,
+        Path(tmp_path),
+        {"Authorization": "Bearer tenant-token"},
+        None,
+        max_workers=2,
+    )
+    second_manifest = json.loads(
+        (tmp_path / "manifest.json").read_text(encoding="utf-8")
+    )
+    second_item = second_manifest["items"][0]
+
+    assert second["_deleted_paths"] == ["folders/old/Old.docx"]
+    assert not old_path.exists()
+    assert second_item["status"] == "deleted"
+
+
 def test_resource_sync_stops_before_scanning_when_cancelled(tmp_path):
     cancel_event = Event()
     cancel_event.set()

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -9,7 +9,7 @@ from threading import Event
 import httpx
 import pytest
 
-from lensnode.datasource_manifest import MARKER_FILE
+from lensnode.datasource_manifest import MARKER_FILE, SyncResult, build_manifest
 from lensnode.datasource_sync import (
     DataSourceSyncError,
     _cleanup_removed_git_repositories,
@@ -143,6 +143,89 @@ def test_list_datasource_files_lists_managed_workspace_files(tmp_path):
     assert result["count"] == 1
     assert result["results"][0]["path"] == "notes.txt"
     assert result["results"][0]["conversion_status"] == "not_converted"
+
+
+def test_list_datasource_files_normalizes_unchanged_sync_status(tmp_path):
+    """A current file remains visible through the public synced filter."""
+
+    target = tmp_path / "catalog"
+    target.mkdir()
+    (target / ".sourcelens-datasource.json").write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+    (target / "report.txt").write_text("report", encoding="utf-8")
+    (target / "manifest.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"local_path": "report.txt", "status": "skipped"}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = list_datasource_files(
+        {
+            "datasource_uuid": "datasource-1",
+            "target_path": str(target),
+            "sync_status": "synced",
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["results"][0]["sync_status"] == "synced"
+
+
+def test_list_datasource_files_skips_unsafe_manifest_paths(tmp_path):
+    """A corrupt manifest entry cannot break or escape the file catalog."""
+
+    target = tmp_path / "catalog"
+    target.mkdir()
+    (target / ".sourcelens-datasource.json").write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+    (target / "manifest.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"local_path": "../outside.txt", "status": "synced"}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = list_datasource_files(
+        {
+            "datasource_uuid": "datasource-1",
+            "target_path": str(target),
+            "conversion_status": "success",
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["count"] == 0
+    assert result["results"] == []
+
+
+def test_manifest_normalization_preserves_missing_scan_count(tmp_path):
+    """A deferred deletion survives the top-level manifest rewrite."""
+
+    item = _manifest_item_to_sync_item(
+        {
+            "local_path": "missing.docx",
+            "status": "missing",
+            "missing_scans": 1,
+        },
+        tmp_path,
+    )
+
+    manifest = build_manifest({}, SyncResult(items=[item]))
+
+    assert manifest["items"][0]["missing_scans"] == 1
 
 
 def test_managed_workspace_path_must_exist(tmp_path):

--- a/lensnode/tests/test_datasource_sync.py
+++ b/lensnode/tests/test_datasource_sync.py
@@ -32,6 +32,7 @@ from lensnode.datasource_sync import (
     _validate_git_tree_size,
     _http_json,
     _manifest_item_to_sync_item,
+    list_datasource_files,
     _poll_feishu_export_task,
     _raise_feishu_business_error,
     _resolve_git_repository_target,
@@ -52,6 +53,96 @@ def test_datasource_sync_workers_defaults_to_four():
     assert datasource_sync_workers({}) == 4
     assert datasource_sync_workers({"max_workers": "8"}) == 8
     assert datasource_sync_workers({"max_workers": "invalid"}) == 4
+
+
+def test_list_datasource_files_returns_safe_paginated_manifest_items(tmp_path):
+    """Datasource file catalogs expose relative paths, never workspace paths."""
+
+    target = tmp_path / "catalog"
+    target.mkdir()
+    (target / ".sourcelens-datasource.json").write_text(
+        json.dumps({"datasource_uuid": "datasource-1"}),
+        encoding="utf-8",
+    )
+    (target / "report.pdf").write_bytes(b"pdf")
+    sidecar = target / "report.pdf.sourcelens"
+    sidecar.mkdir()
+    (sidecar / "meta.json").write_text(
+        json.dumps(
+            {
+                "conversion": {
+                    "status": "success",
+                    "generated_at": "2026-09-09T00:00:00Z",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (target / "manifest.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "source_id": "feishu:token:doc_one",
+                        "local_path": "report.pdf",
+                        "name": "Report",
+                        "file_extension": "pdf",
+                        "status": "synced",
+                        "metadata": {"modified_time": "2026-09-08T00:00:00Z"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = list_datasource_files(
+        {
+            "datasource_uuid": "datasource-1",
+            "target_path": str(target),
+            "page": 1,
+            "page_size": 20,
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["count"] == 1
+    assert result["results"] == [
+        {
+            "path": "report.pdf",
+            "name": "Report",
+            "extension": "pdf",
+            "sync_status": "synced",
+            "conversion_status": "success",
+            "source_updated_at": "2026-09-08T00:00:00Z",
+            "converted_at": "2026-09-09T00:00:00Z",
+            "conversion_error": "",
+        }
+    ]
+
+
+def test_list_datasource_files_lists_managed_workspace_files(tmp_path):
+    """Managed workspaces list source files without exposing sidecar content."""
+
+    target = tmp_path / "managed"
+    target.mkdir()
+    (target / "notes.txt").write_text("notes", encoding="utf-8")
+    sidecar = target / "notes.txt.sourcelens"
+    sidecar.mkdir()
+    (sidecar / "content.md").write_text("derived", encoding="utf-8")
+
+    result = list_datasource_files(
+        {
+            "datasource_uuid": "datasource-1",
+            "source_type": "managed_workspace",
+            "target_path": str(target),
+        },
+        workspace_path=tmp_path,
+    )
+
+    assert result["count"] == 1
+    assert result["results"][0]["path"] == "notes.txt"
+    assert result["results"][0]["conversion_status"] == "not_converted"
 
 
 def test_managed_workspace_path_must_exist(tmp_path):

--- a/lensnode/tests/test_document_convert.py
+++ b/lensnode/tests/test_document_convert.py
@@ -140,6 +140,19 @@ def test_post_process_converts_only_changed_datasource_items(tmp_path):
     unchanged = tmp_path / "unchanged.txt"
     changed.write_text("new content", encoding="utf-8")
     unchanged.write_text("old content", encoding="utf-8")
+    unchanged_sidecar = tmp_path / "unchanged.txt.sourcelens"
+    unchanged_sidecar.mkdir()
+    (unchanged_sidecar / "meta.json").write_text(
+        json.dumps(
+            {
+                "conversion": {
+                    "status": "success",
+                    "options": {"document": True},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
     summary = post_process_documents(
         {
@@ -159,7 +172,73 @@ def test_post_process_converts_only_changed_datasource_items(tmp_path):
     assert summary["candidates"] == 1
     assert summary["converted"] == 1
     assert (tmp_path / "changed.txt.sourcelens" / "content.md").is_file()
-    assert not (tmp_path / "unchanged.txt.sourcelens").exists()
+    assert not (unchanged_sidecar / "content.md").exists()
+
+
+def test_post_process_rechecks_unchanged_files_after_policy_change(tmp_path):
+    """A policy change can convert a file skipped by an earlier sync."""
+
+    document = tmp_path / "document.txt"
+    document.write_text("content", encoding="utf-8")
+
+    summary = post_process_documents(
+        {
+            "datasource_uuid": "ds1",
+            "name": "repo",
+            "source_type": "git",
+            "target_path": str(tmp_path),
+            "conversion": {"document": True},
+        },
+        SyncResult(
+            items=[sync_item(document)],
+            changed_paths=[],
+            changed_only=True,
+        ),
+    )
+
+    assert summary["converted"] == 1
+    assert (tmp_path / "document.txt.sourcelens" / "content.md").is_file()
+
+
+def test_post_process_stops_retrying_unchanged_failed_file_after_limit(
+    tmp_path,
+):
+    """Scheduled syncs do not retry a failed conversion indefinitely."""
+
+    document = tmp_path / "document.txt"
+    document.write_text("content", encoding="utf-8")
+    sidecar = tmp_path / "document.txt.sourcelens"
+    sidecar.mkdir()
+    (sidecar / "meta.json").write_text(
+        json.dumps(
+            {
+                "source": {"sha256": "unchanged"},
+                "conversion": {
+                    "status": "failed",
+                    "attempts": 3,
+                    "options": {"document": True},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = post_process_documents(
+        {
+            "datasource_uuid": "ds1",
+            "name": "repo",
+            "source_type": "git",
+            "target_path": str(tmp_path),
+            "conversion": {"document": True},
+        },
+        SyncResult(
+            items=[sync_item(document)],
+            changed_paths=[],
+            changed_only=True,
+        ),
+    )
+
+    assert summary["candidates"] == 0
 
 
 def test_xlsx_stats_stops_after_scanning_style_only_cells(tmp_path):

--- a/lensnode/tests/test_document_convert.py
+++ b/lensnode/tests/test_document_convert.py
@@ -133,6 +133,35 @@ def test_xlsx_stats_stops_after_cell_scan_budget(tmp_path):
     assert stats["scanned_cells"] == 3
 
 
+def test_post_process_converts_only_changed_datasource_items(tmp_path):
+    """Datasource sync conversion must not revisit unchanged files."""
+
+    changed = tmp_path / "changed.txt"
+    unchanged = tmp_path / "unchanged.txt"
+    changed.write_text("new content", encoding="utf-8")
+    unchanged.write_text("old content", encoding="utf-8")
+
+    summary = post_process_documents(
+        {
+            "datasource_uuid": "ds1",
+            "name": "repo",
+            "source_type": "git",
+            "target_path": str(tmp_path),
+            "conversion": {"document": True},
+        },
+        SyncResult(
+            items=[sync_item(changed), sync_item(unchanged)],
+            changed_paths=["changed.txt"],
+            changed_only=True,
+        ),
+    )
+
+    assert summary["candidates"] == 1
+    assert summary["converted"] == 1
+    assert (tmp_path / "changed.txt.sourcelens" / "content.md").is_file()
+    assert not (tmp_path / "unchanged.txt.sourcelens").exists()
+
+
 def test_xlsx_stats_stops_after_scanning_style_only_cells(tmp_path):
     """Style-only cells cannot exhaust conversion work without truncation."""
 

--- a/release-notes/522.yaml
+++ b/release-notes/522.yaml
@@ -1,0 +1,8 @@
+type: improvement
+audience: admin
+en: >-
+  Datasource details now show the current file catalog, retain files until a
+  second complete scan confirms removal, and load synchronization history more
+  efficiently.
+zh-CN: >-
+  数据源详情现在展示当前文件清单；文件会在第二次完整扫描确认移除后才删除，并且同步历史加载效率更高。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- add a paginated datasource file catalog in the detail drawer
- retain removed files until a second complete scan and convert only changed files
- eliminate sync-history N+1 queries, reduce selected columns, and widen the detail drawer

Closes #522

## Test plan
- [x] `python manage.py test lens.tests.test_api.LensApiTests.test_datasource_sync_tasks_uses_a_fixed_query_count`
- [x] `python manage.py test lens.tests.test_api.LensApiTests` (194 passed; 2 pre-existing unrelated failures)
- [x] `npx eslint src/pages/lens/DataSourceDetailDrawer.vue`
- [x] `npm run build`


___

### **PR Type**
Enhancement


___

### **Description**
- Add paginated datasource file catalog endpoint and detail drawer tab

- Defer deletion until second complete scan; convert only changed files

- Eliminate sync-history N+1 queries and widen detail drawer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Backend["Django API"] --> LensNode["LensNode manifest"]
  LensNode --> Cache["Cache result"]
  Backend --> Cache
  Cache --> Frontend["Vue DataSourceDetailDrawer"]
  Frontend --> Backend
  subgraph Incremental conversion
    Sync["Sync"] --> Changed["Changed paths"]
    Changed --> Convert["Convert only changed"]
    Convert --> Recheck["Recheck policy change"]
    Recheck --> RetryLimit["Max 3 attempts"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>consumers.py</strong><dd><code>Add handler for datasource files result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-62c0c71497704bd2322a9a666aeeae6a982c885a8a39ded831cf226579c99237">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_services.py</strong><dd><code>Add list_datasource_files service function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Add files endpoint and optimize sync-tasks query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+72/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_manifest.py</strong><dd><code>Add marker reader and missing_scans field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-7c14d3f4e0b311c4fca284f0a7c80ee14c6d6ae29084b9c15f99fe2392535535">+19/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Add list function, defer deletion after two scans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+188/-11</a></td>

</tr>

<tr>
  <td><strong>document_convert.py</strong><dd><code>Convert only changed files with retry limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+57/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Handle datasource_list_files message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceDetailDrawer.vue</strong><dd><code>Add files tab with pagination and search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-b0769411d4535ce440e95fe367c2d0996579d7fc5a79c1d0a6ff8475d210a523">+244/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Add tests for fixed query count and file catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_feishu_datasource.py</strong><dd><code>Test missing_scans deferral behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-774662770dec135b2d6afad0a53f0053f689082da6c50ae23fead9216145e22e">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_datasource_sync.py</strong><dd><code>Test list function and manifest normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-00c939748eb16ba28ef58b594ff501234db60e3bfc5a0a09e8a93623f9db81ff">+175/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_document_convert.py</strong><dd><code>Test incremental conversion and retry limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-d1b5eccc8b37d86afa07c94fe7a4b451abfa1697d00108d4122da56ff3df1a3b">+108/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>design-incremental-datasource-sync.md</strong><dd><code>Add design document for incremental sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-f1a71734a12c14bae4440c68eb566ca8d59751a22b74d2abc8723c2b559f1054">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>522.yaml</strong><dd><code>Add release note for datasource improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-68c224e3b6e56415e65145e60521ddb872d49ca053b98a185241a31da683e3b9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add file catalog i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese locale for file catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/523/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

