### PR TITLE
Improve conversation history loading feedback

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -337,6 +337,7 @@
       "errorVisionProviderQuotaExceeded": "The vision provider quota or rate limit is exhausted. Please retry later or contact an administrator.",
       "errorVisionProviderUnavailable": "The vision provider is temporarily unavailable. Please retry later.",
       "retryAction": "Retry",
+      "sessionHistoryLoadFailed": "Conversation history could not be loaded.",
       "loadFailed": "Failed to load Lens chat.",
       "assistantNotFound": "The assistant you're trying to access doesn't exist. Please contact your administrator for a valid link.",
       "sessionAccessDenied": "You don't have access to this session, or it no longer exists. Select one of your recent sessions or start a new one.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -337,6 +337,7 @@
       "errorVisionProviderQuotaExceeded": "视觉服务配额或速率限制已用尽，请稍后重试或联系管理员。",
       "errorVisionProviderUnavailable": "视觉服务暂时不可用，请稍后重试。",
       "retryAction": "重试",
+      "sessionHistoryLoadFailed": "会话记录加载失败。",
       "loadFailed": "加载 Lens chat 失败。",
       "assistantNotFound": "你访问的助手不存在，请联系管理员获取有效的助手链接。",
       "sessionAccessDenied": "你无权访问该会话，或该会话已不存在。请从自己的最近会话中选择，或新建会话。",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -185,7 +185,11 @@
               </div>
             </div>
             <div class="sessions-list">
+              <div v-if="sessionsLoading" class="session-list-loading">
+                <BaseLoading />
+              </div>
               <div
+                v-else
                 v-for="session in sessions"
                 :key="session.uuid"
                 class="session-item"
@@ -262,7 +266,13 @@
                   </div>
                 </template>
               </div>
-              <p v-if="!sessions.length" class="session-list-empty">
+              <div v-if="sessionsError" class="session-list-error">
+                <p>{{ t('lens.chat.sessionHistoryLoadFailed') }}</p>
+                <button type="button" @click="retrySessions">
+                  {{ t('lens.chat.retryAction') }}
+                </button>
+              </div>
+              <p v-else-if="!sessionsLoading && !sessions.length" class="session-list-empty">
                 {{
                   showArchivedSessions
                     ? t('lens.chat.noArchivedSessions')
@@ -374,8 +384,17 @@
             <AssistantEmptyState :variant="emptyVariant" />
           </div>
           <div v-else class="thread">
+            <div v-if="messageLoading" class="thread-loading">
+              <BaseLoading />
+            </div>
+            <div v-else-if="messageError" class="thread-load-error">
+              <p>{{ t('lens.chat.sessionHistoryLoadFailed') }}</p>
+              <button type="button" @click="retrySelectedSession">
+                {{ t('lens.chat.retryAction') }}
+              </button>
+            </div>
             <div
-              v-if="isMobile && !decoratedMessages.length && !showLiveAnswer"
+              v-else-if="isMobile && !decoratedMessages.length && !showLiveAnswer"
               class="chat-welcome"
             >
               <p class="chat-welcome-assistant">{{ assistantName }}</p>
@@ -1935,6 +1954,10 @@ const sessionActivity = useSessionActivity()
 const assistants = ref([])
 const sessions = ref([])
 const messages = ref([])
+const sessionsLoading = ref(false)
+const sessionsError = ref(false)
+const messageLoading = ref(false)
+const messageError = ref(false)
 const feedbackUpdatingRuns = ref(new Set())
 const selectedAssistantUuid = ref('')
 const selectedSessionUuid = ref('')
@@ -3144,6 +3167,10 @@ async function bootstrap() {
   showArchivedSessions.value = false
   resetStreamState()
   booted.value = false
+  sessionsLoading.value = false
+  sessionsError.value = false
+  messageLoading.value = false
+  messageError.value = false
 
   // Anonymous visitors can browse the shared chat page and see the
   // assistant name, but only authenticated users load private sessions.
@@ -3243,16 +3270,29 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
   }
 
   const loadGeneration = ++sessionLoadGeneration
-  const loadedSessions = await listSessions(
-    selectedAssistant.value?.slug || '',
-    {
-      routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
-      archived: showArchivedSessions.value
+  sessionsLoading.value = true
+  sessionsError.value = false
+  let loadedSessions
+  try {
+    loadedSessions = await listSessions(
+      selectedAssistant.value?.slug || '',
+      {
+        routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
+        archived: showArchivedSessions.value
+      }
+    )
+  } catch {
+    if (loadGeneration === sessionLoadGeneration) {
+      sessionsError.value = true
+      sessions.value = []
+      sessionsLoading.value = false
     }
-  )
+    return
+  }
   if (loadGeneration !== sessionLoadGeneration) return
 
   sessions.value = loadedSessions
+  sessionsLoading.value = false
 
   const requestedUuid =
     selectUuid || (useRouteSession ? route.query.session || '' : '')
@@ -3730,6 +3770,11 @@ async function selectSession(session, updateRoute = true) {
   clearAttachments()
   selectedSessionUuid.value = session.uuid
   runStatusResolvingSessionUuid.value = session.uuid
+  messageLoading.value = true
+  messageError.value = false
+  if (sessionChanged) {
+    messages.value = []
+  }
   let loadedMessages
   try {
     loadedMessages = await listMessages(session.uuid)
@@ -3738,12 +3783,18 @@ async function selectSession(session, updateRoute = true) {
     finishRunStatusResolution()
     if ([403, 404].includes(error?.response?.status)) {
       showError(t('lens.chat.sessionAccessDenied'))
+      messageError.value = true
+      messageLoading.value = false
       return
     }
-    throw error
+    messageError.value = true
+    messageLoading.value = false
+    booted.value = true
+    return
   }
   if (!isCurrentLoad()) return
   messages.value = loadedMessages
+  messageLoading.value = false
   // Session history is ready for display. An active run's SSE can stay open
   // for minutes, so it must not keep the whole chat behind the page loader.
   booted.value = true
@@ -3766,6 +3817,15 @@ async function selectSession(session, updateRoute = true) {
   clearUnreadSession(window.localStorage, session.uuid)
   refreshUnreadSessions()
   await maybeResumeActiveRun(session.uuid, isCurrentLoad)
+}
+
+function retrySessions() {
+  return loadSessions('', { useRouteSession: true })
+}
+
+function retrySelectedSession() {
+  if (!selectedSessionUuid.value) return Promise.resolve()
+  return selectSession({ uuid: selectedSessionUuid.value }, false)
 }
 
 // If the session has a run still in progress (e.g. the user navigated away

--- a/release-notes/440.yaml
+++ b/release-notes/440.yaml
@@ -1,0 +1,4 @@
+type: improvement
+audience: user
+en: Improved conversation startup feedback with explicit loading, empty, and retry states while restoring session history.
+zh-CN: 优化会话启动反馈，在恢复会话历史时明确展示加载、空列表和重试状态。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Add explicit loading feedback for session list and conversation history restoration.
- Distinguish loading, empty, and failed session states with retry actions.
- Preserve the selected conversation while messages load or recover from errors.

Closes #440

## Test plan
- [x] `git diff --check`
- [x] Locale JSON validation
- [x] Frontend unit tests (498 passed; 7 blocked by missing local dependencies)
- [ ] ESLint (blocked because dependencies are not installed)


___

### **PR Type**
Enhancement


___

### **Description**
- Add loading skeleton for session list and messages.

- Distinguish loading, empty, and error states.

- Provide retry actions for session and message failures.

- Update locales and add release note.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Open conversation"] --> B{Load sessions}
  B -->|Loading| C["Session list skeleton"]
  B -->|Success| D["Display sessions"]
  B -->|Error| E["Show error + retry button"]
  D --> F{Load messages}
  F -->|Loading| G["Message loading skeleton"]
  F -->|Success| H["Display messages"]
  F -->|Error| I["Show error + retry button"]
  E --> J["Retry sessions"]
  I --> K["Retry messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chat.vue</strong><dd><code>Add loading skeleton and error handling for sessions and messages</code></dd></summary>
<hr>

frontend/src/pages/lens/Chat.vue

<ul><li>Added <code>sessionsLoading</code>, <code>sessionsError</code>, <code>messageLoading</code>, <code>messageError</code> <br>reactive refs.<br> <li> Show <code><BaseLoading></code> skeleton while sessions or messages are loading.<br> <li> Show error state with retry button when loading fails.<br> <li> Modified <code>loadSessions()</code> and <code>selectSession()</code> to set loading/error <br>states.<br> <li> Added <code>retrySessions()</code> and <code>retrySelectedSession()</code> functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/545/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+69/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English locale for load failure message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/en.json

<ul><li>Added locale key <code>sessionHistoryLoadFailed</code> with value "Conversation <br>history could not be loaded."</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/545/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.json</strong><dd><code>Add Chinese locale for load failure message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/locales/zh-CN.json

- Added locale key `sessionHistoryLoadFailed` with value "会话记录加载失败。"


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/545/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>440.yaml</strong><dd><code>Add release note for loading feedback improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/440.yaml

<ul><li>New release note file describing improvement for conversation startup <br>feedback.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/545/files#diff-ba10fb3cad17dbd3c00a6a6b3db1520c31422c392d430f62774635f46bba8699">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

