### PR TITLE
Fix Feishu datasource access revalidation

### DIFF
--- a/frontend/src/pages/lens/DataSourceFormDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceFormDrawer.vue
@@ -1331,7 +1331,15 @@ import {
   X as XIcon,
   XCircle as XCircleIcon
 } from '@lucide/vue'
-import { computed, defineComponent, h, nextTick, ref, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  h,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  watch
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import BaseButton from '@/components/ui/BaseButton.vue'
@@ -1395,6 +1403,7 @@ const gitRepositorySearch = ref('')
 const gitBulkBranch = ref('')
 const acceptedCredentialUuid = ref('')
 const conversionOpen = ref(false)
+let pluginValidationTimer = null
 
 const syncIntervalSeconds = computed({
   get() {
@@ -1901,6 +1910,26 @@ function updatePluginConfig(value) {
   })
   Object.assign(props.config, value)
   emit('connection-change')
+  schedulePluginConnectionValidation()
+}
+
+function schedulePluginConnectionValidation() {
+  if (pluginValidationTimer) {
+    clearTimeout(pluginValidationTimer)
+    pluginValidationTimer = null
+  }
+  if (
+    !isPluginSourceType(props.form.source_type) ||
+    props.form.plugin_key !== 'feishu' ||
+    activeStepKey.value !== 'connection' ||
+    !schemaRequiredFieldsHaveValues(datasourceSchema.value, props.config)
+  ) {
+    return
+  }
+  pluginValidationTimer = setTimeout(() => {
+    pluginValidationTimer = null
+    testConnectionIfVisible()
+  }, 350)
 }
 
 function credentialOptionLabel(credential) {
@@ -2163,6 +2192,13 @@ function testConnectionIfVisible() {
     (pluginConnectionStep || legacyConnectionStep) &&
     canTestConnection.value
   ) {
+    if (
+      pluginConnectionStep &&
+      props.form.plugin_key === 'feishu' &&
+      !schemaRequiredFieldsHaveValues(datasourceSchema.value, props.config)
+    ) {
+      return
+    }
     emit('test-connection')
   }
 }
@@ -2282,6 +2318,12 @@ watch(
   },
   { flush: 'post' }
 )
+
+onBeforeUnmount(() => {
+  if (pluginValidationTimer) {
+    clearTimeout(pluginValidationTimer)
+  }
+})
 
 function datasourceConnectionConfigSignature() {
   if (isPluginSourceType(props.form.source_type)) {

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -536,6 +536,7 @@ const loadingPluginResourceOptions = ref('')
 let pluginResourceRequestId = 0
 const suppressDatasourceConnectionReset = ref(false)
 const datasourceConnectionBaseSignature = ref('')
+let datasourceConnectionRequestId = 0
 const checkingDatasourcePath = ref(false)
 const testingDatasourceConnection = ref(false)
 const refreshingCredentials = ref(false)
@@ -1130,6 +1131,8 @@ function startEdit(row) {
 }
 
 function closeDrawer() {
+  datasourceConnectionRequestId++
+  testingDatasourceConnection.value = false
   showDrawer.value = false
   form.value = {}
   formError.value = ''
@@ -1672,6 +1675,8 @@ function canSaveDatasource() {
 }
 
 function resetDatasourceConnectionResult() {
+  datasourceConnectionRequestId++
+  testingDatasourceConnection.value = false
   if (suppressDatasourceConnectionReset.value) {
     suppressDatasourceConnectionReset.value = false
     return
@@ -1708,6 +1713,7 @@ function resetDatasourceConnectionResult() {
 }
 
 async function testDatasourceConnection() {
+  const requestId = ++datasourceConnectionRequestId
   testingDatasourceConnection.value = true
   datasourceConnectionResult.value = null
   try {
@@ -1718,6 +1724,7 @@ async function testDatasourceConnection() {
           form.value.connection_uuid,
           { datasource_config: buildPluginDatasourceConfig() }
         )
+        if (requestId !== datasourceConnectionRequestId) return
         datasourceConnectionResult.value = {
           status: 'success',
           message: t('lensAdmin.datasourceWizard.feishuResourcesAccessible'),
@@ -1731,6 +1738,7 @@ async function testDatasourceConnection() {
         return
       }
       const resources = await getConnectionResources(form.value.connection_uuid)
+      if (requestId !== datasourceConnectionRequestId) return
       datasourceConnectionResult.value = {
         status: 'success',
         message: 'Plugin Connection resources are available.',
@@ -1755,11 +1763,13 @@ async function testDatasourceConnection() {
         config: buildDatasourceConfig()
       }
     )
+    if (requestId !== datasourceConnectionRequestId) return
     applyDatasourceConnectionResult(result)
     datasourceConnectionResult.value = result
     datasourceConnectionBaseSignature.value =
       datasourceConnectionSignature(true)
   } catch (error) {
+    if (requestId !== datasourceConnectionRequestId) return
     datasourceConnectionResult.value = {
       status: 'failed',
       message:
@@ -1768,7 +1778,9 @@ async function testDatasourceConnection() {
         extractErrorMessage(error, t('lensAdmin.messages.loadFailed'))
     }
   } finally {
-    testingDatasourceConnection.value = false
+    if (requestId === datasourceConnectionRequestId) {
+      testingDatasourceConnection.value = false
+    }
   }
 }
 

--- a/frontend/tests/pluginIntegrations.test.js
+++ b/frontend/tests/pluginIntegrations.test.js
@@ -67,6 +67,29 @@ test('Feishu datasource URLs are checked before they can be saved', async () => 
   )
 })
 
+test('Feishu datasource configuration changes re-run access validation', async () => {
+  const [drawer, page] = await Promise.all([
+    source('pages/lens/DataSourceFormDrawer.vue'),
+    source('pages/lens/DataSources.vue')
+  ])
+  const updatePluginConfig = drawer.match(
+    /function updatePluginConfig\(value\) \{[\s\S]*?\n\}/
+  )?.[0]
+  const scheduleValidation = drawer.match(
+    /function schedulePluginConnectionValidation\(\) \{[\s\S]*?\n\}/
+  )?.[0]
+
+  assert.ok(updatePluginConfig)
+  assert.match(updatePluginConfig, /schedulePluginConnectionValidation\(\)/)
+  assert.ok(scheduleValidation)
+  assert.match(scheduleValidation, /testConnectionIfVisible\(\)/)
+  assert.match(page, /const requestId = \+\+datasourceConnectionRequestId/)
+  assert.match(
+    page,
+    /if \(requestId !== datasourceConnectionRequestId\) return/
+  )
+})
+
 test('Feishu Connection keeps setup guidance beside editable fields', async () => {
   const [page, guide, drawer, chinese, manifestText] = await Promise.all([
     source('pages/lens/Connections.vue'),

--- a/release-notes/532.yaml
+++ b/release-notes/532.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: admin
+en: Fixed Feishu datasource setup getting stuck after entering or changing resource URLs.
+zh-CN: 修复飞书数据源在输入或修改资源地址后无法继续下一步的问题。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- re-run Feishu datasource access validation after resource configuration changes
- debounce validation until required fields are present
- ignore stale validation responses so they cannot incorrectly unlock or block the wizard
- add regression coverage for the revalidation flow

Closes #532

## Test plan
- [x] `node --test tests/pluginIntegrations.test.js`
- [x] `npx eslint src/pages/lens/DataSourceFormDrawer.vue src/pages/lens/DataSources.vue tests/pluginIntegrations.test.js --no-fix` (0 errors; pre-existing formatting warnings remain in `DataSourceFormDrawer.vue`)
- [x] `npm run build`
- [ ] Full unit suite has four unrelated existing failures in BaseSelect and Spanish locale coverage


___

### **PR Type**
Bug fix


___

### **Description**
- Re-run Feishu datasource access validation on config changes

- Debounce validation until required fields are present

- Ignore stale validation responses to prevent incorrect state

- Add regression test for revalidation flow


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User changes Feishu config"] --> B["Debounce 350ms"]
  B --> C["Required fields present?"]
  C -->|"Yes"| D["Schedule validation"]
  D --> E["Trigger testConnectionIfVisible"]
  E --> F["Increment requestId, ignore stale"]
  F --> G["Apply only if requestId matches"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataSourceFormDrawer.vue</strong><dd><code>Add debounced plugin validation on config change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/DataSourceFormDrawer.vue

<ul><li>Import onBeforeUnmount for timer cleanup<br> <li> Add schedulePluginConnectionValidation with debounce<br> <li> Call it from updatePluginConfig on config changes<br> <li> Guard testConnectionIfVisible when Feishu required fields missing<br> <li> Clear debounce timer on component unmount</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/535/files#diff-0b2ea6040d7c458a234eb3d290500ddb300a087019b6b58d947883cda373ec42">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataSources.vue</strong><dd><code>Ignore stale datasource connection responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/DataSources.vue

<ul><li>Introduce requestId counter to track latest validation request<br> <li> Increment requestId on closeDrawer and resetDatasourceConnectionResult<br> <li> Check requestId before processing response in testDatasourceConnection<br> <li> Only update testing flag when requestId matches</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/535/files#diff-1a2dc840b5da820c7b8a16cb18fa4a424860f010974ced2df56948e3cde5c30a">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pluginIntegrations.test.js</strong><dd><code>Add regression test for Feishu revalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/pluginIntegrations.test.js

<ul><li>Add test that updatePluginConfig schedules validation<br> <li> Verify schedulePluginConnectionValidation calls <br>testConnectionIfVisible<br> <li> Verify requestId handling pattern in DataSources.vue</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/535/files#diff-4f7b0be18b55449fe0931d2293fcaa8e993946339d6914638e4c0d2a627cf462">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>532.yaml</strong><dd><code>Add release note for Feishu datasource fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/532.yaml

<ul><li>Add release note for Feishu datasource fix<br> <li> Provide English and Chinese descriptions for admin audience</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/535/files#diff-1f8e9d97cb93cc3712cfb5fc9931cecbb611d6887cbc0c651c9644971a3c267b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

