### PR TITLE
Add searchable conversation history

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -507,7 +507,10 @@
         "planningTasks": "Planning tasks...",
         "delegatingTask": "Delegating subtask...",
         "callingTool": "Calling {name}..."
-      }
+      },
+      "searchSessions": "Search conversations",
+      "searchSessionsPlaceholder": "Search conversation titles",
+      "noSearchResults": "No conversations match your search"
     }
   },
   "auth": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -507,7 +507,10 @@
         "planningTasks": "Planificando tareas...",
         "delegatingTask": "Delegando subtarea...",
         "callingTool": "Llamando a {name}..."
-      }
+      },
+      "searchSessions": "Buscar conversaciones",
+      "searchSessionsPlaceholder": "Buscar títulos de conversaciones",
+      "noSearchResults": "No hay conversaciones que coincidan"
     }
   },
   "auth": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -507,7 +507,10 @@
         "planningTasks": "正在规划任务...",
         "delegatingTask": "委派子任务...",
         "callingTool": "调用工具 {name}..."
-      }
+      },
+      "searchSessions": "搜索会话",
+      "searchSessionsPlaceholder": "搜索会话标题",
+      "noSearchResults": "没有找到匹配的会话"
     }
   },
   "auth": {

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -173,6 +173,15 @@
                   {{ t('lens.chat.archivedSessions') }}
                 </button>
                 <button
+                  type="button"
+                  class="sessions-search-toggle"
+                  :aria-label="t('lens.chat.searchSessions')"
+                  :title="t('lens.chat.searchSessions')"
+                  @click="openSessionSearch"
+                >
+                  <Search :size="15" :stroke-width="2" aria-hidden="true" />
+                </button>
+                <button
                   v-if="!isMobile"
                   type="button"
                   class="sessions-collapse-toggle"
@@ -283,6 +292,44 @@
         />
       </div>
     </aside>
+
+    <BaseModal
+      :show="sessionSearchOpen"
+      :title="t('lens.chat.searchSessions')"
+      @close="closeSessionSearch"
+    >
+      <input
+        ref="sessionSearchInput"
+        v-model="sessionSearchQuery"
+        type="search"
+        class="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-theme outline-none focus:border-primary-500"
+        :placeholder="t('lens.chat.searchSessionsPlaceholder')"
+        :aria-label="t('lens.chat.searchSessions')"
+      />
+      <div class="mt-3 max-h-[50vh] space-y-1 overflow-y-auto">
+        <button
+          v-for="session in searchedSessions"
+          :key="session.uuid"
+          type="button"
+          class="session-search-result"
+          @click="selectSearchedSession(session)"
+        >
+          <span class="truncate">
+            {{ session.title || t('lens.chat.untitledSession') }}
+          </span>
+          <span class="session-search-result-state">
+            {{
+              session.archived
+                ? t('lens.chat.archivedSessions')
+                : t('lens.chat.sessions')
+            }}
+          </span>
+        </button>
+        <p v-if="!searchedSessions.length" class="session-list-empty">
+          {{ t('lens.chat.noSearchResults') }}
+        </p>
+      </div>
+    </BaseModal>
 
     <main class="main-shell">
       <div v-if="isMobile" class="mobile-topbar">
@@ -1783,6 +1830,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  Search,
   Share2,
   ThumbsDown,
   ThumbsUp,
@@ -1967,6 +2015,17 @@ const sidebarOpen = ref(false)
 const sidebarCollapsed = ref(false)
 const sessionHistoryCollapsed = ref(false)
 const showArchivedSessions = ref(false)
+const sessionSearchOpen = ref(false)
+const sessionSearchQuery = ref('')
+const sessionSearchInput = ref(null)
+const sessionSearchResults = ref([])
+const searchedSessions = computed(() => {
+  const query = sessionSearchQuery.value.trim().toLocaleLowerCase()
+  if (!query) return sessionSearchResults.value
+  return sessionSearchResults.value.filter((session) =>
+    (session.title || '').toLocaleLowerCase().includes(query)
+  )
+})
 const deleteSessionTarget = ref(null)
 const deletingSession = ref(false)
 const renamingSessionUuid = ref('')
@@ -3270,6 +3329,41 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
     clearSessionSelection()
   }
   await nextTick(() => composerRef.value?.focus())
+}
+
+async function openSessionSearch() {
+  sessionSearchOpen.value = true
+  sessionSearchQuery.value = ''
+  const slug = selectedAssistant.value?.slug || ''
+  try {
+    const routingMode = isSmartCollaborationConversation.value ? 'smart' : ''
+    const [recent, archived] = await Promise.all([
+      listSessions(slug, { routingMode }),
+      listSessions(slug, { archived: true, routingMode })
+    ])
+    sessionSearchResults.value = [
+      ...recent.map((session) => ({ ...session, archived: false })),
+      ...archived.map((session) => ({ ...session, archived: true }))
+    ]
+  } catch {
+    sessionSearchResults.value = []
+  }
+  await nextTick(() => sessionSearchInput.value?.focus())
+}
+
+function closeSessionSearch() {
+  sessionSearchOpen.value = false
+}
+
+async function selectSearchedSession(session) {
+  sessionSearchOpen.value = false
+  if (showArchivedSessions.value !== session.archived) {
+    showArchivedSessions.value = session.archived
+    sessions.value = sessionSearchResults.value.filter(
+      (item) => item.archived === session.archived
+    )
+  }
+  await selectSession(session)
 }
 
 async function createNewSession(notify = true, allowedAssistantUuids = []) {
@@ -4782,6 +4876,32 @@ onBeforeUnmount(() => {
 .session-filters button:hover,
 .session-filter-active {
   @apply bg-surface-hover text-theme;
+}
+
+.sessions-search-toggle {
+  @apply ml-auto flex h-7 w-7 items-center justify-center rounded-md
+    text-theme-muted transition-colors;
+}
+
+.sessions-search-toggle:hover,
+.sessions-search-toggle:focus-visible {
+  @apply bg-surface-hover text-theme;
+  outline: none;
+}
+
+.session-search-result {
+  @apply flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2
+    text-left text-sm text-theme transition-colors;
+}
+
+.session-search-result:hover,
+.session-search-result:focus-visible {
+  @apply bg-surface-hover;
+  outline: none;
+}
+
+.session-search-result-state {
+  @apply shrink-0 text-xs text-theme-subtle;
 }
 
 .sessions-collapse-toggle {

--- a/release-notes/538.yaml
+++ b/release-notes/538.yaml
@@ -1,0 +1,5 @@
+type: feature
+audience: user
+en: Added searchable conversation history across recent and archived sessions.
+zh-CN: 新增会话历史搜索，支持同时搜索最近会话和已归档会话。
+es: Añadida la búsqueda del historial de conversaciones recientes y archivadas.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Add a search action beside the Recent and Archived conversation tabs.
- Search recent and archived conversation titles in a centered dialog.
- Open a selected result directly and provide localized empty states.

Closes #436

## Test plan
- [x] `git diff --check`
- [ ] Frontend lint (eslint dependency unavailable in workspace)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add search icon in session filter bar for recent/archived conversations

- Implement centered search dialog with keyword filtering on session titles

- Load both recent and archived results, allow direct selection to open session

- Provide localized empty state and i18n entries for three languages


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Session sidebar filter bar"] --> B["Search icon click"]
  B --> C["openSessionSearch()"]
  C --> D["Load recent & archived sessions via listSessions()"]
  D --> E["BaseModal dialog"]
  E --> F["Input v-model=sessionSearchQuery"]
  F --> G["computed searchedSessions filters by title"]
  G --> H["Results list with buttons"]
  H -- click --> I["selectSearchedSession()"]
  I --> J["Close dialog & switch view if needed"]
  J --> K["selectSession(session)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Add search dialog and result handling in Chat.vue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added search toggle button with <code>Search</code> icon beside session filter <br>buttons<br> <li> New <code>openSessionSearch()</code>, <code>closeSessionSearch()</code>, <code>selectSearchedSession()</code> <br>methods<br> <li> <code>sessionSearchResults</code> and <code>searchedSessions</code> computed property for <br>client‑side filtering<br> <li> <code>BaseModal</code> dialog with search input and filtered result list, including <br>empty state<br> <li> Styles for <code>.sessions-search-toggle</code> and <code>.session-search-result</code> to match <br>existing design</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/543/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+120/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English i18n for search feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/en.json

<ul><li>Added three new keys under <code>lens.chat</code>: <code>searchSessions</code>, <br><code>searchSessionsPlaceholder</code>, <code>noSearchResults</code></ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/543/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>es.json</strong><dd><code>Add Spanish i18n for search feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/es.json

- Added Spanish translations for search dialog labels and empty state


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/543/files#diff-ba529cd8e421586279be00c1310ca7d73e9279c6738cd47b4228566944ef2bd2">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese i18n for search feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/zh-CN.json

<ul><li>Added Simplified Chinese translations for search dialog labels and <br>empty state</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/543/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>538.yaml</strong><dd><code>Add release note for search feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/538.yaml

<ul><li>Created release note with <code>feature</code> type, user‑facing, describing <br>searchable conversation history in three languages</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/543/files#diff-84b8925038753278b43ad22aafd324470fbc5ae976ccc81647f3dc88b6cde90f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

