### PR TITLE
Enforce shared Smart Collaboration run budgets

### DIFF
--- a/backend/lens/services.py
+++ b/backend/lens/services.py
@@ -746,18 +746,19 @@ def resume_awaiting_runs_for_lensnode(
     return recovered
 
 
-def fail_running_steps_for_runs(run_ids):
+def fail_running_steps_for_runs(run_ids, status=RunStep.Status.FAILED):
     """Finalize in-flight steps for runs failed outside the step context.
 
     Out-of-band failure paths (lensnode disconnect, orphan reconcile, idle
     sweep) update the Run row directly, so their RUNNING RunStep rows would
     otherwise stay RUNNING forever and disagree with the terminal Run state.
+    The caller may use ``DONE`` when the out-of-band terminal result succeeded.
     """
 
     return RunStep.objects.filter(
         run_id__in=run_ids,
         status=RunStep.Status.RUNNING,
-    ).update(status=RunStep.Status.FAILED, updated_at=timezone.now())
+    ).update(status=status, updated_at=timezone.now())
 
 
 RECONCILE_GRACE_SECONDS = 60
@@ -1385,9 +1386,23 @@ def create_delegated_run(
     )
     if parent_run.session.routing_mode != Session.RoutingMode.SMART:
         raise LensNodeDispatchError("SUBAGENT_NOT_ALLOWED")
+    if parent_run.parent_run_id:
+        raise LensNodeDispatchError("SUBAGENT_NESTED_DISABLED")
     if parent_run.status not in {
         Run.Status.RUNNING,
         Run.Status.STREAMING,
+    }:
+        raise LensNodeDispatchError("PARENT_RUN_NOT_ACTIVE")
+    try:
+        parent_execution = parent_run.execution
+    except RunExecution.DoesNotExist:
+        parent_execution = RunExecution.objects.filter(run=parent_run).first()
+    if parent_execution is None:
+        raise LensNodeDispatchError("PARENT_RUN_EXECUTION_MISSING")
+    if parent_execution.status in {
+        RunExecution.Status.COMPLETED,
+        RunExecution.Status.FAILED,
+        RunExecution.Status.CANCELLED,
     }:
         raise LensNodeDispatchError("PARENT_RUN_NOT_ACTIVE")
     ancestry = set()
@@ -3558,6 +3573,29 @@ def finish_lensnode_run(
             "updated_at",
             *run_result_fields,
         ]
+    )
+
+    # A terminal parent must not leave delegated work running.  This also
+    # covers budget/deadline termination paths that bypass the UI cancel API.
+    descendants = cancel_descendant_runs(run)
+    for descendant in descendants:
+        transaction.on_commit(
+            lambda child=descendant: cancel_run_on_lensnode(child)
+        )
+
+    # A terminal frame can arrive after an individual step's final event (or
+    # after an out-of-band cancellation). Close any remaining in-flight steps
+    # so trajectory state cannot contradict the terminal Run status.
+    fail_running_steps_for_runs(
+        [run.pk],
+        status=(
+            RunStep.Status.DONE
+            if run.status in {
+                Run.Status.DONE,
+                Run.Status.AWAITING_USER_INPUT,
+            }
+            else RunStep.Status.FAILED
+        ),
     )
 
     if hasattr(run, "execution"):

--- a/backend/lens/views/admin_runs.py
+++ b/backend/lens/views/admin_runs.py
@@ -212,8 +212,18 @@ def _duration_ms(started_at, finished_at):
 def _admin_run_model_usage(run):
     """Return metered model calls correlated to one Run UUID."""
 
+    run_uuids = [str(run.uuid)]
+    frontier = [run.pk]
+    while frontier:
+        children = list(
+            Run.objects.filter(parent_run_id__in=frontier).values_list(
+                "pk", "uuid"
+            )
+        )
+        frontier = [pk for pk, _uuid in children]
+        run_uuids.extend(str(run_uuid) for _pk, run_uuid in children)
     usages = LLMUsage.objects.filter(
-        metadata__run_uuid=str(run.uuid),
+        metadata__run_uuid__in=run_uuids,
     ).order_by("created_at")
     calls = []
     total_cost = 0.0
@@ -236,7 +246,8 @@ def _admin_run_model_usage(run):
                 "cost_currency": usage.cost_currency,
                 "success": usage.success,
                 "is_streaming": usage.is_streaming,
-                "is_subagent": bool(metadata.get("is_subagent")),
+                "is_subagent": bool(metadata.get("is_subagent"))
+                or str(metadata.get("run_uuid") or "") != str(run.uuid),
                 "source_type": metadata.get("source_type"),
                 "started_at": (
                     usage.started_at.isoformat() if usage.started_at else None
@@ -354,6 +365,19 @@ def _admin_run_row(run):
     assistant = session.assistant if session else None
     question = (run.input_message.content if run.input_message else "") or ""
     counts = _admin_run_step_counts(run)
+    metered_usage = getattr(run, "_admin_metered_usage", None)
+    if metered_usage:
+        # LLMUsage is the authoritative source once a metering record exists.
+        # Step events are intentionally retained as a fallback for active runs
+        # and older runs created before metering was enabled.
+        for key in (
+            "llm_calls",
+            "total_tokens",
+            "prompt_tokens",
+            "completion_tokens",
+        ):
+            counts[key] = metered_usage[key]
+        counts["total_cost"] = metered_usage["total_cost"]
     execution = run.execution if hasattr(run, "execution") else None
     runtime_snapshot = execution.runtime_snapshot if execution else {}
     admitted_at = execution.admitted_at if execution else None
@@ -439,6 +463,15 @@ def _admin_run_row(run):
         "total_tokens": counts["total_tokens"],
         "prompt_tokens": counts["prompt_tokens"],
         "completion_tokens": counts["completion_tokens"],
+        "cached_tokens": (
+            metered_usage["cached_tokens"] if metered_usage else 0
+        ),
+        "reasoning_tokens": (
+            metered_usage["reasoning_tokens"] if metered_usage else 0
+        ),
+        "subagent_model_calls": (
+            metered_usage["subagent_model_calls"] if metered_usage else 0
+        ),
         "total_cost": counts["total_cost"],
         "token_budget_profile": (execution.token_budget_profile if execution else None),
         "token_budget_max_tokens": max_tokens,
@@ -802,6 +835,10 @@ def _admin_run_resource_usage(run, execution):
 def _admin_run_detail(run):
     """Serialize a run with full Q&A, timeline and execution snapshot."""
 
+    # Attach metered usage before serializing the summary fields so the detail
+    # row and the dedicated usage payload use the same authoritative totals.
+    model_usage = _admin_run_model_usage(run)
+    run._admin_metered_usage = model_usage
     row = _admin_run_row(run)
     out = run.output_message
     assistant = run.session.assistant if run.session else None
@@ -810,7 +847,6 @@ def _admin_run_detail(run):
     agent_rounds = execution.agent_rounds if execution else None
     if agent_rounds is None and assistant:
         agent_rounds = assistant.agent_rounds
-    model_usage = _admin_run_model_usage(run)
     steps = []
     for step in run.steps.all():
         detail, events = _admin_step_detail(step)
@@ -1020,7 +1056,78 @@ class AdminRunListView(APIView):
 
         total = qs.count()
         start = (page - 1) * page_size
-        rows = [_admin_run_row(run) for run in qs[start : start + page_size]]
+        page_runs = list(qs[start : start + page_size])
+        run_ids = [str(run.uuid) for run in page_runs]
+        child_pairs = []
+        frontier = run_ids
+        while frontier:
+            rows = list(
+                Run.objects.filter(parent_run__uuid__in=frontier).values_list(
+                    "uuid", "parent_run__uuid"
+                )
+            )
+            child_pairs.extend(rows)
+            frontier = [str(child) for child, _parent in rows]
+        usage_ids = run_ids + [str(child) for child, _parent in child_pairs]
+        usages = LLMUsage.objects.filter(metadata__run_uuid__in=usage_ids)
+        parent_by_child = {
+            str(child): str(parent) for child, parent in child_pairs
+        }
+        usage_owner = {}
+        for child, parent in child_pairs:
+            owner = str(parent)
+            while owner in parent_by_child:
+                owner = parent_by_child[owner]
+            usage_owner[str(child)] = owner
+        usage_by_run = {}
+        for usage in usages:
+            usage_run_id = str((usage.metadata or {}).get("run_uuid") or "")
+            run_id = usage_owner.get(usage_run_id, usage_run_id)
+            if not run_id:
+                continue
+            usage_by_run.setdefault(run_id, []).append(usage)
+            if run_id != usage_run_id:
+                usage_by_run.setdefault(usage_run_id, []).append(usage)
+        for run in page_runs:
+            calls = usage_by_run.get(str(run.uuid), [])
+            if calls:
+                run._admin_metered_usage = {
+                    "llm_calls": len(calls),
+                    "subagent_model_calls": sum(
+                        bool((item.metadata or {}).get("is_subagent"))
+                        or str((item.metadata or {}).get("run_uuid") or "")
+                        in usage_owner
+                        for item in calls
+                    ),
+                    "total_tokens": sum(
+                        item.total_tokens or 0 for item in calls
+                    ),
+                    "prompt_tokens": sum(
+                        item.prompt_tokens or 0 for item in calls
+                    ),
+                    "completion_tokens": sum(
+                        item.completion_tokens or 0 for item in calls
+                    ),
+                    "cached_tokens": sum(
+                        item.cached_tokens or 0 for item in calls
+                    ),
+                    "reasoning_tokens": sum(
+                        item.reasoning_tokens or 0 for item in calls
+                    ),
+                    "total_cost": (
+                        round(
+                            sum(
+                                float(item.cost or 0)
+                                for item in calls
+                                if item.cost is not None
+                            ),
+                            6,
+                        )
+                        if any(item.cost is not None for item in calls)
+                        else None
+                    ),
+                }
+        rows = [_admin_run_row(run) for run in page_runs]
         return Response(
             {
                 "results": rows,
@@ -1405,15 +1512,26 @@ def _run_trace_summary(
             filter=Q(event_type__endswith=".failed"),
         ),
     )
+    metered = list(
+        LLMUsage.objects.filter(
+            metadata__run_uuid__in=[str(item.uuid) for item in progress_runs]
+        )
+    )
     if not aggregate["event_count"]:
         summary = {
             "event_count": 0,
             "first_timestamp": None,
             "last_timestamp": None,
             "duration_ms": None,
-            "model_calls": 0,
+            "model_calls": len(metered),
             "tool_calls": 0,
-            "total_tokens": 0,
+            "total_tokens": sum(item.total_tokens or 0 for item in metered),
+            "subagent_model_calls": sum(
+                bool((item.metadata or {}).get("is_subagent"))
+                or str((item.metadata or {}).get("run_uuid") or "")
+                != str(run.uuid)
+                for item in metered
+            ),
             "error_count": 0,
             "categories": {},
         }
@@ -1437,6 +1555,9 @@ def _run_trace_summary(
             total_tokens += max(int(value or 0), 0)
         except (TypeError, ValueError):
             pass
+    if metered:
+        total_tokens = sum(item.total_tokens or 0 for item in metered)
+        aggregate["model_calls"] = len(metered)
     first_timestamp = aggregate["first_timestamp"]
     last_timestamp = aggregate["last_timestamp"]
     summary = {
@@ -1450,6 +1571,12 @@ def _run_trace_summary(
         "model_calls": aggregate["model_calls"],
         "tool_calls": aggregate["tool_calls"],
         "total_tokens": total_tokens,
+        "subagent_model_calls": sum(
+            bool((item.metadata or {}).get("is_subagent"))
+            or str((item.metadata or {}).get("run_uuid") or "")
+            != str(run.uuid)
+            for item in metered
+        ),
         "error_count": aggregate["error_count"],
         "categories": categories,
     }
@@ -1476,25 +1603,33 @@ def _trajectory_context(run_uuid):
     except Run.DoesNotExist:
         return None
     trace_runs = [run]
-    trace_runs.extend(
-        run.delegated_runs.select_related(
-            "execution",
-            "session__assistant",
-            "input_message",
-        ).all()
-    )
+    frontier = [run.pk]
+    while frontier:
+        children = list(
+            Run.objects.filter(parent_run_id__in=frontier).select_related(
+                "execution",
+                "session__assistant",
+                "input_message",
+            )
+        )
+        trace_runs.extend(children)
+        frontier = [child.pk for child in children]
     progress_root = run.parent_run or run
     if progress_root.id == run.id:
         progress_runs = trace_runs
     else:
         progress_runs = [progress_root]
-        progress_runs.extend(
-            progress_root.delegated_runs.select_related(
-                "execution",
-                "session__assistant",
-                "input_message",
-            ).all()
-        )
+        frontier = [progress_root.pk]
+        while frontier:
+            children = list(
+                Run.objects.filter(parent_run_id__in=frontier).select_related(
+                    "execution",
+                    "session__assistant",
+                    "input_message",
+                )
+            )
+            progress_runs.extend(children)
+            frontier = [child.pk for child in children]
     return run, trace_runs, progress_root, progress_runs
 
 

--- a/backend/lens/views/gateway.py
+++ b/backend/lens/views/gateway.py
@@ -4,9 +4,13 @@ import hashlib
 import json
 import os
 import re
+import time
+import uuid
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.db.models import Sum
 from django.http import FileResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -15,12 +19,13 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from lens.citations import sanitize_run_citations
+from agentcore_metering.adapters.django.models import LLMUsage
+from lens.citations import public_run_citations, sanitize_run_citations
 from lens.document_attachments import (
     document_attachment_storage,
     get_document_attachment,
 )
-from lens.models import Run, RunOutputFile, Skill
+from lens.models import Run, RunExecution, RunOutputFile, Skill
 from lens.services import (
     LensNodeDispatchError,
     create_delegated_run,
@@ -35,6 +40,8 @@ from .base import EventStreamRenderer, LensNodeAuthMixin
 # prove transport liveness to the LensNode watchdog so it only aborts
 # on a genuinely dead pipe, never on a quiet-but-alive model call.
 GATEWAY_STREAM_HEARTBEAT_S = 10
+RUN_BUDGET_LOCK_TIMEOUT_S = 120
+RUN_BUDGET_WAIT_TIMEOUT_S = 30
 OBSERVATION_ID_PATTERN = re.compile(r"^(?!0{16}$)[0-9a-f]{16}$")
 GENERATION_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 EMPTY_RESPONSE_FINISH_REASON_PATTERN = re.compile(
@@ -121,6 +128,30 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                     f"00-{run.uuid.hex}-"
                     f"{trace_context['parent_observation_id']}-01"
                 )
+        budget_lock = self._acquire_parent_budget_lock(run)
+        if run_uuid and budget_lock == "exhausted":
+            return Response(
+                {
+                    "code": "RUN_TOKEN_BUDGET_EXHAUSTED",
+                    "detail": "The parent Run token budget has been exhausted.",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        if run_uuid and budget_lock is None:
+            return Response(
+                {
+                    "code": "RUN_TOKEN_BUDGET_BUSY",
+                    "detail": "Another model call is reserving this Run budget.",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        effective_max_tokens = request.data.get("max_tokens")
+        if isinstance(budget_lock, tuple) and budget_lock[4] > 0:
+            remaining_tokens = budget_lock[4]
+            effective_max_tokens = min(
+                int(effective_max_tokens or remaining_tokens),
+                remaining_tokens,
+            )
         if request.data.get("stream"):
             return self._stream_response(
                 lensnode,
@@ -128,6 +159,8 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                 messages,
                 tracker_state,
                 request.data,
+                budget_lock,
+                effective_max_tokens,
             )
 
         try:
@@ -139,7 +172,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                 tools=request.data.get("tools"),
                 tool_choice=request.data.get("tool_choice"),
                 temperature=request.data.get("temperature"),
-                max_tokens=request.data.get("max_tokens"),
+                max_tokens=effective_max_tokens,
                 reasoning_effort=request.data.get("reasoning_effort"),
                 return_message=bool(request.data.get("return_message")),
             )
@@ -151,6 +184,8 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                 empty_response,
                 status=status.HTTP_502_BAD_GATEWAY,
             )
+        finally:
+            self._release_parent_budget_lock(budget_lock)
         data = {
             "usage": usage,
             "lensnode_uuid": str(lensnode.uuid),
@@ -161,6 +196,62 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
         else:
             data["content"] = content
         return Response(data)
+
+    @staticmethod
+    def _acquire_parent_budget_lock(run):
+        """Serialize metered calls for one Run tree at its budget boundary."""
+
+        if run is None:
+            return None
+        root = run
+        while root.parent_run_id:
+            root = Run.objects.only("uuid", "parent_run_id").get(
+                pk=root.parent_run_id
+            )
+        limit = int(
+            RunExecution.objects.only("token_budget_max_tokens").get(
+                run_id=root.pk
+            ).token_budget_max_tokens
+            or 0
+        )
+        if not limit:
+            return "disabled"
+        token = uuid.uuid4().hex
+        key = f"lens:run-budget-lock:{root.uuid}"
+        deadline = time.monotonic() + RUN_BUDGET_WAIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if cache.add(key, token, RUN_BUDGET_LOCK_TIMEOUT_S):
+                usage_ids = [str(root.uuid)]
+                frontier = [root.pk]
+                while frontier:
+                    children = list(
+                        Run.objects.filter(parent_run_id__in=frontier).values_list(
+                            "pk", "uuid"
+                        )
+                    )
+                    frontier = [pk for pk, _uuid in children]
+                    usage_ids.extend(
+                        str(run_uuid) for _pk, run_uuid in children
+                    )
+                used = LLMUsage.objects.filter(
+                    metadata__run_uuid__in=usage_ids,
+                ).aggregate(total=Sum("total_tokens"))["total"] or 0
+                if int(used) >= limit:
+                    cache.delete(key)
+                    return "exhausted"
+                return key, token, root.uuid, limit, limit - int(used)
+            time.sleep(0.05)
+        return None
+
+    @staticmethod
+    def _release_parent_budget_lock(lock):
+        """Release a budget lock only when it is still owned by this call."""
+
+        if lock is None or lock == "disabled":
+            return
+        key, token, _root_uuid, _limit, _remaining = lock
+        if cache.get(key) == token:
+            cache.delete(key)
 
     @staticmethod
     def _empty_response_error_payload(error):
@@ -205,6 +296,8 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
         messages,
         tracker_state,
         payload,
+        budget_lock=None,
+        effective_max_tokens=None,
     ):
         """Stream a metered LLM call as SSE chunks.
 
@@ -235,7 +328,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                         tools=payload.get("tools"),
                         tool_choice=payload.get("tool_choice"),
                         temperature=payload.get("temperature"),
-                        max_tokens=payload.get("max_tokens"),
+                        max_tokens=effective_max_tokens,
                         reasoning_effort=payload.get("reasoning_effort"),
                     )
                     token_count = 0
@@ -337,6 +430,7 @@ class LensNodeAIGatewayView(LensNodeAuthMixin, APIView):
                         raise item[1]
             finally:
                 await future
+                self._release_parent_budget_lock(budget_lock)
 
         response = StreamingHttpResponse(
             event_stream(),
@@ -481,6 +575,7 @@ class LensNodeDelegationView(LensNodeAuthMixin, APIView):
                 if run.output_message_id
                 else ""
             ),
+            "citations": public_run_citations(run.citations),
             "error": str(run.error or "")[:500],
         }
 

--- a/lensnode/lensnode/agent_runtime/remote_subagent.py
+++ b/lensnode/lensnode/agent_runtime/remote_subagent.py
@@ -103,9 +103,14 @@ class RemoteSubagentRunnable(Runnable):
 
         self._check_cancelled()
         if payload.get("status") == "done":
+            citations = payload.get("citations") or []
             return {
                 "messages": [
-                    AIMessage(content=str(payload.get("answer") or ""))
+                    AIMessage(
+                        content=str(payload.get("answer") or ""),
+                        additional_kwargs={"delegated_citations": citations},
+                        response_metadata={"delegated_citations": citations},
+                    )
                 ]
             }
         error = str(payload.get("error") or payload.get("status") or "")

--- a/release-notes/465.yaml
+++ b/release-notes/465.yaml
@@ -1,0 +1,9 @@
+type: improvement
+audience: admin
+en: >-
+  Improved Smart Collaboration run governance by enforcing shared parent token
+  budgets, reconciling delegated usage and terminal steps, and preserving
+  delegated citations in administration diagnostics.
+zh-CN: >-
+  优化智能协作运行治理：统一父 Run 与委派模型调用的令牌预算，校准委派用量和终态步骤，
+  并在管理诊断中保留委派引用。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- Enforce one parent Run token budget across concurrent delegated model calls.
- Aggregate parent and descendant metering consistently in Run list, detail, and trajectory views.
- Reconcile terminal Run steps and cancel descendants when a parent terminates.
- Preserve delegated citations through the gateway and remote subagent runtime.
- Reject nested delegated Runs and missing or inactive parent executions.

Closes #465

## Test plan

- [x] `git diff --check`
- [ ] `pytest -q backend/lens/tests/test_services.py backend/lens/tests/test_run_lifecycle.py` (not run: Python/pytest unavailable in the local environment)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enforce shared parent Run token budget with lock across delegated subagents

- Reconcile delegated LLM usage in list, detail, and trajectory views

- Cancel descendant runs and finalize remaining steps on parent termination

- Preserve delegated citations through gateway and remote subagent runtime


___

### Diagram Walkthrough


```mermaid
flowchart LR
  parent["Parent Run"] -- "delegated calls" --> subagent1["Configured Subagent A"]
  parent -- "delegated calls" --> subagent2["Configured Subagent B"]
  subagent1 -- "LLM calls" --> gateway["AI Gateway"]
  subagent2 -- "LLM calls" --> gateway
  gateway -- "budget lock: cache key" --> parent
  gateway -- "authoritative usage" --> admin["Admin API"]
  admin -- "list / detail / trajectory" --> usage["LLMUsage aggregation"]
  parent -- "citations + answer" --> subagent1
  subagent1 --> remote(["remote_subagent.py"])
  remote -- "delegated_citations" --> parent
  parent -- "terminal state" --> finalize(["cancel descendants + close steps"])
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Add descendant cancellation and step finalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/services.py

<ul><li>Made <code>fail_running_steps_for_runs</code> accept a <code>status</code> parameter (FAILED or <br>DONE) to match out-of-band terminal results.<br> <li> Added nested delegation guard and parent execution status checks in <br><code>create_delegated_run</code>.<br> <li> In <code>finish_lensnode_run</code>, cancel descendant runs and close remaining <br>in-flight steps with appropriate status.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/552/files#diff-90f2b98ce99eefa73ecd98fca14fbfacf6a02f8b9776aaeec2b7a92cf5ee9e55">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway.py</strong><dd><code>Enforce parent token budget with lock and propagate citations</code></dd></summary>
<hr>

backend/lens/views/gateway.py

<ul><li>Introduced a distributed budget lock via <code>cache.add</code> to serialize <br>metered calls per Run tree.<br> <li> On each gateway call, acquire lock, check used tokens vs. budget, <br>enforce cap on <code>max_tokens</code>, and return 409 if exhausted.<br> <li> Added <code>_release_parent_budget_lock</code> and proper cleanup in streaming and <br>non-streaming paths.<br> <li> Included <code>citations</code> from <code>public_run_citations</code> in the delegated run <br>payload.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/552/files#diff-7a38a41d1d2cc8239be8f186a349fee86254f97ad1ad16b566c0bacdc0d4fb4d">+99/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remote_subagent.py</strong><dd><code>Preserve delegated citations in subagent response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/agent_runtime/remote_subagent.py

<ul><li>Extract <code>citations</code> from delegated run response payload.<br> <li> Pass <code>delegated_citations</code> to <code>AIMessage</code> via <code>additional_kwargs</code> and <br><code>response_metadata</code> for propagation to parent.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/552/files#diff-a2eda728963d5494672d12e44fc5d423344806da2fbbf4c3e3c9773608266b87">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin_runs.py</strong><dd><code>Reconcile delegated LLMUsage in all observability views</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/views/admin_runs.py

<ul><li>Extended <code>_admin_run_model_usage</code> to recursively include descendant run <br>UUIDs.<br> <li> Made <code>_admin_run_row</code> prefer <code>LLMUsage</code> as the authoritative source when <br>metered usage is attached.<br> <li> In <code>RunRetrieveView</code>, aggregated descendant usage per page using BFS and <br>attached <code>_admin_metered_usage</code>.<br> <li> Updated <code>_run_trace_summary</code> to use metered <code>LLMUsage</code> for model calls and <br>total tokens, and added <code>subagent_model_calls</code>.<br> <li> Changed <code>_trajectory_context</code> to recursively fetch all descendant runs <br>instead of using the <code>delegated_runs</code> relation.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/552/files#diff-4772351526c129276eda806de3b9f93b26cfc0badabb8c53e010081657724a50">+155/-20</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>465.yaml</strong><dd><code>Add release note for shared run budgets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/465.yaml

<ul><li>Added release note for the Smart Collaboration run governance <br>improvements.</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/552/files#diff-c9a8170f2466e6cfa9496f0309522b356e3b05929bd3ed627f493e57db5642eb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

