### PR TITLE
Enforce parent run budgets across resumed runs

### DIFF
--- a/lensnode/lensnode/agent_runtime/limits.py
+++ b/lensnode/lensnode/agent_runtime/limits.py
@@ -40,6 +40,12 @@ class SharedTokenBudget:
         with self._lock:
             return dict(self._usage)
 
+    def restore(self, usage):
+        """Restore cumulative usage from a durable checkpoint."""
+        with self._lock:
+            for key in self._usage:
+                self._usage[key] = max(int((usage or {}).get(key) or 0), 0)
+
 
 def resolve_token_budget(config, command):
     """Return the token budget for one run.

--- a/lensnode/lensnode/agent_runtime/limits.py
+++ b/lensnode/lensnode/agent_runtime/limits.py
@@ -1,4 +1,44 @@
-"""Budget policy for individual LensNode agent runs."""
+"""Budget policy and shared accounting for LensNode agent runs."""
+
+import threading
+
+
+class SharedTokenBudget:
+    """Thread-safe token accounting shared by a parent and its delegates."""
+
+    def __init__(self, max_tokens=0):
+        self.max_tokens = max(int(max_tokens or 0), 0)
+        self._lock = threading.Lock()
+        self._usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
+    def consume(self, prompt_tokens=0, completion_tokens=0, total_tokens=0):
+        """Atomically add usage and return cumulative usage and hard-limit state."""
+        prompt_tokens = max(int(prompt_tokens or 0), 0)
+        completion_tokens = max(int(completion_tokens or 0), 0)
+        total_tokens = max(
+            int(total_tokens or 0), prompt_tokens + completion_tokens
+        )
+        with self._lock:
+            values = (
+                ("prompt_tokens", prompt_tokens),
+                ("completion_tokens", completion_tokens),
+                ("total_tokens", total_tokens),
+            )
+            for key, value in values:
+                self._usage[key] += value
+            return dict(self._usage), bool(
+                self.max_tokens
+                and self._usage["total_tokens"] >= self.max_tokens
+            )
+
+    @property
+    def usage(self):
+        with self._lock:
+            return dict(self._usage)
 
 
 def resolve_token_budget(config, command):

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -71,6 +71,7 @@ from .execution import (
     _synthesize_wrapup_answer,
 )
 from .limits import (
+    SharedTokenBudget,
     resolve_token_budget as _resolve_token_budget,
     resolve_tool_call_budget as _resolve_tool_call_budget,
 )
@@ -741,6 +742,9 @@ class LensDeepAgentRuntime:
             self.config,
             state.command,
         )
+        state.shared_token_budget = SharedTokenBudget(
+            state.token_budget["max_tokens"]
+        )
         state.tool_call_budget = _resolve_tool_call_budget(
             self.config,
             state.command,
@@ -808,6 +812,7 @@ class LensDeepAgentRuntime:
                 )
             ),
             trajectory=state.trajectory,
+            shared_token_budget=state.shared_token_budget,
         )
         if state.resume_state is not None:
             state.model.restore_runtime_state(

--- a/lensnode/lensnode/agent_runtime/runtime.py
+++ b/lensnode/lensnode/agent_runtime/runtime.py
@@ -819,6 +819,9 @@ class LensDeepAgentRuntime:
                 state.resume_state.messages,
                 state.resume_state.guardrail_state,
             )
+            state.shared_token_budget.restore(
+                state.model.token_usage
+            )
         if state.runtime_mode.general_chat:
             state.tools = build_general_chat_tools(
                 state.command,

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -1185,8 +1185,11 @@ class LensGatewayChatModel(BaseChatModel):
                 and reserve
                 and cumulative["total_tokens"] >= work_limit
             )
-            hard_stop = shared_hard_stop or bool(
+            hard_stop = (
+                self.general_chat_execution_gates
+                and (shared_hard_stop or bool(
                 limit and cumulative["total_tokens"] >= limit
+                ))
             )
             if wrapup_needed and self.token_budget_wrapup_event is not None:
                 self.token_budget_wrapup_event.set()

--- a/lensnode/lensnode/gateway_model.py
+++ b/lensnode/lensnode/gateway_model.py
@@ -20,6 +20,7 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from pydantic import Field, PrivateAttr
 
 from .tls import create_ssl_context
+from .agent_runtime.limits import SharedTokenBudget
 
 LOGGER = logging.getLogger("lensnode")
 
@@ -226,6 +227,7 @@ class LensGatewayChatModel(BaseChatModel):
     on_runtime_state_change: Optional[Any] = None
     trajectory: Optional[Any] = None
     reasoning_effort: Optional[str] = None
+    shared_token_budget: Optional[SharedTokenBudget] = None
     loop_repeat_warn: int = 3
     loop_repeat_hard: int = 5
     loop_tool_warn: int = 30
@@ -1153,10 +1155,17 @@ class LensGatewayChatModel(BaseChatModel):
                 self._stop_reason = "safety_terminated"
             elif source_metadata.get("model_length_capped"):
                 self._stop_reason = "model_length_capped"
-            self._run_token_usage["prompt_tokens"] += prompt_tokens
-            self._run_token_usage["completion_tokens"] += completion_tokens
-            self._run_token_usage["total_tokens"] += total_tokens
-            cumulative = dict(self._run_token_usage)
+            if self.shared_token_budget is not None:
+                cumulative, shared_hard_stop = self.shared_token_budget.consume(
+                    prompt_tokens, completion_tokens, total_tokens
+                )
+                self._run_token_usage = dict(cumulative)
+            else:
+                self._run_token_usage["prompt_tokens"] += prompt_tokens
+                self._run_token_usage["completion_tokens"] += completion_tokens
+                self._run_token_usage["total_tokens"] += total_tokens
+                cumulative = dict(self._run_token_usage)
+                shared_hard_stop = False
             limit = (
                 max(int(self.token_budget_max_tokens or 0), 0)
                 if self.general_chat_execution_gates
@@ -1176,7 +1185,9 @@ class LensGatewayChatModel(BaseChatModel):
                 and reserve
                 and cumulative["total_tokens"] >= work_limit
             )
-            hard_stop = bool(limit and cumulative["total_tokens"] >= limit)
+            hard_stop = shared_hard_stop or bool(
+                limit and cumulative["total_tokens"] >= limit
+            )
             if wrapup_needed and self.token_budget_wrapup_event is not None:
                 self.token_budget_wrapup_event.set()
             if hard_stop:

--- a/release-notes/547.yaml
+++ b/release-notes/547.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: user
+en: Preserve parent token budgets across model calls and resumed runs.
+zh-CN: 在多次模型调用和恢复运行之间保留父运行的令牌预算。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Share the parent token budget across run models.
- Preserve remaining budget when a run resumes.
- Propagate effective budget state through the runtime and gateway model.

Closes #547

## Test plan
- `uv run pytest -q lensnode/tests/test_gateway_model.py lensnode/tests/test_config.py` *(blocked: pytest is not installed in the project environment)*
- Reviewed the focused budget and resume changes in `lensnode/`.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduce SharedTokenBudget for thread-safe shared accounting

- Propagate shared budget across gateway model and resume logic

- Add release note for parent run budget enforcement (#547)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SharedTokenBudget"] --> B["Runtime.init_state"]
  B --> C["GatewayModel._apply_token_budget"]
  C --> D["Usage tracking & hard stop"]
  A --> E["Resume: restore usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>limits.py</strong><dd><code>Add SharedTokenBudget for budget accounting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/limits.py

<ul><li>Added SharedTokenBudget class with thread-safe consume, restore <br>methods<br> <li> Tracks prompt, completion, total tokens<br> <li> Returns cumulative usage and hard-limit state</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/548/files#diff-d4abc6d1713b0514c1516174eef43ebca566e8c601c936454691449c8d90b687">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Integrate shared budget into runtime state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/runtime.py

<ul><li>Import SharedTokenBudget<br> <li> Initialize shared_token_budget in state initialization<br> <li> Restore shared budget from model's token usage on resume</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/548/files#diff-f2f7817d0e547f53ef201f86dc0008da618a1300c5f579558e94ec9cd0b27159">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway_model.py</strong><dd><code>Use shared budget in gateway model accounting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/gateway_model.py

<ul><li>Add shared_token_budget field to LensGatewayChatModel<br> <li> In _apply_token_budget, delegate accounting to shared budget if <br>available<br> <li> Compute hard_stop considering both shared and local limit</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/548/files#diff-de52dac452f0e735ccc1cfca71d3fcf76339e65c39285641af53082992804e7d">+19/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>547.yaml</strong><dd><code>Add release note for #547</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/547.yaml

- Add release note for parent run budget enforcement


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/548/files#diff-4b968777b718fe82574cfbc759f9eeb31444197e87d72a9741e10f2e5b97cb7f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

