### PR TITLE
Fix managed workspace datasource setup and uploads

### DIFF
--- a/backend/lens/datasource_services.py
+++ b/backend/lens/datasource_services.py
@@ -198,6 +198,32 @@ def get_datasource_upload_timeout_s():
     return value if value > 0 else DEFAULT_DATASOURCE_UPLOAD_TIMEOUT_S
 
 
+def get_datasource_upload_limits():
+    """Return positive upload limits from global settings."""
+
+    defaults = {
+        "max_bytes": 50 * 1024 * 1024,
+        "max_extracted_bytes": 100 * 1024 * 1024,
+        "max_extracted_files": 300,
+    }
+    prefix = "lens.datasource_upload."
+    rows = {
+        row.key: row.value
+        for row in GlobalSetting.objects.filter(
+            key__in=[prefix + key for key in defaults]
+        )
+    }
+    result = {}
+    for key, default in defaults.items():
+        value = rows.get(prefix + key, default)
+        result[key] = (
+            value
+            if type(value) is int and value > 0
+            else default
+        )
+    return result
+
+
 def check_datasource_path(lensnode, target_path, source_type, config=None):
     """Ask a LensNode to inspect a datasource target path."""
 
@@ -427,7 +453,8 @@ def dispatch_datasource_upload_async(
     if datasource.source_type != DataSource.SourceType.MANAGED_WORKSPACE:
         raise DataSourceDispatchError("DATASOURCE_UPLOAD_NOT_SUPPORTED")
     validate_datasource_lensnode(datasource.lensnode)
-    if len(content) > DATASOURCE_UPLOAD_MAX_BYTES:
+    upload_limits = get_datasource_upload_limits()
+    if len(content) > upload_limits["max_bytes"]:
         raise DataSourceDispatchError("DATASOURCE_UPLOAD_TOO_LARGE")
     upload_conversion = {"document": True, "image": True}
     upload_conversion.update(
@@ -446,6 +473,7 @@ def dispatch_datasource_upload_async(
             "target_path": datasource.target_path,
             "filename": filename,
             "content_base64": base64.b64encode(content).decode("ascii"),
+            "upload_limits": upload_limits,
             "conversion": upload_conversion,
             **_lensnode_gateway_config(),
             "excluded_datasource_roots": excluded_datasource_roots(

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -3547,6 +3547,9 @@ class GlobalSettingSerializer(serializers.ModelSerializer):
         value = attrs.get("value", getattr(self.instance, "value", {}))
 
         positive_integer_keys = {
+            "lens.datasource_upload.max_bytes": "max_bytes",
+            "lens.datasource_upload.max_extracted_bytes": "max_extracted_bytes",
+            "lens.datasource_upload.max_extracted_files": "max_extracted_files",
             "retention.run_days": "run_days",
             "lensnode.defaults.timeout": "timeout",
             "lensnode.defaults.idle_timeout": "idle_timeout",
@@ -3558,7 +3561,7 @@ class GlobalSettingSerializer(serializers.ModelSerializer):
             "lens.datasource_sync.workers": "workers",
         }
         if key in positive_integer_keys:
-            if not isinstance(value, int) or value <= 0:
+            if type(value) is not int or value <= 0:
                 name = positive_integer_keys[key]
                 raise serializers.ValidationError(
                     {"value": f"{name} must be a positive integer"}

--- a/backend/lens/tests/test_upload_limits.py
+++ b/backend/lens/tests/test_upload_limits.py
@@ -1,0 +1,38 @@
+"""Regression tests for configurable upload limits."""
+
+from django.test import TestCase
+
+from lens.datasource_services import get_datasource_upload_limits
+from lens.models import GlobalSetting
+from lens.serializers import GlobalSettingSerializer
+
+
+class UploadLimitsTests(TestCase):
+    """Keep default, override, and validation behavior consistent."""
+
+    def test_defaults_and_overrides(self):
+        """Missing values use defaults and saved values take effect."""
+
+        self.assertEqual(get_datasource_upload_limits(), {
+            "max_bytes": 52428800,
+            "max_extracted_bytes": 104857600,
+            "max_extracted_files": 300,
+        })
+        GlobalSetting.objects.create(
+            key="lens.datasource_upload.max_bytes", value=73400320
+        )
+        self.assertEqual(
+            get_datasource_upload_limits()["max_bytes"], 73400320
+        )
+
+    def test_invalid_limits_are_rejected(self):
+        """Reject booleans, strings, fractions, and nonpositive values."""
+
+        for name in get_datasource_upload_limits():
+            for value in (True, False, 0, -1, 1.5, "100", None):
+                with self.subTest(name=name, value=value):
+                    serializer = GlobalSettingSerializer(data={
+                        "key": f"lens.datasource_upload.{name}",
+                        "value": value,
+                    })
+                    self.assertFalse(serializer.is_valid())

--- a/backend/lens/views/datasources.py
+++ b/backend/lens/views/datasources.py
@@ -11,6 +11,7 @@ from django.db.models import Q
 from django.utils import timezone
 from lens.datasource_services import (
     DATASOURCE_UPLOAD_EXTENSIONS,
+    get_datasource_upload_limits,
     DataSourceDispatchError,
     DataSourcePathError,
     check_datasource_path,
@@ -495,6 +496,12 @@ class DataSourceViewSet(BaseAdminViewSet):
             status=status.HTTP_202_ACCEPTED,
         )
 
+    @action(detail=False, methods=["get"], url_path="upload-limits")
+    def upload_limits(self, request):
+        """Expose effective limits for client-side upload validation."""
+
+        return Response(get_datasource_upload_limits())
+
     @action(detail=True, methods=["post"], url_path="upload")
     def upload(self, request, uuid=None):
         """Queue one file upload into a Managed Workspace."""
@@ -516,7 +523,7 @@ class DataSourceViewSet(BaseAdminViewSet):
                 {"detail": "DATASOURCE_UPLOAD_FILE_REQUIRED"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        if uploaded.size > 50 * 1024 * 1024:
+        if uploaded.size > get_datasource_upload_limits()["max_bytes"]:
             return Response(
                 {"detail": "DATASOURCE_UPLOAD_TOO_LARGE"},
                 status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,

--- a/frontend/src/admin/locales/en.json
+++ b/frontend/src/admin/locales/en.json
@@ -1768,6 +1768,12 @@
       "saveChanges": "Save Changes"
     },
     "resourceSettings": {
+      "max_bytes": "Upload archive size limit",
+      "max_bytesDesc": "Maximum uploaded archive size in bytes.",
+      "max_extracted_bytes": "Extracted size limit",
+      "max_extracted_bytesDesc": "Maximum total extracted size in bytes.",
+      "max_extracted_files": "Extracted file limit",
+      "max_extracted_filesDesc": "Maximum number of files in an archive.",
       "groups": {
         "datasource": "Data Source Sync"
       },
@@ -2137,7 +2143,7 @@
       "uploadStarted": "Upload started",
       "uploadFailed": "Upload failed",
       "uploadZipOnly": "Only ZIP archives are supported for Managed Workspace uploads.",
-      "uploadTooLarge": "The ZIP archive must be 50 MB or smaller.",
+      "uploadTooLarge": "The ZIP archive must be {size} MiB or smaller.",
       "archiveSuccess": "Assistant archived",
       "archiveFailed": "Failed to archive assistant",
       "restoreSuccess": "Assistant restored",

--- a/frontend/src/admin/locales/es.json
+++ b/frontend/src/admin/locales/es.json
@@ -1750,6 +1750,12 @@
       "saveChanges": "Guardar cambios"
     },
     "resourceSettings": {
+      "max_bytes": "Límite del archivo subido",
+      "max_bytesDesc": "Tamaño máximo del archivo en bytes.",
+      "max_extracted_bytes": "Límite del tamaño extraído",
+      "max_extracted_bytesDesc": "Tamaño total máximo extraído en bytes.",
+      "max_extracted_files": "Límite de archivos extraídos",
+      "max_extracted_filesDesc": "Número máximo de archivos en el archivo comprimido.",
       "groups": {
         "datasource": "Sincronización de la fuente de datos"
       },
@@ -2119,7 +2125,7 @@
       "uploadStarted": "Inicio de subida",
       "uploadFailed": "La subida falló",
       "uploadZipOnly": "Las cargas del espacio gestionado solo admiten archivos ZIP.",
-      "uploadTooLarge": "El archivo ZIP debe tener como máximo 50 MB.",
+      "uploadTooLarge": "El archivo ZIP debe tener como máximo {size} MiB.",
       "archiveSuccess": "Asistente archivado",
       "archiveFailed": "Error al archivar asistente",
       "restoreSuccess": "Asistente restaurado",

--- a/frontend/src/admin/locales/zh-CN.json
+++ b/frontend/src/admin/locales/zh-CN.json
@@ -1768,6 +1768,12 @@
       "saveChanges": "保存修改"
     },
     "resourceSettings": {
+      "max_bytes": "上传压缩包大小上限",
+      "max_bytesDesc": "上传压缩包的最大字节数。",
+      "max_extracted_bytes": "解压总大小上限",
+      "max_extracted_bytesDesc": "解压后所有文件的最大总字节数。",
+      "max_extracted_files": "解压文件数上限",
+      "max_extracted_filesDesc": "压缩包中允许的最大文件数量。",
       "groups": {
         "datasource": "数据源同步"
       },
@@ -2137,7 +2143,7 @@
       "uploadStarted": "上传任务已开始",
       "uploadFailed": "上传失败",
       "uploadZipOnly": "托管工作区上传仅支持 ZIP 压缩包。",
-      "uploadTooLarge": "ZIP 压缩包不能超过 50 MB。",
+      "uploadTooLarge": "ZIP 压缩包不能超过 {size} MiB。",
       "archiveSuccess": "助手已归档",
       "archiveFailed": "助手归档失败",
       "restoreSuccess": "助手已恢复",

--- a/frontend/src/api/lens.js
+++ b/frontend/src/api/lens.js
@@ -610,6 +610,11 @@ export async function uploadDataSourceFile(uuid, file) {
   return unwrapResponse(response)
 }
 
+export async function getDataSourceUploadLimits() {
+  const response = await api.get('/lens/admin/datasources/upload-limits/')
+  return unwrapResponse(response)
+}
+
 export async function cancelDataSourceSync(uuid) {
   const response = await api.post(
     `/lens/admin/datasources/${uuid}/cancel-sync/`

--- a/frontend/src/components/lens/ManifestSchemaForm.vue
+++ b/frontend/src/components/lens/ManifestSchemaForm.vue
@@ -175,7 +175,7 @@
           <input
             :id="arrayItemId(field, index)"
             :value="item"
-            :class="[controlClass, 'min-w-0 flex-1 font-mono']"
+        :class="[controlClass, 'min-w-0 flex-1 font-mono']"
             :type="arrayInputType(field)"
             :aria-label="`${field.title || field.key} ${index + 1}`"
             :placeholder="field.description || ''"
@@ -232,7 +232,7 @@
       <input
         v-else
         :id="fieldId(field)"
-        :class="controlClass"
+        :class="[controlClass, isInvalid(field) ? 'border-danger-500 ring-2 ring-danger-500/20' : '']"
         :type="inputType(field)"
         :value="fieldValue(field)"
         :min="field.minimum"
@@ -244,6 +244,9 @@
         :placeholder="inputPlaceholder(field)"
         @input="setField(field, normalizeInput(field, $event.target.value))"
       />
+      <p v-if="isInvalid(field)" class="text-xs text-danger-600">
+        {{ requiredFieldError }}
+      </p>
       <p
         v-if="isResourceOptionLoading(field)"
         class="text-xs leading-5 text-ink-500"
@@ -284,6 +287,8 @@ const props = defineProps({
   removeArrayItemLabel: { type: String, default: 'Remove' },
   selectOptionLabel: { type: String, default: 'Select an option' },
   loadingOptionsLabel: { type: String, default: 'Loading options…' },
+  invalidFields: { type: Array, default: () => [] },
+  requiredFieldError: { type: String, default: 'This field is required.' },
   controlClass: { type: String, default: 'manifest-schema-control' },
   readOnly: { type: Boolean, default: false }
 })
@@ -304,6 +309,10 @@ const fields = computed(() => {
 
 function fieldId(field) {
   return `manifest-field-${field.key}`
+}
+
+function isInvalid(field) {
+  return props.invalidFields.includes(field.key)
 }
 
 function isRequired(field) {

--- a/frontend/src/pages/lens/DataSourceFormDrawer.vue
+++ b/frontend/src/pages/lens/DataSourceFormDrawer.vue
@@ -132,6 +132,7 @@
         <FormRow :label="t('lensAdmin.pages.connections.label')" required>
           <BaseSelect
             :model-value="form.connection_uuid"
+            :class="{ 'border-danger-500 ring-2 ring-danger-500/20': connectionFieldInvalid }"
             @update:model-value="handlePluginConnectionChange"
           >
             <option value="">
@@ -145,6 +146,9 @@
               {{ connection.name }}
             </option>
           </BaseSelect>
+          <p v-if="connectionFieldInvalid" class="mt-1 text-xs text-danger-600">
+            {{ t('lensAdmin.datasourceWizard.requiredField') }}
+          </p>
           <p class="mt-1 text-xs text-ink-500">
             {{ t('lensAdmin.datasourceWizard.createConnectionHint') }}
             <a
@@ -179,6 +183,8 @@
           "
           :resource-count-label="t('lensAdmin.pluginForm.resources')"
           :selected-count-label="t('lensAdmin.pluginForm.selected')"
+          :invalid-fields="missingDatasourceFields"
+          :required-field-error="t('lensAdmin.datasourceWizard.requiredField')"
           :private-resource-label="t('lensAdmin.pluginForm.private')"
           :select-option-label="t('lensAdmin.pluginForm.selectOption')"
           :loading-options-label="t('lensAdmin.pluginForm.loadingOptions')"
@@ -1729,6 +1735,19 @@ const connectionResultMessage = computed(() => {
   }
   return props.connectionResult.message || ''
 })
+
+const missingDatasourceFields = computed(() => {
+  if (!datasourceSchema.value || !isPluginSourceType(props.form.source_type)) return []
+  return (datasourceSchema.value.required || []).filter((key) => {
+    const value = props.config?.[key]
+    return value === undefined || value === null || value === '' ||
+      (Array.isArray(value) && value.length === 0)
+  })
+})
+
+const connectionFieldInvalid = computed(() =>
+  isPluginSourceType(props.form.source_type) && !props.form.connection_uuid
+)
 
 const canProceedWizard = computed(() => {
   if (activeStepKey.value === 'basic') {

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -449,6 +449,7 @@ import {
   scanLensNodeDirs,
   refreshDataSourceAvailability,
   uploadDataSourceFile,
+  getDataSourceUploadLimits,
   setDataSourceEnabled,
   syncDataSource,
   testLensNodeDataSourceConnection,
@@ -2157,12 +2158,14 @@ async function uploadFile(event) {
     uploadDataSource.value = null
     return
   }
-  if (file.size > 50 * 1024 * 1024) {
-    showError(t('lensAdmin.messages.uploadTooLarge'))
-    uploadDataSource.value = null
-    return
-  }
   try {
+    const limits = await getDataSourceUploadLimits()
+    if (file.size > limits.max_bytes) {
+      showError(t('lensAdmin.messages.uploadTooLarge', {
+        size: limits.max_bytes / (1024 * 1024)
+      }))
+      return
+    }
     const result = await uploadDataSourceFile(row.uuid, file)
     showSuccess(
       `${t('lensAdmin.messages.uploadStarted')} (${result.task_id || ''})`

--- a/frontend/src/pages/lens/DataSources.vue
+++ b/frontend/src/pages/lens/DataSources.vue
@@ -340,6 +340,14 @@
                       t('lensAdmin.actions.refreshAvailability')
                     }}</BaseButton
                   >
+                  <BaseButton
+                    v-if="row.source_type === 'managed_workspace'"
+                    size="sm"
+                    variant="outline"
+                    @click.stop="openUpload(row)"
+                  >
+                    {{ t('lensAdmin.actions.uploadFile') }}
+                  </BaseButton>
                   <RowActions :row="row" @edit="startEdit" @delete="remove" />
                 </div>
               </div>

--- a/frontend/src/pages/lens/ResourceSettings.vue
+++ b/frontend/src/pages/lens/ResourceSettings.vue
@@ -180,6 +180,9 @@ const globalSettings = ref([])
 const llmConfigOptions = ref([])
 
 const defaultSettings = {
+  'lens.datasource_upload.max_bytes': 52428800,
+  'lens.datasource_upload.max_extracted_bytes': 104857600,
+  'lens.datasource_upload.max_extracted_files': 300,
   'lens.datasource_sync.timeout_s': 360,
   'lens.datasource_sync.workers': 4,
   'lens.datasource_conversion.vision_model_ref': '',
@@ -191,6 +194,16 @@ const initialSettings = ref({ ...defaultSettings })
 
 const settingDefinitions = computed(() => {
   return [
+    ...['max_bytes', 'max_extracted_bytes', 'max_extracted_files'].map(
+      (key) => ({
+        key: `lens.datasource_upload.${key}`,
+        group: 'datasource',
+        label: t(`lensAdmin.resourceSettings.${key}`),
+        description: t(`lensAdmin.resourceSettings.${key}Desc`),
+        type: 'number',
+        unit: key === 'max_extracted_files' ? '' : 'bytes'
+      })
+    ),
     {
       key: 'lens.datasource_sync.timeout_s',
       group: 'datasource',

--- a/frontend/tests/pluginIntegrations.test.js
+++ b/frontend/tests/pluginIntegrations.test.js
@@ -458,6 +458,14 @@ test('managed workspace setup does not request a credential', async () => {
     /if \(isManagedWorkspace\.value\) \{\s*return false/)
 })
 
+test('managed workspace cards expose a direct upload action', async () => {
+  const page = await source('pages/lens/DataSources.vue')
+
+  assert.match(page, /row\.source_type === 'managed_workspace'/)
+  assert.match(page, /@click\.stop="openUpload\(row\)"/)
+  assert.match(page, /lensAdmin\.actions\.uploadFile/)
+})
+
 test('datasource target path check follows the semantic sync step', async () => {
   const drawer = await source('pages/lens/DataSourceFormDrawer.vue')
 

--- a/lensnode/lensnode/datasource_sync.py
+++ b/lensnode/lensnode/datasource_sync.py
@@ -684,6 +684,12 @@ def upload_managed_workspace(command, workspace_path=WORKSPACE_ROOT):
         )
     except (ValueError, TypeError) as exc:
         raise DataSourceSyncError("DATASOURCE_UPLOAD_CONTENT_INVALID") from exc
+    limits = command.get("upload_limits") or {}
+    max_bytes = limits.get("max_bytes", 50 * 1024 * 1024)
+    if type(max_bytes) is not int or max_bytes <= 0:
+        max_bytes = 50 * 1024 * 1024
+    if len(content) > max_bytes:
+        raise DataSourceSyncError("DATASOURCE_UPLOAD_TOO_LARGE")
     archive_path = target / filename
     staging = target / ".sourcelens-upload-staging.sourcelens"
     if staging.exists():
@@ -694,9 +700,9 @@ def upload_managed_workspace(command, workspace_path=WORKSPACE_ROOT):
     extracted = []
     try:
         if filename.lower().endswith(".zip"):
-            extracted = _extract_zip_archive(staged_archive, staging)
+            extracted = _extract_zip_archive(staged_archive, staging, limits)
         elif filename.lower().endswith((".tar", ".tar.gz", ".tgz")):
-            extracted = _extract_tar_archive(staged_archive, staging)
+            extracted = _extract_tar_archive(staged_archive, staging, limits)
         previous = target / ".sourcelens-uploaded.sourcelens"
         if previous.exists():
             for path in previous.read_text(encoding="utf-8").splitlines():
@@ -751,19 +757,34 @@ def _archive_member_path(root, name):
     return path
 
 
-def _extract_zip_archive(archive_path, root):
+def _upload_extraction_limits(limits):
+    """Normalize optional limits for compatibility with older servers."""
+
+    limits = limits if isinstance(limits, dict) else {}
+    defaults = (UPLOAD_MAX_EXTRACTED_BYTES, UPLOAD_MAX_EXTRACTED_FILES)
+    keys = ("max_extracted_bytes", "max_extracted_files")
+    return tuple(
+        limits[key]
+        if type(limits.get(key)) is int and limits[key] > 0
+        else default
+        for key, default in zip(keys, defaults)
+    )
+
+
+def _extract_zip_archive(archive_path, root, limits=None):
     """Extract a ZIP archive without permitting unsafe members."""
 
     extracted = []
     extracted_bytes = 0
+    max_bytes, max_files = _upload_extraction_limits(limits)
     with zipfile.ZipFile(archive_path) as archive:
         for info in archive.infolist():
             if info.is_dir():
                 continue
-            if len(extracted) >= UPLOAD_MAX_EXTRACTED_FILES:
+            if len(extracted) >= max_files:
                 raise DataSourceSyncError("DATASOURCE_UPLOAD_FILE_LIMIT")
             extracted_bytes += info.file_size
-            if extracted_bytes > UPLOAD_MAX_EXTRACTED_BYTES:
+            if extracted_bytes > max_bytes:
                 raise DataSourceSyncError("DATASOURCE_UPLOAD_SIZE_LIMIT")
             mode = (info.external_attr >> 16) & 0o170000
             if mode == 0o120000:
@@ -778,21 +799,22 @@ def _extract_zip_archive(archive_path, root):
     return extracted
 
 
-def _extract_tar_archive(archive_path, root):
+def _extract_tar_archive(archive_path, root, limits=None):
     """Extract a tar archive without permitting unsafe members."""
 
     extracted = []
     extracted_bytes = 0
+    max_bytes, max_files = _upload_extraction_limits(limits)
     with tarfile.open(archive_path, "r:*") as archive:
         for member in archive.getmembers():
             if member.issym() or member.islnk():
                 raise DataSourceSyncError("DATASOURCE_UPLOAD_LINK_INVALID")
             if not member.isfile():
                 continue
-            if len(extracted) >= UPLOAD_MAX_EXTRACTED_FILES:
+            if len(extracted) >= max_files:
                 raise DataSourceSyncError("DATASOURCE_UPLOAD_FILE_LIMIT")
             extracted_bytes += member.size
-            if extracted_bytes > UPLOAD_MAX_EXTRACTED_BYTES:
+            if extracted_bytes > max_bytes:
                 raise DataSourceSyncError("DATASOURCE_UPLOAD_SIZE_LIMIT")
             path = _archive_member_path(root, member.name)
             if path.exists():

--- a/lensnode/tests/test_upload_limits.py
+++ b/lensnode/tests/test_upload_limits.py
@@ -1,0 +1,54 @@
+"""Archive extraction must honor server-provided limits."""
+
+import zipfile
+
+import pytest
+
+from lensnode.lensnode.datasource_sync import (
+    DataSourceSyncError,
+    _extract_zip_archive,
+    _upload_extraction_limits,
+)
+
+
+def test_limit_defaults():
+    """Invalid and missing limits retain compatibility defaults."""
+
+    assert _upload_extraction_limits(None) == (104857600, 300)
+    assert _upload_extraction_limits({
+        "max_extracted_bytes": -1,
+        "max_extracted_files": True,
+    }) == (104857600, 300)
+
+
+@pytest.mark.parametrize("limits,error", [
+    ({"max_extracted_bytes": 3}, "DATASOURCE_UPLOAD_SIZE_LIMIT"),
+    ({"max_extracted_files": 1}, "DATASOURCE_UPLOAD_FILE_LIMIT"),
+])
+def test_custom_limits(tmp_path, limits, error):
+    """Smaller configured byte and count limits stop extraction."""
+
+    package = tmp_path / "test.zip"
+    root = tmp_path / "output"
+    root.mkdir()
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("a.txt", b"abcd")
+        archive.writestr("b.txt", b"efgh")
+    with pytest.raises(DataSourceSyncError, match=error):
+        _extract_zip_archive(package, root, limits)
+
+
+def test_exact_boundary(tmp_path):
+    """The configured size and file-count boundary is inclusive."""
+
+    package = tmp_path / "test.zip"
+    root = tmp_path / "output"
+    root.mkdir()
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("a.txt", b"abcd")
+    result = _extract_zip_archive(package, root, {
+        "max_extracted_bytes": 4,
+        "max_extracted_files": 1,
+    })
+    assert len(result) == 1
+    assert result[0].read_bytes() == b"abcd"


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Fix managed workspace datasource setup and credential handling
- Add ZIP upload validation and safe staged replacement
- Merge the latest `main` changes into this branch

Closes #531
Closes #533

## Test plan
- [x] Existing validation completed before merge
- [ ] CI checks


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Managed Workspace credential bug in datasource wizard.

- Add configurable upload limits for ZIP imports.

- Implement safe staged replacement on repeated uploads.

- Update frontend with dynamic validation and localized messages.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DataSourceFormDrawer: fix credential bug"] --> B["DataSources.vue: upload action"]
  C["Backend: configurable limits"] --> D["LensNode: staged replacement"]
  D --> E["Frontend: dynamic size check"]
  A --> F["ManifestSchemaForm: inline validation"]
  F --> G["Locales: updated messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>datasource_services.py</strong><dd><code>Add configurable upload limits and dynamic dispatch validation</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-ef239c26b05a584241a27d188bdb8dfe3c9c26afcfb1dee90818432c036c3468">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Validate new datasource upload global settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasources.py</strong><dd><code>Add upload-limits endpoint and dynamic size check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-77def33401b75c8a74c155434c3ea2ed8d4642a899e387de0bbfd0430c9af97a">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_sync.py</strong><dd><code>Integrate configurable extraction limits and staged replacement</code></dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-c1058f4d246c18dc76dbf04e93dd276a757be81f62279924d62205fe0cf978f4">+30/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManifestSchemaForm.vue</strong><dd><code>Add invalid field highlighting for required components</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-7610b90c53f9fc943b7ab5929817d505f0c7056c88e8dba5f538367e6b6d77c5">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSources.vue</strong><dd><code>Add upload button and dynamic size limit check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-1a2dc840b5da820c7b8a16cb18fa4a424860f010974ced2df56948e3cde5c30a">+16/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResourceSettings.vue</strong><dd><code>Add datasource upload limit settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-d608fa1eea914880ae2a33e3c1f283fbf87a4bb2edfe1a7cfd57bb7038a5d037">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lens.js</strong><dd><code>Add getDataSourceUploadLimits API call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-aa9654d28fef5dd3582877a07a1ce1f268f41e2e3e89a1c1628999249284ff62">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Update upload limit settings and message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-90cf74afeb2759ffae3ff15f5e8e2966a106cfed0e1ef40f32de44e3862846b9">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Update upload limit settings and message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-fc5efacc2d4df9cfc4192f70e7478c9ac6da757a78b4543d46b34dd0638149d2">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Update upload limit settings and message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-6d0b7ee00113877c35f15ed48ad2a062ac5035a189acc33ccc9b4dc923f4ec1a">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_upload_limits.py</strong><dd><code>Test default and override upload limit behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-6be6b267232936ffca00d6bb4b43c98c6e87332adf550f0dc921400c55c23554">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_upload_limits.py</strong><dd><code>Test extraction limit defaults and boundary behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-f78fe26e5021d656b6d98adb4d1b3b2fe330c46b69a7f5b3906cebddde6cb84e">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pluginIntegrations.test.js</strong><dd><code>Add test for managed workspace upload action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-4f7b0be18b55449fe0931d2293fcaa8e993946339d6914638e4c0d2a627cf462">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DataSourceFormDrawer.vue</strong><dd><code>Fix credential field bug and add inline validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/538/files#diff-0b2ea6040d7c458a234eb3d290500ddb300a087019b6b58d947883cda373ec42">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

