### PR TITLE
Allow per-request reasoning depth selection

### DIFF
--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -4243,6 +4243,10 @@ class RunCreateSerializer(serializers.Serializer):
     retry_of_run_uuid = serializers.UUIDField(required=False, allow_null=True)
     enqueue = serializers.BooleanField(required=False, default=True)
     run_inline = serializers.BooleanField(required=False, default=False)
+    agent_rounds = serializers.ChoiceField(
+        choices=Assistant.AgentRounds.choices,
+        required=False,
+    )
     attachment_uuids = serializers.ListField(
         child=serializers.UUIDField(),
         required=False,
@@ -4341,6 +4345,7 @@ class RunCreateSerializer(serializers.Serializer):
                 user=request.user if request else None,
                 routing_assistant_uuid=validated_data.get("routing_assistant_uuid"),
                 routing_assistant_uuids=validated_data.get("routing_assistant_uuids"),
+                agent_rounds=validated_data.get("agent_rounds"),
             )
         except AssistantNotRunnableError:
             raise PermissionDenied("You do not have access to this assistant.")

--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -1090,6 +1090,7 @@ def create_execution_run(
     parent_run=None,
     routing_assistant_uuid=None,
     routing_assistant_uuids=None,
+    agent_rounds=None,
 ):
     """Create a queued run for LensNode execution."""
 
@@ -1196,6 +1197,7 @@ def create_execution_run(
     create_run_execution_snapshot(
         run,
         answer_language=answer_language,
+        agent_rounds=agent_rounds,
         routing_assistant_uuids=routing_assistant_uuids,
         routing_assistant_explicit=(explicit_routing_assistant_uuids is not None),
     )
@@ -2259,11 +2261,13 @@ def create_run_execution_snapshot(
     answer_language=None,
     routing_assistant_uuids=None,
     routing_assistant_explicit=False,
+    agent_rounds=None,
 ):
     """Create or return the per-run LensNode execution snapshot."""
 
     assistant = run.session.assistant
-    token_budget = token_budget_for_rounds(assistant.agent_rounds)
+    agent_rounds = agent_rounds or assistant.agent_rounds
+    token_budget = token_budget_for_rounds(agent_rounds)
     profile = getattr(run.session.user, "profile", None)
     answer_language = normalize_answer_language(
         answer_language or getattr(profile, "language", None)
@@ -2295,8 +2299,8 @@ def create_run_execution_snapshot(
             "loaded_skills": loaded_skills,
             "loaded_mcps": build_loaded_mcps(assistant),
             "loaded_plugins": loaded_plugins,
-            "agent_rounds": assistant.agent_rounds,
-            "run_timeout_s": run_timeout_for_rounds(assistant.agent_rounds),
+            "agent_rounds": agent_rounds,
+            "run_timeout_s": run_timeout_for_rounds(agent_rounds),
             "target_dirs": session_source_dirs(run.session),
             "runtime_snapshot": runtime_snapshot,
             "token_budget_profile": token_budget["profile"],

--- a/backend/lens/tests/test_services.py
+++ b/backend/lens/tests/test_services.py
@@ -150,6 +150,69 @@ class LensServiceTests(TransactionTestCase):
             title="",
         )
 
+    @patch("lens.services.async_to_sync")
+    @patch("lens.services.get_channel_layer")
+    def test_request_rounds_freeze_dispatch_and_token_budget(
+        self, get_channel_layer, mock_async_to_sync
+    ):
+        """A request overrides all tier budgets without changing the Assistant."""
+        from lens.serializers import RunCreateSerializer
+
+        self.assistant.agent_rounds = "flash"
+        self.assistant.save(update_fields=["agent_rounds"])
+        for rounds in Assistant.AgentRounds.values:
+            with self.subTest(rounds=rounds):
+                serializer = RunCreateSerializer(
+                    data={
+                        "question": "Analyze this request",
+                        "agent_rounds": rounds,
+                        "enqueue": False,
+                    },
+                    context={"session": self.session},
+                )
+                self.assertTrue(serializer.is_valid(), serializer.errors)
+                run = serializer.save()
+                budget = token_budget_for_rounds(rounds)
+                self.assertEqual(run.execution.agent_rounds, rounds)
+                self.assertEqual(
+                    run.execution.token_budget_max_tokens,
+                    budget["max_tokens"],
+                )
+                self.assistant.refresh_from_db()
+                self.assertEqual(self.assistant.agent_rounds, "flash")
+                create_run_execution_snapshot(run, agent_rounds="balanced")
+                run.execution.refresh_from_db()
+                self.assertEqual(run.execution.agent_rounds, rounds)
+                dispatch_run_to_lensnode(run, "Analyze this request")
+                payload = mock_async_to_sync.return_value.call_args.args[1][
+                    "payload"
+                ]
+                self.assertEqual(payload["agent_rounds"], rounds)
+                self.assertEqual(
+                    payload["max_agent_turns"],
+                    max_agent_turns_for_rounds(rounds),
+                )
+                self.assertEqual(payload["token_budget"], budget)
+
+        default_run = create_execution_run(
+            session=self.session, question="Another question", enqueue=False
+        )
+        self.assertEqual(default_run.execution.agent_rounds, "flash")
+
+    def test_request_rounds_reject_invalid_choices(self):
+        """Reject invalid tiers before creating a Run."""
+        from lens.serializers import RunCreateSerializer
+
+        for rounds in ("", None, "unknown", "MAX", 100):
+            with self.subTest(rounds=rounds):
+                serializer = RunCreateSerializer(
+                    data={"question": "Check status", "agent_rounds": rounds},
+                    context={"session": self.session},
+                )
+                self.assertFalse(serializer.is_valid())
+                self.assertIn("agent_rounds", serializer.errors)
+        self.assertFalse(Run.objects.exists())
+
     def test_run_timeout_is_independent_of_execution_strategy(self):
         for agent_rounds in ("flash", "fast", "balanced", "deep", "max"):
             with self.subTest(agent_rounds=agent_rounds):

--- a/frontend/src/admin/locales/es.json
+++ b/frontend/src/admin/locales/es.json
@@ -2055,6 +2055,8 @@
       "issuedAt": "emitido {time}",
       "revoked": "Revocado",
       "notIssued": "Aún no emitido",
+      "existingDatasources": "Fuentes de datos existentes",
+      "noDatasources": "No hay fuentes de datos",
       "reissue": "Reemitir token",
       "reissueHint": "Reemitir genera un nuevo token y una nueva composición; el token antiguo deja de funcionar inmediatamente.",
       "directoryTree": "Vista previa del directorio",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -222,6 +222,13 @@
       "visitorSubtitle": "There are no assistants to chat with yet. Please contact your administrator."
     },
     "chat": {
+      "reasoningDepth": "Reasoning depth",
+      "reasoningDefault": "Assistant default",
+      "reasoningFlash": "Flash",
+      "reasoningFast": "Fast",
+      "reasoningBalanced": "Balanced",
+      "reasoningDeep": "Deep",
+      "reasoningMax": "Max",
       "liveOutput": "Live output",
       "newSession": "New session",
       "smartCollaboration": "Smart Collaboration",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -222,6 +222,13 @@
       "visitorSubtitle": "Aún no hay asistentes para chatear. Por favor, contacte a su administrador."
     },
     "chat": {
+      "reasoningDepth": "Profundidad de razonamiento",
+      "reasoningDefault": "Predeterminado del asistente",
+      "reasoningFlash": "Flash",
+      "reasoningFast": "Rápido",
+      "reasoningBalanced": "Equilibrado",
+      "reasoningDeep": "Profundo",
+      "reasoningMax": "Máximo",
       "liveOutput": "Salida en vivo",
       "newSession": "Nueva sesión",
       "smartCollaboration": "Colaboración inteligente",
@@ -342,6 +349,7 @@
       "errorVisionProviderQuotaExceeded": "La cuota del proveedor de visión o el límite de velocidad se ha agotado. Por favor, inténtelo de nuevo más tarde o contacte a un administrador.",
       "errorVisionProviderUnavailable": "El proveedor de visión no está disponible temporalmente. Por favor, inténtelo de nuevo más tarde.",
       "retryAction": "Reintentar",
+      "sessionHistoryLoadFailed": "No se pudo cargar el historial de la conversación.",
       "loadFailed": "Error al cargar chat de Lens.",
       "assistantNotFound": "El asistente al que intenta acceder no existe. Por favor, contacte a su administrador para obtener un enlace válido.",
       "sessionAccessDenied": "No tienes acceso a esta sesión, o ya no existe. Seleccione una de sus sesiones recientes o inicie una nueva.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -222,6 +222,13 @@
       "visitorSubtitle": "目前还没有可对话的助手，请联系管理员。"
     },
     "chat": {
+      "reasoningDepth": "推理深度",
+      "reasoningDefault": "助手默认",
+      "reasoningFlash": "极速",
+      "reasoningFast": "快速",
+      "reasoningBalanced": "均衡",
+      "reasoningDeep": "深度",
+      "reasoningMax": "极限",
       "liveOutput": "实时输出",
       "newSession": "新建会话",
       "smartCollaboration": "智能协作",

--- a/frontend/src/pages/lens/Chat.vue
+++ b/frontend/src/pages/lens/Chat.vue
@@ -281,7 +281,10 @@
                   {{ t('lens.chat.retryAction') }}
                 </button>
               </div>
-              <p v-else-if="!sessionsLoading && !sessions.length" class="session-list-empty">
+              <p
+                v-else-if="!sessionsLoading && !sessions.length"
+                class="session-list-empty"
+              >
                 {{
                   showArchivedSessions
                     ? t('lens.chat.noArchivedSessions')
@@ -441,7 +444,9 @@
               </button>
             </div>
             <div
-              v-else-if="isMobile && !decoratedMessages.length && !showLiveAnswer"
+              v-else-if="
+                isMobile && !decoratedMessages.length && !showLiveAnswer
+              "
               class="chat-welcome"
             >
               <p class="chat-welcome-assistant">{{ assistantName }}</p>
@@ -1751,6 +1756,28 @@
               </div>
             </div>
 
+            <div class="composer-rounds-label">
+              <label for="composer-rounds">{{
+                t('lens.chat.reasoningDepth')
+              }}</label>
+              <BaseSelect
+                id="composer-rounds"
+                v-model="agentRounds"
+                class="min-w-0 max-w-full"
+                size="sm"
+                :aria-label="t('lens.chat.reasoningDepth')"
+              >
+                <option value="">{{ t('lens.chat.reasoningDefault') }}</option>
+                <option
+                  v-for="tier in agentRoundsTiers"
+                  :key="tier.value"
+                  :value="tier.value"
+                >
+                  {{ tier.label }}
+                </option>
+              </BaseSelect>
+            </div>
+
             <p v-if="!isMobile" class="disclaimer">
               {{
                 t('lens.chat.disclaimer') ||
@@ -1862,6 +1889,7 @@ import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
 import AuthImage from '@/components/ui/AuthImage.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import RowActionMenu from '@/components/ui/RowActionMenu.vue'
 import BrandLogo from '@/components/layout/BrandLogo.vue'
@@ -2010,6 +2038,14 @@ const feedbackUpdatingRuns = ref(new Set())
 const selectedAssistantUuid = ref('')
 const selectedSessionUuid = ref('')
 const question = ref('')
+const agentRounds = ref('')
+const agentRoundsTiers = computed(() => [
+  { value: 'flash', label: t('lens.chat.reasoningFlash') },
+  { value: 'fast', label: t('lens.chat.reasoningFast') },
+  { value: 'balanced', label: t('lens.chat.reasoningBalanced') },
+  { value: 'deep', label: t('lens.chat.reasoningDeep') },
+  { value: 'max', label: t('lens.chat.reasoningMax') }
+])
 const attachments = ref([])
 const fileInput = ref(null)
 const partialAnswer = ref('')
@@ -3216,6 +3252,7 @@ async function bootstrap() {
   // permanently disabled. A stale submit during the brief load window is
   // instead guarded inside submit() by binding to the session it started in.
   question.value = ''
+  agentRounds.value = ''
   mentionedAssistantUuids.value = []
   currentRun.value = null
   runStatusResolvingSessionUuid.value = ''
@@ -3334,13 +3371,10 @@ async function loadSessions(selectUuid = '', { useRouteSession = true } = {}) {
   sessionsError.value = false
   let loadedSessions
   try {
-    loadedSessions = await listSessions(
-      selectedAssistant.value?.slug || '',
-      {
-        routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
-        archived: showArchivedSessions.value
-      }
-    )
+    loadedSessions = await listSessions(selectedAssistant.value?.slug || '', {
+      routingMode: isSmartCollaborationConversation.value ? 'smart' : '',
+      archived: showArchivedSessions.value
+    })
   } catch {
     if (loadGeneration === sessionLoadGeneration) {
       sessionsError.value = true
@@ -3450,6 +3484,7 @@ async function createNewSession(notify = true, allowedAssistantUuids = []) {
     routingScopeDraft.value = [...(session.allowed_assistant_uuids || [])]
   }
   question.value = ''
+  agentRounds.value = ''
   mentionedAssistantUuids.value = []
   retryDraft.value = null
   clarificationAnswers.value = {}
@@ -3485,6 +3520,7 @@ function clearSessionSelection() {
   messages.value = []
   currentRun.value = null
   question.value = ''
+  agentRounds.value = ''
   mentionedAssistantUuids.value = []
   retryDraft.value = null
   clarificationAnswers.value = {}
@@ -3896,6 +3932,7 @@ async function selectSession(session, updateRoute = true) {
   booted.value = true
   if (sessionChanged) {
     question.value = ''
+    agentRounds.value = ''
     mentionedAssistantUuids.value = []
     retryDraft.value = null
     if (composerRef.value) composerRef.value.style.height = 'auto'
@@ -4177,6 +4214,7 @@ async function submit() {
     showWarning(t('lens.chat.participatingAssistantsRequired'))
     return
   }
+  const agentRoundsAtSubmit = agentRounds.value
   const draftTextAtSubmit = question.value
   const mentionUuidsAtSubmit = [...mentionedAssistantUuids.value]
   const mentionAssistantsAtSubmit = [...mentionedAssistants.value]
@@ -4241,6 +4279,7 @@ async function submit() {
     mentionAssistantsAtSubmit
   )
   question.value = ''
+  agentRounds.value = ''
   mentionedAssistantUuids.value = []
   // Snapshot ready attachments, clear the composer strip, and keep the object
   // URLs alive for the optimistic bubble until the server reload replaces it.
@@ -4254,6 +4293,7 @@ async function submit() {
     question: optimisticText,
     attachmentUuids,
     routingAssistantUuids: mentionUuidsAtSubmit,
+    agentRounds: agentRoundsAtSubmit,
     retryDraft: retryDraftAtSubmit,
     pendingSubmission: pendingRunSubmission.value
   })
@@ -4356,6 +4396,7 @@ async function submit() {
     }
     messages.value = messages.value.filter((m) => m.uuid !== '__optimistic__')
     question.value = draftTextAtSubmit
+    agentRounds.value = agentRoundsAtSubmit
     mentionedAssistantUuids.value = mentionUuidsAtSubmit
     retryDraft.value = retryDraftAtSubmit
     // Only a 4xx response proves that the Run transaction rejected the
@@ -5760,6 +5801,15 @@ onBeforeUnmount(() => {
   --composer-max-height: 200px;
   border-color: var(--sl-border-default);
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.composer-rounds-label {
+  @apply pointer-events-auto mt-2 flex flex-wrap items-center gap-2
+    px-1 text-xs text-ink-500;
+}
+
+.composer-rounds-label :deep([role='combobox']) {
+  min-height: 44px;
 }
 
 .composer:focus-within {

--- a/frontend/src/pages/lens/chatSubmission.js
+++ b/frontend/src/pages/lens/chatSubmission.js
@@ -34,6 +34,7 @@ function isSameSubmission(pending, candidate) {
     pending &&
       pending.sessionUuid === candidate.sessionUuid &&
       pending.question === candidate.question &&
+      pending.agentRounds === candidate.agentRounds &&
       pending.retryOfRunUuid === candidate.retryOfRunUuid &&
       sameUuids(
         pending.routingAssistantUuids,
@@ -56,6 +57,7 @@ export function prepareRunSubmission({
   question,
   attachmentUuids = [],
   routingAssistantUuids = [],
+  agentRounds = '',
   retryDraft = null,
   pendingSubmission = null,
   randomUUID = generateUUID
@@ -67,6 +69,7 @@ export function prepareRunSubmission({
     question,
     attachmentUuids: [...attachmentUuids],
     routingAssistantUuids: [...routingAssistantUuids],
+    agentRounds,
     retryOfRunUuid
   }
   const idempotencyKey = isSameSubmission(pendingSubmission, candidate)
@@ -86,5 +89,6 @@ export function prepareRunSubmission({
   if (routingAssistantUuids.length) {
     payload.routing_assistant_uuids = [...routingAssistantUuids]
   }
+  if (agentRounds) payload.agent_rounds = agentRounds
   return { payload, submission }
 }

--- a/frontend/tests/chatSubmission.test.js
+++ b/frontend/tests/chatSubmission.test.js
@@ -97,3 +97,50 @@ test('sends every explicitly mentioned assistant in one submission', () => {
     'assistant-2'
   ])
 })
+
+test('only sends a reasoning override when explicitly selected', () => {
+  const defaults = { sessionUuid: 'session-1', question: 'Check status' }
+  assert.equal('agent_rounds' in prepareRunSubmission(defaults).payload, false)
+  for (const agentRounds of ['flash', 'fast', 'balanced', 'deep', 'max']) {
+    const prepared = prepareRunSubmission({ ...defaults, agentRounds })
+    assert.equal(prepared.payload.agent_rounds, agentRounds)
+  }
+})
+
+test('replays the same depth but gives a changed depth a new key', () => {
+  const defaults = {
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    agentRounds: 'flash'
+  }
+  const first = prepareRunSubmission({
+    ...defaults,
+    randomUUID: () => 'first'
+  })
+  const replay = prepareRunSubmission({
+    ...defaults,
+    pendingSubmission: first.submission,
+    randomUUID: () => 'replay'
+  })
+  assert.equal(replay.payload.idempotency_key, 'first')
+  for (const agentRounds of ['', 'max']) {
+    const changed = prepareRunSubmission({
+      ...defaults,
+      agentRounds,
+      pendingSubmission: first.submission,
+      randomUUID: () => 'changed'
+    })
+    assert.equal(changed.payload.idempotency_key, 'changed')
+  }
+})
+
+test('a Retry accepts the newly selected reasoning depth', () => {
+  const prepared = prepareRunSubmission({
+    sessionUuid: 'session-1',
+    question: 'Check status',
+    agentRounds: 'max',
+    retryDraft: { question: 'Check status', runUuid: 'run-1' }
+  })
+  assert.equal(prepared.payload.agent_rounds, 'max')
+  assert.equal(prepared.payload.retry_of_run_uuid, 'run-1')
+})

--- a/release-notes/453.yaml
+++ b/release-notes/453.yaml
@@ -1,0 +1,5 @@
+type: feature
+audience: user
+en: Let users choose the reasoning depth for each chat request.
+zh-CN: 支持用户为每次聊天请求选择推理深度。
+es: Permite elegir la profundidad de razonamiento para cada solicitud de chat.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Add a chat composer selector for per-request reasoning depth.
- Persist the selected tier in the run execution snapshot and LensNode dispatch payload.
- Add localized labels and regression coverage for overrides, retries, and idempotency.

Closes #453

## Test plan
- [x] `node --test tests/chatSubmission.test.js`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] Django service tests (blocked locally: `agentcore_task` is not installed)


___

### **PR Type**
Enhancement


___

### **Description**
- Add a selector for per-request reasoning depth in the chat composer

- Override the assistant's default depth per run, freezing it into the execution snapshot

- Include new depth in the LensNode dispatch payload

- Add localization keys and regression tests for the depth override


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User selects depth in composer"] --> B["RunCreateSerializer: agent_rounds"]
  B --> C["create_execution_run()"]
  C --> D["create_run_execution_snapshot(): override assistant default"]
  D --> E["RunExecution.agent_rounds"]
  E --> F["dispatch_run_to_lensnode(): payload includes agent_rounds, max_agent_turns, token_budget"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Add agent_rounds field to RunCreateSerializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Pass agent_rounds through execution chain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.vue</strong><dd><code>Add reasoning depth selector to composer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-6488eb7762aad7465234ff216b98a6f58e55af7322956a1d3bb54fb5b18015c1">+59/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatSubmission.js</strong><dd><code>Include agent_rounds in run payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-e73e7f06403bf2928592a1a33440d3294cbc8dae81ffe7e2c23e12ba28a437e5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_services.py</strong><dd><code>Add tests for request-rounds freeze</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-a092da9d5aefdddee6d3e76aa67ff0f6590dfceb39149e653604f5d07b1babf4">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatSubmission.test.js</strong><dd><code>Test depth override and idempotency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-89187ab7c8cbc45d8e6f2fb7c61019968ae9453513344aa6d38ab844f0fc0d96">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>en.json</strong><dd><code>Add English reasoning depth labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Add Spanish reasoning depth labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-ba529cd8e421586279be00c1310ca7d73e9279c6738cd47b4228566944ef2bd2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.json</strong><dd><code>Add Chinese reasoning depth labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-3431a965cf458e3bbcfe7f18c561c997580f3aef2198cc0192be7e84cb596266">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>453.yaml</strong><dd><code>Add release note for per-request depth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-606eaf4850898103999b2f16b8a6fcedee3bc76bf28e5cb38c3429a2dfef836b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>es.json</strong></td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/550/files#diff-fc5efacc2d4df9cfc4192f70e7478c9ac6da757a78b4543d46b34dd0638149d2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

