### PR TITLE
feat: add runtime restart and recreate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ The one-command installer defaults to HTTP 10083 and HTTPS 10443.
 The one-command installer sets up and starts SourceLens, then checks service
 health.
 
+For day-2 runtime operations, use `scripts/sourcelensctl.sh`. `restart` only
+restarts existing containers; `recreate` applies the current `.env` and Compose
+configuration but does not pull images. Both commands accept `workers`,
+`scheduler`, `lensnode`, or `runtime` (`runtime` means all three services):
+
+```bash
+./scripts/sourcelensctl.sh restart lensnode
+./scripts/sourcelensctl.sh recreate runtime
+```
+
+These commands do not operate on blue/green API/UI, nginx, PostgreSQL, or
+Redis. Use `scripts/install.sh` for API/UI deployments and configuration
+changes that require a blue/green traffic switch.
+
 Requirements:
 
 - Docker with Compose V2 (`docker compose`) must already be installed and

--- a/docs/blue-green-deployment.md
+++ b/docs/blue-green-deployment.md
@@ -98,7 +98,8 @@ is by design; `install.sh` is its only entrypoint.
   the self-signed TLS cert.
 - **Two scripts, shared lib.**
   - `scripts/install.sh` — install **and** upgrade (idempotent, one command).
-  - `scripts/<app>ctl.sh` — day-2 ops: `status` / `restart-workers` / `rollback`.
+  - `scripts/<app>ctl.sh` — day-2 ops: `status` / `restart-workers` /
+    `restart` / `recreate` / `rollback`.
   - `scripts/lib/deploy-common.sh` — `current_color` / `other_color` /
     `wait_for_healthy` / `switch_traffic` shared by both.
 
@@ -273,7 +274,9 @@ same dir):
    reload → `/health` recovers within `valid=10s`.
 4. **Day-2:** `<app>ctl.sh status` shows the active color healthy; `rollback`
    flips to the other color **without a rebuild** and lands on the *old* version;
-   `restart-workers` restarts workers gracefully.
+   `restart` and `recreate` operate only on runtime services (`workers`,
+   `scheduler`, `lensnode`, or `runtime`). They never directly restart or
+   recreate blue/green API/UI, nginx, PostgreSQL, or Redis.
 5. **WS worker (if any):** start a long run, switch mid-run → the run stays
    RUNNING, the worker reconnects, buffered frames flush, the run completes; keep
    the worker down past the grace window → the run correctly fails.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -207,9 +207,9 @@ bootstrap_runtime_state
 # Sourced only now — guaranteed present by this point, either just fetched above
 # (remote mode) or already on disk (--local). Provides
 # current_color/other_color/wait_for_healthy/switch_traffic, shared with
-# scripts/sourcelensctl.sh (day-2 ops: status/restart-workers/rollback —
-# deliberately a separate script, not more subcommands bolted onto this one; see
-# CLAUDE.md's "零停机部署" section for why).
+# scripts/sourcelensctl.sh (day-2 ops: status/restart-workers/restart/recreate/
+# rollback — deliberately a separate script, not more subcommands bolted onto
+# this one; see CLAUDE.md's "零停机部署" section for why).
 # shellcheck source=./lib/deploy-common.sh
 source "$DEPLOY_PATH/scripts/lib/deploy-common.sh"
 

--- a/scripts/sourcelensctl.sh
+++ b/scripts/sourcelensctl.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Day-2 operations for an already-installed sourcelens — status, restarting
-# services, rolling back a blue/green switch. NOT for installing or upgrading to
-# a new version — that's scripts/install.sh. Deliberately a separate script
-# rather than more subcommands on install.sh: "install a new version" and
-# "operate on what's already running" have different risk profiles and don't
-# belong behind the same entrypoint.
+# or recreating runtime services, and rolling back a blue/green switch. NOT for
+# installing or upgrading to a new version — that's scripts/install.sh.
+# Deliberately a separate script rather than more subcommands on install.sh:
+# "install a new version" and "operate on what's already running" have
+# different risk profiles and don't belong behind the same entrypoint.
 #
 # Installed/refreshed automatically every time install.sh runs (it's in
 # install.sh's ASSETS list) — no separate curl needed once install.sh has run at
@@ -12,6 +12,8 @@
 #
 #   ./scripts/sourcelensctl.sh status            # active color + health + which containers are up
 #   ./scripts/sourcelensctl.sh restart-workers   # graceful restart, no image pull, no color switch
+#   ./scripts/sourcelensctl.sh restart lensnode  # restart one runtime service
+#   ./scripts/sourcelensctl.sh recreate runtime  # reread .env and recreate all
 #   ./scripts/sourcelensctl.sh rollback          # flip traffic back to the other color, no pull/build/migrate
 set -euo pipefail
 
@@ -69,11 +71,49 @@ cmd_status() {
 }
 
 cmd_restart_workers() {
+    cmd_restart runtime
+}
+
+services_for_target() {
+    case "$1" in
+        workers) echo "backend-worker" ;;
+        scheduler) echo "backend-scheduler" ;;
+        lensnode) echo "lensnode" ;;
+        runtime) echo "backend-worker backend-scheduler lensnode" ;;
+        *) die "Unsupported target '$1'. Choose workers, scheduler,"\
+            " lensnode, or runtime" ;;
+    esac
+}
+
+cmd_restart() {
+    local target="${1:-}"
+    local services
+    local -a service_args
+    [ -n "$target" ] || die "Usage: $0 restart"\
+        " <workers|scheduler|lensnode|runtime>"
+    services="$(services_for_target "$target")"
+    read -r -a service_args <<< "$services"
+
     acquire_deploy_lock
-    log "Restarting backend-worker / backend-scheduler / lensnode"
-    log "(graceful: CELERY_TASK_ACKS_LATE + stop_grace_period mean in-flight"
-    log "tasks finish before the old process exits, not a hard kill)"
-    docker compose restart backend-worker backend-scheduler lensnode
+    log "Restarting ${target}: ${services}"
+    log "(graceful: stop_grace_period lets in-flight work drain)"
+    docker compose restart "${service_args[@]}"
+    log "Done"
+}
+
+cmd_recreate() {
+    local target="${1:-}"
+    local services
+    local -a service_args
+    [ -n "$target" ] || die "Usage: $0 recreate"\
+        " <workers|scheduler|lensnode|runtime>"
+    services="$(services_for_target "$target")"
+    read -r -a service_args <<< "$services"
+
+    acquire_deploy_lock
+    log "Recreating ${target}: ${services}"
+    log "(no image pull; --no-deps prevents touching PostgreSQL or Redis)"
+    docker compose up -d --force-recreate --no-deps "${service_args[@]}"
     log "Done"
 }
 
@@ -134,6 +174,8 @@ cmd_rollback() {
 case "${1:-}" in
     status) cmd_status ;;
     restart-workers) cmd_restart_workers ;;
+    restart) cmd_restart "${2:-}" ;;
+    recreate) cmd_recreate "${2:-}" ;;
     rollback) cmd_rollback ;;
-    *) die "Usage: $0 {status|restart-workers|rollback}" ;;
+    *) die "Usage: $0 {status|restart-workers|restart|recreate|rollback}" ;;
 esac

--- a/scripts/test_sourcelensctl.sh
+++ b/scripts/test_sourcelensctl.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/sourcelensctl.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ln -s "$SCRIPT_DIR/test_support/fake-docker" "$TEST_DIR/docker"
+
+output="$(DEPLOY_PATH="$SCRIPT_DIR/.." "$SCRIPT" recreate postgresql 2>&1 || true)"
+grep -q "Unsupported target" <<<"$output"
+
+output="$(DEPLOY_PATH="$SCRIPT_DIR/.." "$SCRIPT" restart 2>&1 || true)"
+grep -q "Usage:" <<<"$output"
+
+grep -q "Usage: \$0 restart" "$SCRIPT"
+grep -q "Usage: \$0 recreate" "$SCRIPT"
+grep -q -- "--force-recreate --no-deps" "$SCRIPT"
+
+DOCKER_CALLS="$TEST_DIR/docker-calls" \
+PATH="$TEST_DIR:$PATH" \
+DEPLOY_PATH="$SCRIPT_DIR/.." "$SCRIPT" restart workers
+grep -q '^compose restart backend-worker$' "$TEST_DIR/docker-calls"
+
+DOCKER_CALLS="$TEST_DIR/docker-calls" \
+PATH="$TEST_DIR:$PATH" \
+DEPLOY_PATH="$SCRIPT_DIR/.." "$SCRIPT" recreate runtime
+grep -q '^compose up -d --force-recreate --no-deps backend-worker backend-scheduler lensnode$' \
+    "$TEST_DIR/docker-calls"
+
+echo "sourcelensctl command tests passed"

--- a/scripts/test_support/fake-docker
+++ b/scripts/test_support/fake-docker
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${DOCKER_CALLS:?}"


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Add targeted `restart` and `recreate` commands to `scripts/sourcelensctl.sh`.
- Support `workers`, `scheduler`, `lensnode`, and `runtime` targets.
- Preserve `restart-workers` as a backward-compatible alias.
- Keep mutating day-2 operations under the existing deployment lock.
- Use `docker compose restart` for in-place restarts and `docker compose up -d --force-recreate --no-deps` for recreation without pulling images or touching PostgreSQL and Redis.
- Document the supported scope and the boundary between runtime operations and blue/green deployments.

## Safety

The new commands intentionally reject API/UI, nginx, PostgreSQL, and Redis targets. API/UI deployment and traffic switching remain exclusively handled by `scripts/install.sh`.

## Test plan

- [x] `bash -n scripts/sourcelensctl.sh scripts/test_sourcelensctl.sh scripts/test_support/fake-docker`
- [x] `git diff --check`
- [x] `bash scripts/test_sourcelensctl.sh`
- [x] Docker smoke test: restart and force-recreate the runtime services with the development Compose stack.
- [x] `curl http://localhost:8000/health` returned HTTP 200 and `{"health": "OK"}` after the Docker smoke test.
- [ ] Full backend pytest suite: 675 passed, 3 failed, 31 warnings, and 50 subtests passed. The failures are pre-existing Lens behavior/database compatibility tests and are outside the files changed by this PR:
  - `lens/tests/test_session_management.py::SessionManagementTests::test_archive_filters_lists_clears_pin_and_restores_history`
  - `lens/tests/test_session_titles.py::SessionTitleTests::test_database_defaults_support_old_session_inserts`
  - `lens/tests/test_services.py::LensServiceTests::test_smart_dispatch_allows_empty_coordinator_skills`

## PR Type

- [x] Feature
- [x] Documentation
- [x] Test

## File Walkthrough

- `scripts/sourcelensctl.sh`: adds target validation and the `restart`/`recreate` implementations while retaining the legacy alias.
- `scripts/test_sourcelensctl.sh`: adds command-routing and safety regression tests using a fake Docker executable.
- `scripts/test_support/fake-docker`: records Docker arguments for isolated script tests.
- `README.md`: documents day-2 runtime commands and their safety boundaries.
- `docs/blue-green-deployment.md`: updates the operational command matrix and verification guidance.
- `scripts/install.sh`: keeps the day-2 command list in its explanatory comments current.


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Add restart and recreate commands for runtime services.

- Support workers, scheduler, lensnode, and runtime targets.

- Add tests and update documentation for new commands.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sourcelensctl["sourcelensctl.sh"] --> restart["restart workers|scheduler|lensnode|runtime"]
  sourcelensctl --> recreate["recreate workers|scheduler|lensnode|runtime"]
  restart -- "docker compose restart" --> containers["backend-worker backend-scheduler lensnode"]
  recreate -- "docker compose up -d --force-recreate --no-deps" --> containers
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sourcelensctl.sh</strong><dd><code>Add restart and recreate commands to control script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/sourcelensctl.sh

<ul><li>Add <code>cmd_restart</code> and <code>cmd_recreate</code> functions with target validation.<br> <li> Refactor <code>cmd_restart_workers</code> to call <code>cmd_restart runtime</code>.<br> <li> Update usage string to include new commands.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-99b884bd33f41d997a4674e4e3104d0b498fdcb7e6d07135d40f17fbe28fb30a">+52/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Update install script comments for new commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/install.sh

- Update comment to mention restart and recreate commands.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document runtime restart and recreate commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new restart and recreate commands with examples.<br> <li> Clarify boundary between runtime operations and blue/green deploy.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blue-green-deployment.md</strong><dd><code>Update blue-green deployment docs for new commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/blue-green-deployment.md

<ul><li>Update day-2 ops list to include restart and recreate.<br> <li> Clarify that they only operate on runtime services.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-b04584ccf2811fab42fe33a3c5f7d3e46e40863c597d1f30afd5d1a276e258fe">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sourcelensctl.sh</strong><dd><code>Add tests for restart and recreate commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test_sourcelensctl.sh

<ul><li>Add comprehensive tests for restart and recreate commands.<br> <li> Validate target rejection, usage messages, and docker compose calls.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-1f430994fc64b8392f0cf00d8d861a9b6bcf7089df65ce70083986c9c9842a5e">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fake-docker</strong><dd><code>Add fake-docker helper for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test_support/fake-docker

- Create a fake docker script for testing docker compose calls.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/528/files#diff-02f0bf5ac15b17fe8b204b40a73c8fb5ba84fba28c0d49435e7300678150fcc5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

