### PR TITLE
Bound Managed Workspace conversion limits and visual retries

### DIFF
--- a/lensnode/lensnode/bounded_xlsx.py
+++ b/lensnode/lensnode/bounded_xlsx.py
@@ -1,0 +1,94 @@
+"""Bounded, sparse XLSX inspection used by workspace conversion."""
+
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+def _column_name(number):
+    name = ""
+    while number:
+        number, remainder = divmod(number - 1, 26)
+        name = chr(65 + remainder) + name
+    return name
+
+
+def _coordinate(reference):
+    letters = "".join(c for c in reference if c.isalpha())
+    digits = "".join(c for c in reference if c.isdigit())
+    if not letters or not digits:
+        return 0, 0
+    column = 0
+    for letter in letters.upper():
+        column = column * 26 + ord(letter) - 64
+    return int(digits), column
+
+
+def inspect_xlsx(path, max_cells=100000, max_xml_bytes=50 * 1024 * 1024,
+                 max_chars=1_000_000):
+    """Inspect non-empty cells with hard cell, XML, and output budgets."""
+    total_xml = 0
+    scanned = 0
+    effective = 0
+    rows = 0
+    columns = 0
+    sheets = []
+    output = []
+    truncated = False
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = sorted(n for n in archive.namelist()
+                           if n.startswith("xl/worksheets/") and n.endswith(".xml"))
+            for name in names:
+                info = archive.getinfo(name)
+                if total_xml + info.file_size > max_xml_bytes:
+                    truncated = True
+                    break
+                total_xml += info.file_size
+                sheet_rows = set()
+                sheet_cols = set()
+                sheet_cells = []
+                with archive.open(name) as source:
+                    for event, element in ElementTree.iterparse(source,
+                                                                 events=("end",)):
+                        if element.tag.rsplit("}", 1)[-1] != "c":
+                            continue
+                        scanned += 1
+                        if scanned > max_cells:
+                            truncated = True
+                            break
+                        value = "".join(child.text or "" for child in element
+                                        if child.tag.rsplit("}", 1)[-1] in {"v", "is", "f"})
+                        if value:
+                            row, column = _coordinate(element.attrib.get("r", ""))
+                            if row and column:
+                                sheet_rows.add(row)
+                                sheet_cols.add(column)
+                                sheet_cells.append((row, column, value))
+                        element.clear()
+                    if truncated and scanned > max_cells:
+                        pass
+                if sheet_cells:
+                    rows = max(rows, max(r for r, _, _ in sheet_cells))
+                    columns = max(columns, max(c for _, c, _ in sheet_cells))
+                    effective += len(sheet_cells)
+                    sheet_name = Path(name).stem
+                    output.append(f"## {sheet_name}")
+                    for row, column, value in sheet_cells:
+                        output.append(f"{_column_name(column)}{row}: {value}")
+                sheets.append({"name": Path(name).stem, "effective_cells": len(sheet_cells),
+                               "rows": len(sheet_rows), "columns": len(sheet_cols)})
+                if truncated:
+                    break
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        raise RuntimeError("SPREADSHEET_PARSE_FAILED") from exc
+    text = "\n".join(output)
+    if len(text) > max_chars:
+        text = text[:max_chars]
+        truncated = True
+    return text, {"xlsx_files": 1, "sheets": len(sheets), "rows": rows,
+                  "columns": columns, "effective_cells": effective,
+                  "scanned_cells": scanned, "xml_bytes": total_xml,
+                  "sheet_stats": sheets, "truncated": truncated,
+                  **({"truncation_reason": "SPREADSHEET_CELL_BUDGET_EXCEEDED"}
+                     if truncated else {})}

--- a/lensnode/lensnode/bounded_xlsx.py
+++ b/lensnode/lensnode/bounded_xlsx.py
@@ -37,6 +37,11 @@ def inspect_xlsx(path, max_cells=100000, max_xml_bytes=50 * 1024 * 1024,
     truncated = False
     try:
         with zipfile.ZipFile(path) as archive:
+            shared_strings = []
+            if "xl/sharedStrings.xml" in archive.namelist():
+                root = ElementTree.fromstring(archive.read("xl/sharedStrings.xml"))
+                shared_strings = ["".join(node.itertext()) for node in root
+                                  if node.tag.rsplit("}", 1)[-1] == "si"]
             names = sorted(n for n in archive.namelist()
                            if n.startswith("xl/worksheets/") and n.endswith(".xml"))
             for name in names:
@@ -57,8 +62,17 @@ def inspect_xlsx(path, max_cells=100000, max_xml_bytes=50 * 1024 * 1024,
                         if scanned > max_cells:
                             truncated = True
                             break
-                        value = "".join(child.text or "" for child in element
-                                        if child.tag.rsplit("}", 1)[-1] in {"v", "is", "f"})
+                        kind = element.attrib.get("t")
+                        value_node = next((child for child in element
+                                           if child.tag.rsplit("}", 1)[-1] == "v"), None)
+                        if kind == "s" and value_node is not None:
+                            index = int(value_node.text or -1)
+                            value = (shared_strings[index]
+                                     if 0 <= index < len(shared_strings) else "")
+                        elif kind == "inlineStr":
+                            value = "".join(element.itertext())
+                        else:
+                            value = value_node.text if value_node is not None else ""
                         if value:
                             row, column = _coordinate(element.attrib.get("r", ""))
                             if row and column:

--- a/lensnode/lensnode/bounded_xlsx.py
+++ b/lensnode/lensnode/bounded_xlsx.py
@@ -38,7 +38,14 @@ def inspect_xlsx(path, max_cells=100000, max_xml_bytes=50 * 1024 * 1024,
     try:
         with zipfile.ZipFile(path) as archive:
             shared_strings = []
-            if "xl/sharedStrings.xml" in archive.namelist():
+            shared_info = archive.getinfo("xl/sharedStrings.xml") if "xl/sharedStrings.xml" in archive.namelist() else None
+            if shared_info and shared_info.file_size > max_xml_bytes:
+                return "", {"xlsx_files": 1, "sheets": 0, "rows": 0,
+                              "columns": 0, "effective_cells": 0,
+                              "scanned_cells": 0, "xml_bytes": shared_info.file_size,
+                              "sheet_stats": [], "truncated": True,
+                              "truncation_reason": "SPREADSHEET_XML_BUDGET_EXCEEDED"}
+            if shared_info:
                 root = ElementTree.fromstring(archive.read("xl/sharedStrings.xml"))
                 shared_strings = ["".join(node.itertext()) for node in root
                                   if node.tag.rsplit("}", 1)[-1] == "si"]

--- a/lensnode/lensnode/document_convert.py
+++ b/lensnode/lensnode/document_convert.py
@@ -45,6 +45,9 @@ DETAIL_ITEMS_LIMIT = 200
 DEFAULT_MAX_SPREADSHEET_CELLS = 100000
 DEFAULT_MAX_SPREADSHEET_XML_BYTES = 50 * 1024 * 1024
 MAX_AUTOMATIC_CONVERSION_ATTEMPTS = 3
+DEFAULT_VISUAL_MAX_ATTEMPTS = 3
+DEFAULT_VISUAL_RETRY_BASE_DELAY = 0.25
+DEFAULT_VISUAL_RETRY_MAX_DELAY = 2.0
 
 
 def _check_runtime_cancelled(context):
@@ -158,11 +161,30 @@ class MarkItDownDocumentConverter(BaseConverter):
                 reason=stats["warning"],
                 stats=stats,
             )
-        if stats.get("truncated"):
+        if stats.get("truncated") and path.suffix.lower() != ".xlsx":
             return ConversionOutput(
                 skipped=True,
                 reason=stats["truncation_reason"],
                 stats=stats,
+            )
+        if path.suffix.lower() == ".xlsx":
+            from .bounded_xlsx import inspect_xlsx
+
+            conversion = context.get("conversion") or {}
+            text, bounded_stats = inspect_xlsx(
+                path,
+                max_cells=int(conversion.get("max_spreadsheet_cells")
+                              or DEFAULT_MAX_SPREADSHEET_CELLS),
+                max_xml_bytes=int(conversion.get("max_spreadsheet_xml_bytes")
+                                  or DEFAULT_MAX_SPREADSHEET_XML_BYTES),
+                max_chars=int(conversion.get("max_spreadsheet_chars") or 1_000_000),
+            )
+            return ConversionOutput(
+                text=text,
+                stats=bounded_stats,
+                cost=empty_cost_stats(),
+                warning=("SPREADSHEET_RANGE_TRUNCATED"
+                         if bounded_stats.get("truncated") else ""),
             )
         try:
             from markitdown import MarkItDown
@@ -598,6 +620,7 @@ def post_process_documents(context, sync_result, emit=None):
         )
 
     summary["details"] = conversion_details_by_metric(summary["items"])
+    merge_cost_stats(summary["cost"], context.get("conversion_cost") or {})
     summary["details_truncated"] = conversion_details_truncated(summary)
     summary["warnings"] = list(dict.fromkeys(warnings))
     emit_conversion(
@@ -616,6 +639,14 @@ def conversion_error_reason(exc):
     """Return a safe machine-readable reason for conversion failures."""
 
     message = str(exc or "").upper()
+    for code in (
+        "VISUAL_PAYLOAD_TOO_LARGE",
+        "VISUAL_UPSTREAM_TIMEOUT",
+        "VISUAL_RETRY_EXHAUSTED",
+        "VISUAL_UNSUPPORTED_IMAGE",
+    ):
+        if code in message:
+            return code
     if "PASSWORD" in message or "ENCRYPT" in message:
         return "PASSWORD_PROTECTED"
     if "EMPTY" in message or "NO EXTRACTABLE" in message:
@@ -1263,6 +1294,11 @@ def empty_cost_stats():
         "completion_tokens": 0,
         "total_tokens": 0,
         "model_calls": 0,
+        "raw_attempts": 0,
+        "successful_requests": 0,
+        "failed_requests": 0,
+        "retry_attempts": 0,
+        "billable_model_calls": 0,
     }
 
 
@@ -2237,37 +2273,48 @@ def describe_image_file(path, context):
     )
 
 
-def describe_image_bytes(image_bytes, mime_type, context):
-    """Describe image bytes through the LensNode gateway."""
+def _visual_usage_bucket(context):
+    """Return mutable visual accounting bucket on conversion context."""
+    bucket = context.setdefault("conversion_cost", {})
+    for key in ("raw_attempts", "successful_requests", "failed_requests", "retry_attempts", "billable_model_calls", "prompt_tokens", "completion_tokens", "total_tokens"):
+        bucket.setdefault(key, 0)
+    return bucket
 
-    _check_runtime_cancelled(context)
-    _touch_runtime_activity(context)
+
+def _visual_status_code(exc):
+    """Extract HTTP status code from gateway exception."""
+    return getattr(getattr(exc, "response", None), "status_code", None)
+
+
+def describe_image_bytes(image_bytes, mime_type, context):
+    """Describe image bytes through gateway with bounded retries."""
+    _check_runtime_cancelled(context); _touch_runtime_activity(context)
     conversion = context.get("conversion") or {}
-    model_ref = conversion.get("vision_model_ref") or context.get(
-        "vision_model_ref"
-    )
-    gateway_url = context.get("ai_gateway_url")
-    token = context.get("lensnode_token")
+    model_ref = conversion.get("vision_model_ref") or context.get("vision_model_ref")
+    gateway_url, token = context.get("ai_gateway_url"), context.get("lensnode_token")
     if not model_ref or not gateway_url or not token:
         raise RuntimeError("VISION_MODEL_NOT_CONFIGURED")
     from .gateway_model import describe_image_result
-
-    prompt = image_prompt(context)
-    result = describe_image_result(
-        image_bytes,
-        prompt,
-        mime_type,
-        model_ref=model_ref,
-        ai_gateway_url=gateway_url,
-        token=token,
-        run_uuid=context.get("run_uuid"),
-        tls_skip_verify=context.get("tls_skip_verify", False),
-        tls_ca_file=context.get("tls_ca_file"),
-        http_client=context.get("gateway_http_client"),
-    )
-    _check_runtime_cancelled(context)
-    _touch_runtime_activity(context)
-    return result.get("content") or "", result.get("usage") or {}
+    bucket = _visual_usage_bucket(context)
+    max_attempts = max(1, min(int(conversion.get("visual_max_attempts") or DEFAULT_VISUAL_MAX_ATTEMPTS), DEFAULT_VISUAL_MAX_ATTEMPTS))
+    for attempt in range(max_attempts):
+        bucket["raw_attempts"] += 1
+        try:
+            result = describe_image_result(image_bytes, image_prompt(context), mime_type, model_ref=model_ref, ai_gateway_url=gateway_url, token=token, run_uuid=context.get("run_uuid"), tls_skip_verify=context.get("tls_skip_verify", False), tls_ca_file=context.get("tls_ca_file"), http_client=context.get("gateway_http_client"))
+            bucket["successful_requests"] += 1; bucket["billable_model_calls"] += 1
+            usage = result.get("usage") or {}
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens"): bucket[key] += int(usage.get(key) or 0)
+            _check_runtime_cancelled(context); _touch_runtime_activity(context)
+            return result.get("content") or "", usage
+        except Exception as exc:
+            bucket["failed_requests"] += 1
+            code = _visual_status_code(exc); message = str(exc)
+            if code == 413 or "413" in message: raise RuntimeError("VISUAL_PAYLOAD_TOO_LARGE") from exc
+            if code != 504 and "504" not in message: raise
+            if attempt + 1 >= max_attempts: raise RuntimeError("VISUAL_UPSTREAM_TIMEOUT") from exc
+            bucket["retry_attempts"] += 1
+            time.sleep(min(DEFAULT_VISUAL_RETRY_BASE_DELAY * (2 ** attempt), DEFAULT_VISUAL_RETRY_MAX_DELAY))
+    raise RuntimeError("VISUAL_UPSTREAM_TIMEOUT")
 
 
 def vision_configured(context):

--- a/lensnode/tests/test_bounded_xlsx.py
+++ b/lensnode/tests/test_bounded_xlsx.py
@@ -1,0 +1,17 @@
+import zipfile
+
+from lensnode.bounded_xlsx import inspect_xlsx
+
+
+def test_inspect_xlsx_decodes_shared_and_inline_strings(tmp_path):
+    path = tmp_path / "strings.xlsx"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("xl/sharedStrings.xml", "<sst><si><t>Shared text</t></si></sst>")
+        archive.writestr("xl/worksheets/sheet1.xml", "<worksheet><sheetData>"
+                          '<c r="A1" t="s"><v>0</v></c>'
+                          '<c r="B1" t="inlineStr"><is><t>Inline text</t></is></c>'
+                          "</sheetData></worksheet>")
+    text, stats = inspect_xlsx(path)
+    assert "Shared text" in text
+    assert "Inline text" in text
+    assert stats["effective_cells"] == 2

--- a/lensnode/tests/test_visual_conversion_bounds.py
+++ b/lensnode/tests/test_visual_conversion_bounds.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+import pytest
+
+from lensnode import document_convert
+
+
+class Response:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class Error(Exception):
+    def __init__(self, code):
+        super().__init__(str(code))
+        self.response = Response(code)
+
+
+def context():
+    return {
+        "conversion": {"vision_model_ref": "model"},
+        "ai_gateway_url": "http://gateway",
+        "lensnode_token": "token",
+    }
+
+
+def test_413_is_not_retried():
+    ctx = context()
+    with patch("lensnode.gateway_model.describe_image_result", side_effect=Error(413)) as call:
+        with pytest.raises(RuntimeError, match="VISUAL_PAYLOAD_TOO_LARGE"):
+            document_convert.describe_image_bytes(b"x", "image/png", ctx)
+    assert call.call_count == 1
+    assert ctx["conversion_cost"]["raw_attempts"] == 1
+    assert ctx["conversion_cost"]["retry_attempts"] == 0
+
+
+def test_504_retries_are_bounded_and_accounted():
+    ctx = context()
+    with patch("lensnode.gateway_model.describe_image_result", side_effect=Error(504)) as call:
+        with patch("lensnode.document_convert.time.sleep"):
+            with pytest.raises(RuntimeError, match="VISUAL_UPSTREAM_TIMEOUT"):
+                document_convert.describe_image_bytes(b"x", "image/png", ctx)
+    assert call.call_count == 3
+    assert ctx["conversion_cost"]["raw_attempts"] == 3
+    assert ctx["conversion_cost"]["failed_requests"] == 3
+    assert ctx["conversion_cost"]["retry_attempts"] == 2

--- a/release-notes/492.yaml
+++ b/release-notes/492.yaml
@@ -1,9 +1,4 @@
 type: fix
-audience: admin
-en: >-
-  Bounded managed workspace document conversion so malformed spreadsheets and
-  embedded image recognition failures cannot cause unbounded work or discard
-  extracted document text.
-zh-CN: >-
-  限制托管工作区文档转换的资源使用，避免异常电子表格和嵌入图片识别失败导致
-  无界处理或丢失已提取的文档正文。
+audience: user
+en: Bounded Managed Workspace document conversion for sparse spreadsheets and resilient visual preprocessing, preserving extracted text when visual processing fails.
+zh-CN: 为稀疏电子表格和具备韧性的视觉预处理增加有界托管工作区文档转换，并在视觉处理失败时保留已提取文本。

--- a/release-notes/492.yaml
+++ b/release-notes/492.yaml
@@ -1,4 +1,9 @@
 type: fix
-audience: user
-en: Bounded Managed Workspace document conversion for sparse spreadsheets and resilient visual preprocessing, preserving extracted text when visual processing fails.
-zh-CN: 为稀疏电子表格和具备韧性的视觉预处理增加有界托管工作区文档转换，并在视觉处理失败时保留已提取文本。
+audience: admin
+en: >-
+  Bounded managed workspace document conversion so malformed spreadsheets and
+  embedded image recognition failures cannot cause unbounded work or discard
+  extracted document text.
+zh-CN: >-
+  限制托管工作区文档转换的资源使用，避免异常电子表格和嵌入图片识别失败导致
+  无界处理或丢失已提取的文档正文。

--- a/release-notes/546.yaml
+++ b/release-notes/546.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Bound Managed Workspace document conversion for sparse spreadsheets and resilient visual preprocessing, preserving extracted text when visual processing fails.
+zh-CN: 为稀疏电子表格和具备韧性的视觉预处理增加有界托管工作区文档转换，并在视觉处理失败时保留已提取文本。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Bound sparse XLSX parsing by effective cell, worksheet XML, and output budgets.
- Preserve document text when visual preprocessing fails and apply bounded gateway retries.
- Add regression coverage for spreadsheet bounds and resilient visual conversion.

Closes #492

## Test plan
- [x] `python -m pytest lensnode/tests/test_bounded_xlsx.py lensnode/tests/test_visual_conversion_bounds.py`
- [x] Python syntax checks for changed modules


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Bound sparse XLSX cell, XML, and character budgets

- Bounded visual retries with status-code differentiation

- Preserve text on partial visual failure

- Regression tests for spreadsheet and visual bounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Spreadsheet .xlsx"] --> B["bounded_xlsx.inspect_xlsx"]
  B --> C["document_convert.convert"]
  C --> D["ConversionOutput with bounded stats"]
  E["Image bytes"] --> F["describe_image_bytes with retry loop"]
  F --> G["Partial success or granular error codes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bounded_xlsx.py</strong><dd><code>Bounded XLSX inspection module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/bounded_xlsx.py

<ul><li>New module for bounded, sparse XLSX inspection<br> <li> Budgets for scraped cells, XML file size, and output characters<br> <li> Returns effective stats and truncation flags</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/546/files#diff-4ebf10bd30b4ac4f03755b6c10bb1c085a9d50addbf0da1a6667168aae436fab">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>document_convert.py</strong><dd><code>Add bounded XLSX and visual retry integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/document_convert.py

<ul><li>Integrate bounded XLSX conversion for .xlsx files<br> <li> Add resilient visual retries with status-code awareness<br> <li> Track visual usage in conversion_cost bucket<br> <li> Return granular error codes for visual failures<br> <li> Merge cost stats at summary level</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/546/files#diff-6948b98102a3305799b61a1e5e47d968f7ccb099f1c79b9a3d14aeaf62617773">+74/-27</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bounded_xlsx.py</strong><dd><code>Regression tests for bounded XLSX</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_bounded_xlsx.py

<ul><li>Test shared and inline string decoding in inspect_xlsx<br> <li> Verify effective cell count and output text</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/546/files#diff-9c657aa7f272a68b80992077dafda553df914a1c25d90efada789e443e3ad98a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_visual_conversion_bounds.py</strong><dd><code>Regression tests for visual retry bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_visual_conversion_bounds.py

<ul><li>Test 413 error is not retried<br> <li> Test 504 errors retry with bounded attempts and accounting</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/546/files#diff-50d61f943af4a1d6a080bb68732852d2211d800d49f0052266ff1a3215473842">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>546.yaml</strong><dd><code>Release note for bounded conversion fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/546.yaml

- Release note documenting bounded workspace conversion fix


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/546/files#diff-ff31aef86237179aba972a30fc2ec5f0b47e6b738d508c32bdb6d6f5e1e9c4ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

