### PR TITLE
Refine interactive mindmap layout

### DIFF
--- a/frontend/src/components/ui/MarkdownRenderer.vue
+++ b/frontend/src/components/ui/MarkdownRenderer.vue
@@ -3,6 +3,10 @@
     class="markdown-content prose max-w-none"
     v-html="renderedContent"
     @click="handleMarkdownClick"
+    @pointerdown="handleMindmapPointerDown"
+    @pointermove="handleMindmapPointerMove"
+    @pointerup="handleMindmapPointerUp"
+    @pointercancel="handleMindmapPointerUp"
     @keydown="handleMarkdownKeydown"
   ></div>
 </template>
@@ -43,6 +47,9 @@ const props = defineProps({
 
 const { t } = useI18n()
 const copyResetTimers = new WeakMap()
+const MINDMAP_MAX_ZOOM = 2
+const MINDMAP_MIN_ZOOM = 0.5
+const MINDMAP_ZOOM_STEP = 0.15
 
 const languageLabels = {
   bash: 'Bash',
@@ -288,7 +295,24 @@ async function handleMarkdownClick(event) {
   if (action) {
     const mindmap = action.closest('[data-mindmap-root]')
     if (!mindmap) return
-    const shouldCollapse = action.dataset.mindmapAction === 'collapse'
+    const mindmapAction = action.dataset.mindmapAction
+    if (mindmapAction === 'fullscreen') {
+      await toggleMindmapFullscreen(mindmap)
+      return
+    }
+    if (mindmapAction === 'code') {
+      toggleMindmapCodePanel(mindmap, action)
+      return
+    }
+    if (mindmapAction === 'zoom-in' || mindmapAction === 'zoom-out') {
+      zoomMindmap(mindmap, mindmapAction === 'zoom-in' ? 1 : -1)
+      return
+    }
+    if (mindmapAction === 'fit') {
+      fitMindmap(mindmap)
+      return
+    }
+    const shouldCollapse = mindmapAction === 'collapse'
     mindmap
       .querySelectorAll(
         '[data-mindmap-toggle][data-mindmap-has-children="true"]'
@@ -333,6 +357,35 @@ async function handleMarkdownClick(event) {
       copyResetTimers.delete(button)
     }, 1800)
   )
+}
+
+function handleMindmapPointerDown(event) {
+  const canvas = event.target.closest('.mindmap-canvas')
+  if (!canvas || event.target.closest('button, [data-mindmap-toggle]')) return
+  canvas.dataset.dragging = 'true'
+  canvas.dataset.dragX = String(event.clientX)
+  canvas.dataset.dragY = String(event.clientY)
+  canvas.dataset.scrollLeft = String(canvas.scrollLeft)
+  canvas.dataset.scrollTop = String(canvas.scrollTop)
+  canvas.setPointerCapture?.(event.pointerId)
+}
+
+function handleMindmapPointerMove(event) {
+  const canvas = event.target.closest('.mindmap-canvas')
+  if (!canvas || canvas.dataset.dragging !== 'true') return
+  canvas.scrollLeft =
+    Number(canvas.dataset.scrollLeft) -
+    (event.clientX - Number(canvas.dataset.dragX))
+  canvas.scrollTop =
+    Number(canvas.dataset.scrollTop) -
+    (event.clientY - Number(canvas.dataset.dragY))
+}
+
+function handleMindmapPointerUp(event) {
+  const canvas = event.target.closest('.mindmap-canvas')
+  if (!canvas) return
+  canvas.dataset.dragging = 'false'
+  canvas.releasePointerCapture?.(event.pointerId)
 }
 
 function handleMarkdownKeydown(event) {
@@ -382,6 +435,67 @@ function updateMindmapVisibility(mindmap) {
       isHidden(link.dataset.mindmapLink)
     )
   })
+}
+
+async function toggleMindmapFullscreen(mindmap) {
+  try {
+    if (document.fullscreenElement === mindmap) {
+      await document.exitFullscreen()
+      return
+    }
+    if (document.fullscreenElement) {
+      await document.exitFullscreen()
+    }
+    await mindmap.requestFullscreen()
+  } catch (error) {
+    console.warn('Mindmap fullscreen request failed:', error)
+  }
+}
+
+function toggleMindmapCodePanel(mindmap, button) {
+  const panel = mindmap.querySelector('.mindmap-code-panel')
+  if (!panel) return
+  const isVisible = panel.getAttribute('aria-hidden') !== 'true'
+  panel.setAttribute('aria-hidden', String(isVisible))
+  const label = isVisible ? '查看代码' : '隐藏代码'
+  const labelElement = button.querySelector('.mindmap-tool-code-label')
+  if (labelElement) labelElement.textContent = label
+  button.setAttribute('aria-label', label)
+  button.setAttribute('title', label)
+}
+
+function zoomMindmap(mindmap, direction) {
+  const currentZoom = Number(mindmap.dataset.mindmapZoom || 1)
+  const nextZoom = clampMindmapZoom(currentZoom + direction * MINDMAP_ZOOM_STEP)
+  setMindmapZoom(mindmap, nextZoom)
+}
+
+function fitMindmap(mindmap) {
+  const svg = mindmap.querySelector('.mindmap-svg')
+  const canvas = mindmap.querySelector('.mindmap-canvas')
+  if (!svg || !canvas) return
+  const baseWidth = Number(svg.dataset.mindmapWidth) || 560
+  const viewportWidth = canvas.clientWidth || baseWidth
+  setMindmapZoom(mindmap, Math.min(1, viewportWidth / baseWidth))
+}
+
+function clampMindmapZoom(value) {
+  if (!Number.isFinite(value)) return 1
+  return Math.min(MINDMAP_MAX_ZOOM, Math.max(MINDMAP_MIN_ZOOM, value))
+}
+
+function setMindmapZoom(mindmap, zoom) {
+  const svg = mindmap.querySelector('.mindmap-svg')
+  const canvas = mindmap.querySelector('.mindmap-canvas')
+  if (!svg || !canvas) return
+  const normalizedZoom = clampMindmapZoom(zoom)
+  const baseWidth = Number(svg.dataset.mindmapWidth) || 560
+  const baseHeight = Number(svg.dataset.mindmapHeight) || 180
+  const viewportWidth = canvas.clientWidth || baseWidth
+
+  mindmap.dataset.mindmapZoom = String(normalizedZoom)
+  svg.style.width = `${Math.max(viewportWidth, baseWidth * normalizedZoom)}px`
+  svg.style.height = `${Math.max(180, baseHeight * normalizedZoom)}px`
 }
 </script>
 
@@ -459,37 +573,150 @@ function updateMindmapVisibility(mindmap) {
 }
 
 .markdown-content :deep(.markdown-mindmap) {
+  position: relative;
   @apply my-4 w-full overflow-hidden rounded-lg border;
   border-color: var(--sl-border, #e4e4e7);
   background: var(--sl-bg-surface, #fff);
 }
 
 .markdown-content :deep(.mindmap-toolbar) {
-  @apply flex min-h-10 items-center gap-2 border-b px-3 py-2;
-  border-color: var(--sl-border, #e4e4e7);
-  background: var(--sl-bg-hover, #f8fafc);
-}
-
-.markdown-content :deep(.mindmap-toolbar-title) {
-  @apply mr-auto text-sm font-medium;
-  color: var(--sl-text-primary, #18181b);
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 3;
+  @apply inline-flex items-center gap-0.5 p-1;
+  border: 1px solid var(--sl-border, #e4e4e7);
+  border-radius: 0.625rem;
+  background: var(--sl-bg-surface, #fff);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
 }
 
 .markdown-content :deep(.mindmap-toolbar button) {
-  @apply rounded-md border px-2 py-1 text-xs transition-colors;
-  border-color: var(--sl-border, #d4d4d8);
+  @apply inline-flex h-8 w-8 items-center justify-center border-0 transition-colors;
+  border-radius: 0.375rem;
+  font-size: 0.95rem;
   color: var(--sl-text-secondary, #52525b);
   background: transparent;
 }
 
 .markdown-content :deep(.mindmap-toolbar button:hover) {
-  background: var(--sl-bg-surface, #fff);
+  background: var(--sl-bg-hover, #f1f5f9);
   color: var(--sl-text-primary, #18181b);
 }
 
+.markdown-content :deep(.mindmap-toolbar button:focus-visible) {
+  @apply outline-none ring-2 ring-primary-500 ring-offset-2;
+  --tw-ring-offset-color: var(--sl-bg-surface, #fff);
+}
+
+.markdown-content :deep(.mindmap-tool-button::before) {
+  content: '';
+  display: block;
+  width: 0.95rem;
+  height: 0.95rem;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.markdown-content :deep(.mindmap-tool-zoom-out::before),
+.markdown-content :deep(.mindmap-tool-zoom-in::before) {
+  border: 1.6px solid currentColor;
+  border-radius: 9999px;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0.45rem 1.6px;
+}
+
+.markdown-content :deep(.mindmap-tool-zoom-in::before) {
+  background-image:
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor);
+  background-size:
+    0.45rem 1.6px,
+    1.6px 0.45rem;
+  background-position:
+    center center,
+    center center;
+}
+
+.markdown-content :deep(.mindmap-tool-fit::before) {
+  border: 1.6px solid currentColor;
+  border-radius: 0.2rem;
+}
+
+.markdown-content :deep(.mindmap-tool-fullscreen::before) {
+  background-image:
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor),
+    linear-gradient(currentColor, currentColor);
+  background-size:
+    0.35rem 1.6px,
+    1.6px 0.35rem,
+    0.35rem 1.6px,
+    1.6px 0.35rem,
+    0.35rem 1.6px,
+    1.6px 0.35rem,
+    0.35rem 1.6px,
+    1.6px 0.35rem;
+  background-position:
+    left top,
+    left top,
+    right top,
+    right top,
+    left bottom,
+    left bottom,
+    right bottom,
+    right bottom;
+}
+
+.markdown-content :deep(.mindmap-tool-code) {
+  width: auto;
+  min-width: 6.5rem;
+  gap: 0.35rem;
+  padding: 0 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.markdown-content :deep(.mindmap-tool-code span[aria-hidden='true']) {
+  display: inline-block;
+  flex: 0 0 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.markdown-content :deep(.mindmap-tool-code-label) {
+  white-space: nowrap;
+}
+
+.markdown-content :deep(.mindmap-toolbar-divider) {
+  display: block;
+  width: 1px;
+  height: 1.1rem;
+  margin: 0 0.15rem;
+  background: var(--sl-border, #e4e4e7);
+}
+
 .markdown-content :deep(.mindmap-canvas) {
+  position: relative;
   @apply max-w-full overflow-auto;
+  height: 360px;
+  max-height: 60vh;
   min-height: 180px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.markdown-content :deep(.mindmap-canvas[data-dragging='true']) {
+  cursor: grabbing;
 }
 
 .markdown-content :deep(.mindmap-svg) {
@@ -529,6 +756,56 @@ function updateMindmapVisibility(mindmap) {
 
 .markdown-content :deep(.mindmap-node-hidden) {
   display: none;
+}
+
+.markdown-content :deep(.mindmap-code-panel) {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  @apply m-0 overflow-auto p-3 text-xs leading-relaxed;
+  background: var(--sl-bg-hover, #f8fafc);
+  color: var(--sl-text-primary, #18181b);
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
+.markdown-content :deep(.mindmap-code-panel[aria-hidden='true']) {
+  display: none;
+}
+
+.markdown-content :deep(.mindmap-code-panel code) {
+  font:
+    400 12px/1.6 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace;
+}
+
+.markdown-content :deep(.markdown-mindmap:fullscreen) {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  border-radius: 0;
+  background: var(--sl-bg-surface, #fff);
+}
+
+.markdown-content :deep(.markdown-mindmap:fullscreen .mindmap-canvas) {
+  flex: 1 1 auto;
+  height: auto;
+  max-height: none;
+  min-height: 0;
+}
+
+.markdown-content :deep(.markdown-mindmap:fullscreen .mindmap-svg) {
+  width: 100%;
+  height: 100%;
 }
 
 :global(:root[data-theme='dark'] .markdown-content .markdown-mindmap) {

--- a/frontend/src/utils/mindmap.js
+++ b/frontend/src/utils/mindmap.js
@@ -86,24 +86,86 @@ function flattenTree(root) {
   return nodes
 }
 
-function wrapLabel(label, maxChars = 28) {
-  const chars = Array.from(label)
-  const lines = []
-  for (let index = 0; index < chars.length; index += maxChars) {
-    lines.push(chars.slice(index, index + maxChars).join(''))
+const ROOT_X = 112
+const DOT_GAP = 12
+const TEXT_GAP = 10
+const COLUMN_GAP = 40
+const ROOT_GAP = 104
+const LINE_HEIGHT = 20
+const LEAF_GAP = 12
+const MIN_LEAF_ADVANCE = 34
+const WRAP_WIDTH = 240
+
+function measureWidth(text) {
+  let width = 0
+  for (const char of String(text)) {
+    width += char.codePointAt(0) > 0x2e7f ? 14 : 7.5
   }
-  return lines.length ? lines : ['']
+  return width
+}
+
+function wrapLabel(label, maxWidth = WRAP_WIDTH) {
+  const chars = Array.from(String(label))
+  if (!chars.length) return ['']
+  const lines = []
+  let current = ''
+  let width = 0
+  for (const char of chars) {
+    const charWidth = char.codePointAt(0) > 0x2e7f ? 14 : 7.5
+    if (current && width + charWidth > maxWidth) {
+      lines.push(current)
+      current = ''
+      width = 0
+    }
+    current += char
+    width += charWidth
+  }
+  lines.push(current)
+  return lines
 }
 
 function layoutTree(root) {
   const nodes = flattenTree(root)
-  let nextY = 28
+  const maxDepth = rootDepth(root)
 
+  nodes.forEach((node) => {
+    node.lines = node.depth === 0 ? [] : wrapLabel(node.label)
+    node.textWidth = node.lines.reduce(
+      (width, line) => Math.max(width, measureWidth(line)),
+      0
+    )
+  })
+
+  const columnWidths = []
+  nodes.forEach((node) => {
+    columnWidths[node.depth] = Math.max(
+      columnWidths[node.depth] || 0,
+      node.textWidth
+    )
+  })
+
+  // Labels are left-aligned per depth. Only nodes with children get a dot,
+  // and it sits just after the label; leaves have no dot. A branch leaves
+  // from its parent's dot and stops before the child label, so connectors
+  // remain visually separated from text.
+  const labelX = [ROOT_X]
+  for (let depth = 1; depth <= maxDepth; depth += 1) {
+    labelX[depth] =
+      depth === 1
+        ? ROOT_X + ROOT_GAP
+        : labelX[depth - 1] + columnWidths[depth - 1] + DOT_GAP + COLUMN_GAP
+  }
+
+  let nextY = 24
   const place = (node) => {
-    node.x = 24 + node.depth * 236
+    node.labelX = labelX[node.depth]
+    node.labelEnd = node.labelX + node.textWidth
+    node.hasChildren = node.children.length > 0
+    node.dotX = node.depth === 0 ? ROOT_X : node.labelEnd + DOT_GAP
     if (!node.children.length) {
       node.y = nextY
-      nextY += Math.max(30, wrapLabel(node.label).length * 20 + 10)
+      const lineCount = Math.max(1, node.lines.length)
+      nextY += Math.max(MIN_LEAF_ADVANCE, lineCount * LINE_HEIGHT + LEAF_GAP)
       return
     }
     node.children.forEach(place)
@@ -112,17 +174,13 @@ function layoutTree(root) {
   }
   place(root)
 
-  const maxTextWidth = nodes.reduce((width, node) => {
-    const longestLine = Math.max(
-      ...wrapLabel(node.label).map((line) => Array.from(line).length)
-    )
-    return Math.max(width, longestLine * 9)
-  }, 0)
-
+  const lastWidth = columnWidths[maxDepth] || 0
+  const lastDot =
+    maxDepth === 0 ? ROOT_X : labelX[maxDepth] + lastWidth + DOT_GAP
   return {
     nodes,
-    width: Math.max(560, 24 + rootDepth(root) * 236 + maxTextWidth + 60),
-    height: Math.max(150, nextY + 12)
+    width: Math.max(560, lastDot + 24),
+    height: Math.max(150, nextY + 8)
   }
 }
 
@@ -143,10 +201,14 @@ function branchColor(node) {
 }
 
 function renderText(node) {
-  return wrapLabel(node.label)
+  const textX = node.labelX
+  const firstLineOffset = -((node.lines.length - 1) * LINE_HEIGHT) / 2
+  return node.lines
     .map(
       (line, index) =>
-        `<tspan x="12" dy="${index === 0 ? 0 : 18}">${escapeXml(line)}</tspan>`
+        `<tspan x="${textX}" ` +
+        `dy="${index === 0 ? firstLineOffset : LINE_HEIGHT}">` +
+        `${escapeXml(line)}</tspan>`
     )
     .join('')
 }
@@ -167,11 +229,13 @@ export function renderMindmap(markdown) {
       )
       if (!parent) return ''
       const color = branchColor(node)
-      const middleX = (parent.x + node.x) / 2
+      const startX = parent.dotX
+      const endX = node.labelX - TEXT_GAP
+      const middleX = (startX + endX) / 2
       return (
         `<path class="mindmap-link" data-mindmap-link="${node.path}" ` +
-        `d="M${parent.x},${parent.y} C${middleX},${parent.y} ` +
-        `${middleX},${node.y} ${node.x},${node.y}" stroke="${color}" />`
+        `d="M${startX},${parent.y} C${middleX},${parent.y} ` +
+        `${middleX},${node.y} ${endX},${node.y}" stroke="${color}" />`
       )
     })
     .join('')
@@ -179,41 +243,58 @@ export function renderMindmap(markdown) {
   const renderedNodes = nodes
     .map((node) => {
       const color = branchColor(node)
-      const hasChildren = node.children.length > 0
-      const radius = node.depth === 0 ? 7 : hasChildren ? 6 : 4
+      const radius = node.depth === 0 ? 7 : 6
       const label = node.depth === 0 ? '' : renderText(node)
+      const dot = node.hasChildren
+        ? `<circle cx="${node.dotX}" cy="${node.y}" r="${radius}" ` +
+          `stroke="${color}" fill="white" />`
+        : ''
       return (
         `<g class="mindmap-node" data-mindmap-toggle="true" ` +
         `data-mindmap-path="${node.path}" ` +
-        `data-mindmap-has-children="${hasChildren}" ` +
-        `role="treeitem" tabindex="0" aria-expanded="${hasChildren}" ` +
-        `aria-label="${escapeXml(node.label)}" ` +
-        `transform="translate(${node.x} ${node.y})">` +
-        `<circle cx="0" cy="0" r="${radius}" ` +
-        `stroke="${color}" fill="white" />` +
-        `<text fill="currentColor">${label}</text></g>`
+        `data-mindmap-has-children="${node.hasChildren}" ` +
+        `role="treeitem" tabindex="0" aria-expanded="${node.hasChildren}" ` +
+        `aria-label="${escapeXml(node.label)}">` +
+        dot +
+        `<text x="${node.labelX}" y="${node.y}" ` +
+        `fill="currentColor" dominant-baseline="middle">${label}</text></g>`
       )
     })
     .join('')
 
   return (
     `<div class="markdown-mindmap" data-mindmap-root>` +
-    `<div class="mindmap-toolbar" role="toolbar" ` +
-    `aria-label="思维导图操作">` +
-    `<span class="mindmap-toolbar-title">思维导图</span>` +
-    `<button type="button" data-mindmap-action="expand" ` +
-    `aria-label="全部展开">全部展开</button>` +
-    `<button type="button" data-mindmap-action="collapse" ` +
-    `aria-label="全部收起">全部收起</button>` +
-    `</div>` +
     `<div class="mindmap-canvas" role="group" ` +
     `aria-label="${escapeXml(root.label)}">` +
     `<svg class="mindmap-svg" role="tree" ` +
     `viewBox="0 0 ${width} ${height}" ` +
+    `data-mindmap-width="${width}" data-mindmap-height="${height}" ` +
     `preserveAspectRatio="xMinYMin meet" ` +
     `aria-label="${escapeXml(root.label)}">` +
     `<g class="mindmap-links">${links}</g>` +
     `<g class="mindmap-nodes">${renderedNodes}</g>` +
-    `</svg></div></div>`
+    `</svg>` +
+    `<pre class="mindmap-code-panel" aria-hidden="true">` +
+    `<code>${escapeXml(markdown)}</code></pre></div>` +
+    `<div class="mindmap-toolbar" role="toolbar" ` +
+    `aria-label="思维导图操作">` +
+    `<button type="button" class="mindmap-tool-button ` +
+    `mindmap-tool-zoom-out" data-mindmap-action="zoom-out" ` +
+    `aria-label="缩小" title="缩小"></button>` +
+    `<button type="button" class="mindmap-tool-button ` +
+    `mindmap-tool-zoom-in" data-mindmap-action="zoom-in" ` +
+    `aria-label="放大" title="放大"></button>` +
+    `<button type="button" class="mindmap-tool-button ` +
+    `mindmap-tool-fit" data-mindmap-action="fit" ` +
+    `aria-label="适应画布" title="适应画布"></button>` +
+    `<button type="button" class="mindmap-tool-button ` +
+    `mindmap-tool-fullscreen" data-mindmap-action="fullscreen" ` +
+    `aria-label="全屏查看" title="全屏查看"></button>` +
+    `<span class="mindmap-toolbar-divider" aria-hidden="true"></span>` +
+    `<button type="button" class="mindmap-tool-code" ` +
+    `data-mindmap-action="code" aria-label="查看代码" ` +
+    `title="查看代码"><span aria-hidden="true">&lt;/&gt;</span>` +
+    `<span class="mindmap-tool-code-label">查看代码</span></button>` +
+    `</div></div>`
   )
 }

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -69,6 +69,8 @@ export function sanitizeHtml(dirty) {
       'data-mindmap-has-children',
       'data-mindmap-collapsed',
       'data-mindmap-link',
+      'data-mindmap-width',
+      'data-mindmap-height',
       'viewBox',
       'preserveAspectRatio',
       'aria-hidden',

--- a/frontend/tests/mindmap.test.js
+++ b/frontend/tests/mindmap.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import { parseMindmap, renderMindmap } from '../src/utils/mindmap.js'
 
@@ -24,7 +25,36 @@ test('renders clickable node metadata and branch links', () => {
   assert.match(html, /data-mindmap-toggle="true"/)
   assert.match(html, /data-mindmap-path="0\.1\.2\.1"/)
   assert.match(html, /class="mindmap-link"/)
-  assert.match(html, /data-mindmap-action="collapse"/)
+  assert.doesNotMatch(html, /data-mindmap-action="(?:expand|collapse)"/)
+  assert.match(html, /data-mindmap-action="zoom-out"/)
+  assert.match(html, /data-mindmap-action="zoom-in"/)
+  assert.match(html, /data-mindmap-action="fit"/)
+  assert.match(html, /data-mindmap-action="fullscreen"/)
+  assert.match(html, /data-mindmap-action="code"/)
+  assert.match(html, /data-mindmap-width="[0-9.]+"/)
+  assert.match(html, /data-mindmap-height="[0-9.]+"/)
+  assert.match(
+    html,
+    /class="mindmap-canvas"[\s\S]*class="mindmap-code-panel" aria-hidden="true"/
+  )
+  assert.match(html, /<circle cx="284" cy="[0-9.]+" r="6"/)
+  assert.match(html, /<text x="216" y="[0-9.]+" fill="currentColor"/)
+})
+
+test('draws a dot only on branch nodes, just after the label', () => {
+  const html = renderMindmap(source)
+
+  // "一、定位" is a branch: label spans x=216..272 with its dot at x=284.
+  assert.match(html, /<tspan x="216" dy="0">一、定位<\/tspan>/)
+  assert.match(html, /<circle cx="284" cy="[0-9.]+" r="6"/)
+  // "评估对象" is a leaf at x=324 and must not get a dot.
+  assert.match(html, /<tspan x="324" dy="0">评估对象<\/tspan>/)
+  assert.doesNotMatch(html, /<circle cx="324"/)
+  // The branch leaves the parent dot (284) and ends at the child label (324).
+  assert.match(
+    html,
+    /data-mindmap-link="0\.1\.1" d="M284,[0-9.]+ C[^"]* 314,[0-9.]+"/
+  )
 })
 
 test('does not emit unescaped SVG text', () => {
@@ -32,5 +62,28 @@ test('does not emit unescaped SVG text', () => {
 
   assert.doesNotMatch(html, /<script>/)
   assert.match(html, /&lt;script&gt;/)
+  assert.match(html, /x &amp; y/)
+})
+
+test('renders node positions with sanitizer-allowed SVG attributes', () => {
+  const sanitizer = readFileSync(
+    new URL('../src/utils/sanitize.js', import.meta.url),
+    'utf8'
+  )
+
+  assert.doesNotMatch(renderMindmap(source), /\stransform=/)
+  assert.match(sanitizer, /['"]cx['"]/)
+  assert.match(sanitizer, /['"]cy['"]/)
+  assert.match(sanitizer, /['"]x['"]/)
+  assert.match(sanitizer, /['"]y['"]/)
+  assert.match(sanitizer, /['"]data-mindmap-width['"]/)
+  assert.match(sanitizer, /['"]data-mindmap-height['"]/)
+})
+
+test('includes escaped source code for the code view', () => {
+  const html = renderMindmap('## A <script>alert(1)</script>\n- x & y')
+
+  assert.match(html, /class="mindmap-code-panel" aria-hidden="true"/)
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/)
   assert.match(html, /x &amp; y/)
 })

--- a/release-notes/534.yaml
+++ b/release-notes/534.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Refined interactive mindmap layout with clearer label spacing, canvas panning, and fullscreen zoom support.
+zh-CN: 优化交互式思维导图布局，改善文字与分支间距，并支持画布拖动和全屏缩放。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Refine interactive mindmap toolbar and remove expand/collapse controls.
- Align branch dots, labels, and connectors with clearer spacing.
- Add fixed-height canvas panning and preserve zoom in fullscreen.

Related to #529

## Test plan
- [x] node --test tests/mindmap.test.js
- [x] npx eslint src/components/ui/MarkdownRenderer.vue --ext .vue --no-fix
- [x] npm run build


___

### **PR Type**
Enhancement


___

### **Description**
- Remove expand/collapse, add zoom/fit/fullscreen/code actions

- Implement canvas panning with pointer events

- Refine label wrapping, dot placement, and connector alignment

- Update tests and sanitizer for new attributes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fenced mindmap block"] --> B["parseMindmap"]
  B --> C["layoutTree with pixel-based wrapping"]
  C --> D["renderMindmap with toolbar actions"]
  D --> E["Zoom / Fit / Fullscreen / Code"]
  D --> F["Canvas panning via pointer events"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarkdownRenderer.vue</strong><dd><code>Add mindmap interactions and pointer panning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/MarkdownRenderer.vue

<ul><li>Added pointer event handlers for canvas panning.<br> <li> Implemented zoom, fit, fullscreen, and code panel actions.<br> <li> Restyled toolbar as floating overlay with icon buttons.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/534/files#diff-8acab9a2284f91e2714ae018e98389ad38d85c55215ce785163b9cf790b4c5d3">+289/-12</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mindmap.js</strong><dd><code>Refine layout with pixel-based wrapping and dot alignment</code></dd></summary>
<hr>

frontend/src/utils/mindmap.js

<ul><li>Replaced character-count wrapping with pixel-width wrapping.<br> <li> Aligned labels left per depth, moved dots after label.<br> <li> Adjusted connector paths to start and end at dot/label gaps.<br> <li> Removed expand/collapse rendering, added code panel HTML.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/534/files#diff-6e4986b4ab199c5ce819e83ab30880a3cbdb55ffa9fa8d9a13047297744d5dd6">+121/-40</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanitize.js</strong><dd><code>Allow new mindmap data attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/sanitize.js

- Allowed data-mindmap-width and data-mindmap-height attributes.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/534/files#diff-0e695f4b793e507de5f17d378c483bc1a9f05c49fc81d917abf87cf7382ce4be">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mindmap.test.js</strong><dd><code>Add tests for new toolbar and layout behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/mindmap.test.js

<ul><li>Added tests for toolbar actions (zoom, fit, fullscreen, code).<br> <li> Verified dot placement only on branch nodes.<br> <li> Checked sanitizer allows cx, cy, x, y attributes.<br> <li> Tested escaped source code in code panel.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/534/files#diff-bf67709871374c718bb84fc56a6b5b466edd75fb74ad9895e6cde63d24b47542">+54/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>534.yaml</strong><dd><code>Add release note for mindmap refinement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/534.yaml

- Added release note entry for the mindmap layout refinement.


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/534/files#diff-d3a94a88d556db5b3d0eaac2bdb91f59cf9d1c24a41b5750f8fd29d8e6bb6e0e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

