### PR TITLE
Add interactive mindmap Markdown rendering

### DIFF
--- a/frontend/src/components/ui/MarkdownRenderer.vue
+++ b/frontend/src/components/ui/MarkdownRenderer.vue
@@ -3,6 +3,7 @@
     class="markdown-content prose max-w-none"
     v-html="renderedContent"
     @click="handleMarkdownClick"
+    @keydown="handleMarkdownKeydown"
   ></div>
 </template>
 
@@ -13,6 +14,7 @@ import hljs from 'highlight.js/lib/core'
 import { useI18n } from 'vue-i18n'
 import { copyToClipboard } from '@/utils/clipboard'
 import { sanitizeHtml, escapeHtml } from '@/utils/sanitize'
+import { renderMindmap } from '@/utils/mindmap'
 
 // Import common languages for syntax highlighting
 import javascript from 'highlight.js/lib/languages/javascript'
@@ -61,6 +63,9 @@ const languageLabels = {
 const renderer = new marked.Renderer()
 renderer.code = ({ text, lang }) => {
   const declaredLanguage = typeof lang === 'string' ? lang.trim() : ''
+  if (declaredLanguage.toLowerCase() === 'mindmap') {
+    return renderMindmap(text)
+  }
   const language =
     props.enableHighlight &&
     declaredLanguage &&
@@ -279,6 +284,29 @@ const renderedContent = computed(() => {
 })
 
 async function handleMarkdownClick(event) {
+  const action = event.target.closest('[data-mindmap-action]')
+  if (action) {
+    const mindmap = action.closest('[data-mindmap-root]')
+    if (!mindmap) return
+    const shouldCollapse = action.dataset.mindmapAction === 'collapse'
+    mindmap
+      .querySelectorAll(
+        '[data-mindmap-toggle][data-mindmap-has-children="true"]'
+      )
+      .forEach((node) => {
+        node.dataset.mindmapCollapsed = shouldCollapse ? 'true' : 'false'
+        node.setAttribute('aria-expanded', String(!shouldCollapse))
+      })
+    updateMindmapVisibility(mindmap)
+    return
+  }
+
+  const mindmapNode = event.target.closest('[data-mindmap-toggle]')
+  if (mindmapNode) {
+    toggleMindmapNode(mindmapNode)
+    return
+  }
+
   const button = event.target.closest('[data-markdown-code-copy]')
   if (!button) return
 
@@ -305,6 +333,55 @@ async function handleMarkdownClick(event) {
       copyResetTimers.delete(button)
     }, 1800)
   )
+}
+
+function handleMarkdownKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  const mindmapNode = event.target.closest('[data-mindmap-toggle]')
+  if (!mindmapNode) return
+  event.preventDefault()
+  toggleMindmapNode(mindmapNode)
+}
+
+function toggleMindmapNode(mindmapNode) {
+  const mindmap = mindmapNode.closest('[data-mindmap-root]')
+  if (!mindmap) return
+  mindmapNode.dataset.mindmapCollapsed =
+    mindmapNode.dataset.mindmapCollapsed === 'true' ? 'false' : 'true'
+  mindmapNode.setAttribute(
+    'aria-expanded',
+    mindmapNode.dataset.mindmapCollapsed !== 'true'
+  )
+  updateMindmapVisibility(mindmap)
+}
+
+function updateMindmapVisibility(mindmap) {
+  const nodes = [...mindmap.querySelectorAll('[data-mindmap-toggle]')]
+  const collapsedPaths = new Set(
+    nodes
+      .filter((node) => node.dataset.mindmapCollapsed === 'true')
+      .map((node) => node.dataset.mindmapPath)
+  )
+  const isHidden = (path) => {
+    const segments = path.split('.')
+    return segments.some((_, index) => {
+      if (index === 0) return false
+      return collapsedPaths.has(segments.slice(0, index).join('.'))
+    })
+  }
+
+  nodes.forEach((node) => {
+    node.classList.toggle(
+      'mindmap-node-hidden',
+      isHidden(node.dataset.mindmapPath)
+    )
+  })
+  mindmap.querySelectorAll('[data-mindmap-link]').forEach((link) => {
+    link.classList.toggle(
+      'mindmap-node-hidden',
+      isHidden(link.dataset.mindmapLink)
+    )
+  })
 }
 </script>
 
@@ -381,6 +458,101 @@ async function handleMarkdownClick(event) {
   background: #f3f3f3;
 }
 
+.markdown-content :deep(.markdown-mindmap) {
+  @apply my-4 w-full overflow-hidden rounded-lg border;
+  border-color: var(--sl-border, #e4e4e7);
+  background: var(--sl-bg-surface, #fff);
+}
+
+.markdown-content :deep(.mindmap-toolbar) {
+  @apply flex min-h-10 items-center gap-2 border-b px-3 py-2;
+  border-color: var(--sl-border, #e4e4e7);
+  background: var(--sl-bg-hover, #f8fafc);
+}
+
+.markdown-content :deep(.mindmap-toolbar-title) {
+  @apply mr-auto text-sm font-medium;
+  color: var(--sl-text-primary, #18181b);
+}
+
+.markdown-content :deep(.mindmap-toolbar button) {
+  @apply rounded-md border px-2 py-1 text-xs transition-colors;
+  border-color: var(--sl-border, #d4d4d8);
+  color: var(--sl-text-secondary, #52525b);
+  background: transparent;
+}
+
+.markdown-content :deep(.mindmap-toolbar button:hover) {
+  background: var(--sl-bg-surface, #fff);
+  color: var(--sl-text-primary, #18181b);
+}
+
+.markdown-content :deep(.mindmap-canvas) {
+  @apply max-w-full overflow-auto;
+  min-height: 180px;
+}
+
+.markdown-content :deep(.mindmap-svg) {
+  display: block;
+  width: max(100%, 560px);
+  min-width: 560px;
+  min-height: 180px;
+  color: var(--sl-text-primary, #18181b);
+}
+
+.markdown-content :deep(.mindmap-link) {
+  fill: none;
+  stroke-width: 1.5;
+}
+
+.markdown-content :deep(.mindmap-node) {
+  cursor: pointer;
+  outline: none;
+}
+
+.markdown-content :deep(.mindmap-node circle) {
+  stroke-width: 1.5;
+}
+
+.markdown-content :deep(.mindmap-node text) {
+  font: 400 14px/18px sans-serif;
+}
+
+.markdown-content :deep(.mindmap-node:hover text),
+.markdown-content :deep(.mindmap-node:focus text) {
+  font-weight: 600;
+}
+
+.markdown-content :deep(.mindmap-node:focus circle) {
+  stroke-width: 2.5;
+}
+
+.markdown-content :deep(.mindmap-node-hidden) {
+  display: none;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .markdown-mindmap) {
+  border-color: #3f3f46;
+  background: #19191b;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .mindmap-toolbar) {
+  border-color: #3f3f46;
+  background: #27272a;
+}
+
+:global(:root[data-theme='dark'] .markdown-content .mindmap-toolbar button) {
+  border-color: #52525b;
+  color: #d4d4d8;
+}
+
+:global(
+  :root[data-theme='dark'] .markdown-content .mindmap-toolbar button:hover
+) {
+  background: #3f3f46;
+  color: #fafafa;
+}
+
 .markdown-content :deep(.markdown-code-header) {
   @apply flex min-h-12 items-center border-b px-3.5 py-2;
   border-color: transparent;
@@ -411,7 +583,8 @@ async function handleMarkdownClick(event) {
   content: '';
 }
 
-.markdown-content :deep(.markdown-code-copy[data-markdown-code-copied]::before) {
+.markdown-content
+  :deep(.markdown-code-copy[data-markdown-code-copied]::before) {
   width: 0.8rem;
   height: 0.45rem;
   border-width: 0 0 1.75px 1.75px;

--- a/frontend/src/utils/mindmap.js
+++ b/frontend/src/utils/mindmap.js
@@ -1,0 +1,219 @@
+const BRANCH_COLORS = ['#0057ff', '#27ce6e', '#ff9500', '#f94d4d']
+
+function cleanLabel(value) {
+  return value.replace(/^\s+|\s+$/g, '').replace(/^(\*\*|__)([\s\S]+)\1$/, '$2')
+}
+
+function createNode(label, depth, path) {
+  return {
+    label: cleanLabel(label),
+    depth,
+    path,
+    children: []
+  }
+}
+
+/**
+ * Parse a Markdown outline into a tree suitable for an interactive mindmap.
+ *
+ * Supported input is intentionally small and predictable: headings become
+ * first-level branches and indented Markdown bullets become descendants.
+ */
+export function parseMindmap(markdown) {
+  const root = createNode('思维导图', 0, '0')
+  const stack = [{ node: root, indent: -1 }]
+  let heading = root
+
+  const lines = String(markdown || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/)
+    if (headingMatch) {
+      const node = createNode(
+        headingMatch[1],
+        1,
+        `0.${root.children.length + 1}`
+      )
+      root.children.push(node)
+      heading = node
+      stack.length = 0
+      stack.push({ node: root, indent: -1 }, { node, indent: -1 })
+      continue
+    }
+
+    const bulletMatch = line.match(/^(\s*)(?:[-*+]|\d+\.)\s+(.+?)\s*$/)
+    if (!bulletMatch) continue
+
+    const indent = bulletMatch[1].replace(/\t/g, '  ').length
+    while (stack.length > 2 && indent <= stack[stack.length - 1].indent) {
+      stack.pop()
+    }
+    const parent = stack[stack.length - 1]?.node || heading
+    const path = `${parent.path}.${parent.children.length + 1}`
+    const node = createNode(bulletMatch[2], parent.depth + 1, path)
+    parent.children.push(node)
+    stack.push({ node, indent })
+  }
+
+  if (!root.children.length) {
+    const fallback = String(markdown || '').trim()
+    if (fallback) {
+      root.label = cleanLabel(fallback.split('\n')[0])
+    }
+  }
+  return root
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function flattenTree(root) {
+  const nodes = []
+  const walk = (node) => {
+    nodes.push(node)
+    node.children.forEach(walk)
+  }
+  walk(root)
+  return nodes
+}
+
+function wrapLabel(label, maxChars = 28) {
+  const chars = Array.from(label)
+  const lines = []
+  for (let index = 0; index < chars.length; index += maxChars) {
+    lines.push(chars.slice(index, index + maxChars).join(''))
+  }
+  return lines.length ? lines : ['']
+}
+
+function layoutTree(root) {
+  const nodes = flattenTree(root)
+  let nextY = 28
+
+  const place = (node) => {
+    node.x = 24 + node.depth * 236
+    if (!node.children.length) {
+      node.y = nextY
+      nextY += Math.max(30, wrapLabel(node.label).length * 20 + 10)
+      return
+    }
+    node.children.forEach(place)
+    node.y =
+      (node.children[0].y + node.children[node.children.length - 1].y) / 2
+  }
+  place(root)
+
+  const maxTextWidth = nodes.reduce((width, node) => {
+    const longestLine = Math.max(
+      ...wrapLabel(node.label).map((line) => Array.from(line).length)
+    )
+    return Math.max(width, longestLine * 9)
+  }, 0)
+
+  return {
+    nodes,
+    width: Math.max(560, 24 + rootDepth(root) * 236 + maxTextWidth + 60),
+    height: Math.max(150, nextY + 12)
+  }
+}
+
+function rootDepth(root) {
+  let depth = 0
+  const walk = (node) => {
+    depth = Math.max(depth, node.depth)
+    node.children.forEach(walk)
+  }
+  walk(root)
+  return depth
+}
+
+function branchColor(node) {
+  if (node.depth === 0) return '#0057ff'
+  const firstSegment = Number(node.path.split('.')[1] || 1)
+  return BRANCH_COLORS[(firstSegment - 1) % BRANCH_COLORS.length]
+}
+
+function renderText(node) {
+  return wrapLabel(node.label)
+    .map(
+      (line, index) =>
+        `<tspan x="12" dy="${index === 0 ? 0 : 18}">${escapeXml(line)}</tspan>`
+    )
+    .join('')
+}
+
+/**
+ * Render a tree as a self-contained, sanitizable SVG mindmap.
+ */
+export function renderMindmap(markdown) {
+  const root = parseMindmap(markdown)
+  const { nodes, width, height } = layoutTree(root)
+  const links = nodes
+    .filter((node) => node.depth > 0)
+    .map((node) => {
+      const parent = nodes.find((candidate) =>
+        node.path.startsWith(`${candidate.path}.`)
+          ? node.path.split('.').length === candidate.path.split('.').length + 1
+          : false
+      )
+      if (!parent) return ''
+      const color = branchColor(node)
+      const middleX = (parent.x + node.x) / 2
+      return (
+        `<path class="mindmap-link" data-mindmap-link="${node.path}" ` +
+        `d="M${parent.x},${parent.y} C${middleX},${parent.y} ` +
+        `${middleX},${node.y} ${node.x},${node.y}" stroke="${color}" />`
+      )
+    })
+    .join('')
+
+  const renderedNodes = nodes
+    .map((node) => {
+      const color = branchColor(node)
+      const hasChildren = node.children.length > 0
+      const radius = node.depth === 0 ? 7 : hasChildren ? 6 : 4
+      const label = node.depth === 0 ? '' : renderText(node)
+      return (
+        `<g class="mindmap-node" data-mindmap-toggle="true" ` +
+        `data-mindmap-path="${node.path}" ` +
+        `data-mindmap-has-children="${hasChildren}" ` +
+        `role="treeitem" tabindex="0" aria-expanded="${hasChildren}" ` +
+        `aria-label="${escapeXml(node.label)}" ` +
+        `transform="translate(${node.x} ${node.y})">` +
+        `<circle cx="0" cy="0" r="${radius}" ` +
+        `stroke="${color}" fill="white" />` +
+        `<text fill="currentColor">${label}</text></g>`
+      )
+    })
+    .join('')
+
+  return (
+    `<div class="markdown-mindmap" data-mindmap-root>` +
+    `<div class="mindmap-toolbar" role="toolbar" ` +
+    `aria-label="思维导图操作">` +
+    `<span class="mindmap-toolbar-title">思维导图</span>` +
+    `<button type="button" data-mindmap-action="expand" ` +
+    `aria-label="全部展开">全部展开</button>` +
+    `<button type="button" data-mindmap-action="collapse" ` +
+    `aria-label="全部收起">全部收起</button>` +
+    `</div>` +
+    `<div class="mindmap-canvas" role="group" ` +
+    `aria-label="${escapeXml(root.label)}">` +
+    `<svg class="mindmap-svg" role="tree" ` +
+    `viewBox="0 0 ${width} ${height}" ` +
+    `preserveAspectRatio="xMinYMin meet" ` +
+    `aria-label="${escapeXml(root.label)}">` +
+    `<g class="mindmap-links">${links}</g>` +
+    `<g class="mindmap-nodes">${renderedNodes}</g>` +
+    `</svg></div></div>`
+  )
+}

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -43,7 +43,13 @@ export function sanitizeHtml(dirty) {
       'td',
       'span',
       'div',
-      'button'
+      'button',
+      'svg',
+      'g',
+      'path',
+      'circle',
+      'text',
+      'tspan'
     ],
     ALLOWED_ATTR: [
       'href',
@@ -55,7 +61,31 @@ export function sanitizeHtml(dirty) {
       'rel',
       'type',
       'aria-label',
-      'data-markdown-code-copy'
+      'data-markdown-code-copy',
+      'data-mindmap-root',
+      'data-mindmap-action',
+      'data-mindmap-toggle',
+      'data-mindmap-path',
+      'data-mindmap-has-children',
+      'data-mindmap-collapsed',
+      'data-mindmap-link',
+      'viewBox',
+      'preserveAspectRatio',
+      'aria-hidden',
+      'role',
+      'tabindex',
+      'cx',
+      'cy',
+      'r',
+      'd',
+      'fill',
+      'stroke',
+      'stroke-width',
+      'x',
+      'y',
+      'dx',
+      'dy',
+      'text-anchor'
     ]
   })
 }

--- a/frontend/tests/mindmap.test.js
+++ b/frontend/tests/mindmap.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseMindmap, renderMindmap } from '../src/utils/mindmap.js'
+
+const source = `## **一、定位**
+- 评估对象
+- 传统差异
+  - 仅评估输出文本
+## **二、方法**
+- 客观评测`
+
+test('parses headings and indented bullets into a hierarchical tree', () => {
+  const tree = parseMindmap(source)
+
+  assert.equal(tree.children[0].label, '一、定位')
+  assert.equal(tree.children[0].children[1].children[0].label, '仅评估输出文本')
+  assert.equal(tree.children[1].children[0].label, '客观评测')
+})
+
+test('renders clickable node metadata and branch links', () => {
+  const html = renderMindmap(source)
+
+  assert.match(html, /data-mindmap-root/)
+  assert.match(html, /data-mindmap-toggle="true"/)
+  assert.match(html, /data-mindmap-path="0\.1\.2\.1"/)
+  assert.match(html, /class="mindmap-link"/)
+  assert.match(html, /data-mindmap-action="collapse"/)
+})
+
+test('does not emit unescaped SVG text', () => {
+  const html = renderMindmap('## A <script>alert(1)</script>\n- x & y')
+
+  assert.doesNotMatch(html, /<script>/)
+  assert.match(html, /&lt;script&gt;/)
+  assert.match(html, /x &amp; y/)
+})

--- a/lensnode/lensnode/agent_runtime/system_prompts.py
+++ b/lensnode/lensnode/agent_runtime/system_prompts.py
@@ -83,6 +83,21 @@ def _confidentiality_guidance():
     )
 
 
+def _interactive_visualization_guidance():
+    """Return the chat format contract for interactive visualizations."""
+
+    return (
+        "Interactive visualization formatting:\n"
+        "- When the user explicitly asks for a mindmap or thought map and "
+        "the result is intended to be shown in chat, emit one fenced "
+        "`mindmap` code block. Inside it, use Markdown headings for major "
+        "branches and indented Markdown bullets for child nodes.\n"
+        "- Keep any short explanation outside the `mindmap` code block. "
+        "Do not use Mermaid for this format unless the user explicitly "
+        "requests Mermaid.\n"
+    )
+
+
 def _subject_display_names(command):
     """Return safe public names for user-uploaded documents."""
 
@@ -130,6 +145,7 @@ def _knowledge_system_prompt(
     subjects, references = _public_source_inventory(command)
     answer_language = _command_answer_language(command)
     language_requirement = _answer_language_requirement(answer_language)
+    visualization_guidance = _interactive_visualization_guidance()
     context_guidance = _context_guidance(context_skill_contents or [])
     runtime_guidance_text = "\n".join(runtime_guidance or ())
     code_analysis_guidance = ""
@@ -196,6 +212,7 @@ def _knowledge_system_prompt(
         collaboration_guidance +
         f"{_platform_safety_boundary()}\n"
         f"{language_requirement}\n\n"
+        f"{visualization_guidance}\n"
         f"{_workspace_guide_prompt(workspace_guide)}"
         f"{_platform_safety_boundary()}\n"
         f"{scenario['prompt']}\n\n"
@@ -346,6 +363,7 @@ def _general_chat_system_prompt(
     skill_guidance = _general_chat_guidance(context_skill_contents or [])
     history_artifact_guidance = _history_artifact_guidance(command)
     confidentiality_guidance = _confidentiality_guidance()
+    visualization_guidance = _interactive_visualization_guidance()
     report_guidance = _report_execution_guidance(command)
     return (
         f"{_platform_safety_boundary()}\n"
@@ -353,6 +371,7 @@ def _general_chat_system_prompt(
         f"{_workspace_guide_prompt(workspace_guide)}"
         "You are running inside SourceLens LensNode as General Chat.\n\n"
         f"{confidentiality_guidance}\n\n"
+        f"{visualization_guidance}\n\n"
         "Skills and Plugin virtual Skills provide optional task guidance. "
         "Use them when relevant, but decide from the user's request and all "
         "currently authorized tools; a missing or incomplete Skill must not "

--- a/lensnode/tests/test_system_prompts.py
+++ b/lensnode/tests/test_system_prompts.py
@@ -1,0 +1,21 @@
+from lensnode.agent_runtime.system_prompts import (
+    _general_chat_system_prompt,
+    _knowledge_system_prompt,
+)
+
+
+def test_general_chat_describes_interactive_mindmap_format():
+    prompt = _general_chat_system_prompt({"task": "general_chat"})
+
+    assert "fenced `mindmap` code block" in prompt
+    assert "indented Markdown bullets" in prompt
+
+
+def test_knowledge_prompt_describes_interactive_mindmap_format():
+    prompt = _knowledge_system_prompt(
+        {"prompt": "Answer from the selected workspace."},
+        {"task": "knowledge"},
+    )
+
+    assert "fenced `mindmap` code block" in prompt
+    assert "Do not use Mermaid" in prompt

--- a/release-notes/529.yaml
+++ b/release-notes/529.yaml
@@ -1,0 +1,4 @@
+type: feature
+audience: user
+en: Added interactive mindmaps to chat for explicitly requested mindmap responses, with collapsible nodes and keyboard interaction.
+zh-CN: 为聊天中明确请求的思维导图响应新增交互式思维导图，支持节点折叠和键盘操作。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Render explicitly requested `mindmap` Markdown blocks as accessible, collapsible SVG diagrams in chat.
- Add click and keyboard interaction for expanding and collapsing mindmap nodes.
- Sanitize generated SVG and interaction attributes.
- Document the LensNode output contract and add focused regression tests.

Closes #529

## Test plan
- [x] `node --test frontend/tests/mindmap.test.js`
- [x] `lensnode/.venv/bin/python -m pytest -q lensnode/tests/test_system_prompts.py`
- [x] `npm run build`
- [x] Targeted ESLint checks


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Render fenced mindmap blocks as collapsible SVG diagrams

- Add keyboard/click interaction and sanitize SVG markup

- Document LensNode output contract and add regression tests


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User requests mindmap"] --> B["LensNode emits fenced mindmap block"]
  B --> C["MarkdownRenderer processes code block"]
  C --> D["mindmap.js parseMindmap creates tree"]
  D --> E["mindmap.js renderMindmap generates SVG"]
  E --> F["sanitize.js allows SVG elements"]
  F --> G["Click/keydown handlers toggle nodes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>system_prompts.py</strong><dd><code>Add mindmap formatting guidance to system prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-3412700156257c47eb378ccbe14d3ca9f3d96f4731ff1582070256d753c9df9e">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MarkdownRenderer.vue</strong><dd><code>Render mindmap blocks and handle interaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-8acab9a2284f91e2714ae018e98389ad38d85c55215ce785163b9cf790b4c5d3">+174/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mindmap.js</strong><dd><code>New utility for parsing and rendering mindmaps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-6e4986b4ab199c5ce819e83ab30880a3cbdb55ffa9fa8d9a13047297744d5dd6">+219/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sanitize.js</strong><dd><code>Allow SVG elements and mindmap attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-0e695f4b793e507de5f17d378c483bc1a9f05c49fc81d917abf87cf7382ce4be">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_system_prompts.py</strong><dd><code>Add tests for mindmap guidance in prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-8ecddfbc38b0820c6ec170e6dc40cbc66d09b0ca60d6f2d02516a1b3fbb52426">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mindmap.test.js</strong><dd><code>Add unit tests for mindmap parse and render</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-bf67709871374c718bb84fc56a6b5b466edd75fb74ad9895e6cde63d24b47542">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>529.yaml</strong><dd><code>Add release note entry for interactive mindmaps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/530/files#diff-189fa427c5611feeb33012de2fbb6ce81bb45bdbbf5bc274c922338b23ae0bcf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

