### PR TITLE
Document PyPI agentcore migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ dependencies.
 | `agentcore-task` | `0.1.0` | `agentcore_task.adapters.django` | `/api/v1/tasks/` |
 | `agentcore-notifier` | `0.1.0` | `agentcore_notifier.adapters.django` | `/api/v1/admin/notifications/` |
 
+The image build resolves these minimum versions from PyPI with `uv pip compile`;
+the generated `requirements.txt` is used only inside the image and is ignored by
+Git. Rebuild the development image after pulling this migration so any previous
+editable-install finder files are removed.
+
+For temporary agentcore source debugging, mount a checkout read-only and set
+`PYTHONPATH` to its package directory. Remove `PYTHONPATH` to return to the
+installed package. Do not run `uv pip install -e` in the container.
+
 ## Celery Task System
 
 - **Discovery**: `core/celery.py` calls `autodiscover_tasks()` to load `tasks.py` from every app

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,6 +135,13 @@ Agentcore 通过项目依赖从 Python 包索引安装。
 | `agentcore-task` | `0.1.0` | `agentcore_task.adapters.django` | `/api/v1/tasks/` |
 | `agentcore-notifier` | `0.1.0` | `agentcore_notifier.adapters.django` | `/api/v1/admin/notifications/` |
 
+镜像构建通过 `uv pip compile` 从 PyPI 解析这些最低版本；生成的
+`requirements.txt` 只在镜像内使用，并已被 Git 忽略。拉取本次迁移后，请重新构建
+开发镜像，以清理旧的可编辑安装 finder 文件。
+
+如需临时调试 agentcore 源码，可只读挂载源码目录并设置 `PYTHONPATH` 指向对应包目录；
+移除 `PYTHONPATH` 即可恢复使用已安装的包。不要在容器内运行 `uv pip install -e`。
+
 ## Celery 任务机制
 
 - **任务发现**：`core/celery.py` 通过 `autodiscover_tasks()` 自动加载各 app 的 `tasks.py`

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -442,7 +442,7 @@
           <li>Feishu/Lark (agentcore-notifier Webhook)</li>
           <li>LLM Provider (OpenAI · Claude · GLM · Kimi)</li>
           <li>Git/Jira/Feishu Docs (source_sync pull)</li>
-          <li>Unified metering via metering submodule</li>
+          <li>Unified metering via the agentcore-metering package</li>
         </ul>
       </div>
     </div>

--- a/docs/deployment.html
+++ b/docs/deployment.html
@@ -118,7 +118,7 @@
         <!-- Image build note -->
         <rect x="60" y="420" width="760" height="60" rx="8" fill="#FDFCFB" stroke="#E8E4DE" stroke-width="1"/>
         <text x="80" y="442" fill="#8B8680" font-size="9" font-weight="600">Dockerfile multi-stage build:</text>
-        <text x="80" y="458" fill="#8B8680" font-size="8">target=backend → Python 3.12 · install agentcore/* editable · gunicorn entrypoint.sh (register_periodic_tasks → migrate → collectstatic → gunicorn)</text>
+        <text x="80" y="458" fill="#8B8680" font-size="8">target=backend → Python 3.12 · install agentcore packages from PyPI · gunicorn entrypoint.sh (register_periodic_tasks → migrate → collectstatic → gunicorn)</text>
         <text x="80" y="472" fill="#8B8680" font-size="8">DEV_MODE=1 enables Django runserver override · APT/PIP mirror: tuna tsinghua · frontend target builds Vue → /opt/backend/core/staticfiles</text>
 
         <!-- Depends on arrows (api → postgres/redis) -->


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Document the agentcore migration to PyPI packages and the required development image rebuild.
- Document the supported read-only `PYTHONPATH` workflow for temporary agentcore source debugging.
- Remove stale submodule and editable-install references from deployment and architecture documentation.

Closes #521

## Test plan
- [x] `uv pip compile pyproject.toml` resolves agentcore packages from PyPI
- [x] `git diff --check`


___

### **PR Type**
Documentation


___

### **Description**
- Update architecture and deployment docs to reflect PyPI agentcore packages

- Document development image rebuild requirement after migration

- Document PYTHONPATH workflow for temporary agentcore source debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Documentation updates"] --> arch["docs/architecture.html"]
  docs --> dep["docs/deployment.html"]
  docs --> readme["README.md"]
  docs --> readme_cn["README.zh-CN.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>architecture.html</strong><dd><code>Update metering dependency reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/architecture.html

<ul><li>Replace 'metering submodule' reference with 'agentcore-metering <br>package'</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/549/files#diff-4e0d9ace78651c3d7f39eeb32f614f5ab488eae1cf41b898f2653b88428a13c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deployment.html</strong><dd><code>Update deployment image build note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/deployment.html

<ul><li>Change image build description from 'install agentcore/* editable' to <br>'install agentcore packages from PyPI'</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/549/files#diff-9acdcae091e33f99387c49c0ff455ba81cdfa0c2f50f2a803dd2510719810625">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document rebuild and PYTHONPATH workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add note about image rebuild requirement<br> <li> Add section on temporary PYTHONPATH debugging workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/549/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>Translate migration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh-CN.md

<ul><li>Add Chinese translation of image rebuild note<br> <li> Add Chinese translation of PYTHONPATH debugging section</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/549/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

