### PR TITLE
Fix datasource runtime paths and assistant workspace validation

### DIFF
--- a/backend/lens/plugins/snapshots.py
+++ b/backend/lens/plugins/snapshots.py
@@ -27,6 +27,35 @@ SENSITIVE_CONFIG_KEYS = frozenset(
 )
 
 
+def datasource_runtime_target_path(
+    datasource,
+    lensnode,
+    datasource_config,
+):
+    """Return the stable runtime path for one resolved datasource config."""
+
+    if datasource.target_path:
+        return datasource.target_path
+    identity = {
+        "plugin_key": datasource.plugin_key,
+        "source_type": datasource.source_type,
+        "datasource_config": datasource_config,
+        "sync_policy": datasource.sync_policy or {},
+    }
+    config_hash = hashlib.sha256(
+        json.dumps(
+            identity,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:12]
+    return (
+        f"{lensnode.workspace_path}/datasources/"
+        f"{datasource.uuid}-{config_hash}"
+    )
+
+
 def create_datasource_sync_snapshot(datasource, *, lensnode=None):
     """Resolve one external datasource into an immutable execution snapshot."""
 
@@ -86,19 +115,11 @@ def create_datasource_sync_snapshot(datasource, *, lensnode=None):
         )
     except DatasourceProviderError as exc:
         raise PluginRegistryError(str(exc)) from exc
-    target_path = datasource.target_path
-    if not target_path:
-        config_hash = hashlib.sha256(
-            json.dumps(
-                datasource.datasource_config,
-                sort_keys=True,
-                separators=(",", ":"),
-            ).encode("utf-8")
-        ).hexdigest()[:12]
-        target_path = (
-            f"{lensnode.workspace_path}/datasources/"
-            f"{datasource.uuid}-{config_hash}"
-        )
+    target_path = datasource_runtime_target_path(
+        datasource,
+        lensnode,
+        datasource_config,
+    )
     resolved_config = {
         "endpoint": endpoint,
         "connection_config": deepcopy(connection.config),

--- a/backend/lens/serializers.py
+++ b/backend/lens/serializers.py
@@ -114,18 +114,6 @@ def _task_names(lensnode):
     return names
 
 
-def _dir_paths(lensnode):
-    """Return available directory paths reported by a LensNode."""
-
-    paths = set()
-    for item in lensnode.available_dirs or []:
-        if isinstance(item, str):
-            paths.add(item)
-        elif isinstance(item, dict) and item.get("path"):
-            paths.add(item["path"])
-    return paths
-
-
 def validate_retrieval_scope(value):
     """Validate retrieval_scope JSON."""
 
@@ -187,17 +175,12 @@ def validate_selected_dirs(value, lensnode=None):
     if not isinstance(value, list):
         raise serializers.ValidationError("selected_dirs must be a list")
 
-    available = _dir_paths(lensnode) if lensnode else None
     for item in value:
         if not isinstance(item, dict):
             raise serializers.ValidationError("selected_dirs items must be objects")
         path = item.get("path")
         if not isinstance(path, str) or not path:
             raise serializers.ValidationError("selected_dirs.path is required")
-        if available is not None and path not in available:
-            raise serializers.ValidationError(
-                f"selected_dirs path is not available on LensNode: {path}"
-            )
         if "retrieval_scope" in item:
             validate_retrieval_scope(item.get("retrieval_scope"))
     return value

--- a/backend/lens/tests/test_api.py
+++ b/backend/lens/tests/test_api.py
@@ -1907,7 +1907,7 @@ class LensApiTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("selected_task", response.data)
 
-    def test_assistant_create_rejects_unreported_dir(self):
+    def test_assistant_create_allows_unreported_dir(self):
         payload = {
             "name": "Bad Dir",
             "slug": "bad-dir",
@@ -1922,8 +1922,11 @@ class LensApiTests(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("selected_dirs", str(response.data))
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.data["selected_dirs"],
+            [{"path": "/workspace/missing"}],
+        )
 
     def test_general_chat_create_allows_empty_dirs_with_skill(self):
         payload = {

--- a/lensnode/lensnode/main.py
+++ b/lensnode/lensnode/main.py
@@ -1222,6 +1222,13 @@ class LensNodeClient:
                 material,
                 message.get("trigger") or "plugin",
             )
+            # Plugin builders receive the immutable snapshot, but older plugin
+            # packages may omit the resolved workspace target from the
+            # provider command. Keep the runtime target authoritative so the
+            # control plane can publish unbound datasource results safely.
+            resolved = snapshot.get("resolved_config") or {}
+            if resolved.get("target_path") and not command.get("target_path"):
+                command["target_path"] = resolved["target_path"]
             plugin_http_pool = getattr(
                 self,
                 "plugin_http_pool",

--- a/lensnode/tests/test_plugin_runtime.py
+++ b/lensnode/tests/test_plugin_runtime.py
@@ -270,6 +270,7 @@ def test_plugin_sync_does_not_fallback_to_legacy_credentials(monkeypatch):
     def fake_sync(command, workspace, emit):
         seen["token"] = command["config"].get("access_token")
         seen["directory"] = command["config"].get("directory")
+        seen["target_path"] = command["target_path"]
         seen["allow_submodules"] = command["config"].get(
             "allow_submodules"
         )
@@ -283,6 +284,7 @@ def test_plugin_sync_does_not_fallback_to_legacy_credentials(monkeypatch):
     assert result["status"] == "success"
     assert seen["token"] == "secret"
     assert seen["directory"] == "docs"
+    assert seen["target_path"] == "/workspace/repo"
     assert seen["allow_submodules"] is False
 
 

--- a/release-notes/561.yaml
+++ b/release-notes/561.yaml
@@ -1,0 +1,5 @@
+type: bugfix
+audience: user
+en: Fixed assistant configuration failures when selected workspace paths are not present in the LensNode heartbeat report.
+zh-CN: 修复助手配置中的工作区路径未出现在 LensNode 心跳上报目录列表时无法保存的问题。
+es: Se corrigieron los errores de configuración del asistente cuando las rutas de trabajo seleccionadas no aparecen en el informe de heartbeat de LensNode.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Persist deterministic datasource runtime target paths in sync snapshots.
- Keep LensNode plugin sync commands on the resolved runtime target.
- Allow assistant `selected_dirs` paths that are absent from stale LensNode heartbeat reports.

Closes #561

## Test plan
- [x] Python compilation check
- [x] `git diff --check`
- [ ] Django API test (blocked by existing test database migration issue)


___

### **PR Type**
Bug fix


___

### **Description**
- Allow selected_dirs paths absent from stale LensNode heartbeat

- Persist deterministic datasource runtime target paths in snapshots

- Keep plugin sync commands authoritative with resolved target_path


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshots.py</strong><dd><code>Refactor datasource runtime target path generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/plugins/snapshots.py

<ul><li>Added <code>datasource_runtime_target_path</code> function for stable hash-based <br>path generation<br> <li> Used it in <code>create_datasource_sync_snapshot</code> replacing inline hash logic<br> <li> Includes datasource config and sync policy in the hash identity</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-84c004e9a3155cce95776f0360ed9db19f75b2df3488e222d709bc7b845d23c4">+34/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Remove LensNode directory availability validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/serializers.py

<ul><li>Removed <code>_dir_paths</code> helper<br> <li> Eliminated stale heartbeat validation for <code>selected_dirs</code> in <br><code>validate_selected_dirs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-72c1bb0e599db4e5be8d127f9a01ce85f02bc96d0baa7d03da4a38f86d08c0f4">+0/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Set authoritative target_path in plugin sync command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/lensnode/main.py

<ul><li>Ensures <code>target_path</code> is set in plugin sync command from resolved config <br>if missing from command<br> <li> Keeps runtime target authoritative for plugin compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-e1ebe8331348ab3a4c69a0afe4bfd5b6d7ca5b90aa7eb300eb2806cfe013549f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Update test for assistant unreported directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/lens/tests/test_api.py

<ul><li>Changed <code>test_assistant_create_rejects_unreported_dir</code> to allow <br>unreported dir (status 201) instead of rejecting (400)<br> <li> Verification now checks that <code>selected_dirs</code> includes the unreported <br>path</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-17135aa1177c1cb0bc6ecb3e8148ef6c4aa2558599662f67cdbc35d4e9b21d12">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_plugin_runtime.py</strong><dd><code>Update test for target_path in plugin sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lensnode/tests/test_plugin_runtime.py

<ul><li>Added assertion for <code>target_path</code> in plugin sync test<br> <li> Validates that the target path is correctly forwarded</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-0f170425f7e5bf57146cd53e3454b526f8f7c964bf55d9350c2e1811fadfd34f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>561.yaml</strong><dd><code>Add release notes for issue #561</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/561.yaml

<ul><li>Added release notes in English, Chinese, and Spanish for the bug fix</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/562/files#diff-dbc09ffd8c626d297aaf2848290b0e3cf27bb0c4ccf8991a8a3859c315634463">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

