### PR TITLE
Fix LensNode control channel shutdown callbacks

### DIFF
--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -147,6 +147,19 @@ class LensNodeClient:
         self._pending_terminal_frames = collections.OrderedDict()
         self._pending_datasource_terminal_frames = collections.OrderedDict()
 
+    def _enqueue_from_thread(self, loop, payload):
+        """Schedule an outbound frame while tolerating loop shutdown."""
+
+        if loop.is_closed():
+            return
+        try:
+            loop.call_soon_threadsafe(self._enqueue, payload)
+        except (RuntimeError, AttributeError):
+            LOGGER.debug(
+                "Dropped outbound frame after event loop shutdown",
+                exc_info=True,
+            )
+
     def _enqueue(self, payload):
         """Append an outbound frame to the durable outbox.
 
@@ -941,7 +954,7 @@ class LensNodeClient:
                 "task_id": task_id,
                 **event,
             }
-            loop.call_soon_threadsafe(self._enqueue, payload)
+            self._enqueue_from_thread(loop, payload)
 
         try:
             if plugin:
@@ -1293,7 +1306,7 @@ class LensNodeClient:
                 "task_id": task_id,
                 **event,
             }
-            loop.call_soon_threadsafe(self._enqueue, payload)
+            self._enqueue_from_thread(loop, payload)
 
         try:
             command = {
@@ -1566,7 +1579,7 @@ class LensNodeClient:
         loop = asyncio.get_running_loop()
 
         def emit(payload):
-            loop.call_soon_threadsafe(self._enqueue, payload)
+            self._enqueue_from_thread(loop, payload)
 
         completed = False
         slot_acquired = False
@@ -1916,14 +1929,15 @@ class LensNodeClient:
     def _log_connection_error(self, error):
         """Log WebSocket connection errors."""
 
-        LOGGER.warning(
+        LOGGER.error(
             task_log(
                 (
                     "Checked LensNode control channel "
                     f"{self.config.name}. Current status is error."
                 ),
                 details=[f"Error: {error}"],
-            )
+            ),
+            exc_info=(type(error), error, error.__traceback__),
         )
 
     def _log_disconnected(self, status_code, message):

--- a/lensnode/pyproject.toml
+++ b/lensnode/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pillow>=10.0.0",
     "pymupdf>=1.24.0",
     "sentry-sdk>=1.40.0",
-    "websockets>=15.0",
+    "websockets==15.0.1",
 ]
 
 [project.optional-dependencies]

--- a/lensnode/tests/test_main_tls.py
+++ b/lensnode/tests/test_main_tls.py
@@ -142,3 +142,15 @@ def test_run_forever_starts_runtime_cleanup(monkeypatch):
     asyncio.run(exercise())
 
     assert cleanup_started is True
+
+
+def test_thread_enqueue_ignores_closed_event_loop():
+    """Background workers cannot crash when the client loop has closed."""
+
+    client = _make_client()
+    loop = asyncio.new_event_loop()
+    loop.close()
+
+    client._enqueue_from_thread(loop, {"type": "run_output"})
+
+    assert not client._outbox

--- a/release-notes/551.yaml
+++ b/release-notes/551.yaml
@@ -1,0 +1,4 @@
+type: fix
+audience: admin
+en: Fixed LensNode control-channel errors that could occur while the event loop was shutting down.
+zh-CN: 修复 LensNode 事件循环关闭期间可能出现的控制通道错误。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Guard outbound control-channel callbacks when the asyncio event loop is already closed.
- Preserve full traceback details for control-channel connection errors.
- Pin the LensNode `websockets` dependency to 15.0.1 and add regression coverage.

Closes #431

## Test plan
- [x] `python3 -m py_compile lensnode/lensnode/main.py lensnode/tests/test_main_tls.py`
- [x] `git diff --check origin/main...HEAD`
- [ ] Full LensNode pytest suite (environment dependencies unavailable)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Guard outbound callbacks during event loop shutdown

- Preserve full traceback for connection errors

- Pin websockets to 15.0.1 and add regression test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  emit --> _enqueue_from_thread --> check{loop closed?}
  check -- yes --> return
  check -- no --> call_soon_threadsafe --> _enqueue
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Guard outbound callbacks during shutdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/main.py

<ul><li>Added <code>_enqueue_from_thread</code> method to guard <code>call_soon</code> during shutdown<br> <li> Replaced three <code>loop.call_soon_threadsafe</code> calls with <br><code>_enqueue_from_thread</code><br> <li> Changed connection error log level to ERROR and included full <br>traceback</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/551/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+19/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_main_tls.py</strong><dd><code>Test thread enqueue ignores closed loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_main_tls.py

<ul><li>Added regression test <code>test_thread_enqueue_ignores_closed_event_loop</code><br> <li> Verifies no crash when event loop is closed</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/551/files#diff-bc99d96e237833f5aeb490bb1f7fa15fd7719bb19a09c919215612bbc0676cd3">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Pin websockets dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/pyproject.toml

- Pinned `websockets` dependency to exact version 15.0.1


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/551/files#diff-0c1753523f3d947030264901da252eaeb9441e74e2dab26b09fe1aa7a6c2e78e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>551.yaml</strong><dd><code>Add release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/551.yaml

<ul><li>Added release note entry for #431 control channel fix with English and <br>Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/551/files#diff-a0291387000bb7e15d8d9725e5023f0613d7d419fc53a59481a88e8ed9e8822d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

