### PR TITLE
Keep chat composer compact for long input

### DIFF
--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -1951,6 +1951,7 @@ let citationRequestId = 0
 
 const RUN_POLL_INTERVAL_MS = 3000
 const RUN_POLL_MAX_ATTEMPTS = 160
+const COMPOSER_MAX_HEIGHT = 200
 const TITLE_POLL_INTERVAL_MS = 2000
 const TITLE_POLL_MAX_ATTEMPTS = 15
 const streamError = ref('')
@@ -3700,7 +3701,8 @@ function autoResizeTextarea(el) {
   const target = el?.target ?? el
   if (!target) return
   target.style.height = 'auto'
-  target.style.height = Math.min(target.scrollHeight, 200) + 'px'
+  target.style.height =
+    Math.min(target.scrollHeight, COMPOSER_MAX_HEIGHT) + 'px'
 }
 
 async function handlePrimaryAction() {
@@ -5573,6 +5575,7 @@ onBeforeUnmount(() => {
 
 .composer {
   @apply flex items-center gap-3 rounded-xl border bg-surface px-4 py-2.5;
+  --composer-max-height: 200px;
   border-color: var(--sl-border-default);
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
 }
@@ -5609,8 +5612,9 @@ onBeforeUnmount(() => {
     leading-6 outline-none;
   color: var(--sl-text-primary);
   min-height: 2.5rem;
-  max-height: 200px;
+  max-height: var(--composer-max-height);
   resize: none;
+  overflow-x: hidden;
   overflow-y: auto;
   align-self: flex-end;
 }

--- a/frontend/tests/chatComposerKeyboard.test.js
+++ b/frontend/tests/chatComposerKeyboard.test.js
@@ -22,6 +22,19 @@ test('submits with Enter and preserves multiline input with Shift+Enter', async 
   assert.doesNotMatch(source, /@keydown\.ctrl\.enter/)
 })
 
+test('keeps long composer input scrollable within a bounded height', async () => {
+  const source = await readFile(
+    new URL('../src/pages/lens/Chat.vue', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(source, /const COMPOSER_MAX_HEIGHT = 200/)
+  assert.match(source, /Math\.min\(target\.scrollHeight, COMPOSER_MAX_HEIGHT\)/)
+  assert.match(source, /max-height: var\(--composer-max-height\)/)
+  assert.match(source, /overflow-y: auto/)
+  assert.match(source, /overflow-x: hidden/)
+})
+
 test('resolves only explicit non-composing Enter presses as actions', () => {
   assert.equal(resolveComposerEnterAction({ key: 'Enter' }), 'primary')
   assert.equal(

--- a/release-notes/443.yaml
+++ b/release-notes/443.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Keep the chat composer compact for long multiline messages by scrolling excess text inside the input area.
+zh-CN: 优化长文本输入体验：聊天输入框保持紧凑，超出内容在输入区域内滚动。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Bound the chat composer textarea to a readable maximum height.
- Keep excess multiline content scrollable inside the textarea.
- Add regression coverage while preserving existing keyboard behavior.

Closes #443

## Test plan
- [x] `node --test tests/chatComposerKeyboard.test.js`
- [x] `git diff --check`


___

### **PR Type**
Enhancement


___

### **Description**
- Bound composer textarea to a readable maximum height with vertical scrolling.

- Replace magic number with a CSS custom property for consistent max-height.

- Preserve keyboard submission, newline insertion, and short-message appearance.

- Add regression tests for the scrollable bounded input behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User types long text"] --> B["Textarea scrolls within bounded height"]
  B --> C["Compact composer maintained"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Bound textarea height and enable scroll</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Add <code>COMPOSER_MAX_HEIGHT</code> constant (200px) and replace inline <code>200</code> in <br><code>autoResizeTextarea</code>.<br> <li> Introduce <code>--composer-max-height</code> CSS custom property on <code>.composer</code>.<br> <li> Set <code>max-height: var(--composer-max-height)</code>, <code>overflow-x: hidden</code>, <br><code>overflow-y: auto</code> on <code>.composer-input</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/544/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatComposerKeyboard.test.js</strong><dd><code>Add regression test for compact composer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/tests/chatComposerKeyboard.test.js

<ul><li>Add regression test verifying <code>COMPOSER_MAX_HEIGHT</code>, <code>Math.min</code> with <br>variable, CSS variable in <code>max-height</code>, and <code>overflow-y: auto</code> / <br><code>overflow-x: hidden</code> in the template.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/544/files#diff-f4d6d900a93f82cf14902b6d1f0633c6fbee024330cfae0d056f12ca1564377c">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>443.yaml</strong><dd><code>Add release note entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/443.yaml

<ul><li>Add release note explaining the compact composer change in both <br>English and Chinese.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/544/files#diff-a372a27f873558038d8280c67abeaca1a614b7b2818bf6867ae4b08c73f9778f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

