### PR TITLE
Fix unsupported release note category

### DIFF
--- a/release-notes/561.yaml
+++ b/release-notes/561.yaml
@@ -1,4 +1,4 @@
-type: bugfix
+type: fix
 audience: user
 en: Fixed assistant configuration failures when selected workspace paths are not present in the LensNode heartbeat report.
 zh-CN: 修复助手配置中的工作区路径未出现在 LensNode 心跳上报目录列表时无法保存的问题。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Replace the unsupported `bugfix` release note category with the supported `fix` category.
- Restore release-note validation and Build and Deploy workflow execution.

Closes #563

## Test plan
- [x] `python -m unittest scripts.test_release_notes`
- [x] `git diff --check`


___

### **PR Type**
Bug fix


___

### **Description**
- Fix release note category from 'bugfix' to 'fix'

- Restore release-note validation and Build and Deploy workflow execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  release_notes["release-notes/561.yaml"] --> |"category: bugfix -> fix"| validation["Release note validation passes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>561.yaml</strong><dd><code>Fix release note category</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-notes/561.yaml

<ul><li>Changed <code>type</code> field from <code>bugfix</code> to <code>fix</code> to ensure workflow compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/oneprolabs/sourcelens/pull/564/files#diff-dbc09ffd8c626d297aaf2848290b0e3cf27bb0c4ccf8991a8a3859c315634463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

